### PR TITLE
More generic implementation of jQuery.fn[bind,one,unbind]

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -915,7 +915,7 @@ jQuery.each(["bind", "one"], function( i, name ) {
 		}
 
 		var handler = name === "one" ? jQuery.proxy( fn, function( event ) {
-			jQuery( this ).unbind( event, handler );
+			jQuery.fn.unbind.call( [ this ], event, handler );
 			return fn.apply( this, arguments );
 		}) : fn;
 


### PR DESCRIPTION
This commit makes the implementation of jQuery.fn.bind, jQuery.fn.one, and jQuery.fn.unbind more generic so that they may be called in the context of a jQuery-like object, as well as an actual jQuery object. This can be useful for 3rd parties who wish to use these functions to bind/unbind events for any set of arbitrary objects in an Array.
