### PR TITLE
Bug 7990: "script space quota exhausted" fix

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -105,7 +105,12 @@ jQuery.fn = jQuery.prototype = {
 		// Handle HTML strings
 		if ( typeof selector === "string" ) {
 			// Are we dealing with HTML string or an ID?
-			match = quickExpr.exec( selector );
+			if ( selector.length > 1024 ) {
+				// Assume very large strings are HTML and skip the regex check
+				match = [ null, selector, null ];
+			} else {
+				match = quickExpr.exec( selector );
+			}
 
 			// Verify a match, and that no context was specified for #id
 			if ( match && (match[1] || !context) ) {

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -468,7 +468,7 @@ test("isWindow", function() {
 });
 
 test("jQuery('html')", function() {
-	expect(15);
+	expect(18);
 
 	QUnit.reset();
 	jQuery.foo = false;
@@ -500,6 +500,19 @@ test("jQuery('html')", function() {
 
 	ok( jQuery("<div></div>")[0], "Create a div with closing tag." );
 	ok( jQuery("<table></table>")[0], "Create a table with closing tag." );
+
+	// Test very large html string #7990
+	var i;
+	var li = '<li>very large html string</li>';
+	var html = ['<ul>'];
+	for ( i = 0; i < 50000; i += 1 ) {
+		html.push(li);
+	}
+	html.push('</ul>');
+	html = jQuery(html.join(''))[0];
+	equals( html.nodeName.toUpperCase(), 'UL');
+	equals( html.firstChild.nodeName.toUpperCase(), 'LI');
+	equals( html.childNodes.length, 50000 );
 });
 
 test("jQuery('html', context)", function() {


### PR DESCRIPTION
This patch works around a Firefox RegExp back-tracking limitation that causes a "script space quota exhausted" exception when a large html string is passed to the jQuery constructor function.  The patch also includes a unit test.

See http://bugs.jquery.com/ticket/7990
