### PR TITLE
Fix #8985 use DocumentFragment get the default display value of an elemen in IE domain'set page

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -585,30 +585,27 @@ function defaultDisplay( nodeName ) {
 				iframe = document.createElement( "iframe" );
 				iframe.frameBorder = iframe.width = iframe.height = 0;
 			}
-			if (!fragment) {
+			if ( !fragment ) {
 				document.body.appendChild( iframe );
 				try {
-					iframeDoc = iframe.contentDocument || iframe.contentWindow.document;				
-				}
-				catch(e){					
+					iframeDoc = iframe.contentWindow.document;
+					
+				// Fixes #8985 where document.domain has been set in IE
+				} catch ( securityError ) {					
 					document.body.removeChild( iframe );
 					fragment = document.createDocumentFragment();
 				}
-			}			
+			}
 			
-			if( iframeDoc ) {
+			if ( iframeDoc ) {
 				iframeDoc.write( "<!doctype><html><body></body></html>" );
-				iframeDoc.close();				
-				elem = iframeDoc.createElement( nodeName );
-				iframeDoc.body.appendChild( elem );
-				display = jQuery.css( elem, "display" );
-				document.body.removeChild( iframe );
-			} else {
-				elem = document.createElement( nodeName );
-				fragment.appendChild( elem );
-				display = elem.currentStyle.display;
-				fragment.removeChild( elem );
-			}			
+				iframeDoc.close();	
+			}
+			
+			elem = ( iframeDoc || document ).createElement( nodeName );
+			( fragment || iframeDoc.body ).appendChild( elem );				
+			display = jQuery.css( elem, "display" );
+			iframeDoc ? document.body.removeChild( iframe ) : fragment.removeChild( elem );
 		}
 
 		// Store the correct default display


### PR DESCRIPTION
Fix #8985: http://bugs.jquery.com/ticket/8985

1: In IE domain setted page, to avoid the page throws an Uncaught Error and function failed , use DocumentFragment get the default display value of an element more info see: http://cmc3.cn/n/useFragmentGetNodedefaultDisplay.html

2: Add iframeDoc.close(); Fix #8994 for the IE Throbber of Doom issue. The screencast showing the problem, see: http://www.screenr.com/yja by jdalton.

3: Remove the if statement contains “ !iframe.createElement” ,  which will always be true ( iframe's createElement method  has never been existed).

4: Use crossbrowser support
iframe.contentWindow.document
instead of 
( iframe.contentWindow || iframe.contentDocument ).document

Test Case with this patch:

The page did not set document.domain: http://cmc3.cn/c/fix_8985_no_domain.html
The page set document.domain: http://cmc3.cn/c/fixd_8985_domain_set.html

Please check,Thanks!
