### PR TITLE
Simplify the code detect mouseenter/leave event

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -1134,14 +1134,9 @@ function liveHandler( event ) {
 				if ( handleObj.preType === "mouseenter" || handleObj.preType === "mouseleave" ) {
 					event.type = handleObj.preType;
 					related = jQuery( event.relatedTarget ).closest( handleObj.selector )[0];
-
-					// Make sure not to accidentally match a child element with the same selector
-					if ( related && jQuery.contains( elem, related ) ) {
-						related = elem;
-					}
 				}
 
-				if ( !related || related !== elem ) {
+				if ( !related || related !== elem && !jQuery.contains( elem, related ) ) {
 					elems.push({ elem: elem, handleObj: handleObj, level: close.level });
 				}
 			}


### PR DESCRIPTION
The original commit:
https://github.com/jquery/jquery/commit/a9b81d759af3a4574a42ca1de93be1247f7953a2

which Fixes #5884, but the code is redundant.

if jQuery.contains( elem, related ) then 'related' can't push in the "elems" that fire live mouseenter/leave event. and the variable "related " is not used.

so just " && !jQuery.contains( elem, related ) "
