### PR TITLE
Fix 8346 ( jQuery.css() incompatible with vendor prefixed properties in IE9 )

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -3,6 +3,7 @@
 var ralpha = /alpha\([^)]*\)/i,
 	ropacity = /opacity=([^)]*)/,
 	rdashAlpha = /-([a-z])/ig,
+	// fixed for IE9, see #8346
 	rupper = /([A-Z]|^ms)/g,
 	rnumpx = /^-?\d+(?:px)?$/i,
 	rnum = /^-?\d/,


### PR DESCRIPTION
Link to the bug report: http://bugs.jquery.com/ticket/8346
