### PR TITLE
Minor bugfix for evalScript, which was triggering $.ajax()'s cache-busting

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -751,6 +751,7 @@ function evalScript( i, elem ) {
 		jQuery.ajax({
 			url: elem.src,
 			async: false,
+			cache: true,
 			dataType: "script"
 		});
 	} else {


### PR DESCRIPTION
Cache AJAX requests in evalScript, to more-closely approximate the behaviour of DOM insertion
