### PR TITLE
effects.js cleanup

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -1,8 +1,7 @@
 (function( jQuery ) {
 
 var elemdisplay = {},
-	iframe = null,
-	iframeDoc = null,
+	iframe, iframeDoc,
 	rfxtypes = /^(?:toggle|show|hide)$/,
 	rfxnum = /^([+\-]=)?([\d+.\-]+)([a-z%]*)$/i,
 	timerId,
@@ -547,12 +546,9 @@ function defaultDisplay( nodeName ) {
 
 		elem.remove();
 
+		// If the simple way fails,
+		// get element's real default display by attaching it to a temp iframe
 		if ( display === "none" || display === "" ) {
-
-			// Get element's real default display by attaching it to a temp iframe
-			// Conritbutions from Louis Remi and Julian Aurbourg
-			// based on recommendation by Louis Remi
-
 			// No iframe to use yet, so create it
 			if ( !iframe ) {
 				iframe = document.createElement( "iframe" );


### PR DESCRIPTION
How is it better?
- reduce function calls
- simplify easing resolution logic
- move some var to the top of the scope (improve code consistency and never hurts)

Oh and I moved the private function at the **bottom** of the file, because I thought it made more sense this way.

I actually took the good ideas from my previous PR, stripped it from what already landed (sync animations) and stopped systematically caching out-of-scope vars.
