### PR TITLE
Passing undefined to $.fn.text triggers the getter

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -41,7 +41,7 @@ jQuery.fn.extend({
 			});
 		}
 
-		if ( typeof text !== "object" && text !== undefined ) {
+		if ( typeof text !== "object" && arguments.length ) {
 			return this.empty().append( (this[0] && this[0].ownerDocument || document).createTextNode( text ) );
 		}
 

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -16,7 +16,7 @@ test("text()", function() {
 });
 
 var testText = function(valueObj) {
-	expect(4);
+	expect(5);
 	var val = valueObj("<div><b>Hello</b> cruel world!</div>");
 	equals( jQuery("#foo").text(val)[0].innerHTML.replace(/>/g, "&gt;"), "&lt;div&gt;&lt;b&gt;Hello&lt;/b&gt; cruel world!&lt;/div&gt;", "Check escaped text" );
 
@@ -28,6 +28,7 @@ var testText = function(valueObj) {
 
 	// Blackberry 4.6 doesn't maintain comments in the DOM
 	equals( jQuery("#nonnodes")[0].childNodes.length < 3 ? 8 : j[2].nodeType, 8, "Check node,textnode,comment with text()" );
+	equal(jQuery("<div/>").text(undefined).text(), "undefined", "Setter is triggered when undefined passed to .text()");
 }
 
 test("text(String)", function() {


### PR DESCRIPTION
Passing undefined to `$.fn.text()` triggers getter functionality instead of the setter functionality. For example the following code throws an exception:

```
var text;
$("<div/>").text(text).append($("<span/>"))
```

This pull request fixes this issue.

[Bug 9427](http://bugs.jquery.com/ticket/9427)
