### PR TITLE
#8570 - Value of radio inputs resets when type is set after the value in all IEs.

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -360,6 +360,15 @@ jQuery.extend({
 				// We can't allow the type property to be changed (since it causes problems in IE)
 				if ( rtype.test( elem.nodeName ) && elem.parentNode ) {
 					jQuery.error( "type property can't be changed" );
+				} else if ( !jQuery.support.radioValue && value === "radio" && jQuery.nodeName(elem, "input") ) {
+					// Setting the type on a radio button after the value resets the value in IE6-9
+					// Reset value to it's default in case type is set after value
+					var val = elem.getAttribute("value");
+					elem.setAttribute( "type", value );
+					if ( val ) {
+						elem.value = val;
+					}
+					return value;
 				}
 			}
 		},
@@ -432,7 +441,6 @@ if ( !jQuery.support.getSetAttribute ) {
 	});
 	
 	// Use this for any attribute on a form in IE6/7
-	// And the name attribute
 	formHook = jQuery.attrHooks.name = jQuery.attrHooks.value = jQuery.valHooks.button = {
 		get: function( elem, name ) {
 			if ( name === "value" && !jQuery.nodeName( elem, "button" ) ) {

--- a/src/support.js
+++ b/src/support.js
@@ -115,6 +115,11 @@ jQuery.support = (function() {
 		div.cloneNode( true ).fireEvent( "onclick" );
 	}
 
+	input = document.createElement("input");
+	input.value = "t";
+	input.setAttribute("type", "radio");
+	support.radioValue = input.value === "t";
+
 	div.innerHTML = "<input type='radio' name='radiotest' checked='checked'/>";
 
 	fragment = document.createDocumentFragment();

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -177,7 +177,7 @@ test("attr(Hash)", function() {
 });
 
 test("attr(String, Object)", function() {
-	expect(29);
+	expect(30);
 
 	var div = jQuery("div").attr("foo", "bar"),
 		fail = false;
@@ -290,7 +290,10 @@ test("attr(String, Object)", function() {
 	}
 	ok( thrown, "Exception thrown when trying to change type property" );
 	equals( "button", button.attr("type"), "Verify that you can't change the type of a button element" );
-	
+
+	var $radio = jQuery("<input>", { "value": "sup", "type": "radio" }).appendTo("#testForm");
+	equals( $radio.val(), "sup", "Value is not reset when type is set after value on a radio" );
+
 	// Setting attributes on svg elements (bug #3116)
 	var $svg = jQuery("<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' version='1.1' baseProfile='full' width='200' height='200'>"
 		+ "<circle cx='200' cy='200' r='150' />"
@@ -557,6 +560,7 @@ test( "val(Array of Numbers) (Bug #7123)", function() {
 test("val(Function) with incoming value", function() {
 	expect(10);
 
+	QUnit.reset();
 	var oldVal = jQuery("#text1").val();
 
 	jQuery("#text1").val(function(i, val) {


### PR DESCRIPTION
Reset the value on a radio input if the type is set after the value in IE6-9.
[#8570](http://jqbug.com/8570)
