### PR TITLE
Change fixes the issue http://bugs.jquery.com/ticket/6409

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -203,7 +203,7 @@ jQuery.fn.extend({
 							end = ((parts[1] === "-=" ? -1 : 1) * end) + start;
 						}
 
-						e.custom( start, end, unit );
+						e.custom( start, end, name != "opacity" ? unit : "" );
 
 					} else {
 						e.custom( start, val, "" );


### PR DESCRIPTION
Method animate() assumes (and appends) px unit for any numeric value if no unit is given.

This is done also for opacity which causes Linux Chrome browser in latest version behave improperly.
