### PR TITLE
#7369 - Using an attribute selector in closest for a non-existent attribute raised an exception on disconnected nodes

### DIFF
--- a/src/traversing.js
+++ b/src/traversing.js
@@ -112,7 +112,7 @@ jQuery.fn.extend({
 
 				} else {
 					cur = cur.parentNode;
-					if ( !cur || !cur.ownerDocument || cur === context ) {
+					if ( !cur || !cur.ownerDocument || cur === context || cur.nodeType === 11 ) {
 						break;
 					}
 				}

--- a/test/unit/traversing.js
+++ b/test/unit/traversing.js
@@ -124,7 +124,7 @@ test("filter(jQuery)", function() {
 })
 
 test("closest()", function() {
-	expect(11);
+	expect(13);
 	same( jQuery("body").closest("body").get(), q("body"), "closest(body)" );
 	same( jQuery("body").closest("html").get(), q("html"), "closest(html)" );
 	same( jQuery("body").closest("div").get(), [], "closest(div)" );
@@ -144,6 +144,10 @@ test("closest()", function() {
 
 	// Test on disconnected node
 	equals( jQuery("<div><p></p></div>").find("p").closest("table").length, 0, "Make sure disconnected closest work." );
+
+	// Bug #7369
+	equals( jQuery('<div foo="bar"></div>').closest('[foo]').length, 1, "Disconnected nodes with attribute selector" );
+	equals( jQuery('<div>text</div>').closest('[lang]').length, 0, "Disconnected nodes with text and non-existent attribute selector" );
 });
 
 test("closest(Array)", function() {


### PR DESCRIPTION
- This is also #42 in the <a href="https://docs.google.com/a/thisismedium.com/document/d/1MrLFvoxW7GMlH9KK-bwypn77cC98jUnz7sMW1rg_TP4/edit?hl=en#">1.6 requests</a>.
- I had though this was fixed in sizzle, but didn't realize that this only failed for disconnected nodes that have text, attributes set, or children.  In other words,

failed...<pre>$(&#39;&lt;div&gt;text&lt;/div&gt;&#39;).closest('[attr]')</pre> didn't fail... <pre>$(&#39;&lt;div&gt;&lt;/div&gt;&#39;).closest('[attr]')</pre> 
