### PR TITLE
Fix for JSLint Errors in build process

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -826,6 +826,8 @@ function doScrollCheck() {
 }
 
 // Expose jQuery to the global object
-return window.jQuery = window.$ = jQuery;
+window.jQuery = window.$ = jQuery;
+
+return jQuery;
 
 })();


### PR DESCRIPTION
Running make produces the following error when jQuery is checked against JSLint 

return window.jQuery = window.$ = jQuery;

```
Problem at line 846 character 21: Missing semicolon.
```

return window.jQuery = window.$ = jQuery;

```
Problem at line 846 character 22: Expected an identifier and instead saw '='.
```

undefined

This commit fixes that and passes all unit tests.
