### PR TITLE
Don't access queue[0] when queue is undefined

### DIFF
--- a/src/queue.js
+++ b/src/queue.js
@@ -78,7 +78,7 @@ jQuery.fn.extend({
 		return this.each(function( i ) {
 			var queue = jQuery.queue( this, type, data );
 
-			if ( type === "fx" && queue[0] !== "inprogress" ) {
+			if ( type === "fx" && queue && queue[0] !== "inprogress" ) {
 				jQuery.dequeue( this, type );
 			}
 		});


### PR DESCRIPTION
Little extra check to make sure that the "queue" variable is not undefined before trying to access queue[0], to avoid the TypeError exception that causes.
