### PR TITLE
support for list attribute in modern HTML5 capable browsers

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -3,7 +3,7 @@
 var rclass = /[\n\t\r]/g,
 	rspaces = /\s+/,
 	rreturn = /\r/g,
-	rspecialurl = /^(?:href|src|style)$/,
+	rspecialurl = /^(?:href|src|style|list)$/,
 	rtype = /^(?:button|input)$/i,
 	rfocusable = /^(?:button|input|object|select|textarea)$/i,
 	rclickable = /^a(?:rea)?$/i,

--- a/test/index.html
+++ b/test/index.html
@@ -81,6 +81,11 @@
 		<form id="form" action="formaction">
 			<label for="action" id="label-for">Action:</label>
 			<input type="text" name="action" value="Test" id="text1" maxlength="30"/>
+			<datalist id="datalist">
+				<select>
+					<option value="option"></option>
+				</select>
+			</datalist>
 			<input type="text" name="text2" value="Test" id="text2" disabled="disabled"/>
 			<input type="radio" name="radio1" id="radio1" value="on"/>
 

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -29,7 +29,7 @@ test("jQuery.props: itegrity test", function() {
 });
 
 test("attr(String)", function() {
-	expect(37);
+	expect(38);
 
 	// This one sometimes fails randomly ?!
 	equals( jQuery('#text1').attr('value'), "Test", 'Check for value attribute' );
@@ -61,7 +61,9 @@ test("attr(String)", function() {
 
 	equals( jQuery("<option/>").attr("selected"), false, "Check selected attribute on disconnected element." );
 
-
+	jQuery("#text1").attr("list", "datalist");
+	equals(jQuery("#text1").attr("list"), 'datalist', "Check setting list-attribute");
+	
 	// Related to [5574] and [5683]
 	var body = document.body, $body = jQuery(body);
 


### PR DESCRIPTION
The list IDL attribute is a readonly property. To change you have to manipulate the content attribute (setAttribute). I have simply added the list-attribute to the rspecialurl regexp.

The commit also includes a test, but I haven't run it (windows machine + no time to install everything, where is the ant build-file?).
