### PR TITLE
Removing the second capture group from rts regex

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -7,7 +7,7 @@ var jsc = jQuery.now(),
 	rbracket = /\[\]$/,
 	jsre = /\=\?(&|$)/,
 	rquery = /\?/,
-	rts = /([?&])_=[^&]*(&?)/,
+	rts = /([?&])_=[^&]*/,
 	rurl = /^(\w+:)?\/\/([^\/?#]+)/,
 	r20 = /%20/g,
 	rhash = /#.*$/,
@@ -275,7 +275,7 @@ jQuery.extend({
 			var ts = jQuery.now();
 
 			// try replacing _= if it is there
-			var ret = s.url.replace(rts, "$1_=" + ts + "$2");
+			var ret = s.url.replace(rts, "$1_=" + ts);
 
 			// if nothing was replaced, add timestamp to the end
 			s.url = ret + ((ret === s.url) ? (rquery.test(s.url) ? "&" : "?") + "_=" + ts : "");


### PR DESCRIPTION
After the changes suggested by Jeff Roberson, the second capture group is no longer needed. See
http://stackoverflow.com/questions/3771105/can-someone-tell-me-the-purpose-of-the-second-capture-group-in-the-jquery-rts-reg
