### PR TITLE
Bug #9185; Make attr return undefined when called on the document

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -293,8 +293,8 @@ jQuery.extend({
 	attr: function( elem, name, value, pass ) {
 		var nType = elem.nodeType;
 		
-		// don't get/set attributes on text, comment and attribute nodes
-		if ( !elem || nType === 3 || nType === 8 || nType === 2 ) {
+		// don't get/set attributes on document, text, comment and attribute nodes
+		if ( !elem || nType === 9 || nType === 3 || nType === 8 || nType === 2 ) {
 			return undefined;
 		}
 

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -40,7 +40,7 @@ test("jQuery.attrFix/jQuery.propFix integrity test", function() {
 });
 
 test("attr(String)", function() {
-	expect(37);
+	expect(38);
 
 	equals( jQuery("#text1").attr("type"), "text", "Check for type attribute" );
 	equals( jQuery("#radio1").attr("type"), "radio", "Check for type attribute" );
@@ -78,6 +78,9 @@ test("attr(String)", function() {
 	// list attribute is readonly by default in browsers that support it
 	jQuery("#list-test").attr("list", "datalist");
 	equals( jQuery("#list-test").attr("list"), "datalist", "Check setting list attribute" );
+	
+	// [9185] calling attr on the document should return undefined
+	strictEqual( jQuery(document).attr('nodeName'), undefined, "Make sure that calling attr on the document returns undefined");
 
 	// Related to [5574] and [5683]
 	var body = document.body, $body = jQuery(body);


### PR DESCRIPTION
Before jQuery 1.6, it was possible (if silly) to get the properties of the `document` object using `attr()`. This functionality has obviously been broken in 1.6. This patch makes `attr` return `undefined` (as for comment and text nodes) rather than throwing an error when trying `document.getAttribute()`.
