### PR TITLE
#5866 Fixed ajax requests without protocol in IE7

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -552,8 +552,8 @@ jQuery.extend({
 			);
 
 			// Add missing protocol for IE7 (#5866)
-			if ( !parts[ 1 ] && parts[ 0 ] && rprotocol.test( parts[ 0 ] ) ) {
-				s.url = protocol + s.url;
+			if ( !parts[ 1 ] ) {
+				s.url = s.url.replace( rprotocol , protocol + "//" );
 			}
 		}
 


### PR DESCRIPTION
Hi,

this commits fixed an older Bug #5866 which appears since jQuery 1.4. In jQuery 1.4 the way we select the XMLHttpRequest or the ActiveXObject has changed. For preformance reasons the XMLHttpRequest is preferred if we can use it and thats okay. But we all know that Mircrosoft failed to implement the XMLHttpRequest in IE7.
So the XMLHttpRequest in IE7 aborts with an error if you fire an ajax request _without_ protocol in url. The easiest way to get around is to add the protocol to the url if it´s missing.
- Request to http://fail.tld/tempalte/dialog
  $.ajax({
  url : '//fail.tld/tempalte/dialog'
  });

I hope you push my little commit into the 1.5 branch.

Best regards,
 Sören

jsFiddle: http://jsfiddle.net/WuGZh/
Bug: http://bugs.jquery.com/ticket/5866
