### PR TITLE
Nulling all elements created in support.js; Fixes #9471

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -245,7 +245,7 @@ jQuery.support = (function() {
 	}
 
 	// Null connected elements to avoid leaks in IE
-	marginDiv = div = input = null;
+	testElement = fragment = select = opt = body = marginDiv = div = input = null;
 
 	return support;
 })();


### PR DESCRIPTION
I've noticed a swell in memory leak tickets all related to the same issue so I decided to give this a deeper more thorough look. I rebuilt the test case and ran it through sIEve and I can confirm the leak when using iframes. Every time an iframe is loaded with jQuery, more orphaned elements are introduced by the support module. 

Nulling all of the references in support caps the memory leak. The only way I was able to confirm this was by running sIEve again and observing that no unexpected orphan elements were being reported.
