### PR TITLE
MIT license copyright notice year

### DIFF
--- a/MIT-LICENSE.txt
+++ b/MIT-LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2010 John Resig, http://jquery.com/
+Copyright (c) 2011 John Resig, http://jquery.com/
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
The year in the MIT license's copyright notice should be updated from 2010 to 2011.
