### PR TITLE
Make fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,10 @@ min: ${JQ_MIN}
 
 ${JQ_MIN}: ${JQ}
 	@@echo "Building" ${JQ_MIN}
-	@@${COMPILER} ${JQ} > ${JQ_MIN}
+	@@${COMPILER} ${JQ} > ${JQ_MIN}.tmp
+	@@echo ";" >> ${JQ_MIN}.tmp
+	@@sed 's/\*\/(/*\/ʩ(/' ${JQ_MIN}.tmp | tr "ʩ" "\n" > ${JQ_MIN}
+	@@rm -rf ${JQ_MIN}.tmp
 
 clean:
 	@@echo "Removing Distribution directory:" ${DIST_DIR}

--- a/build/uglify.js
+++ b/build/uglify.js
@@ -143,7 +143,7 @@ function show_copyright(comments) {
                 if (c.type == "comment1") {
                         ret += "//" + c.value + "\n";
                 } else {
-                        ret += "/*" + c.value + "*/\n";
+                        ret += "/*" + c.value + "*/";
                 }
         }
         return ret;
@@ -181,7 +181,7 @@ function squeeze_it(code) {
                         });
                 if (options.ast)
                         return sys.inspect(ast, null, null);
-                result += time_it("generate", function(){ return pro.gen_code(ast, options.beautify && options.beautify_options) }) + ";";
+                result += time_it("generate", function(){ return pro.gen_code(ast, options.beautify && options.beautify_options) });
                 return result;
         } catch(ex) {
                 sys.debug(ex.stack);


### PR DESCRIPTION
Instead of monkey-patching the uglify files, I got the make file to add the newline after the comment block and the trailing semi-colon. Unfortunately, in the context of a make file it's impossible (read i spent forever and couldn't find a way) to get sed to insert a new line. However, tr considers "\n" a special character which it adds itself when specified. 

So, i inserted a unicode symbol that would never ( though $.ʩ would look sexy ) get used in source otherwise to get replaced with a new line. 

Not sure if this is even worth it - but hell, I spent so much time on the sed crap I figured might as well pull req :p
