### PR TITLE
A more modest valHooks proposal

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -153,15 +153,15 @@ jQuery.fn.extend({
 	},
 
 	val: function( value ) {
-		var hooks, val,
+		var hooks, ret,
 			elem = this[0];
 		
 		if ( !arguments.length ) {
 			if ( elem ) {
 				hooks = jQuery.valHooks[ elem.nodeName.toLowerCase() ] || jQuery.valHooks[ elem.type ];
 
-				if ( hooks && "get" in hooks && (val = hooks.get( elem )) !== undefined ) {
-					return val;
+				if ( hooks && "get" in hooks && (ret = hooks.get( elem )) !== undefined ) {
+					return ret;
 				}
 
 				return (elem.value || "").replace(rreturn, "");
@@ -173,15 +173,16 @@ jQuery.fn.extend({
 		var isFunction = jQuery.isFunction( value );
 
 		return this.each(function( i ) {
-			var self = jQuery(this);
+			var self = jQuery(this), val;
 
 			if ( this.nodeType !== 1 ) {
 				return;
 			}
 
-			val = value;
 			if ( isFunction ) {
 				val = value.call( this, i, self.val() );
+			} else {
+				val = value;
 			}
 
 			// Treat null/undefined as ""; convert numbers to string


### PR DESCRIPTION
- The main difference is that this does not allow arbitrarily adding hooks to any collection of elements.
- Modularizes val into a set of easily maintainable and conditional hooks.
- valHooks is placed at jQuery.valHooks
  - This could technically be extended, but I do not see it being used except in very rare cases since you can only apply valHooks to nodeNames and input types, and not a collection of elements as before. We could theoretically privatize valHooks taking it off of jQuery and only use it internally for our own convenience, but again, I do not believe this patch carries with it the dangers of the first proposal.
- Slightly improved performance of val on radios and checkboxes for browsers that support checkOn, given the conditional attachment of its hook.
### Performance
- http://jsperf.com/valhooks-vs-val
  - There is a noticeable improvement in getting the value
  - Setting looks about the same, maybe a slight decrease, probably due to accessing nodeName and type on the elem.
