### PR TITLE
Bug 7345; Add support for explicit/relative string values in .css - modif

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -7,8 +7,8 @@ var ralpha = /alpha\([^)]*\)/i,
 	rupper = /([A-Z]|^ms)/g,
 	rnumpx = /^-?\d+(?:px)?$/i,
 	rnum = /^-?\d/,
-	rrelNum = /=/,
-	rrelString = /[^+\-\de]+/g,
+	rrelNum = /^[+\-]=/,
+	rrelNumFilter = /[^+\-\.\de]+/g,
 
 	cssShow = { position: "absolute", visibility: "hidden", display: "block" },
 	cssWidth = [ "Left", "Right" ],
@@ -77,26 +77,27 @@ jQuery.extend({
 		}
 
 		// Make sure that we're working with the right name
-		var ret, parsed, type, origName = jQuery.camelCase( name ),
+		var ret, type, origName = jQuery.camelCase( name ),
 			style = elem.style, hooks = jQuery.cssHooks[ origName ];
 
 		name = jQuery.cssProps[ origName ] || origName;
 
 		// Check if we're setting a value
 		if ( value !== undefined ) {
+			type = typeof value;
+
 			// Make sure that NaN and null values aren't set. See: #7116
-			if ( typeof value === "number" && isNaN( value ) || value == null ) {
+			if ( type === "number" && isNaN( value ) || value == null ) {
 				return;
 			}
 
-			// convert string to number or relative number
-			if ( type === "string" ) {
-				parsed = +value.replace( rrelString, '' );
-				value = rrelNum.test( value ) ? parsed + jQuery.css( elem, name ) : parsed;
+			// convert relative number strings (+= or -=) to relative numbers. #7345
+			if ( type === "string" && rrelNum.test( value ) ) {
+				value = +value.replace( rrelNumFilter, '' ) + parseFloat( jQuery.css( elem, name ) );
 			}
 
 			// If a number was passed in, add 'px' to the (except for certain CSS properties)
-			if ( typeof value === "number" && !jQuery.cssNumber[ origName ] ) {
+			if ( type === "number" && !jQuery.cssNumber[ origName ] ) {
 				value += "px";
 			}
 

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -106,24 +106,35 @@ test("css(String|Hash)", function() {
 });
 
 test("css() explicit and relative values", function() {
+	expect(9);
 	var $elem = jQuery('#nothiddendiv');
-	
+
 	$elem.css({ width: 1, height: 1 });
-	ok( [$elem.width(), $elem.height()], [1,1] );
-	$elem.css({ width: "+=9", height: "+=9" });
-	ok( [$elem.width(), $elem.height()], [10,10] );
-	$elem.css({ width: "-=9", height: "-=9" });
-	ok( [$elem.width(), $elem.height()], [1,1] );
-	$elem.css({ width: "+=9px", height: "+=9px" });
-	ok( [$elem.width(), $elem.height()], [10,10] );
-	$elem.css({ width: "-=9px", height: "-=9px" });
-	ok( [$elem.width(), $elem.height()], [1,1] );
-	$elem.css("width", "+=9").css("height", "+=9");
-	ok( [$elem.width(), $elem.height()], [10,10] );
-	$elem.css("width", "+9").css("height", "+9");
-	ok( [$elem.width(), $elem.height()], [9,9] );
-	$elem.css("width", "-9").css("height", "-9");
-	ok( [$elem.width(), $elem.height()], [0,0] );
+	equals( $elem.width(), 1, "Initial css set or width/height works (hash)" );
+
+	$elem.css({ width: "+=9" });
+	equals( $elem.width(), 10, "'+=9' on width (hash)" );
+
+	$elem.css({ width: "-=9" });
+	equals( $elem.width(), 1, "'-=9' on width (hash)" );
+
+	$elem.css({ width: "+=9px" });
+	equals( $elem.width(), 10, "'+=9px' on width (hash)" );
+
+	$elem.css({ width: "-=9px" });
+	equals( $elem.width(), 1, "'-=9px' on width (hash)" );
+
+	$elem.css( "width", "+=9" );
+	equals( $elem.width(), 10, "'+=9' on width (params)" );
+
+	$elem.css( "width", "-=9" ) ;
+	equals( $elem.width(), 1, "'-=9' on width (params)" );
+
+	$elem.css( "width", "+=9px" );
+	equals( $elem.width(), 10, "'+=9px' on width (params)" );
+
+	$elem.css( "width", "-=9px" );
+	equals( $elem.width(), 1, "'-=9px' on width (params)" );
 });
 
 test("css(String, Object)", function() {


### PR DESCRIPTION
Bug 7345; Add support for explicit/relative string values in .css - modified from original pull req by brandonaron #78 - https://github.com/jquery/jquery/pull/78

Checks for an equals sign to add/substract values - otherwise, reduces string to +digit or -digit to use. 
