### PR TITLE
Improve performance of get() for negative indices. Fixes #5476.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -215,7 +215,7 @@ jQuery.fn = jQuery.prototype = {
 			this.toArray() :
 
 			// Return just the object
-			( num < 0 ? this.slice(num)[ 0 ] : this[ num ] );
+			( num < 0 ? this[ this.length + num ] : this[ num ] );
 	},
 
 	// Take an array of elements and push it onto the stack

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -547,15 +547,15 @@ test("toArray()", function() {
 })
 
 test("get(Number)", function() {
-	expect(1);
+	expect(2);
 	equals( jQuery("p").get(0), document.getElementById("firstp"), "Get A Single Element" );
+	strictEqual( jQuery("#firstp").get(1), undefined, "Try get with index larger elements count" );
 });
 
 test("get(-Number)",function() {
-	expect(1);
-	equals( jQuery("p").get(-1),
-		document.getElementById("first"),
-		"Get a single element with negative index" )
+	expect(2);
+	equals( jQuery("p").get(-1), document.getElementById("first"), "Get a single element with negative index" );
+	strictEqual( jQuery("#firstp").get(-2), undefined, "Try get with index negative index larger then elements count" );
 })
 
 test("each(Function)", function() {


### PR DESCRIPTION
Check the bug ticket for discussion and a performance test.

This commit also fixes an inconsistency in the return values of `get()` e.g.
    <p id="foo">bar</p>
    $("#foo").get(0) //yields the element
    $("#foo").get(1) //yields undefined
    $("#foo").get(-1); //yields the element
    $("#foo").get(-2); //still yields the element #foo instead of undefined
    //new version return undefined for the last use case
