### PR TITLE
Bug 8198

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -80,7 +80,6 @@
 				script = document.createElement("script"),
 				id = "script" + jQuery.now();
 
-			script.type = "text/javascript";
 			try {
 				script.appendChild( document.createTextNode( "window." + id + "=1;" ) );
 			} catch(e) {}


### PR DESCRIPTION
Removed script.type = "text/javascript" from support.js since it is not needed.
