### PR TITLE
Fix inconsistent behavior between various ajax methods

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -161,10 +161,7 @@ jQuery.fn.extend({
 				// We assume that it's the callback
 				callback = params;
 				params = undefined;
-
-			// Otherwise, build a param string
 			} else if ( typeof params === "object" ) {
-				params = jQuery.param( params, jQuery.ajaxSettings.traditional );
 				type = "POST";
 			}
 		}


### PR DESCRIPTION
Serializing at this point is unnecessary, and causes any data arguments previously set with ajaxSetup() to be overridden.  ajax() already takes care of serializing the data as needed.
