### PR TITLE
Calling $.get() / $.post() without a callback argument

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -269,6 +269,10 @@ jQuery.each( [ "get", "post" ], function( i, method ) {
 			type = type || callback;
 			callback = data;
 			data = undefined;
+		// shift arguments if callback argument was omitted
+		} else if ( typeof callback === 'string') {
+			type = callback;
+			callback = undefined;
 		}
 
 		return jQuery.ajax({


### PR DESCRIPTION
Since I find the Promise interface that's implemented by jqXHR much cleaner,  I'm changing some of my code to start working with that instead of passing a callback as an argument. One thing I noticed while doing that, is that `$.get()` and `$.post()` doesn't support passing an dataType argument when the callback is omitted (`$.get(url, data, dataType)` signature). That commit fixes that.

I also wanted to add support for `$.get(url, dataType)` signature, but its impossible because there's no way to tell if the second argument is the data or the dataType, as they can both be strings. Its still better after this change tho, as you'll need to `$.get(url, null, dataType)` instead of `$.get(url, null, null, dataType)`.

If you choose not to add support for that, please add a comment in the docs to reflect that. Maybe even change the function signature description to `jQuery.get( url, [data,] [success(data, textStatus, jqXHR), [dataType] ] )` ?
