### PR TITLE
Fix 8456 - null parent stops mouseenter

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -661,7 +661,7 @@ var withinElement = function( event ) {
 
 		// Chrome does something similar, the parentNode property
 		// can be accessed but is null.
-		if ( parent !== document && !parent.parentNode ) {
+		if ( parent && parent !== document && !parent.parentNode ) {
 			return;
 		}
 		// Traverse up the tree

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -683,6 +683,20 @@ test("hover()", function() {
 	equals( times, 4, "hover handlers fired" );
 });
 
+test("mouseover triggers mouseenter", function() {
+	expect(1);
+	
+	var count = 0,
+		elem = jQuery("<a />");
+	elem.mouseenter(function () {
+	  count++;
+	});
+	elem.trigger('mouseover');
+	equals(count, 1, "make sure mouseover triggers a mouseenter" );
+	
+	elem.remove();
+});
+
 test("trigger() shortcuts", function() {
 	expect(6);
 


### PR DESCRIPTION
Fixes #8456. Make sure parent is not null before crawling into its lap, so mouseenter is triggered on a mouseover event. 
