### PR TITLE
Nokia browser support workaround

### DIFF
--- a/src/dimensions.js
+++ b/src/dimensions.js
@@ -35,8 +35,10 @@ jQuery.each([ "Height", "Width" ], function( i, name ) {
 
 		if ( jQuery.isWindow( elem ) ) {
 			// Everyone else use document.documentElement or document.body depending on Quirks vs Standards mode
-			return elem.document.compatMode === "CSS1Compat" && elem.document.documentElement[ "client" + name ] ||
-				elem.document.body[ "client" + name ] || window.screen && window.screen[ name.toLowerCase() ];
+			// 3rd condition allows Nokia support, as it supports the docElem prop but not CSS1Compat
+			var docElemProp = elem.document.documentElement[ "client" + name ];
+			return elem.document.compatMode === "CSS1Compat" && docElemProp ||
+				elem.document.body[ "client" + name ] || docElemProp;
 
 		// Get document width or height
 		} else if ( elem.nodeType === 9 ) {


### PR DESCRIPTION
Getting window dimensions currently fails in Nokia browsers, causing a JS error (and consequently making jQuery Mobile fail to render the page). Based on a tip from Ben Nolan, this fix returns window.screen[width|height] if the other  attempts at getting window dimensions fail. On mobile at least, it seems to make sense, and on desktop (assuming this issue would ever show up on desktop), this might be better than returning false or undefined.
