### PR TITLE
Support $('form').submit() even when the form has <input name="submit">

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -392,7 +392,16 @@ jQuery.event = {
 						}
 
 						jQuery.event.triggered = type;
-						elem[ type ]();
+
+                                                // Sometimes a function can be clobbered by an element
+                                                // e.g. a form containing <input name="submit">
+                                                if (typeof elem[type] === "function") {
+                                                    elem[ type ]();
+                                                } else {
+                                                    // Create a new element of the same type
+                                                    // and use the (accessible) method from that element
+                                                    document.createElement(elem.tagName)[type].call(elem);
+                                                }
 					}
 				} catch ( ieError ) {}
 


### PR DESCRIPTION
Work around method names on HTML Elements being clobbered by other elements.

This will allow a <form> containing an <input name="submit"> (for example) to be submitted with $('form').submit();
