### PR TITLE
Remove unsafe access to frameElement in event.js - replace with different logic

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -25,13 +25,6 @@ jQuery.event = {
 			return;
 		}
 
-		// For whatever reason, IE has trouble passing the window object
-		// around, causing it to be cloned in the process leading to a
-		// weird state where "elem == window" but NOT "elem === window"
-		if ( elem == window ) {
-			elem = window;
-		}
-
 		if ( handler === false ) {
 			handler = returnFalse;
 		} else if ( !handler ) {


### PR DESCRIPTION
Bug 8018 - http://bugs.jquery.com/ticket/8018

This fix works due to the way that IE handles things like `window === window.window` (false) and `window == window.window` (true).

A try catch may be more traditional but this reduces code and seems to work.

Credits to Shawn Smith for the fix.
