### PR TITLE
Fix #7054 - IE memory leak in cleanData

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -617,6 +617,11 @@ jQuery.extend({
 							jQuery.removeEvent( elem, type, data.handle );
 						}
 					}
+
+					// Null the DOM reference to avoid IE6/7/8 leak (#7054)
+					if ( data.handle ) {
+						data.handle.elem = null;
+					}
 				}
 
 				if ( deleteExpando ) {


### PR DESCRIPTION
Ensure that the DOM element ref in an event handler is removed by cleanData to avoid an IE6/7/8 memory leak. Fixes #7054. 

Tested with the code linked in the ticket, and no longer leaks.
