### PR TITLE
Only save old display value in `.hide()` if it's not `"none"`

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -49,9 +49,13 @@ jQuery.fn.extend({
 
 		} else {
 			for ( var i = 0, j = this.length; i < j; i++ ) {
-				var old = jQuery.data(this[i], "olddisplay");
+				var old = jQuery.data(this[i], "olddisplay"), currentVal;
 				if ( !old ) {
-					jQuery.data( this[i], "olddisplay", jQuery.css( this[i], "display" ) );
+					currentVal = jQuery.css( this[i], "display" );
+
+					if ( currentVal !== "none" ) {
+						jQuery.data( this[i], "olddisplay", currentVal );
+					}
 				}
 			}
 

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -6,12 +6,22 @@ test("sanity check", function() {
 });
 
 test("show()", function() {
-	expect(23);
+	expect(24);
 	var pass = true, div = jQuery("#main div");
 	div.show().each(function(){
 		if ( this.style.display == "none" ) pass = false;
 	});
 	ok( pass, "Show" );
+
+	pass = true;
+
+	var newEl = jQuery('<div style="display: none;"></div>').appendTo(document.body);
+	newEl.hide().show().each(function () {
+		if (this.style.display == 'none' ) pass = false;
+	});
+	ok ( pass, 'Show after hiding an element with inline display:none' );
+
+	newEl.remove();
 
 	var speeds = {
 	  "null speed": null,


### PR DESCRIPTION
The following code should not result in an element that is still hidden:

```
jQuery('<div style="display: none;"></div>').appendTo(document.body).hide().show();
```

The included commit fixes this issue.
