### PR TITLE
Fixes Issue #7809

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -386,7 +386,7 @@ function cloneCopyEvent(orig, ret) {
 			curData.events = {};
 
 			for ( var type in events ) {
-				for ( var handler in events[ type ] ) {
+				for ( var handler = 0; handler < events[type].length; handler++) ) {
 					jQuery.event.add( this, type, events[ type ][ handler ], events[ type ][ handler ].data );
 				}
 			}


### PR DESCRIPTION
Fixes issue #7809: cloneCopyEvent function inner for-in loop [line 5012] on Array object, which causes object keys to be iterated, including custom functions on the Array prototype. (http://bugs.jquery.com/ticket/7809)

The ticket has been closed an invalidated, however I feel that this bug effects jQuery's ability to be used with other libraries (Prototype, for example) that modify the Array prototype. it does not seem like good form to say that the way to fix the problem is "don't do it", when the problem is caused by using functionality that exists at the core of JavaScript itself; functionality that several libraries use.

(reason for close) bah, sorry, left a trailing comma in there
