### PR TITLE
provide a consistent way to deal with boolean content attributes

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -6,6 +6,7 @@ var rclass = /[\n\t\r]/g,
 	rtype = /^(?:button|input)$/i,
 	rfocusable = /^(?:button|input|object|select|textarea)$/i,
 	rclickable = /^a(?:rea)?$/i,
+	special = /^(?:data-|aria-)/,
 	formHook;
 
 jQuery.fn.extend({
@@ -311,7 +312,7 @@ jQuery.extend({
 
 		if ( value !== undefined ) {
 
-			if ( value === null || value === false ) {
+			if ( value === null || (value === false && !special.test( name )) ) {
 				jQuery.removeAttr( elem, name );
 				return undefined;
 
@@ -319,7 +320,7 @@ jQuery.extend({
 				return ret;
 
 			} else {
-				if( value === true ){
+				if( value === true && !special.test( name ) ){
 					value = name;
 				}
 				elem.setAttribute( name, "" + value );


### PR DESCRIPTION
There was an attribute hook for checked, disabled etc., which does what this patch is doing. The difference is, that this patch doesn't look for the name of the attribute. With this change, the logic is more consitent and futureproof. 

jQuery has not to have a list of current widley used boolean content-attributes. Simply the developer has to decide, which attributes are boolean. 

This also means, that HTML5 boolean attributes can be used the same way checked, disabled are used:

```
$.attr(video, 'controls', true); // sets controls="controls"
$.attr(input, 'required', false); // removes required
```

Due to the fact, that true/false are not valid values for content attributes and jQuery's attr already had a general abstraction for removing attributes (value === null), this change won't break anything (despite of some very rare cases using aria-\* attributes without stringifying true/false) and makes attr more consistent.
