### PR TITLE
Adds support for multiplication and division to jQuery's relative-value syntax 

### DIFF
--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -109,13 +109,26 @@ test("css(String|Hash)", function() {
 });
 
 test("css() explicit and relative values", function() {
-	expect(27);
+	expect(32);
 	var $elem = jQuery("#nothiddendiv");
 
-	$elem.css({ width: 1, height: 1, paddingLeft: "1px", opacity: 1 });
+	$elem.css({ width: 1, height: 1, paddingLeft: "1px", opacity: 1, marginTop: 1 });
 	equals( $elem.width(), 1, "Initial css set or width/height works (hash)" );
 	equals( $elem.css("paddingLeft"), "1px", "Initial css set of paddingLeft works (hash)" );
 	equals( $elem.css("opacity"), "1", "Initial css set of opacity works (hash)" );
+	equals( $elem.css("marginTop"), "1px", "Initial css set of marginTop works (hash)" );
+
+	$elem.css({ marginTop: "*=2px" });
+	equals( $elem.css("marginTop"), "2px", "'*=2px' on marginTop (hash)" );
+
+	$elem.css({ marginTop: "*=3px" });
+	equals( $elem.css("marginTop"), "6px", "'*=3px' on marginTop (hash)" );
+
+	$elem.css( "marginTop", "/=3px" );
+	equals( $elem.css("marginTop"), "2px", "'/=3px' on marginTop (params)" );
+
+	$elem.css( "marginTop", "/=2px" );
+	equals( $elem.css("marginTop"), "1px", "'/=2px' on marginTop (params)" );
 
 	$elem.css({ width: "+=9" });
 	equals( $elem.width(), 10, "'+=9' on width (hash)" );


### PR DESCRIPTION
Today, .css() and .animate() support += and -= for setting relative values. However, certain properties (in my case, 2d and 3d scale) are multipliers of each other. It's also helpful to "double" or "half" the current value.

I've included unit tests for the feature, and ensured that all the existing unit tests all pass as well.

For more information, see the associated bug: http://bugs.jquery.com/ticket/10229
