### PR TITLE
Bug #7608 elem.runtimeStyle throws exception in Opera; +1 unit test

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -263,8 +263,9 @@ if ( document.defaultView && document.defaultView.getComputedStyle ) {
 
 if ( document.documentElement.currentStyle ) {
 	currentStyle = function( elem, name ) {
-		var left, rsLeft,
+		var left, 
 			ret = elem.currentStyle && elem.currentStyle[ name ],
+			rsLeft = elem.runtimeStyle && elem.runtimeStyle[ name ],
 			style = elem.style;
 
 		// From the awesome hack by Dean Edwards
@@ -275,16 +276,19 @@ if ( document.documentElement.currentStyle ) {
 		if ( !rnumpx.test( ret ) && rnum.test( ret ) ) {
 			// Remember the original values
 			left = style.left;
-			rsLeft = elem.runtimeStyle.left;
 
 			// Put in the new values to get a computed value out
-			elem.runtimeStyle.left = elem.currentStyle.left;
+			if ( rsLeft ) {
+				elem.runtimeStyle.left = elem.currentStyle.left;
+			}
 			style.left = name === "fontSize" ? "1em" : (ret || 0);
 			ret = style.pixelLeft + "px";
 
 			// Revert the changed values
 			style.left = left;
-			elem.runtimeStyle.left = rsLeft;
+			if ( rsLeft ) {
+				elem.runtimeStyle.left = rsLeft;
+			}
 		}
 
 		return ret === "" ? "auto" : ret;

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -320,3 +320,25 @@ test(":visible selector works properly on children with a hidden parent (bug #45
 	jQuery('#table').css('display', 'none').html('<tr><td>cell</td><td>cell</td></tr>');
 	equals(jQuery('#table td:visible').length, 0, "hidden cell children not perceived as visible");
 });
+
+test("internal ref to elem.runtimeStyle (bug #7608)", function () {
+  expect(1);
+  
+  var result = true, 
+      val = 10;
+
+  jQuery('<div id="bug7608" style="width:200px;border:solid 1px red;">' +
+    '<div  id="test" style="width:0%; background:#000;">&nbsp;</div></div>').appendTo("body");
+    
+  try {
+	// the bug is located within src/css.js
+    jQuery("#bug7608 #test").animate( { width: val }, 1000);    
+    
+  } catch (e) {
+    result = false;  
+  }
+  
+  ok( result, "elem.runtimeStyle does not throw exception" );
+  
+  jQuery("#bug7608").remove();
+});


### PR DESCRIPTION
The elem.runtimeStyle property is not supported by Opera; evaluates access before attempting to reference properties.

Blocker: http://bugs.jquery.com/ticket/7608
