### PR TITLE
Ticket #5479. Enhancement of removeAttr()

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -363,11 +363,11 @@ jQuery.extend({
 	},
 
 	removeAttr: function( elem, value ) {
-		var propName,attrNames,name;
+		var propName, attrNames, name;
 		if ( elem.nodeType === 1 ) {
 			attrNames = (value || "").split( rspace );
 			
-			for ( i = 0, l = attrNames.length; i < l; i++ ) {
+			for ( var i = 0, l = attrNames.length; i < l; i++ ) {
 				name = jQuery.attrFix[ attrNames[ i ] ] || attrNames[ i ];
 			
 				if ( jQuery.support.getSetAttribute ) {


### PR DESCRIPTION
removeAttr() now behaves like removeClass() in that it can remove multiple attributes instead of just one. Ticket #5479
