### PR TITLE
Fixes #9521. Prioritize #id over <tag> to avoid XSS via location.hash.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -16,8 +16,8 @@ var jQuery = function( selector, context ) {
 	rootjQuery,
 
 	// A simple way to check for HTML strings or ID strings
-	// (both of which we optimize for)
-	quickExpr = /^(?:[^<]*(<[\w\W]+>)[^>]*$|#([\w\-]*)$)/,
+	// Prioritize #id over <tag> to avoid XSS via location.hash (#9521)
+	quickExpr = /^(?:[^#<]*(<[\w\W]+>)[^>]*$|#([\w\-]*)$)/,
 
 	// Check if a string has a non-whitespace character in it
 	rnotwhite = /\S/,

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -467,6 +467,24 @@ test("isXMLDoc - HTML", function() {
 	document.body.removeChild( iframe );
 });
 
+test("XSS via location.hash", function() {
+	expect(1);
+	
+	stop();
+	jQuery._check9521 = function(x){
+		ok( x, "script called from #id-like selector with inline handler" );
+		jQuery("#check9521").remove();
+		delete jQuery._check9521;
+		start();
+	};
+	try {
+		// This throws an error because it's processed like an id
+		jQuery( '#<img id="check9521" src="no-such-.gif" onerror="jQuery._check9521(false)">' ).appendTo("#qunit-fixture");
+	} catch (err) {
+		jQuery._check9521(true);
+	};
+});
+
 if ( !isLocal ) {
 test("isXMLDoc - XML", function() {
 	expect(3);


### PR DESCRIPTION
Test had to be async, unfortunately. This patch causes Sizzle to reject a string like `"#<img ...>"` by throwing an error: "Syntax error, unrecognized expression: <" which is probably a good thing since this is a security issue.
