### PR TITLE
jQuery.clone() check destination child nodes are not null. Fixes #9587

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -564,7 +564,10 @@ jQuery.extend({
 			// with an element if you are cloning the body and one of the
 			// elements on the page has a name or id of "length"
 			for ( i = 0; srcElements[i]; ++i ) {
-				cloneFixAttributes( srcElements[i], destElements[i] );
+				// Ensure that the destination node is not null; Fixes #9587
+				if ( destElements[i] ) {
+					cloneFixAttributes( srcElements[i], destElements[i] );
+				}
 			}
 		}
 

--- a/test/index.html
+++ b/test/index.html
@@ -281,6 +281,8 @@ Z</textarea>
 		</div>
 
 		<div id="fx-tests"></div>
+
+		<div id="no-clone-exception"><object><embed></embed></object></div>
 	</div>
 </body>
 </html>

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -1465,3 +1465,14 @@ test("jQuery.buildFragment - plain objects are not a document #8950", function()
 	} catch (e) {}
 
 });
+
+test("jQuery.clone - no exceptions for object elements #9587", function() {
+	expect(1);
+
+	try {
+		jQuery("#no-clone-exception").clone();
+		ok( true, "cloned with no exceptions" );
+	} catch( e ) {
+		ok( false, e.message );
+	}
+});


### PR DESCRIPTION
Had to add static markup to the test fixture, otherwise the error cannot be reproduced.
