### PR TITLE
Fix #7398 - Frameset documents

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -125,6 +125,12 @@
 	// Figure out if the W3C box model works as expected
 	// document.body must exist before we can do this
 	jQuery(function() {
+	
+		// Frameset documents with no body should not run this code
+		if ( !document.getElementsByTagName("body").length ) {
+			return;
+		}
+		
 		var div = document.createElement("div");
 		div.style.width = div.style.paddingLeft = "1px";
 


### PR DESCRIPTION
Don't do body-related feature detects on frameset documents that ain't got no body. Fixes #7398. Test case frameset document is attached to the ticket. 
