### PR TITLE
Adds fillOpacity to internal cssNumber. Fixes #9548

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -50,13 +50,14 @@ jQuery.extend({
 
 	// Exclude the following css properties to add px
 	cssNumber: {
-		"zIndex": true,
+		"fillOpacity": true,
 		"fontWeight": true,
-		"opacity": true,
-		"zoom": true,
 		"lineHeight": true,
+		"opacity": true,
+		"orphans": true,
 		"widows": true,
-		"orphans": true
+		"zIndex": true,
+		"zoom": true
 	},
 
 	// Add in properties whose names you wish to fix before

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -475,3 +475,13 @@ test("widows & orphans #8936", function () {
 
 	$p.remove();
 });
+
+test("Do not append px to 'fill-opacity' #9548", 1, function() {
+
+	var $div = jQuery("<div>").appendTo("#qunit-fixture");
+
+	$div.css("fill-opacity", 0).animate({ "fill-opacity": 1.0 }, 0, function () {
+		equal( jQuery(this).css("fill-opacity"), 1, "Do not append px to 'fill-opacity'");
+	});
+
+});


### PR DESCRIPTION
http://bugs.jquery.com/ticket/9548

Also, re-order cssNumber alphabetically
