### PR TITLE
#7058 - Make sure border widths return 0px on IE when border-style is "none".

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -259,6 +259,15 @@ if ( document.defaultView && document.defaultView.getComputedStyle ) {
 
 		return ret;
 	};
+} else {
+	// Lacking computed styles, make sure that border-width returns 0px if border-style is none
+	jQuery.each(["Top", "Right", "Bottom", "Left"], function( i, name ) {
+		jQuery.cssHooks[ "border"+name+"Width" ] = {
+			get: function( elem, computed ) {
+				return computed && jQuery.css(elem, "border"+name+"Style") === "none" ? "0px" : undefined;
+			}
+		};
+	});
 }
 
 if ( document.documentElement.currentStyle ) {

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -320,3 +320,16 @@ test(":visible selector works properly on children with a hidden parent (bug #45
 	jQuery('#table').css('display', 'none').html('<tr><td>cell</td><td>cell</td></tr>');
 	equals(jQuery('#table td:visible').length, 0, "hidden cell children not perceived as visible");
 });
+
+test("border widths 0px if border-style:none (bug #7058)", function() {
+	expect(4);
+	var $fix = jQuery('<div id="test7058" style="border: 2px solid blue"></div>').appendTo("body");
+	equals($fix.css("borderRightWidth"), "2px", "Border width from style attribute");
+	$fix.css("border", "none");
+	equals($fix.css("borderRightWidth"), "0px", "border:none should have 0px width");
+	$fix.css("borderRightColor", "#f00");
+	equals($fix.css("borderRightWidth"), "0px", "border:none should have 0px width");
+	$fix.css("border", "4px inset #f00");
+	equals($fix.css("borderRightWidth"), "4px", "Border width from explicit border css call");
+	$fix.remove();
+});


### PR DESCRIPTION
[#7058](http://bugs.jquery.com/ticket/7058)
