### PR TITLE
Add shorthand functions for more HTTP methods

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -265,7 +265,7 @@ jQuery.each( "ajaxStart ajaxStop ajaxComplete ajaxError ajaxSuccess ajaxSend".sp
 	};
 });
 
-jQuery.each( [ "get", "post" ], function( i, method ) {
+jQuery.each( [ "get", "post", "put", "delete" ], function( i, method ) {
 	jQuery[ method ] = function( url, data, callback, type ) {
 		// shift arguments if data argument was omitted
 		if ( jQuery.isFunction( data ) ) {


### PR DESCRIPTION
In most of my projects now I have to use my own shorthand methods for this. I'm pretty sure it could be useful to many people, plus it adds consistency. More and more people are using all HTTP verbs in their requests with all the RESTful apis coming out, so why not support those in shorthand functions?

http://bugs.jquery.com/ticket/10257
