### PR TITLE
Fix 7340 focusin focusout bubble

### DIFF
--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -1966,6 +1966,31 @@ test("window resize", function() {
 	ok( !jQuery._data(window, "__events__"), "Make sure all the events are gone." );
 });
 
+test("focusin bubbles", function() {
+	expect(4);
+	
+	var input = jQuery( '<input type="text" />' ).prependTo( "body" ), 
+		order = 0;
+
+	jQuery( "body" ).bind( "focusin.focusinBubblesTest", function(){
+		equals( 1, order++, "focusin on the body second" );
+	});
+
+	input.bind( "focusin.focusinBubblesTest", function(){
+		equals( 0, order++, "focusin on the element first" );
+	});
+
+	// DOM focus method
+	input[0].focus();
+	// jQuery trigger, which calls DOM focus
+	order = 0;
+	input[0].blur();
+	input.trigger( "focus" );
+
+	input.remove();
+	jQuery( "body" ).unbind( "focusin.focusinBubblesTest" );
+});
+
 /*
 test("jQuery(function($) {})", function() {
 	stop();


### PR DESCRIPTION
Fixes #7340. Use a single capturing handler to simulate bubbling focusin/focusout event on non-IE browsers. Allow native DOM methods to fire events other than the currently active one back into jQuery. 
