### PR TITLE
Bug 2616 - jQuery.map with object support

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -712,15 +712,29 @@ jQuery.extend({
 
 	// arg is for internal usage only
 	map: function( elems, callback, arg ) {
-		var ret = [], value;
+		var ret = [],
+			value,
+			length = elems.length,
+			// same object detection used in jQuery.each, not full-proof but very speedy.
+			isObj = length === undefined;
 
-		// Go through the array, translating each of the items to their
-		// new value (or values).
-		for ( var i = 0, length = elems.length; i < length; i++ ) {
-			value = callback( elems[ i ], i, arg );
+		if ( isObj ) {
+			for ( key in elems ) {
+				value = callback( elems[ key ], key, arg );
 
-			if ( value != null ) {
-				ret[ ret.length ] = value;
+				if ( value != null ) {
+					ret[ ret.length ] = value;
+				}
+			}
+		} else {
+			// Go through the array, translating each of the items to their
+			// new value (or values).
+			for ( var i = 0; i < length; i++ ) {
+				value = callback( elems[ i ], i, arg );
+
+				if ( value != null ) {
+					ret[ ret.length ] = value;
+				}
 			}
 		}
 

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -608,7 +608,7 @@ test("first()/last()", function() {
 });
 
 test("map()", function() {
-	expect(2);//expect(6);
+	expect(6);
 
 	same(
 		jQuery("#ap").map(function(){
@@ -625,26 +625,24 @@ test("map()", function() {
 		q("ap","ap","ap"),
 		"Single Map"
 	);
-
-	return;//these haven't been accepted yet
-
+	
 	//for #2616
 	var keys = jQuery.map( {a:1,b:2}, function( v, k ){
 		return k;
-	}, [ ] );
+	});
 
 	equals( keys.join(""), "ab", "Map the keys from a hash to an array" );
 
 	var values = jQuery.map( {a:1,b:2}, function( v, k ){
 		return v;
-	}, [ ] );
+	});
 
 	equals( values.join(""), "12", "Map the values from a hash to an array" );
 
 	var scripts = document.getElementsByTagName("script");
 	var mapped = jQuery.map( scripts, function( v, k ){
 		return v;
-	}, {length:0} );
+	});
 
 	equals( mapped.length, scripts.length, "Map an array(-like) to a hash" );
 


### PR DESCRIPTION
I had a previous pull request that I removed, I accidentally made the change on my jquery/master copy instead of branching. Woops! This feels better.

Since it was 3 years ago, it didn't seem like it's a huge priority. I wanted to make the addition to handle objects without sacrificing the raw speed of $.map for arrays. Underscore.js already implements this: http://documentcloud.github.com/underscore/#map

Here are some benchmarks: http://jsperf.com/old-map-vs-new-map-with-obj-support/2

The pull request contains test: $.new_map_forin_2.

Some more tests here: http://jsfiddle.net/mmhwZ/16/
