### PR TITLE
Fixes #9279. Resets liveFired in withinElement.

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -654,7 +654,8 @@ var withinElement = function( event ) {
 	// Check if mouse(over|out) are still within the same parent element
 	var related = event.relatedTarget,
 		inside = false,
-		eventType = event.type;
+		eventType = event.type,
+		eventLiveFired = event.liveFired;
 
 	event.type = event.data;
 
@@ -669,6 +670,7 @@ var withinElement = function( event ) {
 			jQuery.event.handle.apply( this, arguments );
 
 			event.type = eventType;
+			event.liveFired = eventLiveFired;
 		}
 	}
 },

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -2212,6 +2212,23 @@ test("custom events with colons (#3533, #8272)", function() {
 
 });
 
+test("mouseenter/mouseleave delegates do not interfere with mouseover/mouseout delegates (#9279)", function() {
+	expect(1);
+
+	var count = 0,
+		$div = jQuery("<div><a class='test1' /><a class='test2' /></div>");
+	$div.delegate( "a.test1", "mouseenter mouseleave", function(e) {
+		ok( false, "This assertion shouldn't be reached");
+	});
+	$div.delegate( "a.test2", "mouseover mouseout", function(e) {
+		count++;
+	});
+
+	jQuery ( "a.test2", $div).trigger("mouseover").trigger("mouseout");
+	$div.remove();
+	equals( count, 2, "make sure delegate handles mouseover and mouseout");
+});
+
 (function(){
 	// This code must be run before DOM ready!
 	var notYetReady, noEarlyExecution,


### PR DESCRIPTION
Fixes #9279. Resets liveFired in withinElement so a live handler for a mouseenter doesn't prevent a live handler for a mouseover from firing (and similarly for mouseleave and mouseout). The test in this check-in should work in jQuery 1.5 and edge with this commit but not vanilla edge.

I'm new to the jQuery source code, but this bug was blocking our production code from upgrading to 1.6.2 and I took a stab at it. Let me know if I've done something horribly wrong. :D
