### PR TITLE
Fix removeData for case when cache is a frame's window

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -189,9 +189,9 @@ jQuery.extend({
 		var internalCache = cache[ id ][ internalKey ];
 
 		// Browsers that fail expando deletion also refuse to delete expandos on
-		// the window, but it will allow it on all other JS objects; other browsers
-		// don't care
-		if ( jQuery.support.deleteExpando || cache != window ) {
+		// the window (or any iframe window), but it will allow it on all other JS objects; 
+		// other browsers don't care
+		if ( jQuery.support.deleteExpando || !jQuery.isWindow( cache ) ) {
 			delete cache[ id ];
 		} else {
 			cache[ id ] = null;

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -392,6 +392,7 @@ test("bind(), iframes", function() {
 	}).click().unbind("click");
 });
 
+
 test("bind(), trigger change on select", function() {
 	expect(5);
 	var counter = 0;
@@ -2207,6 +2208,18 @@ test("custom events with colons (#3533, #8272)", function() {
 	};
 	tab.remove();
 
+});
+
+test("unload with iframes", function(){
+	expect(1)
+	stop()
+	var frame = jQuery("#loadediframe");
+	jQuery(frame[0].contentWindow).bind("unload", function(){
+		ok(true, "called unload")
+		start();
+	})
+	// change the url to trigger unload
+	frame.attr("src", "data/iframe.html?param=true")
 });
 
 (function(){


### PR DESCRIPTION
See http://bugs.jquery.com/ticket/10080.  The test case in this commit currently breaks in IE8, but works in other browsers.  The change in removeData fixes it by ensuring the cache is not any window object.
