### PR TITLE
Move jQuery/$ global variable leakage to end of file so we can still live on the same page as Prototype - fixes #8033

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1054,6 +1054,6 @@ function doScrollCheck() {
 }
 
 // Expose jQuery to the global object
-return (window.jQuery = window.$ = jQuery);
+return jQuery;
 
 })();

--- a/src/outro.js
+++ b/src/outro.js
@@ -1,1 +1,2 @@
+window.jQuery = window.$ = jQuery;
 })(window);

--- a/test/data/offset/absolute.html
+++ b/test/data/offset/absolute.html
@@ -26,7 +26,7 @@
 		<script src="../../../src/offset.js"></script>
 		<script type="text/javascript" src="../../../dist/jquery.js"></script>
 		<script type="text/javascript" charset="utf-8">
-			$(function() {
+			jQuery(function($) {
 				$('.absolute').click(function() {
 					$('#marker').css( $(this).offset() );
 					var pos = $(this).position();

--- a/test/data/offset/body.html
+++ b/test/data/offset/body.html
@@ -18,7 +18,7 @@
 		<script src="../../../src/css.js"></script>
 		<script src="../../../src/offset.js"></script>
 		<script type="text/javascript" charset="utf-8">
-			$(function() {
+			jQuery(function($) {
 				$('body').click(function() {
 					$('#marker').css( $(this).offset() );
 					return false;

--- a/test/data/offset/fixed.html
+++ b/test/data/offset/fixed.html
@@ -22,7 +22,7 @@
 		<script src="../../../src/css.js"></script>
 		<script src="../../../src/offset.js"></script>
 		<script type="text/javascript" charset="utf-8">
-			$(function() {
+			jQuery(function($) {
 				window.scrollTo(1000,1000);
 				$('.fixed').click(function() {
 					$('#marker').css( $(this).offset() );

--- a/test/data/offset/relative.html
+++ b/test/data/offset/relative.html
@@ -20,7 +20,7 @@
 		<script src="../../../src/css.js"></script>
 		<script src="../../../src/offset.js"></script>
 		<script type="text/javascript" charset="utf-8">
-			$(function() {
+			jQuery(function($) {
 				$('.relative').click(function() {
 					$('#marker').css( $(this).offset() );
 					var pos = $(this).position();

--- a/test/data/offset/scroll.html
+++ b/test/data/offset/scroll.html
@@ -23,7 +23,7 @@
 		<script src="../../../src/css.js"></script>
 		<script src="../../../src/offset.js"></script>
 		<script type="text/javascript" charset="utf-8">
-			$(function() {
+			jQuery(function($) {
 				window.scrollTo(1000,1000);
 				$('#scroll-1')[0].scrollLeft = 5;
 				$('#scroll-1')[0].scrollTop = 5;

--- a/test/data/offset/static.html
+++ b/test/data/offset/static.html
@@ -20,7 +20,7 @@
 		<script src="../../../src/css.js"></script>
 		<script src="../../../src/offset.js"></script>
 		<script type="text/javascript" charset="utf-8">
-			$(function() {
+			jQuery(function($) {
 				$('.static').click(function() {
 					$('#marker').css( $(this).offset() );
 					var pos = $(this).position();

--- a/test/data/offset/table.html
+++ b/test/data/offset/table.html
@@ -20,7 +20,7 @@
 		<script src="../../../src/css.js"></script>
 		<script src="../../../src/offset.js"></script>
 		<script type="text/javascript" charset="utf-8">
-			$(function() {
+			jQuery(function($) {
 				$('table, th, td').click(function() {
 					$('#marker').css( $(this).offset() );
 					return false;


### PR DESCRIPTION
I also updated the test cases that referenced $ directly to use the jQuery variable, that way we didn't have to rely on it being leaked in the non built version, since we currently already expose jQuery without the explicit leak.
