### PR TITLE
Bug #6242

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -195,6 +195,17 @@ jQuery.extend({
 	},
 
 	ajax: function( origSettings ) {
+		// IE8 leaks a lot when we've set abort, and IE6-8 a little
+		// when we have set onreadystatechange. Bug #6242
+		// XXX IE7 still leaks when abort is called, no matter what
+		// we do
+		function cleanup() {
+			// IE6 will throw an error setting xhr.abort
+			try {
+				xhr.abort = xhr.onreadystatechange = jQuery.noop;
+			} catch(e) {}
+		}
+
 		var s = jQuery.extend(true, {}, jQuery.ajaxSettings, origSettings),
 			jsonp, status, data, type = s.type.toUpperCase(), noContent = rnoContent.test(type);
 
@@ -403,13 +414,12 @@ jQuery.extend({
 
 				requestDone = true;
 				if ( xhr ) {
-					xhr.onreadystatechange = jQuery.noop;
+					cleanup();
 				}
 
 			// The transfer is complete and the data is available, or the request timed out
 			} else if ( !requestDone && xhr && (xhr.readyState === 4 || isTimeout === "timeout") ) {
 				requestDone = true;
-				xhr.onreadystatechange = jQuery.noop;
 
 				status = isTimeout === "timeout" ?
 					"timeout" :
@@ -451,10 +461,7 @@ jQuery.extend({
 					xhr.abort();
 				}
 
-				// Stop memory leaks
-				if ( s.async ) {
-					xhr = null;
-				}
+				cleanup();
 			}
 		};
 


### PR DESCRIPTION
[#6242](http://bugs.jquery.com/ticket/6242) is a memory leak caused by the custom abort handler on $.ajax. This patch fixes that leak, collects all the leak-fixing inside a single function, and ensures that leak cleanup is called unconditionally no matter whether a request is aborted, completed synchronous, or completed asynchronous. It also removes an `xhr = null` that claimed to stop memory leaks, but in my testing appeared to do absolutely nothing.
