### PR TITLE
Bug 8255: setting the list attribute in browsers which support datalist

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -3,7 +3,7 @@
 var rclass = /[\n\t\r]/g,
 	rspaces = /\s+/,
 	rreturn = /\r/g,
-	rspecialurl = /^(?:href|src|style|list)$/,
+	rspecial = /^(?:href|src|style|list)$/,
 	rtype = /^(?:button|input)$/i,
 	rfocusable = /^(?:button|input|object|select|textarea)$/i,
 	rclickable = /^a(?:rea)?$/i,
@@ -296,7 +296,7 @@ jQuery.extend({
 		// Only do all the following if this is a node (faster for style)
 		if ( elem.nodeType === 1 ) {
 			// These attributes require special treatment
-			var special = rspecialurl.test( name );
+			var special = rspecial.test( name );
 
 			// Safari mis-reports the default selected property of an option
 			// Accessing the parent's selectedIndex property fixes it

--- a/test/index.html
+++ b/test/index.html
@@ -81,11 +81,6 @@
 		<form id="form" action="formaction">
 			<label for="action" id="label-for">Action:</label>
 			<input type="text" name="action" value="Test" id="text1" maxlength="30"/>
-			<datalist id="datalist">
-				<select>
-					<option value="option"></option>
-				</select>
-			</datalist>
 			<input type="text" name="text2" value="Test" id="text2" disabled="disabled"/>
 			<input type="radio" name="radio1" id="radio1" value="on"/>
 
@@ -165,7 +160,7 @@
 			<input name="types[]" id="types_anime" type="checkbox" value="anime" />
 			<input name="types[]" id="types_movie" type="checkbox" value="movie" />
 		</form>
-
+		
 		<form id="testForm" action="#" method="get">
 			<textarea name="T3" rows="2" cols="15">?
 Z</textarea>
@@ -206,6 +201,10 @@ Z</textarea>
 			<select name="D4" disabled="disabled">
 				<option selected="selected" value="NO">NO</option>
 			</select>
+			<input id="list-test" type="text" />
+			<datalist id="datalist">
+				<option value="option"></option>
+			</datalist>
 		</form>
 		<div id="moretests">
 			<form>

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -60,9 +60,10 @@ test("attr(String)", function() {
 	equals( jQuery('#tAnchor5').attr('href'), "#5", 'Check for non-absolute href (an anchor)' );
 
 	equals( jQuery("<option/>").attr("selected"), false, "Check selected attribute on disconnected element." );
-
-	jQuery("#text1").attr("list", "datalist");
-	equals(jQuery("#text1").attr("list"), 'datalist', "Check setting list-attribute");
+	
+	// Bug#8255 List is readonly by default in browsers that support it
+	jQuery("#list-test").attr("list", "datalist");
+	equals( jQuery("#list-test").attr("list"), "datalist", "Check setting list-attribute" );
 	
 	// Related to [5574] and [5683]
 	var body = document.body, $body = jQuery(body);


### PR DESCRIPTION
ticket: http://bugs.jquery.com/ticket/8255 All credit to aFarkas for finding the fix for this.  I only did the testing.
To see the problem, view the fiddle attached to the ticket in Safari 5 or F4.
The list attribute could not be set in browsers which supported the datalist for a text input, such as safari 5 and firefox 4b10.
