### PR TITLE
Fixes 6398. Enables custom "submit" events in IE on non DOM elements

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -716,7 +716,7 @@ if ( !jQuery.support.submitBubbles ) {
 
 	jQuery.event.special.submit = {
 		setup: function( data, namespaces ) {
-			if ( this.nodeName.toLowerCase() !== "form" ) {
+			if ( this.nodeName && this.nodeName.toLowerCase() !== "form" ) {
 				jQuery.event.add(this, "click.specialSubmit", function( e ) {
 					var elem = e.target,
 						type = elem.type;

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -493,7 +493,7 @@ test("bind(name, false), unbind(name, false)", function() {
 });
 
 test("bind()/trigger()/unbind() on plain object", function() {
-	expect( 7 );
+	expect( 8 );
 
 	var obj = {};
 
@@ -503,8 +503,13 @@ test("bind()/trigger()/unbind() on plain object", function() {
 	// Make sure it doesn't complain when no events are found
 	jQuery(obj).unbind("test");
 
-	jQuery(obj).bind("test", function(){
-		ok( true, "Custom event run." );
+	jQuery(obj).bind({
+		test: function() {
+			ok( true, "Custom event run." );
+		},
+		submit: function() {
+			ok( true, "Custom submit event run." );
+		}
 	});
 
 	var events = jQuery(obj).data("__events__");
@@ -516,8 +521,10 @@ test("bind()/trigger()/unbind() on plain object", function() {
 
 	// Should trigger 1
 	jQuery(obj).trigger("test");
+	jQuery(obj).trigger("submit");
 
 	jQuery(obj).unbind("test");
+	jQuery(obj).unbind("submit");
 
 	// Should trigger 0
 	jQuery(obj).trigger("test");


### PR DESCRIPTION
[#6398](http://bugs.jquery.com/ticket/6398)
