### PR TITLE
Ticket #8013 Restores perf loss for any method that used domManip

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -347,7 +347,14 @@ jQuery.fn.extend({
 							root(this[i], first) :
 							this[i],
 						i > 0 || results.cacheable || (this.length > 1 && i > 0) ?
-							jQuery(fragment).clone(true)[0] :
+							(
+								//	Making this check restores the performance loss in 1.5
+								!jQuery.support.noCloneEvent ?
+									//	IE requires extra handling to avoid event overwriting
+									jQuery(fragment).clone( true )[0] :
+									//	Use native api for speed
+									fragment.cloneNode( true )
+							) :
 							fragment
 					);
 				}


### PR DESCRIPTION
Ticket #8013 Restores perf loss for any method that used domManip. The IE patch that introduced the issue is still in place, instead I'm only running it through that path if its absolutely nec. IE requires the run through clone, so its still slow.

http://bugs.jquery.com/ticket/8013
