### PR TITLE
Fix #7793 - isDefaultPrevented on bubbling events

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -600,6 +600,12 @@ jQuery.Event = function( src ) {
 	if ( src && src.type ) {
 		this.originalEvent = src;
 		this.type = src.type;
+		// Events bubbling up the document may have been marked as prevented
+		// by a handler lower down the tree; reflect the correct value.
+		this.isDefaultPrevented =
+			(src.defaultPrevented===true ? true :
+			 src.getPreventDefault ? src.getPreventDefault() :
+			 src.returnValue===false) ? returnTrue : returnFalse;
 	// Event type
 	} else {
 		this.type = src;

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -295,6 +295,44 @@ test("live/delegate immediate propagation", function() {
 	$p.undelegate( "click" );
 });
 
+test("bind/delegate bubbling, isDefaultPrevented", function() {
+	expect(2);
+	var $anchor2 = jQuery( "#anchor2" ),
+		$main = jQuery( "#main" ),
+		fakeClick = function($jq) {
+			// Prefer a native click so we don't get jQuery simulated bubbling
+			if ( $jq[0].click ) {
+				$jq[0].click();	// IE
+			}
+			else if ( document.createEvent ) {
+				var e = document.createEvent( 'MouseEvents' );
+				e.initEvent( "click", true, true ); 
+				$jq[0].dispatchEvent(e);
+			}
+			else {
+				$jq.click();
+			}
+		};
+	$anchor2.click(function(e) {
+		e.preventDefault();
+	});
+	$main.delegate("#foo", "click", function(e) {
+		equals( e.isDefaultPrevented(), true, "isDefaultPrevented true passed to bubbled event" );
+	});
+	fakeClick( $anchor2 );
+	$anchor2.unbind( "click" );
+	$main.undelegate( "click" );
+	$anchor2.click(function(e) {
+		// Let the default action occur
+	});
+	$main.delegate("#foo", "click", function(e) {
+		equals( e.isDefaultPrevented(), false, "isDefaultPrevented false passed to bubbled event" );
+	});
+	fakeClick( $anchor2 );
+	$anchor2.unbind( "click" );
+	$main.undelegate( "click" );
+});
+
 test("bind(), iframes", function() {
 	// events don't work with iframes, see #939 - this test fails in IE because of contentDocument
 	var doc = jQuery("#loadediframe").contents();


### PR DESCRIPTION
When a native browser event is bubbling up the DOM, make sure that the correct isDefaultPrevented value is reflected by jQuery's Event object. Fixes #7793.
