### PR TITLE
Fix #7762

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -1177,21 +1177,4 @@ jQuery.each( ("blur focus focusin focusout load resize scroll unload click dblcl
 	}
 });
 
-// Prevent memory leaks in IE
-// Window isn't included so as not to unbind existing unload events
-// More info:
-//  - http://isaacschlueter.com/2006/10/msie-memory-leaks/
-if ( window.attachEvent && !window.addEventListener ) {
-	jQuery(window).bind("unload", function() {
-		for ( var id in jQuery.cache ) {
-			if ( jQuery.cache[ id ].handle ) {
-				// Try/Catch is to handle iframes being unloaded, see #4280
-				try {
-					jQuery.event.remove( jQuery.cache[ id ].handle.elem );
-				} catch(e) {}
-			}
-		}
-	});
-}
-
 })( jQuery );


### PR DESCRIPTION
I’ve tested and confirmed that currently supported versions of IE6 no longer leak memory on inter-page requests due circular references caused by event handlers. I tested this by creating 20,000 event listeners on an element, then navigating to about:blank and checking the memory delta using sIEve. I tested both custom and regular event handlers and both do not leak.
