### PR TITLE
Fixes #10098. Avoid a slashy-starry char sequence.

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -45,7 +45,7 @@ var r20 = /%20/g,
 	ajaxLocParts,
 	
 	// Avoid comment-prolog char sequence (#10098); must appease lint and evade compression
-	allTypes = "*/".concat("*");
+	allTypes = ["*/"] + ["*"];
 
 // #8138, IE may throw an exception when accessing
 // a field from window.location if document.domain has been set


### PR DESCRIPTION
Fixes #10098. Avoid a slashy-starry char sequence in literal strings to evade faulty script compressors. T-Mobile in particular has a compressor that causes this problem. String.concat was used because backslash-encoded characters are detected/bitched/converted by jslint and simple "+" is precomputed by uglify.js compression.
