### PR TITLE
Fix #6876 - CRLF encoding in forms

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -99,9 +99,9 @@ jQuery.fn.extend({
 				null :
 				jQuery.isArray(val) ?
 					jQuery.map( val, function(val, i){
-						return {name: elem.name, value: val};
+						return {name: elem.name, value: val.replace(/\r?\n/g, "\r\n")};
 					}) :
-					{name: elem.name, value: val};
+					{name: elem.name, value: val.replace(/\r?\n/g, "\r\n")};
 		}).get();
 	}
 });

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -842,20 +842,20 @@ test("serialize()", function() {
 		'Check input serialization as query string');
 
 	equals( jQuery('#testForm').serialize(),
-		'T3=%3F%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My+Name=me&S1=abc&S3=YES&S4=',
+		'T3=%3F%0D%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My+Name=me&S1=abc&S3=YES&S4=',
 		'Check form serialization as query string');
 
 	equals( jQuery('#testForm :input').serialize(),
-		'T3=%3F%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My+Name=me&S1=abc&S3=YES&S4=',
+		'T3=%3F%0D%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My+Name=me&S1=abc&S3=YES&S4=',
 		'Check input serialization as query string');
 
 	equals( jQuery('#form, #testForm').serialize(),
-		"action=Test&radio2=on&check=on&hidden=&foo%5Bbar%5D=&name=name&search=search&email=dave%40jquery.com&number=43&select1=&select2=3&select3=1&select3=2&select5=3&T3=%3F%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My+Name=me&S1=abc&S3=YES&S4=",
+		"action=Test&radio2=on&check=on&hidden=&foo%5Bbar%5D=&name=name&search=search&email=dave%40jquery.com&number=43&select1=&select2=3&select3=1&select3=2&select5=3&T3=%3F%0D%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My+Name=me&S1=abc&S3=YES&S4=",
 		'Multiple form serialization as query string');
 
   /* Temporarily disabled. Opera 10 has problems with form serialization.
 	equals( jQuery('#form, #testForm :input').serialize(),
-		"action=Test&radio2=on&check=on&hidden=&foo%5Bbar%5D=&name=name&search=search&email=dave%40jquery.com&number=43&select1=&select2=3&select3=1&select3=2&T3=%3F%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My+Name=me&S1=abc&S3=YES&S4=",
+		"action=Test&radio2=on&check=on&hidden=&foo%5Bbar%5D=&name=name&search=search&email=dave%40jquery.com&number=43&select1=&select2=3&select3=1&select3=2&T3=%3F%0D%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My+Name=me&S1=abc&S3=YES&S4=",
 		'Mixed form/input serialization as query string');
 	*/
 	jQuery("#html5email, #html5number").remove();


### PR DESCRIPTION
When serializing text, encode all line breaks as CR/LF pairs per the W3C. Fixes #6876. 

http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.1
