### PR TITLE
Fixing Bug #2551 -- select.val() broken in IE after form.reset() 

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -172,6 +172,15 @@ jQuery.fn.extend({
 						options = elem.options,
 						one = elem.type === "select-one";
 
+					// in IE, a select is improperly reset when the parent 
+					// form is reset, but setting the .selectedIndex = to 
+					// itself fixes. See #2551
+					// NOTE: this fix only necessary for single-selects,
+					// and would break multi-selects
+					if ( one ) {
+						elem.selectedIndex = elem.selectedIndex;
+					}
+
 					// Nothing was selected
 					if ( index < 0 ) {
 						return null;

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -443,6 +443,18 @@ test("val()", function() {
 	checks.remove();
 });
 
+// testing if a form.reset() breaks a subsequent call to a select element's .val() (in IE only)
+test("val(select) after form.reset() (Bug #2551)", function() {
+	expect(2);
+
+	var $el = jQuery('#select5');
+	$el.get(0).form.reset();
+	equals( $el.val(), "3", "Check value of select after form reset." );
+
+	// re-verify the multi-select is not broken (after form.reset) by our fix for single-select
+	same( jQuery('#select3').val(), ['1', '2'], 'Call val() on a multiple="multiple" select' );
+});
+
 var testVal = function(valueObj) {
 	expect(8);
 


### PR DESCRIPTION
http://bugs.jquery.com/ticket/2551
