### PR TITLE
Make cached rspaces regex definitions consistent. Fixes #9008

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -13,7 +13,7 @@ var r20 = /%20/g,
 	rquery = /\?/,
 	rscript = /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
 	rselectTextarea = /^(?:select|textarea)/i,
-	rspacesAjax = /\s+/,
+	rspaces = /\s+/,
 	rts = /([?&])_=[^&]*/,
 	rurl = /^([\w\+\.\-]+:)(?:\/\/([^\/?#:]*)(?::(\d+))?)?/,
 
@@ -71,7 +71,7 @@ function addToPrefiltersOrTransports( structure ) {
 		}
 
 		if ( jQuery.isFunction( func ) ) {
-			var dataTypes = dataTypeExpression.toLowerCase().split( rspacesAjax ),
+			var dataTypes = dataTypeExpression.toLowerCase().split( rspaces ),
 				i = 0,
 				length = dataTypes.length,
 				dataType,
@@ -599,7 +599,7 @@ jQuery.extend({
 		s.url = ( ( url || s.url ) + "" ).replace( rhash, "" ).replace( rprotocol, ajaxLocParts[ 1 ] + "//" );
 
 		// Extract dataTypes list
-		s.dataTypes = jQuery.trim( s.dataType || "*" ).toLowerCase().split( rspacesAjax );
+		s.dataTypes = jQuery.trim( s.dataType || "*" ).toLowerCase().split( rspaces );
 
 		// Determine if a cross-domain request is in order
 		if ( s.crossDomain == null ) {

--- a/src/event.js
+++ b/src/event.js
@@ -4,7 +4,7 @@ var hasOwn = Object.prototype.hasOwnProperty,
 	rnamespaces = /\.(.*)$/,
 	rformElems = /^(?:textarea|input|select)$/i,
 	rperiod = /\./g,
-	rspace = / /g,
+	rspaces = /\s+/,
 	rescape = /[^\w\s.|`]/g,
 	fcleanup = function( nm ) {
 		return nm.replace(rescape, "\\$&");
@@ -1177,7 +1177,7 @@ function liveHandler( event ) {
 }
 
 function liveConvert( type, selector ) {
-	return (type && type !== "*" ? type + "." : "") + selector.replace(rperiod, "`").replace(rspace, "&");
+	return (type && type !== "*" ? type + "." : "") + selector.replace(rperiod, "`").replace(rspaces, "&");
 }
 
 jQuery.each( ("blur focus focusin focusout load resize scroll unload click dblclick " +


### PR DESCRIPTION
Tested and passing
- FF 3.0.x, 3.6.x, 4.x
- Chrome current-1 ( 10, 11 )
- Safari 3, 4, 5
- IE 6, 7, 8
- Opera current-1 ( 11.01, 11.10 )

Not tested in IE 9
