### PR TITLE
Fixes `match` var in global scope

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -121,7 +121,7 @@ jQuery.extend({
 	// A method for determining if a DOM node can handle the data expando
 	acceptData: function( elem ) {
 		if ( elem.nodeName ) {
-			match = jQuery.noData[ elem.nodeName.toLowerCase() ];
+			var match = jQuery.noData[ elem.nodeName.toLowerCase() ];
 
 			if ( match ) {
 				return !(match === true || elem.getAttribute("classid") !== match);


### PR DESCRIPTION
acceptData was defining `match` globally. This patch passes all unit tests.
