### PR TITLE
using jQuery.nodeName where applicable

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -707,7 +707,7 @@ if ( !jQuery.support.submitBubbles ) {
 
 	jQuery.event.special.submit = {
 		setup: function( data, namespaces ) {
-			if ( this.nodeName && !jQuery.nodeName( this, "form" ) ) {
+			if ( !jQuery.nodeName( this, "form" ) ) {
 				jQuery.event.add(this, "click.specialSubmit", function( e ) {
 					var elem = e.target,
 						type = elem.type;


### PR DESCRIPTION
I noticed we were using jQuery.nodeName (comparison) in places and not in others. Figured it's good to be consistent.

I didn't touch the function cloneFixAttributes as it's doing multiple checks on the nodeName but it's storing it in a local var. Replacing it with jQuery.nodeName would prob hurt performance a little.
