### PR TITLE
Add head/tail methods - seems reasonable to have these if you have map

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -620,6 +620,28 @@ jQuery.extend({
 		return object;
 	},
 
+	head: function( object, callback, args ) {
+		if ( args ) {
+			callback.apply( object[ 0 ], args );
+		// A special, fast, case for the most common use of each
+                } else {
+			callback.call( object[0],0, object[0] );
+                }
+
+                return object;
+
+	},
+
+	tail: function( object, callback, args ) {
+		var len = object.length-1;
+		if( args ) {
+			callback.apply( object[ len ], args );
+		} else {
+			callback.call( object[ len ], len, object[ len ] );
+		}
+		return object;
+	},
+
 	// Use native String.trim function wherever possible
 	trim: trim ?
 		function( text ) {

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -807,6 +807,20 @@ test("jQuery.each(Object,Function)", function() {
 	equals( "baz", f.foo, "Loop over a function" );
 });
 
+test("jQuery.head(Object, Function)", function() {
+	expect(1);
+        var total = 0;
+	jQuery.head([1,2,3], function(i,v){ total += v; });
+	equals( total, 1, "CAR/head" );
+});
+
+test("jQuery.tail(Object, Function)", function() {
+	expect(1);
+	var total = 0;
+	jQuery.tail([1,2,3], function(i,v){ total += v; });
+	equals( total, 3, "tail" );
+});
+
 test("jQuery.makeArray", function(){
 	expect(17);
 


### PR DESCRIPTION
Both methods accept callbacks and I would have a use for - tail is more useful than head (as head is effectively array[0])

Anyway - seemed that these were missing from the api as I actually needed them today, so requesting that they are added or a reasonable argument as to why they are missing (reasonable could be not worth it, too many bytes/increases download size or whatever)

Thanks,
Kev
