### PR TITLE
fixes 2 selector tests broken by recent QUnit commit

### DIFF
--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -278,7 +278,7 @@ test("pseudo - child", function() {
 	expect(31);
 	t( "First Child", "p:first-child", ["firstp","sndp"] );
 	t( "Last Child", "p:last-child", ["sap"] );
-	t( "Only Child", "a:only-child", ["simon1","anchor1","yahoo","anchor2","liveLink1","liveLink2"] );
+	t( "Only Child", "#main a:only-child", ["simon1","anchor1","yahoo","anchor2","liveLink1","liveLink2"] );
 	t( "Empty", "ul:empty", ["firstUL"] );
 	t( "Is A Parent", "p:parent", ["firstp","ap","sndp","en","sap","first"] );
 
@@ -295,7 +295,7 @@ test("pseudo - child", function() {
 	QUnit.reset();
 	
 	t( "Last Child", "p:last-child", ["sap"] );
-	t( "Last Child", "a:last-child", ["simon1","anchor1","mark","yahoo","anchor2","simon","liveLink1","liveLink2"] );
+	t( "Last Child", "#main a:last-child", ["simon1","anchor1","mark","yahoo","anchor2","simon","liveLink1","liveLink2"] );
 	
 	t( "Nth-child", "#main form#form > *:nth-child(2)", ["text1"] );
 	t( "Nth-child", "#main form#form > :nth-child(2)", ["text1"] );


### PR DESCRIPTION
from the commit comment: added "#main" ancestor selector to an "Only Child" and "Last Child" test to fix broken tests caused by QUnit commit abfab1713ccb588aa87136b199a9ddc8d1b56c4b (Aug 29, 2010) 
