### PR TITLE
Fix for jQuery bug ticket 7602 (ClientRect returned from jQuery.fn.offset for disconnected elements)

### DIFF
--- a/src/offset.js
+++ b/src/offset.js
@@ -30,7 +30,7 @@ if ( "getBoundingClientRect" in document.documentElement ) {
 
 		// Make sure we're not dealing with a disconnected DOM node
 		if ( !box || !jQuery.contains( docElem, elem ) ) {
-			return box || { top: 0, left: 0 };
+			return box ? { top: box.top, left: box.left } : { top: 0, left: 0 };
 		}
 
 		var body = doc.body,


### PR DESCRIPTION
Here's a quick fix for the bug I reported. It basically converts the hard-to-modify ClientRect into a generic object with top and left properties, which is the same as the object used for connected elements and therefore returned in all other cases.
