### PR TITLE
Changing Object.prototype breaks jQuery.isEmptyObject

### DIFF
--- a/speed/jquery-basis.js
+++ b/speed/jquery-basis.js
@@ -484,7 +484,9 @@ jQuery.extend({
 
 	isEmptyObject: function( obj ) {
 		for ( var name in obj ) {
-			return false;
+			if ( obj.hasOwnProperty(name) ) {
+				return false;
+			}
 		}
 		return true;
 	},


### PR DESCRIPTION
Once the Object prototype is changed, jQuery.isEmptyObject would always return false, even for an empty object.

With this change, jQuery.isEmptyObject({}) will always return true, even if Object.prototype is modified.
