### PR TITLE
Fix for Bug #6298

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -200,7 +200,7 @@ jQuery.extend({
 				// XHR object first and then try the ActiveX control if it
 				// throws an error
 				try {
-					new XMLHttpRequest();
+					var makeJsLintHappy = new XMLHttpRequest();
 					return function () {
 						return new XMLHttpRequest();
 					};


### PR DESCRIPTION
This bug has about over 9000 dupes in the bug tracker (at least 3), so here is a patch. Passes QUnit and the test case provided in duplicate [#6586](http://dev.jquery.com/ticket/6586). I hate the JSLint assignment fix, but am not sure how to keep it from complaining about the fact that, yes, we really do want to call `new XMLHttpRequest()` for its side-effects.
