### PR TITLE
Bugfix for #7945

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -727,7 +727,7 @@ jQuery.extend({
 		}
 
 		// If an array was passed in, assume that it is an array of form elements.
-		if ( jQuery.isArray(a) || a.jquery ) {
+		if ( jQuery.isArray(a) || (a.jquery && !jQuery.isPlainObject(a)) ) {
 			// Serialize the form elements
 			jQuery.each( a, function() {
 				add( this.name, this.value );

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -815,7 +815,7 @@ test("serialize()", function() {
 });
 
 test("jQuery.param()", function() {
-	expect(22);
+	expect(24);
 
 	equals( !jQuery.ajaxSettings.traditional, true, "traditional flag, falsy by default" );
 
@@ -849,6 +849,11 @@ test("jQuery.param()", function() {
 	equals( jQuery.param({"foo": {"bar": []} }), "foo%5Bbar%5D=", "Empty array param" );
 	equals( jQuery.param({"foo": {"bar": [], foo: 1} }), "foo%5Bbar%5D=&foo%5Bfoo%5D=1", "Empty array param" );
 	equals( jQuery.param({"foo": {"bar": {}} }), "foo%5Bbar%5D=", "Empty object param" );
+
+	equals( jQuery.param({"jquery": "1.4.2"}), "jquery=1.4.2" );
+
+	// Make sure jQuery objects are properly serialized
+	equals( jQuery.param(jQuery("#form :input")), "action=Test&text2=Test&radio1=on&radio2=on&check=on&=on&hidden=&foo%5Bbar%5D=&name=name&search=search&button=&=foobar&select1=&select2=3&select3=1&select4=1&select5=3");
 
 	jQuery.ajaxSetup({ traditional: true });
 


### PR DESCRIPTION
Bug report: http://bugs.jquery.com/ticket/7945

The fix adds another check in addition to the simple a.jquery to make sure that we don't treat a plain object that happened to have a property named `jquery` as a jQuery object.
