### PR TITLE
Ticket #7883, .delegate and .live support accepting false as the fn arg, like bind

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -1023,10 +1023,15 @@ jQuery.each(["live", "die"], function( i, name ) {
 			return this;
 		}
 
-		if ( jQuery.isFunction( data ) ) {
+		if ( jQuery.isFunction( data ) || data === false ) {
 			fn = data;
 			data = undefined;
 		}
+		
+		if ( fn === false ) {
+			fn = returnFalse;
+		}
+				
 
 		types = (types || "").split(" ");
 

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -527,6 +527,45 @@ test("bind(name, false), unbind(name, false)", function() {
 	equals( main, 1, "Verify that the trigger happened correctly." );
 });
 
+test("live(name, false), die(name, false)", function() {
+	expect(3);
+
+	var main = 0;
+	jQuery("#main").live("click", function(e){ main++; });
+	jQuery("#ap").trigger("click");
+	equals( main, 1, "Verify that the trigger happened correctly." );
+
+	main = 0;
+	jQuery("#ap").live("click", false);
+	jQuery("#ap").trigger("click");
+	equals( main, 0, "Verify that no bubble happened." );
+
+	main = 0;
+	jQuery("#ap").die("click", false);
+	jQuery("#ap").trigger("click");
+	equals( main, 1, "Verify that the trigger happened correctly." );
+});
+
+test("delegate(selector, name, false), undelegate(selector, name, false)", function() {
+	expect(3);
+
+	var main = 0;
+
+	jQuery("#main").delegate("#ap", "click", function(e){ main++; });
+	jQuery("#ap").trigger("click");
+	equals( main, 1, "Verify that the trigger happened correctly." );
+
+	main = 0;
+	jQuery("#ap").delegate("#groups", "click", false);
+	jQuery("#groups").trigger("click");
+	equals( main, 0, "Verify that no bubble happened." );
+
+	main = 0;
+	jQuery("#ap").undelegate("#groups", "click", false);
+	jQuery("#groups").trigger("click");
+	equals( main, 1, "Verify that the trigger happened correctly." );
+});
+
 test("bind()/trigger()/unbind() on plain object", function() {
 	expect( 8 );
 


### PR DESCRIPTION
http://bugs.jquery.com/ticket/7883

Checks if `data` is false, if so, allow it to be re-assigned to fn as though it was a function. Checks if fn is false, if so assign returnFalse handler. 
