### PR TITLE
Ability to avoid expando collisions

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -372,12 +372,20 @@ jQuery.extend = jQuery.fn.extend = function() {
 };
 
 jQuery.extend({
-	noConflict: function( deep ) {
+	noConflict: function( deep, expandoPrefix ) {
 		window.$ = _$;
 
 		if ( deep ) {
 			window.jQuery = _jQuery;
 		}
+                
+                // If the expando needs a prefix for explicit uniqueness
+                // and the cache has not been used yet (otherwise it's worth the risk).
+                // See #6842
+                if ( expandoPrefix && jQuery.isEmptyObject( jQuery.cache ) ) {
+                        // Set the expando to the old one plus the prefix
+                        jQuery.expando = expandoPrefix + jQuery.expando;
+                }
 
 		return jQuery;
 	},

--- a/src/data.js
+++ b/src/data.js
@@ -9,8 +9,9 @@ jQuery.extend({
 	// Please use with caution
 	uuid: 0,
 
-	// Unique for each copy of jQuery on the page	
-	expando: "jQuery" + jQuery.now(),
+	// Usually unique for each copy of jQuery on the page and for each version
+	// Use a jQuery.noConflict(true, 'unqiuePrefix') to manually avoid time collisions
+	expando: "jQuery" + jQuery.fn.jquery + jQuery.now(),
 
 	// The following elements throw uncatchable exceptions if you
 	// attempt to add expando properties to them.

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -183,7 +183,7 @@ test("browser", function() {
 }
 
 test("noConflict", function() {
-	expect(7);
+	expect(9);
 
 	var $$ = jQuery;
 
@@ -197,8 +197,32 @@ test("noConflict", function() {
 	equals( jQuery, originaljQuery, "Make sure jQuery was reverted." );
 	equals( $, original$, "Make sure $ was reverted." );
 	ok( $$("#main").html("test"), "Make sure that jQuery still works." );
-
-	jQuery = $$;
+	
+	jQuery = $ = $$;
+	
+	var oldExpando = jQuery.expando;
+	var oldCache   = jQuery.cache;
+	var testPrefix = 'testPrefix';
+	
+	// simulate no data in the cache
+	jQuery.cache = {};
+	
+	equals( jQuery.noConflict(true, testPrefix).expando, testPrefix + oldExpando, "noConflict prefix was added" );
+	
+	jQuery = $ = $$;
+	
+	// Set the expando back to the original
+	jQuery.expando = oldExpando;
+	
+	// Populate jQuery.cache
+	jQuery.cache = {'key': 'val'};
+	
+	equals( jQuery.noConflict(true, testPrefix).expando, oldExpando, "noConflict does not allow a prefix if jQuery.cache has been used" )
+	
+	jQuery = $ = $$;
+	
+	// Replace the data that was there prior to the tests for good measure
+	jQuery.cache = oldCache;
 });
 
 test("trim", function() {


### PR DESCRIPTION
The potential bug I reported is here: http://dev.jquery.com/ticket/6842

I want to be able to guarantee that my expando doesn't collide with another. V8 is now scarily close to being able to instantiate two instances of jQuery in the same millisecond. The only way I can think of to reliably do this (keeping in mind the case where two copies of jQuery are deeply noConflicted), is to explicitly pass in a unique prefix.

This patch reduces normal conflicts between different versions of jQuery by adding in the version to the expando, and also exposes a second parameter to jQuery.noConflict

For example:

<include jQuery>
myJQ = jQuery.noConflict(true, 'myUniquePrefix');

Generally, this is necessary for third party widgets that use jQuery and don't want to collide with whatever is on the page.

I did add a check to not allow a prefix to be added if the jQuery.cache had been used, that way no connections would be lost between old expando values. The best-practice here being that you call this new noConflict(true, 'prefix') before you use anything in the library.

Test cases are provided (and passing) for both the case when a prefix is added with or without an empty jQuery.cache.
