### PR TITLE
Fixes #6988

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -224,7 +224,8 @@ jQuery.fn.extend({
 				var values = jQuery.makeArray(val);
 
 				jQuery( "option", this ).each(function() {
-					this.selected = jQuery.inArray( this.text, values ) >= 0;
+					var val = this.value || this.text;
+					this.selected = jQuery.inArray( val, values ) >= 0;
 				});
 
 				if ( !values.length ) {


### PR DESCRIPTION
jQuery gets confused when there is options in a multiple select with the value attribute. Instead of using the val() of the element, that is 1 if value is set and option1 if no value if set, use this.text, that is consistent. Fixes #6988
