### PR TITLE
rurl pattern fails to match single-slash URIs

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -19,7 +19,7 @@ var r20 = /%20/g,
 	rucHeadersFunc = function( _, $1, $2 ) {
 		return $1 + $2.toUpperCase();
 	},
-	rurl = /^([\w\+\.\-]+:)\/\/([^\/?#:]*)(?::(\d+))?/,
+	rurl = /^([\w\+\.\-]+:)\/{1,2}([^\/?#:]*)(?::(\d+))?/,
 
 	// Keep a copy of the old load method
 	_load = jQuery.fn.load,


### PR DESCRIPTION
Some environments use a single slash URI, like Adobe AIR's "app:/filename.html". This fixed src/ajax.js for me in Adobe AIR 2.5.
