### PR TITLE
Adds QUnit Aliases to testrunner.js. Fixes #8991

### DIFF
--- a/test/data/testrunner.js
+++ b/test/data/testrunner.js
@@ -24,3 +24,12 @@ jQuery.noConflict(); // Allow the test to run with other libs or jQuery's.
 
 	document.write("<scr" + "ipt src='http://swarm.jquery.org/js/inject.js?" + (new Date).getTime() + "'></scr" + "ipt>");
 })();
+
+// QUnit Aliases
+(function() {
+
+	window.equals = window.equal;
+	window.same = window.deepEqual;	
+
+})();
+


### PR DESCRIPTION
Following up on a discussion had with Jorn in #jquery-dev, I've added these aliases to preempt test suite failure when QUnit drops the "equals" and "same" assertions.
