### PR TITLE
7608 unit test update; adds call to stop()

### DIFF
--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -330,6 +330,6 @@ test("internal ref to elem.runtimeStyle (bug #7608)", function () {
 	} catch (e) {
 		result = false;
 	}
-	
+
 	ok( result, "elem.runtimeStyle does not throw exception" );
 });


### PR DESCRIPTION
7608 unit test update; adds call to stop() - fixes failing timer test
