### PR TITLE
Swallowing an exception in FF4

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -177,11 +177,14 @@
 		var el = document.createElement("div");
 		eventName = "on" + eventName;
 
-		var isSupported = (eventName in el);
-		if ( !isSupported ) {
-			el.setAttribute(eventName, "return;");
-			isSupported = typeof el[eventName] === "function";
-		}
+		var isSupported = false;
+		try {
+			isSupported = (eventName in el); 
+			if (!isSupported) {
+				el.setAttribute(eventName, "return;");
+				isSupported = typeof el[eventName] === "function";
+			}
+		} catch (e) {}
 		el = null;
 
 		return isSupported;


### PR DESCRIPTION
If jQuery is used as a part of a browser extension in Firefox, it will work for FF3 but not necessarily in FF4. In particular, when jQuery is loaded using loadSubScript() passing a wrappedJSObject as a context, it will throw an exception in eventSupported():

```
"Component is not available"  nsresult: "0x80040111 (NS_ERROR_NOT_AVAILABLE)"
```

FF4 throws this exception if the event that is being checked is not supported on these lines:

```
var isSupported = (eventName in el); 

isSupported = typeof el[eventName] === "function";
```

This problem seems to be specific to loading jQuery using loadSubScript() since I cannot reproduce it in the console.

A workaround is a simple try/catch block. 
