### PR TITLE
Quick improvement to the performace of .index() with no arguments

### DIFF
--- a/src/traversing.js
+++ b/src/traversing.js
@@ -145,12 +145,17 @@ jQuery.fn.extend({
 	// Determine the position of an element within
 	// the matched set of elements
 	index: function( elem ) {
-		if ( !elem || typeof elem === "string" ) {
-			return jQuery.inArray( this[0],
-				// If it receives a string, the selector is used
-				// If it receives nothing, the siblings are used
-				elem ? jQuery( elem ) : this.parent().children() );
+
+		// No argument, return index in parent
+		if ( !elem ) {
+			return ( this[0] && this[0].parentNode ) ? this.prevAll().length : -1;
 		}
+
+		// index in selector
+		if ( typeof elem === "string" ) {
+			return jQuery.inArray( this[0], jQuery( elem ) );
+		}
+
 		// Locate the position of the desired element
 		return jQuery.inArray(
 			// If it receives a jQuery object, the first element is used

--- a/test/unit/traversing.js
+++ b/test/unit/traversing.js
@@ -99,9 +99,11 @@ test("is(jQuery)", function() {
 });
 
 test("index()", function() {
-	expect(1);
+	expect( 2 );
 
-	equals( jQuery("#text2").index(), 2, "Returns the index of a child amongst its siblings" )
+	equal( jQuery("#text2").index(), 2, "Returns the index of a child amongst its siblings" );
+	
+	equal( jQuery("<div/>").index(), -1, "Node without parent returns -1" );
 });
 
 test("index(Object|String|undefined)", function() {


### PR DESCRIPTION
Born out of a discussion in #jquery: It seems that using `.prevAll().length` is quicker than `.index()`, so why not make `.index()` use `prevAll().length`?

http://jsperf.com/index-optimized/2
