### PR TITLE
#7017 - Accessing the 'type' property on VML elements fails on IE.

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -665,7 +665,8 @@ if ( !jQuery.support.submitBubbles ) {
 		setup: function( data, namespaces ) {
 			if ( this.nodeName.toLowerCase() !== "form" ) {
 				jQuery.event.add(this, "click.specialSubmit", function( e ) {
-					var elem = e.target, type = elem.type;
+					// Accessing type property on VML elements fails on IE.
+					var elem = e.target, type = elem.nodeName.toLowerCase() === "input" ? elem.type : "";
 
 					if ( (type === "submit" || type === "image") && jQuery( elem ).closest("form").length ) {
 						return trigger( "submit", this, arguments );
@@ -673,7 +674,8 @@ if ( !jQuery.support.submitBubbles ) {
 				});
 	 
 				jQuery.event.add(this, "keypress.specialSubmit", function( e ) {
-					var elem = e.target, type = elem.type;
+					// Accessing type property on VML elements fails on IE.
+					var elem = e.target, type = elem.nodeName.toLowerCase() === "input" ? elem.type : "";
 
 					if ( (type === "text" || type === "password") && jQuery( elem ).closest("form").length && e.keyCode === 13 ) {
 						return trigger( "submit", this, arguments );


### PR DESCRIPTION
Accessing certain properties on VML elements produces an error "Failed" with no other diagnostic information. After this error, the state of the browser is permanently affected until browser restart; many common properties produce the same "Failed" error.

Test case: http://gist.github.com/582889
Upstream bug report: https://connect.microsoft.com/IE/feedback/details/581183/
