### PR TITLE
Decreased likelihood of expando collision

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -10,7 +10,7 @@ jQuery.extend({
 	uuid: 0,
 
 	// Unique for each copy of jQuery on the page	
-	expando: "jQuery" + jQuery.now(),
+	expando: "jQuery" + jQuery.fn.jquery + (Math.random() * 10e15),
 
 	// The following elements throw uncatchable exceptions if you
 	// attempt to add expando properties to them.


### PR DESCRIPTION
This seems like a pretty good compromise for avoid expando collisions between multiple jQuery instances.

Now that there are no local references to jQuery.expando, it is also possible to modify the value as long as nothing has used it yet. (without a change in the jQuery api)
