### PR TITLE
Wrap obj.constructor test in try/catch. Thanks to bkrausz. Fixes #9897

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -500,10 +500,15 @@ jQuery.extend({
 			return false;
 		}
 
-		// Not own constructor property must be Object
-		if ( obj.constructor &&
-			!hasOwn.call(obj, "constructor") &&
-			!hasOwn.call(obj.constructor.prototype, "isPrototypeOf") ) {
+		try {
+			// Not own constructor property must be Object
+			if ( obj.constructor &&
+				!hasOwn.call(obj, "constructor") &&
+				!hasOwn.call(obj.constructor.prototype, "isPrototypeOf") ) {
+				return false;
+			}
+		} catch ( e ) {
+			// IE8,9 Will throw exceptions on certain host objects #9897
 			return false;
 		}
 

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -290,7 +290,7 @@ test("type", function() {
 });
 
 test("isPlainObject", function() {
-	expect(14);
+	expect(15);
 
 	stop();
 
@@ -330,6 +330,13 @@ test("isPlainObject", function() {
 
 	// Window
 	ok(!jQuery.isPlainObject(window), "window");
+
+	try {
+		jQuery.isPlainObject( window.location );
+		ok( true, "Does not throw exceptions on host objects");
+	} catch ( e ) {
+		ok( false, "Does not throw exceptions on host objects -- FAIL");
+	}
 
 	try {
 		var iframe = document.createElement("iframe");


### PR DESCRIPTION
No significant performance difference to be seen:

http://jsperf.com/isplainobject-with-try-catch-junk

Passing in all supported browsers
