### PR TITLE
Fix 8108 tweak

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -68,7 +68,9 @@ jQuery.extend({
 			// TODO: This is a hack for 1.5 ONLY. Avoids exposing jQuery
 			// metadata on plain JS objects when the object is serialized using
 			// JSON.stringify
-			cache[ id ].toJSON = jQuery.noop;
+			if ( !isNode ) {
+				cache[ id ].toJSON = jQuery.noop;
+			}
 		}
 
 		// An object can be passed to jQuery.data instead of a key/value pair; this gets
@@ -168,6 +170,13 @@ jQuery.extend({
 		// data if it existed
 		if ( internalCache ) {
 			cache[ id ] = {};
+			// TODO: This is a hack for 1.5 ONLY. Avoids exposing jQuery
+			// metadata on plain JS objects when the object is serialized using
+			// JSON.stringify
+			if ( !isNode ) {
+				cache[ id ].toJSON = jQuery.noop;
+			}
+
 			cache[ id ][ internalKey ] = internalCache;
 
 		// Otherwise, we need to eliminate the expando on the node to avoid

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -338,17 +338,11 @@ test("data-* attributes", function() {
 		num++;
 	}
 
-	// TODO: Remove this hack which was introduced for 1.5.1
-	num--;
-
 	equals( num, check.length, "Make sure that the right number of properties came through." );
 
 	for ( var prop in obj2 ) {
 		num2++;
 	}
-
-	// TODO: Remove this hack which was introduced for 1.5.1
-	num2--;
 
 	equals( num2, check.length, "Make sure that the right number of properties came through." );
 


### PR DESCRIPTION
Only perpetrate the .toJSON hack on data caches when they are attached to a plain Javascript object. Part of the continuing saga of #8108. 
