### PR TITLE
#7587 - $.parseJSON huge performance optimization by skipping regex

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -518,13 +518,13 @@ jQuery.extend({
 		// Make sure the incoming data is actual JSON
 		// Logic borrowed from http://json.org/json2.js
 			// Try to use the native JSON parser first
-		if (window.JSON && window.JSON.parse){
+		if ( window.JSON && window.JSON.parse ) {
 			try {
 				return window.JSON.parse( data );
 			} catch(e) {
 				jQuery.error( "Invalid JSON: " + data );
 			}
-		}else if ( rvalidchars.test(data.replace(rvalidescape, "@")
+		} else if ( rvalidchars.test(data.replace(rvalidescape, "@")
 			.replace(rvalidtokens, "]")
 			.replace(rvalidbraces, "")) ) {
 			return (new Function("return " + data))();


### PR DESCRIPTION
this checking skips the expensive regex/replace validation on the JSON when using the browser's native JSON parser because the threat to security is gone. My tests show this reduces the runtime of the parseJSON function to 1/3rd of the original code.

http://bugs.jquery.com/ticket/7587

Performance test here: http://jsperf.com/parsejson-optimization/2
