### PR TITLE
Support data attributes with single letters and numbers in the name

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -45,7 +45,7 @@ var jQuery = function( selector, context ) {
 	rmozilla = /(mozilla)(?:.*? rv:([\w.]+))?/,
 
 	// Matches dashed string for camelizing
-	rdashAlpha = /-([a-z])/ig,
+	rdashAlphaNumeric = /-([a-z]|[0-9])/ig,
 
 	// Used by jQuery.camelCase as callback to replace()
 	fcamelCase = function( all, letter ) {
@@ -593,7 +593,7 @@ jQuery.extend({
 	// Converts a dashed string to camelCased string;
 	// Used by both the css and data modules
 	camelCase: function( string ) {
-		return string.replace( rdashAlpha, fcamelCase );
+		return string.replace( rdashAlphaNumeric, fcamelCase );
 	},
 
 	nodeName: function( elem, name ) {

--- a/src/data.js
+++ b/src/data.js
@@ -1,7 +1,9 @@
 (function( jQuery ) {
 
 var rbrace = /^(?:\{.*\}|\[.*\])$/,
-	rmultiDash = /([a-z])([A-Z])/g;
+	rnumberDash = /([a-z])([0-9])/g,
+	rsingleLetterDash = /([A-Z])([A-Z])/g,
+	rmultiDash = /([a-z]|[0-9])([A-Z])/g;
 
 jQuery.extend({
 	cache: {},
@@ -287,7 +289,8 @@ function dataAttr( elem, key, data ) {
 	// If nothing was found internally, try to fetch any
 	// data from the HTML5 data-* attribute
 	if ( data === undefined && elem.nodeType === 1 ) {
-		var name = "data-" + key.replace( rmultiDash, "$1-$2" ).toLowerCase();
+		var replacer = "$1-$2";
+		var name = "data-" + key.replace( rmultiDash, replacer ).replace( rsingleLetterDash, replacer ).replace( rnumberDash, replacer ).toLowerCase();
 
 		data = elem.getAttribute( name );
 

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -1109,10 +1109,14 @@ test("jQuery.camelCase()", function() {
 
 	var tests = {
 		"foo-bar": "fooBar", 
-		"foo-bar-baz": "fooBarBaz"
+		"foo-bar-baz": "fooBarBaz",
+		"foo-f-bar-b": "fooFBarB",
+		"f-foo": "fFoo",
+		"foo-2-bar-3": "foo2Bar3",
+		"2-foo-bar": "2FooBar"
 	};
 
-	expect(2);
+	expect(6);
 
 	jQuery.each( tests, function( key, val ) {
 		equal( jQuery.camelCase( key ), val, "Converts: " + key + " => " + val );

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -298,10 +298,10 @@ test(".data(String) and .data(String, Object)", function() {
 });
 
 test("data-* attributes", function() {
-	expect(37);
+	expect(45);
 	var div = jQuery("<div>"),
-		child = jQuery("<div data-myobj='old data' data-ignored=\"DOM\" data-other='test'></div>"),
-		dummy = jQuery("<div data-myobj='old data' data-ignored=\"DOM\" data-other='test'></div>");
+		child = jQuery("<div data-myobj='old data' data-ignored=\"DOM\" data-other='test' data-point-2='yes' data-12-numbers-first='yes' data-numbers-123-middle='yes' data-single-o-letter='yes'></div>"),
+		dummy = jQuery("<div data-myobj='old data' data-ignored=\"DOM\" data-other='test' data-point-2='yes' data-12-numbers-first='yes' data-numbers-123-middle='yes' data-single-o-letter='yes'></div>");
 
 	equals( div.data("attr"), undefined, "Check for non-existing data-attr attribute" );
 
@@ -325,13 +325,13 @@ test("data-* attributes", function() {
 	child.data("ignored", "cache");
 	equals( child.data("ignored"), "cache", "Cached data used before DOM data-* fallback");
 
-	var obj = child.data(), obj2 = dummy.data(), check = [ "myobj", "ignored", "other" ], num = 0, num2 = 0;
+	var obj = child.data(), obj2 = dummy.data(), check = [ "myobj", "ignored", "other", "12NumbersFirst", "numbers123Middle", "singleOLetter", "point2" ], num = 0, num2 = 0;
 
 	dummy.remove();
 
 	for ( var i = 0, l = check.length; i < l; i++ ) {
-		ok( obj[ check[i] ], "Make sure data- property exists when calling data-." );
-		ok( obj2[ check[i] ], "Make sure data- property exists when calling data-." );
+		ok( obj[ check[i] ], "Make sure data-" + check[i] + " property exists when calling data-." );
+		ok( obj2[ check[i] ], "Make sure data-" + check[i] + " property exists when calling data-." );
 	}
 
 	for ( var prop in obj ) {
@@ -357,9 +357,9 @@ test("data-* attributes", function() {
 		.attr("data-point", "5.5")
 		.attr("data-pointe", "5.5E3")
 		.attr("data-pointbad", "5..5")
-		.attr("data-pointbad2", "-.")
+		.attr("data-pointbad-2", "-.")
 		.attr("data-badjson", "{123}")
-		.attr("data-badjson2", "[abc]")
+		.attr("data-badjson-2", "[abc]")
 		.attr("data-empty", "")
 		.attr("data-space", " ")
 		.attr("data-null", "null")


### PR DESCRIPTION
This fixes [9318](http://bugs.jquery.com/ticket/9318) and the related [9487](http://bugs.jquery.com/ticket/9487).

However I think there may be need for further discussion.  This change makes camel casing work in a way that makes it impossible to distinguish between `data-foo-2` and `data-foo2`, since they will now both be `foo2` when camel cased.

I'm not sure what the best approach is for this, should the dash remain in the case of numbers so that `data-foo-2` becomes `foo-2` and `data-foo2` becomes `foo2`?
