### PR TITLE
Adding native Date.now() support to now()

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -788,15 +788,9 @@ jQuery.extend({
 		return length ? fn( elems[0], key ) : undefined;
 	},
 
-	now: (function() {
-		return 'now' in Date && jQuery.isFunction(Date.now) ?
-			function() {
-				return Date.now();
-			} :
-			function() {
-				return +new Date();
-			}
-	}()),
+	now: Date.now || function() {
+		return (new Date()).getTime();
+	},
 
 	// Create a simple deferred (one callbacks list)
 	_Deferred: function() {


### PR DESCRIPTION
Extended the now() method with a conditional check if Date.now() is available and if so, use that (which is considerably faster):

http://jsperf.com/native-date-now-vs-new-date-gettime
