### PR TITLE
fixed jQuery.getScript on local development environment.

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -287,11 +287,12 @@ jQuery.extend({
 
 		// Matches an absolute URL, and saves the domain
 		var parts = rurl.exec( s.url ),
-			remote = parts && (parts[1] && parts[1] !== location.protocol || parts[2] !== location.host);
+			remote = parts && (parts[1] && parts[1] !== location.protocol || parts[2] !== location.host),
+			local = location.protocol == 'file:';
 
 		// If we're requesting a remote document
 		// and trying to load JSON or Script with a GET
-		if ( s.dataType === "script" && type === "GET" && remote ) {
+		if ( s.dataType === "script" && type === "GET" && (remote || local)) {
 			var head = document.getElementsByTagName("head")[0] || document.documentElement;
 			var script = document.createElement("script");
 			if ( s.scriptCharset ) {


### PR DESCRIPTION
on local develpment environment, `jQuery.getScript` raises `Origin null is not allowed by Access-Control-Allow-Origin.` exception when I tried to load "./foo.js" on "file:///foo.html".  
this fix ensure same behavior on live environment.
