### PR TITLE
#7780 $.isPlainObject is inconsistent with 'special objects'

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -526,7 +526,7 @@ jQuery.extend({
     if ( !("constructor" in obj) || /Location/.test(obj.constructor.toString() ) ) {
       return false;
     }
-    		
+	
 		// Own properties are enumerated firstly, so to speed up,
 		// if last one is own, then all properties are own.
 	

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -247,7 +247,7 @@ test("type", function() {
 });
 
 test("isPlainObject", function() {
-	expect(14);
+	expect(18);
 
 	stop();
 
@@ -291,6 +291,9 @@ test("isPlainObject", function() {
   // Special Host Objects
   ok(!jQuery.isPlainObject(document.location), "!document.location");
   ok(!jQuery.isPlainObject(window.location), "!window.location");
+
+  ok(!jQuery.isPlainObject(document.top), "!document.top");
+  ok(!jQuery.isPlainObject(window.top), "!window.top");
   
 	try {
 		var iframe = document.createElement("iframe");


### PR DESCRIPTION
Co-written by danheberden 

The issue arose in the ajax rewrite - when using $.isPlainObject to test against document.location or window.location, IE and FF return true for 2 different reasons. 

Passes all existing unit tests in 
IE6,7,8
FF3.0.12,3.6.12,4b
Chrome
Safari
Opera

Includes 2 unit tests
