### PR TITLE
Bug Fix for #6911 

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -1075,8 +1075,8 @@ function liveHandler( event ) {
 		events = events.events;
 	}
 
-	// Make sure we avoid non-left-click bubbling in Firefox (#3861)
-	if ( event.liveFired === this || !events || !events.live || event.button && event.type === "click" ) {
+	// Make sure we avoid non-left-click bubbling in Firefox (#3861) and disabled elements in IE (#6911)
+	if ( event.liveFired === this || !events || !events.live || event.target.disabled || event.button && event.type === "click" ) {
 		return;
 	}
 	


### PR DESCRIPTION
Reformatted inline with style guidelines. Test case is already present in delegatetest.html and works properly. 

Prevent disabled form elements in IE to bubble events via live and delegate.
