### PR TITLE
#8994 – Slightly improved `defaultDisplay()`

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -594,7 +594,7 @@ function defaultDisplay( nodeName ) {
 			// document to it; WebKit & Firefox won't allow reusing the iframe document.
 			if ( !iframeDoc || !iframe.createElement ) {
 				iframeDoc = ( iframe.contentWindow || iframe.contentDocument ).document;
-				iframeDoc.write( "<!doctype html><html><body>" );
+				iframeDoc.write( ( document.compatMode === "CSS1Compat" ? "<!doctype html>" : "" ) + "<html><body>" );
 				iframeDoc.close();
 			}
 


### PR DESCRIPTION
``` js
iframeDoc.write( "<!doctype><html><body></body></html>" );
```

In theory (as per HTML), the opening and closing `<html>` and `<body>` tags are optional, and can be omitted. However, some testing revealed that in this case the opening tags were needed, else the `body` wasn’t auto-generated. Omitting the closing tags doesn’t make a difference though, so we could save some bytes there.

`<!doctype>` triggers quirks mode, so I changed that to `<!doctype html>` in case the main document is in standards mode. Here’s the test case I used: http://mathiasbynens.be/demo/doctype

`document.body` was being used multiple times in the same context, so I cached a reference to it in a variable.
