### PR TITLE
Fixes #7762: unload cleanup is called on IE7, IE8, but should be only on IE6

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -1181,8 +1181,10 @@ jQuery.each( ("blur focus focusin focusout load resize scroll unload click dblcl
 // Window isn't included so as not to unbind existing unload events
 // More info:
 //  - http://isaacschlueter.com/2006/10/msie-memory-leaks/
-if ( window.attachEvent && !window.addEventListener ) {
-	jQuery(window).bind("unload", function() {
+// Checking for no XHR or custom XHR means IE6, the single browser where the code is needed, see #7762
+if ( window.attachEvent && !window.addEventListener && 
+	( !window.XMLHttpRequest || XMLHttpRequest.prototype.constructor ) ) {
+	jQuery(window).bind("unload", function() { // will not execute in IE>6
 		for ( var id in jQuery.cache ) {
 			if ( jQuery.cache[ id ].handle ) {
 				// Try/Catch is to handle iframes being unloaded, see #4280


### PR DESCRIPTION
The condition is already a hidden sniffing: "window.attachEvent && !window.addEventListener" sniffs for IE assuming that any IE leak, but that's not true. Only IE6 does.

On IE7 that may be visible as sluggishness and CPU load when leaving a page with many handlers on slow PC.

I added a check for non-existance of native XHR to ensure that only IE6 gets the code execute, so IE7, IE8 users don't execute the unnecessary code.
