### PR TITLE
Check body existence before referencing its properties (fixes Nokia error)

### DIFF
--- a/src/dimensions.js
+++ b/src/dimensions.js
@@ -38,9 +38,10 @@ jQuery.each([ "Height", "Width" ], function( i, name ) {
 		if ( jQuery.isWindow( elem ) ) {
 			// Everyone else use document.documentElement or document.body depending on Quirks vs Standards mode
 			// 3rd condition allows Nokia support, as it supports the docElem prop but not CSS1Compat
-			var docElemProp = elem.document.documentElement[ "client" + name ];
+			var docElemProp = elem.document.documentElement[ "client" + name ],
+				body = elem.document.body;
 			return elem.document.compatMode === "CSS1Compat" && docElemProp ||
-				elem.document.body[ "client" + name ] || docElemProp;
+				body && body[ "client" + name ] || docElemProp;
 
 		// Get document width or height
 		} else if ( elem.nodeType === 9 ) {


### PR DESCRIPTION
Make sure body is defined before attempting to access its properties. This check prevents an error from occurring when the width() or height() methods are called before the body is defined in browsers that return false on the first condition and proceed on to the second. For example, simply calling $( window ).width() from a script in the HEAD will throw an error in Nokia webkit browsers without this check in place.
