### PR TITLE
Bug 3333

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -240,6 +240,25 @@ if ( !jQuery.support.opacity ) {
 	};
 }
 
+jQuery(function() {
+	// This hook cannot be added until DOM ready because the support test
+	// for it is not run until after DOM ready
+	if ( !jQuery.support.reliableMarginRight ) {
+		jQuery.cssHooks.marginRight = {
+			get: function( elem, computed ) {
+				// WebKit Bug 13343 - getComputedStyle returns wrong value for margin-right
+				// Work around by temporarily setting element display to inline-block
+				var ret = "0px",
+					display = elem.style.display;
+				elem.style.display = "inline-block";
+				ret = getComputedStyle( elem, "margin-right", "margin-right" );
+				elem.style.display = display;
+				return ret;
+			}
+		}
+	}
+});
+
 if ( document.defaultView && document.defaultView.getComputedStyle ) {
 	getComputedStyle = function( elem, newName, name ) {
 		var ret, defaultView, computedStyle;

--- a/src/support.js
+++ b/src/support.js
@@ -67,7 +67,8 @@
 		boxModel: null,
 		inlineBlockNeedsLayout: false,
 		shrinkWrapBlocks: false,
-		reliableHiddenOffsets: true
+		reliableHiddenOffsets: true,
+		reliableMarginRight: true
 	};
 
 	input.checked = true;
@@ -187,6 +188,17 @@
 		// (IE < 8 fail this test)
 		jQuery.support.reliableHiddenOffsets = jQuery.support.reliableHiddenOffsets && tds[0].offsetHeight === 0;
 		div.innerHTML = "";
+
+		// Check if div with explicit width and no margin-right incorrectly
+		// gets computed margin-right based on width of container. For more
+		// info see bug #3333
+		// Fails in WebKit before Feb 2011 nightlies
+		// WebKit Bug 13343 - getComputedStyle returns wrong value for margin-right
+		if ( document.defaultView && document.defaultView.getComputedStyle ) {
+			div.style.width = "1px";
+			div.style.marginRight = "0";
+			jQuery.support.reliableMarginRight = ( parseInt(document.defaultView.getComputedStyle(div).marginRight, 10) || 0 ) === 0;
+		}
 
 		body.removeChild( div ).style.display = "none";
 		div = tds = null;

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -333,3 +333,15 @@ test("internal ref to elem.runtimeStyle (bug #7608)", function () {
 
 	ok( result, "elem.runtimeStyle does not throw exception" );
 });
+
+test("marginRight computed style (bug #3333)", function() {
+	expect(1);
+
+	var $div = jQuery("#foo");
+	$div.css({
+		width: "1px",
+		marginRight: 0
+	});
+
+	equals($div.css("marginRight"), "0px");
+});


### PR DESCRIPTION
Fixed bug #3333. Three changes:
- Added unit test for correct margin-right when width on element is set and no margin-right is set
- Added jQuery.support.reliableMarginRight flag for detecting this WebKit bug
- Added css hook ( if bug detected ) to work around bug by temporarily setting element display to inline-block
