### PR TITLE
Adding feature: `$( [ $('<p></p>'), $('<span></span>') ] );`

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -655,6 +655,15 @@ jQuery.extend({
 			if ( array.length == null || type === "string" || type === "function" || type === "regexp" || jQuery.isWindow( array ) ) {
 				push.call( ret, array );
 			} else {
+				if ( type === "array" ) {
+					var realArray = [ ];
+					jQuery.each( array, function ( index, nodeList ) {
+						if ( nodeList instanceof jQuery.fn.init) {
+							jQuery.merge( realArray, nodeList );
+						}
+					 } );
+					ret.selector = array = realArray;
+				}
 				jQuery.merge( ret, array );
 			}
 		}


### PR DESCRIPTION
Adding feature: `$( [ $('<p></p>'), $('<span></span>') ] );` is now allowed and returns the same thing as `$('<p></p>').add($('<span></span>'));`. Although it was already possible, doing it with a large set of element implied a lot of calls to $().add.
Bug found here: http://stackoverflow.com/questions/5823776/jquery-append-doesnt-work-with-arrays-of-disconected-dom-nodes/5823999#5823999
Full jQuery file can be found here: https://gist.github.com/raw/947169/6a9711ead197e17a636d7c43b72dc8efd7a6baec/jQuery.js

I wanted to post this as an issue but I couldn't find how to post one on this repository...
