### PR TITLE
$.inArray crushes IE6 and Chrome if second argument is `null` or `undefined`

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -678,8 +678,7 @@ jQuery.extend({
 	},
 
 	inArray: function( elem, array ) {
-		if (!jQuery.isArray(array))
-		{
+		if ( !array ) {
 			return -1;
 		}
 

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -916,6 +916,16 @@ test("jQuery.makeArray", function(){
 	same( jQuery.makeArray({length: "5"}), [], "Make sure object is coerced properly.");
 });
 
+test("jQuery.inArray", function(){
+	expect(3);
+
+	equals( jQuery.inArray( 0, false ), -1 , "Search in 'false' as array returns -1 and doesn't throw exception" );
+
+	equals( jQuery.inArray( 0, null ), -1 , "Search in 'null' as array returns -1 and doesn't throw exception" );
+
+	equals( jQuery.inArray( 0, undefined ), -1 , "Search in 'undefined' as array returns -1 and doesn't throw exception" );
+});
+
 test("jQuery.isEmptyObject", function(){
 	expect(2);
 


### PR DESCRIPTION
$.inArray crushes IE6 and Chrome if second argument is `null` or `undefined`, but in Firefox and Opera native functions returns `-1`.

Appended patch unifies $.inArray behavior and avoids JS-engine from crush.

Here is a test page:

``` html
<!DOCTYPE html>
<html>
<head>
  <title>$.inArray test</title>
  <script src="/dist/jquery.js" type="text/javascript"></script>
</head>
<body>
  <div id="console"></div>
  <script>
    function print(text)
    {
      document.getElementById('console').innerHTML += text + '<br />';
    }

    function checkInArray(value, array)
    {
      try {
        return 'Ok. Result: ' + $.inArray(value, array) + '<br />';
      }
      catch (e) {
        return 'Error ' + e.message + '<br />';
      }
    }

    print('Value in array');
    print(checkInArray(1, [1]));

    print('Value in empty array');
    print(checkInArray(1, []));

    print('Value in object');
    print(checkInArray(1, {1: 2, 2: 1}));

    print('Value in string');
    print(checkInArray(1, 'string'));

    print('Value in int');
    print(checkInArray(1, 'int'));

    print('Value in false');
    print(checkInArray(1, false));

    print('Value in undefined');
    print(checkInArray(1, undefined));

    print('Value in null');
    print(checkInArray(1, null));
  </script>
</body>
</html>
```
