### PR TITLE
Test for remote ajax with forced lowerCase on the host and protocol. Fixes #6908

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -287,7 +287,7 @@ jQuery.extend({
 
 		// Matches an absolute URL, and saves the domain
 		var parts = rurl.exec( s.url ),
-			remote = parts && (parts[1] && parts[1] !== location.protocol || parts[2] !== location.host);
+			remote = parts && (parts[1] && parts[1].toLowerCase() !== location.protocol || parts[2].toLowerCase() !== location.host);
 
 		// If we're requesting a remote document
 		// and trying to load JSON or Script with a GET


### PR DESCRIPTION
Currently a url passed into ajax with capitalization in the host or protocol will be considered remote.
This sets everything to lowercase for the comparison.

Fixes #6908
http://bugs.jquery.com/ticket/6908
