### PR TITLE
Fix #10208. Check for `button` as well as `input`

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -702,8 +702,9 @@ if ( !jQuery.support.submitBubbles ) {
 		setup: function( data, namespaces ) {
 			if ( !jQuery.nodeName( this, "form" ) ) {
 				jQuery.event.add(this, "click.specialSubmit", function( e ) {
+					// Avoid triggering error on non-existent type attribute in IE VML (#7071)
 					var elem = e.target,
-						type = jQuery.nodeName( elem, "input" ) ? elem.type : "";
+						type = jQuery.nodeName( elem, "input" ) || jQuery.nodeName( elem, "button" ) ? elem.type : "";
 
 					if ( (type === "submit" || type === "image") && jQuery( elem ).closest("form").length ) {
 						trigger( "submit", this, arguments );
@@ -712,7 +713,7 @@ if ( !jQuery.support.submitBubbles ) {
 
 				jQuery.event.add(this, "keypress.specialSubmit", function( e ) {
 					var elem = e.target,
-						type = jQuery.nodeName( elem, "input" ) ? elem.type : "";
+						type = jQuery.nodeName( elem, "input" ) || jQuery.nodeName( elem, "button" ) ? elem.type : "";
 
 					if ( (type === "text" || type === "password") && jQuery( elem ).closest("form").length && e.keyCode === 13 ) {
 						trigger( "submit", this, arguments );

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -1633,7 +1633,7 @@ test("live with change", function(){
 });
 
 test("live with submit", function() {
-	expect(5);
+	expect(7);
 
 	var count1 = 0, count2 = 0;
 
@@ -1658,6 +1658,10 @@ test("live with submit", function() {
 	jQuery("#testForm input[name=sub1]")[0].click();
 	equals( count1, 2, "Verify form submit." );
 	equals( count2, 2, "Verify body submit." );
+
+	jQuery("#testForm button[name=sub4]")[0].click();
+	equals( count1, 3, "Verify form submit." );
+	equals( count2, 3, "Verify body submit." );
 
 	jQuery("#testForm").die("submit");
 	jQuery("#testForm input[name=sub1]").die("click");


### PR DESCRIPTION
Fix #10208. Check for `button` as well as `input` when performing the #7071 VML crash workaround for IE special-events submit code.
