### PR TITLE
Support for relative values for $().css setters (#7345)

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -6,6 +6,7 @@ var ralpha = /alpha\([^)]*\)/i,
 	rupper = /([A-Z])/g,
 	rnumpx = /^-?\d+(?:px)?$/i,
 	rnum = /^-?\d/,
+	rrelnum = /^([+\-]=)?([\d+.\-]+)(.*)$/,
 
 	cssShow = { position: "absolute", visibility: "hidden", display: "block" },
 	cssWidth = [ "Left", "Right" ],
@@ -89,6 +90,14 @@ jQuery.extend({
 			// If a number was passed in, add 'px' to the (except for certain CSS properties)
 			if ( typeof value === "number" && !jQuery.cssNumber[ origName ] ) {
 				value += "px";
+			}
+
+			if ( typeof value === "string" ) {
+				var parts = rrelnum.exec( value );
+				if ( parts && parts[1] ) {
+					var relVal = parseFloat( parts[2] );
+					value = ( ( parts[1] === "-=" ? -1 : 1 ) * relVal ) + jQuery.css( elem, name );
+				}
 			}
 
 			// If a hook was provided, use that value, otherwise just set the specified value

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -103,6 +103,22 @@ test("css(String|Hash)", function() {
 	equals( child[0].style.fontSize, old, "Make sure font-size isn't changed on null." );
 });
 
+test("css(String, String|Object) with relative values", function() {
+	var $elem = jQuery('#nothiddendiv');
+	$elem.css({ width: 1, height: 1 });
+	ok( [$elem.width(), $elem.height()], [1,1] );
+	$elem.css({ width: "+=9", height: "+=9" });
+	ok( [$elem.width(), $elem.height()], [10,10] );
+	$elem.css({ width: "-=9", height: "-=9" });
+	ok( [$elem.width(), $elem.height()], [1,1] );
+	$elem.css({ width: "+=9px", height: "+=9px" });
+	ok( [$elem.width(), $elem.height()], [10,10] );
+	$elem.css({ width: "-=9px", height: "-=9px" });
+	ok( [$elem.width(), $elem.height()], [1,1] );
+	$elem.css("width", "+=9").css("height", "+=9");
+	ok( [$elem.width(), $elem.height()], [10,10] );
+});
+
 test("css(String, Object)", function() {
 	expect(22);
 


### PR DESCRIPTION
This is for ticket #7345. Supporting +=/-= for setting values in $().css.

We might want to share the rrelnum regex with the rfxnum regex from effects.js since they are the same.

Also, this patch doesn't really take other units than pixels into consideration.
