### PR TITLE
#7780 $.isPlainObject is inconsistent with 'special objects'

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -522,6 +522,11 @@ jQuery.extend({
 			return false;
 		}
 		
+    //  Fixed #7780, Firefox and IE evaluate location incorrectly
+    if ( !("constructor" in obj) || /Location/.test(obj.constructor.toString() ) ) {
+      return false;
+    }
+    		
 		// Own properties are enumerated firstly, so to speed up,
 		// if last one is own, then all properties are own.
 	

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -288,6 +288,10 @@ test("isPlainObject", function() {
 	// Window
 	ok(!jQuery.isPlainObject(window), "window");
 
+  // Special Host Objects
+  ok(!jQuery.isPlainObject(document.location), "!document.location");
+  ok(!jQuery.isPlainObject(window.location), "!window.location");
+  
 	try {
 		var iframe = document.createElement("iframe");
 		document.body.appendChild(iframe);


### PR DESCRIPTION
Co-written by danheberden 

The issue arose in the ajax rewrite - when using $.isPlainObject to test against document.location or window.location, IE and FF return true for 2 different reasons. 

Passes all existing unit tests in 
IE6,7,8
FF3.0.12,3.6.12,4b
Chrome
Safari
Opera

Includes 2 unit tests
