### PR TITLE
Support 6897

### DIFF
--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -3,6 +3,31 @@ module("attributes");
 var bareObj = function(value) { return value; };
 var functionReturningObj = function(value) { return (function() { return value; }); };
 
+test("jQuery.props: itegrity test", function() {
+  
+  expect(1);
+  
+  //  This must be maintained and equal jQuery.props
+  //  Ensure that accidental or erroneous property 
+  //  overwrites don't occur
+  //  This is simply for better code coverage and future proofing. 
+  var propsShouldBe = {
+    "for": "htmlFor",
+    "class": "className",
+    readonly: "readOnly",
+    maxlength: "maxLength",
+    cellspacing: "cellSpacing",
+    rowspan: "rowSpan",
+    colspan: "colSpan",
+    tabindex: "tabIndex",
+    usemap: "useMap",
+    frameborder: "frameBorder"
+  };
+  
+  same(propsShouldBe, jQuery.props, "jQuery.props passes integrity check");
+
+});
+
 test("attr(String)", function() {
 	expect(31);
 


### PR DESCRIPTION
Simply sets a rule that jQuery.props must at least look like this to pass - in the event that it has been programmatically overwritten.
