### PR TITLE
Fix for crash on init in a Blackberry WebWorks App  

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -7,7 +7,7 @@ var r20 = /%20/g,
 	rheaders = /^(.*?):[ \t]*([^\r\n]*)\r?$/mg, // IE leaves an \r character at EOL
 	rinput = /^(?:color|date|datetime|email|hidden|month|number|password|range|search|tel|text|time|url|week)$/i,
 	// #7653, #8125, #8152: local protocol detection
-	rlocalProtocol = /(?:^file|^widget|\-extension):$/,
+	rlocalProtocol = /(?:^local|^file|^widget|\-extension):$/,
 	rnoContent = /^(?:GET|HEAD)$/,
 	rprotocol = /^\/\//,
 	rquery = /\?/,
@@ -19,7 +19,7 @@ var r20 = /%20/g,
 	rucHeadersFunc = function( _, $1, $2 ) {
 		return $1 + $2.toUpperCase();
 	},
-	rurl = /^([\w\+\.\-]+:)(?:\/\/([^\/?#:]*)(?::(\d+))?|\/[^\/])/,
+	rurl = /^([\w\+\.\-]+:)(?:(?:\/\/)?([^\/?#:]*)(?::(\d+))?|\/[^\/])/,
 
 	// Keep a copy of the old load method
 	_load = jQuery.fn.load,


### PR DESCRIPTION
On such a device, document.location.href yields an URL like 'local:/file.html', which in turn crashes jquery on startup. That's because the rurl regex in ajax.js is not prepared to handle an omitted authority part.

This patch fixes the regex to make the '//' after the scheme optional, effectively making the authority part optional, as per section 3 of http://www.ietf.org/rfc/rfc2396.txt

In addition it adds the 'local' scheme to the rLocalProtocol regex, so that local:/file resources are recognized as such.

Fixes startup crash in bbwp - compiled apps 
