### PR TITLE
data: Storing internal cache in a separate place

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -154,7 +154,7 @@ jQuery.event = {
 		}
 
 		var ret, type, fn, j, i = 0, all, namespaces, namespace, special, eventType, handleObj, origType,
-			elemData = jQuery.hasData( elem ) && jQuery._data( elem ),
+			elemData = jQuery.hasData( elem, true ) && jQuery._data( elem ),
 			events = elemData && elemData.events;
 
 		if ( !elemData || !events ) {
@@ -321,16 +321,13 @@ jQuery.event = {
 		// Handle a global trigger
 		if ( !elem ) {
 			// TODO: Stop taunting the data cache; remove global events and always attach to document
-			jQuery.each( jQuery.cache, function() {
-				// internalKey variable is just used to make it easier to find
-				// and potentially change this stuff later; currently it just
-				// points to jQuery.expando
-				var internalKey = jQuery.expando,
-					internalCache = this[ internalKey ];
-				if ( internalCache && internalCache.events && internalCache.events[ type ] ) {
-					jQuery.event.trigger( event, data, internalCache.handle.elem );
+			var i,
+				cache = jQuery.internalCache;
+			for ( i in cache ) {
+				if ( cache[ i ].events && cache[ i ].events[ type ] ) {
+					jQuery.event.trigger( event, data, cache[ i ].handle.elem );
 				}
-			});
+			}
 			return;
 		}
 

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -356,15 +356,14 @@ function cloneCopyEvent( src, dest ) {
 		return;
 	}
 
-	var internalKey = jQuery.expando,
-		oldData = jQuery.data( src ),
-		curData = jQuery.data( dest, oldData );
+	// copy standard data
+	jQuery.data( dest, jQuery.data( src ) );
 
-	// Switch to use the internal data object, if it exists, for the next
-	// stage of data copying
-	if ( (oldData = oldData[ internalKey ]) ) {
-		var events = oldData.events;
-				curData = curData[ internalKey ] = jQuery.extend({}, oldData);
+	// copy internal data
+	if ( jQuery.hasData( src, true ) ) {
+		var oldData = jQuery._data( src ),
+			curData = jQuery._data( dest, oldData ),
+			events = oldData.events;
 
 		if ( events ) {
 			delete curData.handle;
@@ -706,7 +705,11 @@ jQuery.extend({
 	},
 
 	cleanData: function( elems ) {
-		var data, id, cache = jQuery.cache, internalKey = jQuery.expando, special = jQuery.event.special,
+		var data, id, 
+			cache = jQuery.cache,
+			internalCache = jQuery.internalCache,
+			internalKey = jQuery.expando,
+			special = jQuery.event.special,
 			deleteExpando = jQuery.support.deleteExpando;
 
 		for ( var i = 0, elem; (elem = elems[i]) != null; i++ ) {
@@ -717,7 +720,7 @@ jQuery.extend({
 			id = elem[ jQuery.expando ];
 
 			if ( id ) {
-				data = cache[ id ] && cache[ id ][ internalKey ];
+				data = internalCache[ id ];
 
 				if ( data && data.events ) {
 					for ( var type in data.events ) {
@@ -738,11 +741,11 @@ jQuery.extend({
 
 				if ( deleteExpando ) {
 					delete elem[ jQuery.expando ];
-
 				} else if ( elem.removeAttribute ) {
 					elem.removeAttribute( jQuery.expando );
 				}
 
+				delete internalCache[ id ];
 				delete cache[ id ];
 			}
 		}

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -10,8 +10,12 @@ function dataTests (elem) {
 	// expect(32)
 
 	function getCacheLength() {
-		var cacheLength = 0;
-		for (var i in jQuery.cache) {
+		var i,
+			cacheLength = 0;
+		for (i in jQuery.cache) {
+			++cacheLength;
+		}
+		for (i in jQuery.internalCache) {
 			++cacheLength;
 		}
 
@@ -52,21 +56,31 @@ function dataTests (elem) {
 	equals( jQuery._data(elem, "foo"), "foo2", "Setting internal data works" );
 	equals( jQuery.data(elem, "foo"), "foo1", "Setting internal data does not override user data" );
 
-	var internalDataObj = jQuery.data(elem, jQuery.expando);
-	strictEqual( jQuery._data(elem), internalDataObj, "Internal data object is accessible via jQuery.expando property" );
+
+	function getInternalDataObject() {
+		if ( elem.nodeType ) {
+			return jQuery.internalCache[ elem[ jQuery.expando ] ];
+		} else {
+			return elem[ jQuery.expando ] && elem[ jQuery.expando ][ jQuery.expando ] || undefined;
+		}
+	}
+
+	var internalDataObj = getInternalDataObject();
+
+	strictEqual( jQuery._data( elem ), internalDataObj, "Internal data object is where expected" );
 	notStrictEqual( dataObj, internalDataObj, "Internal data object is not the same as user data object" );
 
 	strictEqual( elem.boom, undefined, "Data is never stored directly on the object" );
 
-	jQuery.removeData(elem, "foo");
+	jQuery.removeData( elem, "foo" );
 	strictEqual( jQuery.data(elem, "foo"), undefined, "jQuery.removeData removes single properties" );
 
-	jQuery.removeData(elem);
-	strictEqual( jQuery.data(elem, jQuery.expando), internalDataObj, "jQuery.removeData does not remove internal data if it exists" );
+	jQuery.removeData( elem );
+	strictEqual( jQuery._data(elem), internalDataObj, "jQuery.removeData does not remove internal data if it exists" );
 
 	jQuery.removeData(elem, undefined, true);
 
-	strictEqual( jQuery.data(elem, jQuery.expando), undefined, "jQuery.removeData on internal data works" );
+	strictEqual( getInternalDataObject(), undefined, "jQuery.removeData on internal data works" );
 	strictEqual( jQuery.hasData(elem), false, "jQuery.hasData agrees all data has been removed from object" );
 
 	jQuery._data(elem, "foo", "foo2");


### PR DESCRIPTION
Adding a second cache for our 'internal data' to avoid having it show up on `$.fn.data()[ jQuery.expando ]`

This only stores in a separate cache for nodes - plain objects using private data still get the expando treatment.

Fixes #8921 - http://jqbug.com/8921
