### PR TITLE
Ticket 7917 - .animate() when used with large groups of elements is not in sync

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -11,7 +11,20 @@ var elemdisplay = {},
 		[ "width", "marginLeft", "marginRight", "paddingLeft", "paddingRight" ],
 		// opacity animations
 		[ "opacity" ]
-	];
+	],
+	fxNow;
+
+function clearFxNow() {
+	fxNow = undefined;
+}
+
+function makeFxNow() {
+	if ( !fxNow ) {
+		fxNow = jQuery.now();
+		setTimeout( clearFxNow, 0 );
+	}
+	return fxNow;
+}
 
 jQuery.fn.extend({
 	show: function( speed, easing, callback ) {
@@ -130,7 +143,7 @@ jQuery.fn.extend({
 				}
 
 				if ( prop[p] === "hide" && hidden || prop[p] === "show" && !hidden ) {
-					return opt.complete.call(this);
+					return opt.complete.call( this );
 				}
 
 				if ( isElement && ( p === "height" || p === "width" ) ) {
@@ -210,7 +223,6 @@ jQuery.fn.extend({
 					}
 				}
 			});
-
 			// For JS strict compliance
 			return true;
 		});
@@ -349,7 +361,7 @@ jQuery.fx.prototype = {
 		var self = this,
 			fx = jQuery.fx;
 
-		this.startTime = jQuery.now();
+		this.startTime = fxNow || makeFxNow();
 		this.start = from;
 		this.end = to;
 		this.unit = unit || this.unit || ( jQuery.cssNumber[ this.prop ] ? "" : "px" );
@@ -394,7 +406,9 @@ jQuery.fx.prototype = {
 
 	// Each step of an animation
 	step: function( gotoEnd ) {
-		var t = jQuery.now(), done = true;
+
+		var t = fxNow || makeFxNow(),
+			done = true;
 
 		if ( gotoEnd || t >= this.options.duration + this.startTime ) {
 			this.now = this.end;
@@ -469,6 +483,7 @@ jQuery.extend( jQuery.fx, {
 		if ( !timers.length ) {
 			jQuery.fx.stop();
 		}
+
 	},
 
 	interval: 13,


### PR DESCRIPTION
It may not allow for multiple synchronized "slots" as proposed by [Ticket 6281](http://bugs.jquery.com/ticket/6281), but it also doesn't add any additional arguments to the fn signatures.
# HUGE UPDATES

So - After reviewing some of the other techinques out there for doing this, I think that this one is probably going to offer the smallest footprint in terms of code size and function execution time.  I've given up on adding a `jQuery.fx.sync` flag as someone brought up the point - "When will you want them to not be in sync???"

All the research steps (and a nifty test/animate.html showing the problem) can be found on this branch: https://github.com/gnarf37/jquery/commits/animate_fix
