### PR TITLE
input type=datetime-local (ajax doesn't support it, yet)

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -5,7 +5,7 @@ var r20 = /%20/g,
 	rCRLF = /\r?\n/g,
 	rhash = /#.*$/,
 	rheaders = /^(.*?):[ \t]*([^\r\n]*)\r?$/mg, // IE leaves an \r character at EOL
-	rinput = /^(?:color|date|datetime|email|hidden|month|number|password|range|search|tel|text|time|url|week)$/i,
+	rinput = /^(?:color|date|datetime|datetime-local|email|hidden|month|number|password|range|search|tel|text|time|url|week)$/i,
 	// #7653, #8125, #8152: local protocol detection
 	rlocalProtocol = /^(?:about|app|app\-storage|.+\-extension|file|res|widget):$/,
 	rnoContent = /^(?:GET|HEAD)$/,


### PR DESCRIPTION
html5 knows datetime-local as input-type, too, but in ajax.js, there wasn't any support in jquery.

http://www.w3.org/TR/html-markup/input.datetime-local.html
