### PR TITLE
don't unnecessarily fallback from offsetWidth/offsetHeight, fixes #9598

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -315,21 +315,20 @@ function getWH( elem, name, extra ) {
 	var val = name === "width" ? elem.offsetWidth : elem.offsetHeight,
 		which = name === "width" ? cssWidth : cssHeight;
 
-	if ( extra !== "margin" && extra !== "border" ) {
-		jQuery.each( which, function() {
-			val -= parseFloat( jQuery.css( elem, "border" + this + "Width" ) ) || 0;
-			if ( !extra ) {
-				val -= parseFloat( jQuery.css( elem, "padding" + this ) ) || 0;
-			}
-		});
-	}
-
 	if ( val > 0 ) {
-		if ( extra === "margin" ) {
+		if ( extra !== "border" ) {
 			jQuery.each( which, function() {
-				val += parseFloat( jQuery.css( elem, extra + this ) ) || 0;
+				if ( !extra ) {
+					val -= parseFloat( jQuery.css( elem, "padding" + this ) ) || 0;
+				}
+				if ( extra === "margin" ) {
+					val += parseFloat( jQuery.css( elem, extra + this ) ) || 0;
+				} else {
+					val -= parseFloat( jQuery.css( elem, "border" + this + "Width" ) ) || 0;
+				}
 			});
 		}
+
 		return val + "px";
 	}
 


### PR DESCRIPTION
@timmywil's solution to fix for #9300 and #9441 goes 99% of the way. It corrects all the behaviors I identified and helped resolve. This last little bit is an optimization in cases where the offsetWidth is greater than zero and composed solely of padding and border. Also, it moves all the "extra" calcs back inside the jQuery.each call, which I believe is another speed boost. Obviously, all unit tests passed in Chrome and FF and should pass in other browsers as it's really just a refactor.
