### PR TITLE
#7840 Element data cache properly cleared by removeData() (when no arguments passed); Inc unit tests

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -108,6 +108,10 @@ jQuery.extend({
 
 		// Otherwise, we want to remove all of the element's data
 		} else {
+            if ( isNode ) {
+		        delete cache[ id ];			
+            }
+
 			if ( isNode && jQuery.support.deleteExpando ) {
 				delete elem[ jQuery.expando ];
 
@@ -115,11 +119,9 @@ jQuery.extend({
 				elem.removeAttribute( jQuery.expando );
 
 			// Completely remove the data cache
-			} else if ( isNode ) {
-				delete cache[ id ];
-
-			// Remove all fields from the object
 			} else {
+
+				// Remove all fields from the object
 				for ( var n in elem ) {
 					delete elem[ n ];
 				}

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -372,3 +372,19 @@ test(".removeData()", function() {
 	div.removeData("test.foo");
 	equals( div.data("test.foo"), undefined, "Make sure data is intact" );
 });
+
+test(".removeData() with no arguments", function() {
+	expect(2);
+	var doc = jQuery(document.body), 
+	    id;
+
+	doc.data("test", "testing");
+	
+    id = doc.attr(jQuery.expando);
+    
+    doc.removeData();
+	
+	equals( doc.data("test"), undefined, "Check removal of data" );
+    equals( jQuery.cache[id], undefined, "Ensure data is also removed from jQuery.cache" );
+});
+


### PR DESCRIPTION
Moved the `if ( isNode )` condition to ensure it doesn't get skipped.
