### PR TITLE
Fix #7736 : precising rfxnum regex

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -2,7 +2,7 @@
 
 var elemdisplay = {},
 	rfxtypes = /^(?:toggle|show|hide)$/,
-	rfxnum = /^([+\-]=)?([\d+.\-]+)(.*)$/,
+	rfxnum = /^([+\-]=)?([\d+.\-]+)([a-z%]*)$/i,
 	timerId,
 	fxAttrs = [
 		// height animations


### PR DESCRIPTION
I'm trying to create a new cssHooks for the transform scale property, and I want to be able to pass values such as "0.5,2" (half the scale on X axis and twice the scale on Y axis).
Currently, when using such value, the rfxnum regex will be matched, "0.5" will be considered to be the value and ",2" the unit. Additionaly, jQuery will waste time trying to calculate the start value.
