### PR TITLE
Save some bytes by using unquoted attribute values in the innerHTML

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -24,8 +24,7 @@ jQuery.support = (function() {
 
 	// Preliminary tests
 	div.setAttribute("className", "t");
-	div.innerHTML = "   <link><table></table><a href='/a' style='top:1px;float:left;opacity:.55;'>a</a><input type=checkbox>";
-
+	div.innerHTML = "   <link><table></table><a href=/a style=top:1px;float:left;opacity:.55>a</a><input type=checkbox>";
 
 	all = div.getElementsByTagName( "*" );
 	a = div.getElementsByTagName( "a" )[ 0 ];


### PR DESCRIPTION
Save some bytes by omitting the trailing semicolon in the @style attribute value. Also, both `/a` and `top:1px;float:left;opacity:.55` are valid unquoted attribute values in HTML:

http://mothereffingunquotedattributes.com/#%2Fa
http://mothereffingunquotedattributes.com/#top%3A1px%3Bfloat%3Aleft%3Bopacity%3A.55

So get rid of the quotes.

This breaks in XHTML though.
