### PR TITLE
Fix #8018 in a minor release by using try/catch - move to code functionality change in major release.

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -23,16 +23,16 @@ jQuery.event = {
 			return;
 		}
 
-                // TODO :: Use a try/catch until it's safe to pull this out (likely 1.6)
-                // Minor release fix for bug #8018
-                try {
+		// TODO :: Use a try/catch until it's safe to pull this out (likely 1.6)
+		// Minor release fix for bug #8018
+		try {
 			// For whatever reason, IE has trouble passing the window object
 			// around, causing it to be cloned in the process
 			if ( jQuery.isWindow( elem ) && ( elem !== window && !elem.frameElement ) ) {
 				elem = window;
 			}
-                }
-                catch ( e ) {}
+		}
+		catch ( e ) {}
 
 		if ( handler === false ) {
 			handler = returnFalse;


### PR DESCRIPTION
Pretty simple fix. When it throws an error, the functionality ends up being the same as pull request 193 is in all cases. That might be a good direction to move this in 1.6.
