### PR TITLE
Reverts broken support string. Fixes #10197

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -24,7 +24,7 @@ jQuery.support = (function() {
 
 	// Preliminary tests
 	div.setAttribute("className", "t");
-	div.innerHTML = "   <link><table></table><a href='/a' style='top:1px;float:left;opacity:.55;'>a</a><input type=checkbox>";
+	div.innerHTML = "   <link/><table></table><a href='/a' style='top:1px;float:left;opacity:.55;'>a</a><input type='checkbox'/>";
 
 
 	all = div.getElementsByTagName( "*" );


### PR DESCRIPTION
To avoid breaking in xhtml/xml doctypes, element markup should always be correctly closed. 

See: http://bugs.jquery.com/ticket/10197
