### PR TITLE
Prevent IE from crashing when clicking VML nodes

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -265,7 +265,7 @@ jQuery.event = {
 			}
 		}
 	},
-	
+
 	// Events that are safe to short-circuit if no handlers are attached.
 	// Native DOM events should not be added, they may have inline handlers.
 	customEvent: {
@@ -311,7 +311,7 @@ jQuery.event = {
 		event.exclusive = exclusive;
 		event.namespace = namespaces.join(".");
 		event.namespace_re = new RegExp("(^|\\.)" + namespaces.join("\\.(?:.*\\.)?") + "(\\.|$)");
-		
+
 		// triggerHandler() and global events don't bubble or run the default action
 		if ( onlyHandlers || !elem ) {
 			event.preventDefault();
@@ -402,7 +402,7 @@ jQuery.event = {
 				jQuery.event.triggered = undefined;
 			}
 		}
-		
+
 		return event.result;
 	},
 
@@ -470,8 +470,11 @@ jQuery.event = {
 			event.target = event.srcElement || document;
 		}
 
+    var nodeType;
+    try { nodeType = event.target.nodeType } catch( ieError ) { /* IE exception for accessing non-existent DOM properties of VML nodes */ }
+
 		// check if target is a textnode (safari)
-		if ( event.target.nodeType === 3 ) {
+		if ( nodeType === 3 ) {
 			event.target = event.target.parentNode;
 		}
 


### PR DESCRIPTION
This issues seems to be in the same vein as #7071, addressed by pull request #434. When you click a VML node in IE, an exception occurs. This does not involve the VML node having an event binding, just that you click it. It has to do with how IE handles accessing non-existent properties of DOM nodes. Instead of returning `undefined`, it throws an exception. Catching the exception prevents IE from crashing.
