### PR TITLE
Fixes #9572. Don't camelize the `-ms-` prefix because Microsoft didn't. A

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -47,6 +47,7 @@ var jQuery = function( selector, context ) {
 
 	// Matches dashed string for camelizing
 	rdashAlpha = /-([a-z]|[0-9])/ig,
+	rmsPrefix = /^-ms-/,
 
 	// Used by jQuery.camelCase as callback to replace()
 	fcamelCase = function( all, letter ) {
@@ -590,10 +591,10 @@ jQuery.extend({
 		}
 	},
 
-	// Converts a dashed string to camelCased string;
-	// Used by both the css and data modules
+	// Convert dashed to camelCase; used by the css and data modules
+	// Microsoft forgot to hump their vendor prefix (#9572)
 	camelCase: function( string ) {
-		return string.replace( rdashAlpha, fcamelCase );
+		return string.replace(rmsPrefix, "ms-").replace( rdashAlpha, fcamelCase );
 	},
 
 	nodeName: function( elem, name ) {

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -1129,10 +1129,15 @@ test("jQuery.camelCase()", function() {
 
 	var tests = {
 		"foo-bar": "fooBar",
-		"foo-bar-baz": "fooBarBaz"
+		"foo-bar-baz": "fooBarBaz",
+		"girl-u-want": "girlUWant",
+		"the-4th-dimension": "the4thDimension",
+		"-o-tannenbaum": "OTannenbaum",
+		"-moz-illa": "MozIlla",
+		"-ms-take": "msTake"
 	};
 
-	expect(2);
+	expect(7);
 
 	jQuery.each( tests, function( key, val ) {
 		equal( jQuery.camelCase( key ), val, "Converts: " + key + " => " + val );


### PR DESCRIPTION
Fixes #9572. Don't camelize the `-ms-` prefix because Microsoft didn't. Also affects `-ms-*` `.data()` names, but that is probably OK since we may be storing CSS names in data. That's my excuse and I'm sticking to it.
