### PR TITLE
CSS/Effects: Extending cssHooks to have a .map property to map non-numeri

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -45,6 +45,21 @@ jQuery.extend({
 					return elem.style.opacity;
 				}
 			}
+		},
+		lineHeight: {
+			map: {
+				normal: "1.2"
+			}
+		},
+		letterSpacing: {
+			map: {
+				normal: "0px"
+			}
+		},
+		fontWeight: {
+			map: {
+				normal: "400"
+			}
 		}
 	},
 
@@ -111,13 +126,9 @@ jQuery.extend({
 			}
 
 		} else {
-			// If a hook was provided get the non-computed value from there
-			if ( hooks && "get" in hooks && (ret = hooks.get( elem, false, extra )) !== undefined ) {
-				return ret;
-			}
-
-			// Otherwise just get the value from the style object
-			return style[ name ];
+			return hookGet( hooks, elem, false, extra, name, function( elem, name ) {
+				return style[ name ];
+			});
 		}
 	},
 
@@ -134,14 +145,7 @@ jQuery.extend({
 			name = "float";
 		}
 
-		// If a hook was provided get the computed value from there
-		if ( hooks && "get" in hooks && (ret = hooks.get( elem, true, extra )) !== undefined ) {
-			return ret;
-
-		// Otherwise, if a way to get the computed value exists, use that
-		} else if ( curCSS ) {
-			return curCSS( elem, name );
-		}
+		return hookGet( hooks, elem, true, extra, name, curCSS );
 	},
 
 	// A method for quickly swapping in/out CSS properties to get correct calculations
@@ -367,6 +371,27 @@ if ( jQuery.expr && jQuery.expr.filters ) {
 	jQuery.expr.filters.visible = function( elem ) {
 		return !jQuery.expr.filters.hidden( elem );
 	};
+}
+
+function hookGet( hooks, elem, computed, extra, name, getFn ) {
+	var ret;
+
+	// If a hook was provided get the non-computed value from there
+	if ( hooks && "get" in hooks ) {
+		ret = hooks.get( elem, computed, extra );
+	}
+
+	// If there wasn't a hook, or it returned undefined use the default function
+	if ( ret === undefined ) {
+		ret = getFn( elem, name );
+	}
+
+	// Map the values
+	if ( hooks && "map" in hooks && ret in hooks.map ) {
+		ret = hooks.map[ ret ];
+	}
+
+	return ret;
 }
 
 })( jQuery );

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -1045,3 +1045,19 @@ test("callbacks should fire in correct order (#9100)", function() {
 				}
 			});
 });
+
+asyncTest( "animate letterspacing works correctly with 'normal' letterspacing (#8627)", function() {
+	var div = jQuery( "<div style='letter-spacing: normal'>" );
+
+	expect( 4 );
+	div.animate({ letterSpacing: 10 }, 1000, function() {
+		equal( parseInt(div.css('letterSpacing'), 10), 10, "Letter spacing is 10 at end" );
+		start();
+	});
+	equal( parseInt(div.css('letterSpacing'), 10), 0, "Letter spacing is 0 at start" );
+	setTimeout(function() {
+		notEqual( parseFloat(div.css('letterSpacing')), 0, "Letter spacing is not 0 in middle" );
+		notEqual( parseFloat(div.css('letterSpacing')), 10, "Letter spacing is not 10 in middle" );
+	}, 500);
+	
+});


### PR DESCRIPTION
CSS/Effects: Extending cssHooks to have a .map property to map non-numeric values (like 'normal') to numeric values so they can animate - +1 unit test for #8627 - Fixes #8627

http://bugs.jquery.com/ticket/8627
