### PR TITLE
Bug 8113; .get/post to use GET/POST (uppercase) as in prior versions

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -233,7 +233,7 @@ jQuery.each( [ "get", "post" ], function( i, method ) {
 		}
 
 		return jQuery.ajax({
-			type: method,
+			type: method.toUpperCase(),
 			url: url,
 			data: data,
 			success: callback,


### PR DESCRIPTION
http://www.ietf.org/rfc/rfc2616.txt Section 5.1.1
