### PR TITLE
Fixes #9381.

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -408,7 +408,7 @@ jQuery.fx.prototype = {
 
 		t.elem = this.elem;
 
-		if (requestAnimationFrame) {
+		if ( requestAnimationFrame ) {
 			setTimeout(fx.tick, this.options.duration);
 		}
 


### PR DESCRIPTION
Please contact me if you hav any issues with this patch. I'd like to discuss it further.

I don't see this changing animation behavior in any significant way other than addressing the above issue.

I'd predict (thought I'm not an expert) that firing a single "setTimeout" request per animation fired should result in at worst a marginal performance cost. However, I'd love to see any benchmarks that will confirm this or prove me wrong. Does anyone have a set of benchmarks measuring helpful for measuring either FPS or CPU consumption when using jQuery's animate functions?
