### PR TITLE
Fix and test for #7730 and #7885

### DIFF
--- a/src/offset.js
+++ b/src/offset.js
@@ -187,10 +187,12 @@ jQuery.offset = {
 		// need to be able to calculate position if either top or left is auto and position is absolute
 		if ( calculatePosition ) {
 			curPosition = curElem.position();
+			curTop = curPosition.top;
+			curLeft = curPosition.left;
+		} else {
+			curTop = parseFloat( curCSSTop ) || 0;
+			curLeft = parseFloat( curCSSLeft ) || 0;
 		}
-
-		curTop  = calculatePosition ? curPosition.top  : parseInt( curCSSTop,  10 ) || 0;
-		curLeft = calculatePosition ? curPosition.left : parseInt( curCSSLeft, 10 ) || 0;
 
 		if ( jQuery.isFunction( options ) ) {
 			options = options.call( elem, i, curOffset );

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -422,6 +422,32 @@ test("offsetParent", function(){
 	equals( div[1], jQuery("#nothiddendiv")[0], "The div is the offsetParent." );
 });
 
+test("fractions (see #7730 and #7885)", function() {
+	expect(2);
+	
+	jQuery('body').append('<div id="fractions"/>');
+	
+	var expected = { top: 1000, left: 1000 };
+	var div = jQuery('#fractions');
+	
+	div.css({
+		position: 'absolute',
+		left: '1000.7432222px',
+		top: '1000.532325px',
+		width: 100,
+		height: 100
+	});
+	
+	div.offset(expected);
+	
+	var result = div.offset();
+
+	equals( result.top, expected.top, "Check top" );
+	equals( result.left, expected.left, "Check left" );
+	
+	div.remove();
+});
+
 function testoffset(name, fn) {
 
 	test(name, function() {


### PR DESCRIPTION
This addresses the issue of setOffset using parseInt to read in CSS position values; if the CSS values contain fractions this will result in a sub-pixel offest (if the browser supports it) or a possible off-by-one pixel error. When setting a position repeatedly (e.g., the ui autocomplete widget) this may cause alternating positions which differ by one pixel.

By using parseFloat instead of parseInt the issue can be resolved.

I used the minimal jsFiddle example in #7885 as a test case and ran the tests in the latest Firefox, Opera, Chrome, and Safari on Mac; as well as IE7 and IE8 on Windows.
