### PR TITLE
Add support for registering jQuery as an AMD module. Only does so if the 

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -930,6 +930,20 @@ function doScrollCheck() {
 	jQuery.ready();
 }
 
+// Expose jQuery as an AMD module, but only for AMD loaders that
+// understand the issues with loading multiple versions of jQuery
+// in a page that all might call define(). The loader will indicate
+// they have special allowances for multiple jQuery versions by
+// specifying define.amd.jQuery = true. Register as a named module,
+// since jQuery can be concatenated with other files that may use define,
+// but not use a proper concatenation script that understands anonymous
+// AMD modules. A named AMD is safest and most robust way to register.
+// Lowercase jquery is used because AMD module names are derived from
+// file names, and jQuery is normally delivered in a lowercase file name.
+if ( typeof define === "function" && define.amd && define.amd.jQuery ) {
+	define( "jquery", [], function () { return jQuery; } );
+}
+
 // Expose jQuery to the global object
 return jQuery;
 

--- a/test/data/testinit.js
+++ b/test/data/testinit.js
@@ -1,7 +1,19 @@
 var jQuery = this.jQuery || "jQuery", // For testing .noConflict()
 	$ = this.$ || "$",
 	originaljQuery = jQuery,
-	original$ = $;
+	original$ = $,
+        amdDefined;
+
+/**
+ * Set up a mock AMD define function for testing AMD registration.
+ */
+function define(name, dependencies, callback) {
+	amdDefined = callback();
+}
+
+define.amd = {
+	jQuery: true
+};
 
 /**
  * Returns an array of elements with the given IDs, eg.

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -214,6 +214,12 @@ test("browser", function() {
 });
 }
 
+test("amdModule", function() {
+	expect(1);
+
+	equals( jQuery, amdDefined, "Make sure defined module matches jQuery" );
+});
+
 test("noConflict", function() {
 	expect(7);
 
@@ -850,7 +856,7 @@ test("jQuery.each(Object,Function)", function() {
 		f[i] = "baz";
 	});
 	equals( "baz", f.foo, "Loop over a function" );
-	
+
 	var stylesheet_count = 0;
 	jQuery.each(document.styleSheets, function(i){
 		stylesheet_count++;


### PR DESCRIPTION
Add support for registering jQuery as an AMD module. Only does so if the AMD loader indicates it has special allowances for multiple versions of jQuery being loaded in a page.

The "special allowances" should be:
- Being able to restrict registration of jQuery to a specific version.
- Allow multiple versions of jQuery to be loaded in a page if the loader supports different "sandboxes" for defined modules.

An AMD loader needs to have these special allowances for jQuery since jQuery is commonly used by third-party libs used in pages that can load more than one version of jQuery in a page. While this conceptually could happen with any library/toolkit script, jQuery's popularity make it an actual issue, and an AMD loader needs to be able to account for it, or specifically tells its users the restrictions it has with its use and jQuery.

With [this RequireJS commit](https://github.com/jrburke/requirejs/commit/a5715e6293eb6a13e44135f8d4dfd728d3a1a68e), RequireJS demonstrates meeting these allowances by allowing the developer to specify the version of jQuery they want to allow registered, so if more than one jQuery with a define() call happens, RequireJS will only pay attention to the desired version. The RequireJS commit contains some unit tests to show either 1.4.4 for 1.5.2  being used depending on version set in the RequireJS config.

This helps avoid the issue of some other third party code on a page accidentally loading a version of jQuery the main page developer was not expecting and have it clobber the one that was desired.

RequireJS also supports "contexts" that act like "sandboxes" and allow the developer to load two different versions of jQuery to be loaded and used in a page, as long as jQuery uses define() to register.

RequireJS 1.0 can support this model if/when jQuery decides to accept this pull request, as long as we agree that define.amd.jQuery === true is the capability name/test. If the jQuery project prefers a different capability name, just let me know (preferably within the next week), and I can have the capability flag in the RequireJS 1.0 release.

This pull request includes a define qunit test that was originally authored by csnover, but changed to fit the current suggested capability check.
