### PR TITLE
1.7 Remove multiple attributes (Symmetry with removeClass) Combines patches submitted by leeoniya, zertosh and my own tests. Fixes#5479

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -362,18 +362,26 @@ jQuery.extend({
 		}
 	},
 
-	removeAttr: function( elem, name ) {
-		var propName;
+	removeAttr: function( elem, value ) {
+		var propName, attrNames, name, l,
+			i = 0;
+
 		if ( elem.nodeType === 1 ) {
-			name = jQuery.attrFix[ name ] || name;
+			attrNames = (value || "").split( rspace );
+			l = attrNames.length;
 
-			// See #9699 for explanation of this approach (setting first, then removal)
-			jQuery.attr( elem, name, "" );
-			elem.removeAttribute( name );
+			for ( ; i < l; i++ ) {
+				name = attrNames[ i ];
+				name = jQuery.attrFix[ name ] || name;
 
-			// Set corresponding property to false for boolean attributes
-			if ( rboolean.test( name ) && (propName = jQuery.propFix[ name ] || name) in elem ) {
-				elem[ propName ] = false;
+				// See #9699 for explanation of this approach (setting first, then removal)
+				jQuery.attr( elem, name, "" );
+				elem.removeAttribute( name );
+
+				// Set corresponding property to false for boolean attributes
+				if ( rboolean.test( name ) && (propName = jQuery.propFix[ name ] || name) in elem ) {
+					elem[ propName ] = false;
+				}
 			}
 		}
 	},

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -532,6 +532,28 @@ test("prop(String, Object)", function() {
 	jQuery( document ).removeProp("nonexisting");
 });
 
+test("removeAttr(Multi String)", function() {
+	expect(8);
+
+	var div = jQuery("<div id='a' alt='b' title='c' rel='d'></div>"),
+		tests = {
+			id: "a",
+			alt: "b",
+			title: "c",
+			rel: "d"
+		};
+
+	jQuery.each( tests, function( key, val ) {
+		equal( div.attr(key), val, "Attribute `" + key + "` exists, and has a value of `" + val + "`" );
+	});
+
+	div.removeAttr( "id alt title rel" );
+
+	jQuery.each( tests, function( key, val ) {
+		equal( div.attr(key), undefined, "Attribute `" + key + "` was removed" );
+	});
+});
+
 test("prop('tabindex')", function() {
 	expect(8);
 


### PR DESCRIPTION
1.7 Remove multiple attributes (Symmetry with removeClass) Combines patches submitted by leeoniya, zertosh and my own tests. Fixes#5479

I wasn't expecting the whitespaces cleanup, that was free (thanks pre-commit hook). I can redo this if necessary.

This combines and supercedes the following pull requests: 

https://github.com/jquery/jquery/pull/114/

https://github.com/jquery/jquery/pull/472
