### PR TITLE
Fix multiple test suite fails from VML addition and some run order in IE6

### DIFF
--- a/test/data/testsuite.css
+++ b/test/data/testsuite.css
@@ -109,3 +109,6 @@ div#show-tests * { display: none; }
 #nothiddendiv { font-size: 16px; }
 #nothiddendivchild.em { font-size: 2em; }
 #nothiddendivchild.prct { font-size: 150%; }
+
+/* For testing type on vml in IE #7071 */
+v\:oval { behavior:url(#default#VML); display:inline-block; }

--- a/test/index.html
+++ b/test/index.html
@@ -45,10 +45,6 @@
 	<script src="unit/effects.js"></script>
 	<script src="unit/offset.js"></script>
 	<script src="unit/dimensions.js"></script>
-
-	<!-- For testing http://bugs.jquery.com/ticket/7071 -->
-	<xml:namespace ns="urn:schemas-microsoft-com:vml" prefix="v" />
-	<style>v\:oval { behavior:url(#default#VML); display:inline-block; }</style>
 </head>
 
 <body id="body">
@@ -151,7 +147,6 @@
 			<span id="test.foo[5]bar" class="test.foo[5]bar"></span>
 
 			<foo_bar id="foobar">test element</foo_bar>
-			<v:oval id="oval" style="width:100pt;height:75pt;" fillcolor="red"> </v:oval>
 		</form>
 		<b id="floatTest">Float test.</b>
 		<iframe id="iframe" name="iframe"></iframe>

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -492,6 +492,7 @@ test("val()", function() {
 var testVal = function(valueObj) {
 	expect(8);
 
+	QUnit.reset();
 	jQuery("#text1").val(valueObj( "test" ));
 	equals( document.getElementById("text1").value, "test", "Check for modified (via val(String)) value of input element" );
 
@@ -504,15 +505,16 @@ var testVal = function(valueObj) {
 	jQuery("#text1").val(valueObj( null ));
 	equals( document.getElementById("text1").value, "", "Check for modified (via val(null)) value of input element" );
 
-	jQuery("#select1").val(valueObj( "3" ));
-	equals( jQuery("#select1").val(), "3", "Check for modified (via val(String)) value of select element" );
+	var $select1 = jQuery("#select1");
+	$select1.val(valueObj( "3" ));
+	equals( $select1.val(), "3", "Check for modified (via val(String)) value of select element" );
 
-	jQuery("#select1").val(valueObj( 2 ));
-	equals( jQuery("#select1").val(), "2", "Check for modified (via val(Number)) value of select element" );
+	$select1.val(valueObj( 2 ));
+	equals( $select1.val(), "2", "Check for modified (via val(Number)) value of select element" );
 
-	jQuery("#select1").append("<option value='4'>four</option>");
-	jQuery("#select1").val(valueObj( 4 ));
-	equals( jQuery("#select1").val(), "4", "Should be possible to set the val() to a newly created option" );
+	$select1.append("<option value='4'>four</option>");
+	$select1.val(valueObj( 4 ));
+	equals( $select1.val(), "4", "Should be possible to set the val() to a newly created option" );
 
 	// using contents will get comments regular, text, and comment nodes
 	var j = jQuery("#nonnodes").contents();

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -778,6 +778,8 @@ test("trigger() shortcuts", function() {
 	elem.remove();
 
 	// test that special handlers do not blow up with VML elements (#7071)
+	jQuery('<xml:namespace ns="urn:schemas-microsoft-com:vml" prefix="v" />').appendTo('head');
+	jQuery('<v:oval id="oval" style="width:100pt;height:75pt;" fillcolor="red"> </v:oval>').appendTo('#form');
 	jQuery("#oval").click().keydown();
 });
 


### PR DESCRIPTION
VML.type test was causing multiple test suite fails, fix attributes.js fail in IE6 where the val(String/Number) tests were interfering with the val(Function) tests
