### PR TITLE
jQuery.buildFragment, ensure doc is a document; Fixes #8950

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -437,8 +437,21 @@ function cloneFixAttributes( src, dest ) {
 }
 
 jQuery.buildFragment = function( args, nodes, scripts ) {
-	var fragment, cacheable, cacheresults,
-		doc = (nodes && nodes[0] ? nodes[0].ownerDocument || nodes[0] : document);
+	var fragment, cacheable, cacheresults, doc;
+
+  // nodes may contain either an explicit document object,
+  // a jQuery collection or context object.
+  // If nodes[0] contains a valid object to assign to doc
+  if ( nodes && nodes[0] ) {
+    doc = nodes[0].ownerDocument || nodes[0];
+  }
+
+  // Ensure that an attr object doesn't incorrectly stand in as a document object
+	// Chrome and Firefox seem to allow this to occur and will throw exception
+	// Fixes #8950
+	if ( !doc.createDocumentFragment ) {
+		doc = document;
+	}
 
 	// Only cache "small" (1/2 KB) HTML strings that are associated with the main document
 	// Cloning options loses the selected state, so don't cache them
@@ -500,7 +513,7 @@ jQuery.each({
 function getAll( elem ) {
 	if ( "getElementsByTagName" in elem ) {
 		return elem.getElementsByTagName( "*" );
-	
+
 	} else if ( "querySelectorAll" in elem ) {
 		return elem.querySelectorAll( "*" );
 

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -1382,6 +1382,15 @@ test("jQuery.buildFragment - no plain-text caching (Bug #6779)", function() {
 		}
 		catch(e) {}
 	}
-    equals($f.text(), bad.join(""), "Cached strings that match Object properties");
+	equals($f.text(), bad.join(""), "Cached strings that match Object properties");
 	$f.remove();
+});
+
+test("jQuery.buildFragment - plain objects are not a document #8950", function() {
+	expect(1);
+
+	try {
+		jQuery('<input type="hidden">', {});
+		ok( true, "Does not allow attribute object to be treated like a doc object");
+	} catch (e) {}
 });


### PR DESCRIPTION
Updated to reflect reviews from predecessor pull request. Opting for simpler approach in favor for readability and clarity.

Replaces https://github.com/jquery/jquery/pull/347
