### PR TITLE
Fix proposal for bug 4386. Make sure IE clones body elements correctly.

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -10,6 +10,8 @@ var rinlinejQuery = / jQuery\d+="(?:\d+|null)"/g,
 	// checked="checked" or checked (html5)
 	rchecked = /checked\s*(?:[^=]|=\s*.checked.)/i,
 	raction = /\=([^="'>\s]+\/)>/g,
+	rbodystart = /^\s*<body/i,
+	rbodyend = /<\/body>\s*$/i,
 	wrapMap = {
 		option: [ 1, "<select multiple='multiple'>", "</select>" ],
 		legend: [ 1, "<fieldset>", "</fieldset>" ],
@@ -198,11 +200,12 @@ jQuery.fn.extend({
 				// the name attribute on an input).
 				var html = this.outerHTML,
 					ownerDocument = this.ownerDocument;
-
 				if ( !html ) {
 					var div = ownerDocument.createElement("div");
 					div.appendChild( this.cloneNode(true) );
 					html = div.innerHTML;
+				} else if ( rbodystart.test(html) && rbodyend.test(html) ) {
+					html = html.replace( rbodystart, "<div>" ).replace( rbodyend, "</div>" );
 				}
 
 				return jQuery.clean([html.replace(rinlinejQuery, "")

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -814,7 +814,7 @@ test("replaceAll(String|Element|Array&lt;Element&gt;|jQuery)", function() {
 });
 
 test("clone()", function() {
-	expect(31);
+	expect(32);
 	equals( 'This is a normal link: Yahoo', jQuery('#en').text(), 'Assert text for #en' );
 	var clone = jQuery('#yahoo').clone();
 	equals( 'Try them out:Yahoo', jQuery('#first').append(clone).text(), 'Check for clone' );
@@ -872,6 +872,8 @@ test("clone()", function() {
 	form.appendChild( div );
 
 	equals( jQuery(form).clone().children().length, 1, "Make sure we just get the form back." );
+
+	equal( jQuery("body").clone().children()[0].id, "qunit-header", "Make sure cloning body works" );
 });
 
 if (!isLocal) {


### PR DESCRIPTION
At least IE6 (7/8?) has a problem with cloning the body element directly.

If the body contains more then one immediate child only the children of the first one are cloned all other subsequent immediate children of body are discarded.

If the body contains only one immediate child only the children of this element are cloned but not the element itself.

[#4386](http://bugs.jquery.com/ticket/4386)
