### PR TITLE
jQuery.param thinks that { jquery: "1.4.2" } is a jQuery object

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -664,7 +664,7 @@ jQuery.extend({
 		}
 
 		// If an array was passed in, assume that it is an array of form elements.
-		if ( jQuery.isArray(a) || a.jquery ) {
+		if ( jQuery.isArray(a) || a instanceof jQuery ) {
 			// Serialize the form elements
 			jQuery.each( a, function() {
 				add( this.name, this.value );

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -793,7 +793,7 @@ test("serialize()", function() {
 });
 
 test("jQuery.param()", function() {
-	expect(22);
+	expect(24);
 
 	equals( !jQuery.ajaxSettings.traditional, true, "traditional flag, falsy by default" );
 
@@ -827,6 +827,11 @@ test("jQuery.param()", function() {
 	equals( jQuery.param({"foo": {"bar": []} }), "foo%5Bbar%5D=", "Empty array param" );
 	equals( jQuery.param({"foo": {"bar": [], foo: 1} }), "foo%5Bbar%5D=&foo%5Bfoo%5D=1", "Empty array param" );
 	equals( jQuery.param({"foo": {"bar": {}} }), "foo%5Bbar%5D=", "Empty object param" );
+
+	equals( jQuery.param({"jquery": "1.4.2"}), "jquery=1.4.2" );
+
+	// Make sure jQuery objects are properly serialized
+	equals( jQuery.param(jQuery("#form :input")), "action=Test&text2=Test&radio1=on&radio2=on&check=on&=on&hidden=&foo%5Bbar%5D=&name=name&search=search&button=&=foobar&select1=&select2=3&select3=1&select4=1&select5=3");
 
 	jQuery.ajaxSetup({ traditional: true });
 


### PR DESCRIPTION
I stumbled upon a bug where .param thought that { jquery: "1.4.2" } is a jQuery object and tried to iterate over it as it was an array. The result was undefined=undefined instead of jquery=1.4.2.

The commit fixes that. It also tests if .param works nicely with actual jQuery objects.
