### PR TITLE
2 lines fix to make $.fn.animate compatible with jQuery.cssHooks

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -181,9 +181,9 @@ jQuery.fn.extend({
 
 						// We need to compute starting value
 						if ( unit !== "px" ) {
-							self.style[ name ] = (end || 1) + unit;
+							jQuery.style( self, name, (end || 1) + unit);
 							start = ((end || 1) / e.cur(true)) * start;
-							self.style[ name ] = start + unit;
+							jQuery.style( self, name, start + unit);
 						}
 
 						// If a +=/-= token was provided, we're doing a relative animation


### PR DESCRIPTION
I've been using the new jQuery.cssHooks to implement a cross browser rotate plugin.
It worked like a charm, but I ran into an issue when trying to animate this property:
Some code in $.fn.animate was accessing the starting value of the animation using
elem.style[property] = value
I replaced those (2) lines to use my custom setter
jQuery.style( elem, property, value)
And it worked like a charm!

I'd love to have this available in 1.4.3
