### PR TITLE
Avoid sed due to portability issues between GNU and BSD versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ DIST_DIR = ${PREFIX}/dist
 
 JS_ENGINE ?= `which node nodejs`
 COMPILER = ${JS_ENGINE} ${BUILD_DIR}/uglify.js --unsafe
+POST_COMPILER = ${JS_ENGINE} ${BUILD_DIR}/post-compile.js
 
 BASE_FILES = ${SRC_DIR}/core.js\
 	${SRC_DIR}/support.js\
@@ -106,8 +107,8 @@ ${JQ_MIN}: jquery
 	@@if test ! -z ${JS_ENGINE}; then \
 		echo "Minifying jQuery" ${JQ_MIN}; \
 		${COMPILER} ${JQ} > ${JQ_MIN}.tmp; \
-		sed '$ s#^\( \*/\)\(.\+\)#\1\n\2;#' ${JQ_MIN}.tmp > ${JQ_MIN}; \
-		rm -rf ${JQ_MIN}.tmp; \
+		${POST_COMPILER} ${JQ_MIN}.tmp > ${JQ_MIN}; \
+		rm -f ${JQ_MIN}.tmp; \
 	else \
 		echo "You must have NodeJS installed in order to minify jQuery."; \
 	fi

--- a/build/post-compile.js
+++ b/build/post-compile.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+var print = require("sys").print,
+	src = require("fs").readFileSync(process.argv[2], "utf8");
+
+// Previously done in sed but reimplemented here due to portability issues
+print(src.replace(/^(\s*\*\/)(.+)/m, "$1\n$2;"));


### PR DESCRIPTION
I noticed that the recent commit (jquery/jquery@ba43d37394b6018779d9a668c548e11579cd424a) to fix `sed` caused the semicolon to disappear from the end of the final `jquery.min.js`. Looking further into it, it appears that the Mac OS X (10.6.6) version of `sed` doesn't support the `.\+` syntax. I tried replacing it with `.\{1,\}` only to discover that the BSD `sed` also doesn't support inserting newline characters in the replacement string. It simply adds an `'n'`.

To avoid these issues, this pull request's commit replaces the `sed` call with a simple post-compile script that uses `node`.
