### PR TITLE
Bug #7524

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -138,15 +138,17 @@ jQuery.fn.extend({
 
 		if ( typeof key === "undefined" ) {
 			if ( this.length ) {
-				var attr = this[0].attributes, name;
 				data = jQuery.data( this[0] );
 
-				for ( var i = 0, l = attr.length; i < l; i++ ) {
-					name = attr[i].name;
-
-					if ( name.indexOf( "data-" ) === 0 ) {
-						name = name.substr( 5 );
-						dataAttr( this[0], name, data[ name ] );
+				if ( this[0].nodeType === 1 ) {
+					var attr = this[0].attributes, name;
+					for ( var i = 0, l = attr.length; i < l; i++ ) {
+						name = attr[i].name;
+	
+						if ( name.indexOf( "data-" ) === 0 ) {
+							name = name.substr( 5 );
+							dataAttr( this[0], name, data[ name ] );
+						}
 					}
 				}
 			}

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -79,7 +79,7 @@ test("jQuery.data", function() {
 });
 
 test(".data()", function() {
-	expect(4);
+	expect(5);
 
 	var div = jQuery("#foo");
 	strictEqual( div.data("foo"), undefined, "Make sure that missing result is undefined" );
@@ -90,6 +90,9 @@ test(".data()", function() {
 
 	var nodiv = jQuery("#unfound");
 	equals( nodiv.data(), null, "data() on empty set returns null" );
+
+	var obj = { foo: "bar" };
+	equals( jQuery(obj).data(), obj, "Retrieve data object from a wrapped JS object (#7524)" );
 })
 
 test(".data(String) and .data(String, Object)", function() {


### PR DESCRIPTION
For [#7524](http://bugs.jquery.com/ticket/7524). The <del>unpleasant</del> new pull-attributes-from-DOMery broke calling `$.fn.data` on wrapped JS objects with no arguments; this fixes it.
