### PR TITLE
shortern constructor reference resolving and prototype wiring

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -107,7 +107,9 @@ function init ( selector, context ) {
 			match = quickExpr.exec( selector );
 
 			// Verify a match, and that no context was specified for #id
-			if ( match && (match[1] || !context) ) {
+            ///(match[1] || !context) means you should not have and #id selector
+            ///and with a context, if you use #id selector, context should be empty
+            if ( match && (match[1] || !context) ) {
 
 				// HANDLE: $(html) -> $(array)
 				if ( match[1] ) {


### PR DESCRIPTION
change return new jQuery.fn.init( selector, context );
to return new init( selector, context ); so that reference path is shorten

change jQuery.fn = jQuery.prototype = {
to jQuery.fn = init.prototype = {

remove jQuery.fn.init member make the core smaller

remove confusing line jQuery.fn.init.prototype = jQuery.fn;

rerun all test case passed, rerun all speed test, performance almost the same though, but not slower
benefit: less ninja-ish
