### PR TITLE
attrOrDefault method

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -26,6 +26,13 @@ jQuery.fn.extend({
 	attr: function( name, value ) {
 		return jQuery.access( this, name, value, true, jQuery.attr );
 	},
+	
+	attrOrDefault: function( name, defaultValue ) {
+		var value = this.attr( name );
+		return value !== undefined ? value :
+			   jQuery.isFunction( defaultValue ) ? defaultValue.call( this ) :
+			   defaultValue;
+	},
 
 	removeAttr: function( name, fn ) {
 		return this.each(function(){

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -355,6 +355,29 @@ test("attr('tabindex', value)", function() {
 	equals(element.attr('tabindex'), -1, 'set negative tabindex');
 });
 
+test("attrOrDefault(String, String)", function() {
+	expect(2);
+	
+	var element = jQuery('#testForm');
+
+	equals(element.attrOrDefault('method', 'post'), 'get', 'return attribute value if attribute is set');
+	equals(element.attrOrDefault('attrthatisntset', 'post'), 'post', 'return default value if attribute isn\'t set');
+});
+
+test("attrOrDefault(String, Function)", function() {
+	expect(2);
+	
+	var element = jQuery('#testForm');
+	
+	equals(element.attrOrDefault('method', function () {
+		return jQuery(this).attr('id');
+	}), 'get', 'return attribute value if attribute is set');
+	
+	equals(element.attrOrDefault('attrthatisntset', function () {
+		return jQuery(this).attr('id');
+	}), 'testForm', 'return attribute value if attribute is set');
+});
+
 test("removeAttr(String)", function() {
 	expect(7);
 	equals( jQuery('#mark').removeAttr( "class" )[0].className, "", "remove class" );


### PR DESCRIPTION
A little helper method for returning a default value if the specified attribute isn't set.

For example, if we have a slider:
    <input type="range" max="50" id="slider" />
And we would like to get the min, max and step attributes,
and provide default values for them if they aren't set,
we would do something like the following:
    var slider = $('#slider'),
        min = slider.attr('min'),
        max = slider.attr('max'),
        step = slider.attr('step');

```
if (min === undefined) min = 0;
if (max === undefined) max = 100;
if (step === undefined) step = 1;
```

But with the attrOrDefault method, we can do the following:
    var slider = $('#slider'),
        min = slider.attr('min', 0),
        max = slider.attr('max', 100),
        step = slider.attr('step', 1);

Unit tests are also included.
