### PR TITLE
Only unbind all matching handlers if passed handler is undefined. Fixes #9959

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -204,12 +204,14 @@ jQuery.event = {
 			}
 
 			if ( !handler ) {
-				for ( j = 0; j < eventType.length; j++ ) {
-					handleObj = eventType[ j ];
+				if ( typeof handler === "undefined" ) {
+					for ( j = 0; j < eventType.length; j++ ) {
+						handleObj = eventType[ j ];
 
-					if ( all || namespace.test( handleObj.namespace ) ) {
-						jQuery.event.remove( elem, origType, handleObj.handler, j );
-						eventType.splice( j--, 1 );
+						if ( all || namespace.test( handleObj.namespace ) ) {
+							jQuery.event.remove( elem, origType, handleObj.handler, j );
+							eventType.splice( j--, 1 );
+						}
 					}
 				}
 


### PR DESCRIPTION
Only unbind all matching handlers if passed handler is undefined -- #9959 (http://bugs.jquery.com/ticket/9959)
