### PR TITLE
Update unit tests for widows & orphans. Supplements #8971

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -229,15 +229,6 @@ jQuery.each(["height", "width"], function( i, name ) {
 	};
 });
 
-// Fixes #8971
-jQuery.each( ["widows","orphans"], function( i, name ) {
-	jQuery.cssHooks[ name ] = {
-		get: function( elem, computed ) {
-			return elem.style[ name ];
-		}
-	};
-});
-
 if ( !jQuery.support.opacity ) {
 	jQuery.cssHooks.opacity = {
 		get: function( elem, computed ) {

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -406,16 +406,16 @@ test("widows & orphans #8936", function () {
 			orphans: 0
 		});
 
-		equal( $p.css("widows"), 0, "widows correctly start with value 0");
-		equal( $p.css("orphans"), 0, "orphans correctly start with value 0");
+		equal( $p.css("widows") || jQuery.style( $p[0], "widows" ), 0, "widows correctly start with value 0");
+		equal( $p.css("orphans") || jQuery.style( $p[0], "orphans" ), 0, "orphans correctly start with value 0");
 
 		$p.css({
 			widows: 3,
 			orphans: 3
 		});
 
-		equal( $p.css("widows"), 3, "widows correctly set to 3");
-		equal( $p.css("orphans"), 3, "orphans correctly set to 3");
+		equal( $p.css("widows") || jQuery.style( $p[0], "widows" ), 3, "widows correctly set to 3");
+		equal( $p.css("orphans") || jQuery.style( $p[0], "orphans" ), 3, "orphans correctly set to 3");
 	} else {
 
 		expect(1);


### PR DESCRIPTION
Resolving issue where Firefox 4 returns an empty computed style for widows and orphans
