### PR TITLE
Fix 7922 ie live click submit

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -709,8 +709,7 @@ if ( !jQuery.support.submitBubbles ) {
 						type = elem.type;
 
 					if ( (type === "submit" || type === "image") && jQuery( elem ).closest("form").length ) {
-						e.liveFired = undefined;
-						return trigger( "submit", this, arguments );
+						trigger( "submit", this, arguments );
 					}
 				});
 
@@ -719,8 +718,7 @@ if ( !jQuery.support.submitBubbles ) {
 						type = elem.type;
 
 					if ( (type === "text" || type === "password") && jQuery( elem ).closest("form").length && e.keyCode === 13 ) {
-						e.liveFired = undefined;
-						return trigger( "submit", this, arguments );
+						trigger( "submit", this, arguments );
 					}
 				});
 
@@ -783,7 +781,7 @@ if ( !jQuery.support.changeBubbles ) {
 		if ( data != null || val ) {
 			e.type = "change";
 			e.liveFired = undefined;
-			return jQuery.event.trigger( e, arguments[1], elem );
+			jQuery.event.trigger( e, arguments[1], elem );
 		}
 	};
 
@@ -797,7 +795,7 @@ if ( !jQuery.support.changeBubbles ) {
 				var elem = e.target, type = elem.type;
 
 				if ( type === "radio" || type === "checkbox" || elem.nodeName.toLowerCase() === "select" ) {
-					return testChange.call( this, e );
+					testChange.call( this, e );
 				}
 			},
 
@@ -809,7 +807,7 @@ if ( !jQuery.support.changeBubbles ) {
 				if ( (e.keyCode === 13 && elem.nodeName.toLowerCase() !== "textarea") ||
 					(e.keyCode === 32 && (type === "checkbox" || type === "radio")) ||
 					type === "select-multiple" ) {
-					return testChange.call( this, e );
+					testChange.call( this, e );
 				}
 			},
 
@@ -848,8 +846,18 @@ if ( !jQuery.support.changeBubbles ) {
 }
 
 function trigger( type, elem, args ) {
-	args[0].type = type;
-	return jQuery.event.handle.apply( elem, args );
+	// Piggyback on a donor event to simulate a different one.
+	// Fake originalEvent to avoid donor's stopPropagation, but if the
+	// simulated event prevents default then we do the same on the donor.
+	// Don't pass args or remember liveFired; they apply to the donor event.
+	var event = jQuery.extend( {}, args[ 0 ] );
+	event.type = type;
+	event.originalEvent = {};
+	event.liveFired = undefined;
+	jQuery.event.handle.call( elem, event );
+	if ( event.isDefaultPrevented() ) {
+		args[ 0 ].preventDefault();
+	}
 }
 
 // Create "bubbling" focus and blur events

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -1452,6 +1452,8 @@ test("live with change", function(){
 });
 
 test("live with submit", function() {
+	expect(5);
+
 	var count1 = 0, count2 = 0;
 
 	jQuery("#testForm").live("submit", function(ev) {
@@ -1468,7 +1470,16 @@ test("live with submit", function() {
 	equals( count1, 1, "Verify form submit." );
 	equals( count2, 1, "Verify body submit." );
 
+	jQuery("#testForm input[name=sub1]").live("click", function(ev) {
+		ok( true, "cancelling submit still calls click handler" );
+	});
+
+	jQuery("#testForm input[name=sub1]")[0].click();
+	equals( count1, 2, "Verify form submit." );
+	equals( count2, 2, "Verify body submit." );
+
 	jQuery("#testForm").die("submit");
+	jQuery("#testForm input[name=sub1]").die("click");
 	jQuery("body").die("submit");
 });
 


### PR DESCRIPTION
Fix #7922. Copy the donor event when simulating a bubbling submit in IE so that we don't accidentally stop propagation on it. 
