### PR TITLE
Ruby-like shortcuts for map()

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -282,7 +282,27 @@ jQuery.fn = jQuery.prototype = {
 	},
 
 	map: function( callback ) {
-		return this.pushStack( jQuery.map(this, function( elem, i ) {
+		var args = arguments;
+
+		return this.pushStack(jQuery.map(this, function( elem, i ) {
+			if (typeof callback == 'string') {
+				var argsToPassFurther =  Array.prototype.slice.call(args, 1);
+
+				if (elem[callback] != undefined) {
+					if (jQuery.isFunction(elem[callback])) {
+						return elem[callback].apply(elem, argsToPassFurther);
+					} else {
+						return elem[callback];
+					}
+				} else if (callback.substr(0,1) == '$') {
+					var method = callback.substr(1);
+
+					if (jQuery.isFunction(jQuery.fn[method])) {
+						return jQuery.fn[method].apply(jQuery(elem), argsToPassFurther);
+					}
+				}
+			}
+
 			return callback.call( elem, i, elem );
 		}));
 	},

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -653,7 +653,25 @@ test("first()/last()", function() {
 });
 
 test("map()", function() {
-	expect(8);
+	expect(11);
+
+	same(
+		jQuery("#ap a").map('id'),
+		jQuery("#ap a").map(function(){ return this.id; }),
+		"DOM property name instead of callback"
+	);
+
+	same(
+		jQuery("#ap a").map('getAttribute', 'id'),
+		jQuery("#ap a").map(function(){ return this.getAttribute('id'); }),
+		"DOM method name instead of callback"
+	);
+
+	same(
+		jQuery("#ap a").map('$attr', 'id'),
+		jQuery("#ap a").map(function(){ return this.getAttribute('id'); }),
+		"jQuery method name prefixed with '$' instead of callback"
+	);
 
 	same(
 		jQuery("#ap").map(function(){


### PR DESCRIPTION
Hello,

I've put together a couple of tweaks to the map() method to allow for Ruby-like shortcuts. For example, to collect IDs from the selected elements you can say one of these:

```
$(selector).map('id');
$(selector).map('getAttribute', 'id');
$(selector).map('$attr', 'id');
```

I hope this is useful.
