### PR TITLE
Bug #7417 .css('border-spacing') throws exception in IE8, inconsistent in Opera; +10 Unit tests

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -6,6 +6,7 @@ var ralpha = /alpha\([^)]*\)/i,
 	rupper = /([A-Z])/g,
 	rnumpx = /^-?\d+(?:px)?$/i,
 	rnum = /^-?\d/,
+	rspaces = /\s+/,
 
 	cssShow = { position: "absolute", visibility: "hidden", display: "block" },
 	cssWidth = [ "Left", "Right" ],
@@ -47,7 +48,22 @@ jQuery.extend({
 					return elem.style.opacity;
 				}
 			}
-		}
+		},
+		borderSpacing: {
+			get: function( elem, computed ) {
+				if ( computed ) {
+					//  borderSpacing allows "x y" or "x", 
+					//  which throws exceptions in curCSS
+					//  when setting to style.left
+					var ret = getComputedStyle ?  getComputedStyle( elem, "borderSpacing", "borderSpacing" ) : elem.currentStyle.borderSpacing;
+					return !rspaces.test( ret ) ? ret + " " + ret : ret;
+				} 
+				return elem.style.borderSpacing;
+			}, 
+			set: function( elem, value ) {
+				return value;
+			}    
+		}  		
 	},
 
 	// Exclude the following css properties to add px

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -320,3 +320,49 @@ test(":visible selector works properly on children with a hidden parent (bug #45
 	jQuery('#table').css('display', 'none').html('<tr><td>cell</td><td>cell</td></tr>');
 	equals(jQuery('#table td:visible').length, 0, "hidden cell children not perceived as visible");
 });
+
+test("borderSpacing cssHook, Bug 7417", function () {
+  expect(9);
+
+  jQuery('<table/>', {
+    id: "tableborderspacing",
+    html:'<tr><td>A</td><td>B</td></tr>'
+  }).appendTo('body');
+  
+  equals( jQuery('#tableborderspacing').css("border-spacing"), "2px 2px", "Default border-spacing is Xpx Ypx, no exceptions thrown" );
+  
+  jQuery('#tableborderspacing').css("border-spacing", "5px");
+
+  equals( jQuery('#tableborderspacing').css("border-spacing"), "5px 5px", "Manually set border-spacing is 5px 5px, set with one val" );
+  
+  jQuery('#tableborderspacing').css("border-spacing", "10px 8px");
+
+  equals( jQuery('#tableborderspacing').css("border-spacing"), "10px 8px", "Manually set border-spacing is 10px 8px, set with two vals" );
+  
+  jQuery('#tableborderspacing').css("border-spacing", "8em 1em");
+
+  equals( jQuery('#tableborderspacing').css("border-spacing"), "128px 16px", "Manually set border-spacing 8em 1em == 128px 16px, set with two vals" );
+
+  jQuery('#tableborderspacing').css("border-spacing", "2px 1pt");
+
+  equals( jQuery('#tableborderspacing').css("border-spacing"), "2px 1px", "Manually set border-spacing is 2px 1pt == 2px 1px, set with two vals" );
+  
+  jQuery('#tableborderspacing').css("border-spacing", "A");
+
+  equals( jQuery('#tableborderspacing').css("border-spacing"), "2px 1px", "Setting border-spacing to 'A' has no effect" );
+  
+  jQuery('#tableborderspacing').css("border-spacing", null);
+
+  equals( jQuery('#tableborderspacing').css("border-spacing"), "2px 1px", "Setting border-spacing to `null` has no effect" );  
+
+  jQuery('#tableborderspacing').css("border-spacing", undefined);
+
+  equals( jQuery('#tableborderspacing').css("border-spacing"), "2px 1px", "Setting border-spacing to `undefined` has no effect" );  
+  
+  jQuery('#tableborderspacing').css("border-spacing", NaN);
+
+  equals( jQuery('#tableborderspacing').css("border-spacing"), "2px 1px", "Setting border-spacing to `NaN` has no effect" );  
+  
+  jQuery('#tableborderspacing').remove();
+});
+


### PR DESCRIPTION
In addition to throwing exception in IE8; borderSpacing returns "NNpx" in opera by default, and "NNpx NNpx" in all others. This adds a cssHook to normalize
