### PR TITLE
Readability Improvement for jQuery.when()

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -929,10 +929,9 @@ jQuery.extend({
 
 		if ( length > 1 ) {
 			resolveArray = new Array( length );
-			jQuery.each( args, function( index, element, args ) {
+			jQuery.each( args, function( index, element ) {
 				jQuery.when( element ).then( function( value ) {
-					args = arguments;
-					resolveArray[ index ] = args.length > 1 ? slice.call( args, 0 ) : value;
+					resolveArray[ index ] = arguments.length > 1 ? slice.call( arguments, 0 ) : value;
 					if( ! --length ) {
 						deferred.resolveWith( promise, resolveArray );
 					}


### PR DESCRIPTION
After a few minutes of rmurphey, DaveMethin, and me wondering what `args` did in this block of code by we determined it was just defining a variable that wasn't even really needed.

Net gain + readability , -4 bytes gzipped minified.
