### PR TITLE
New Flag: jQuery.support.raf - Allow disabling requestAnimationFrame for people having issues with #9381

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -1,10 +1,11 @@
 (function( jQuery ) {
 
-var elemdisplay = {},
+var timerId,
+	fxNow,
+	elemdisplay = {},
 	iframe, iframeDoc,
 	rfxtypes = /^(?:toggle|show|hide)$/,
 	rfxnum = /^([+\-]=)?([\d+.\-]+)([a-z%]*)$/i,
-	timerId,
 	fxAttrs = [
 		// height animations
 		[ "height", "marginTop", "marginBottom", "paddingTop", "paddingBottom" ],
@@ -13,10 +14,12 @@ var elemdisplay = {},
 		// opacity animations
 		[ "opacity" ]
 	],
-	fxNow,
 	requestAnimationFrame = window.webkitRequestAnimationFrame ||
 		window.mozRequestAnimationFrame ||
-		window.oRequestAnimationFrame;
+		window.oRequestAnimationFrame,
+	support = jQuery.support;
+
+support.raf = !!requestAnimationFrame;
 
 jQuery.fn.extend({
 	show: function( speed, easing, callback ) {
@@ -410,7 +413,7 @@ jQuery.fx.prototype = {
 
 		if ( t() && jQuery.timers.push(t) && !timerId ) {
 			// Use requestAnimationFrame instead of setInterval if available and not disabled
-			if ( fx.raf && requestAnimationFrame ) {
+			if ( support.raf && requestAnimationFrame ) {
 				timerId = 1;
 				raf = function() {
 					// When timerId gets set to null at any point, this stops
@@ -558,9 +561,7 @@ jQuery.extend( jQuery.fx, {
 				fx.elem[ fx.prop ] = fx.now;
 			}
 		}
-	},
-	// if request animation frame is available, default to using it
-	raf: !!requestAnimationFrame
+	}
 });
 
 if ( jQuery.expr && jQuery.expr.filters ) {


### PR DESCRIPTION
Effects: Adding `jQuery.support.raf` boolean to allow disabling the use of requestAnimationFrame to allow people to work around #9381

http://jqbug.com/9381

Just submitting for some discussion.  The general idea here is you would set `jQuery.support.raf = false` in a codebase where you haven't gotten around to properly implementing design patterns necessary to avoid queuing new animations while they aren't running.

I feel that no matter how much we try to educate the best practices mentioned in the ticket, there will still be situations where the end user can't manage to set up the animation queueing properly.

As coded, this flag can not be changed while animations are running, and thus, should only be set once (and only to false) before any animations are queued.

It is likely possible to replace the current `requestAnimationFrame` & `setInterval` code with a ["recursive setTimeout pattern"](http://www.erichynds.com/javascript/a-recursive-settimeout-pattern/) that more closely approximates the rAF implementations.  If we were to do that, you could actually probably shorten the whole thing quite effectively, and allow toggling this flag while running.
