### PR TITLE
Bugfix in Webkit browsers

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -178,7 +178,7 @@ jQuery.fn.extend({
 
 			try { 
 				// first try use innerHTML
-				elem.innerHTML = '';
+				elem.innerHTML = "";
 			} catch(e) {
 				// Remove any remaining nodes
 				while ( elem.firstChild ) {


### PR DESCRIPTION
Line 5663: Bugfix in Webkit browsers when use jQuery empty function (demo only valid for Webkit http://goo.gl/zow5W)
