### PR TITLE
AJAX: Support for If-Match and If-Unmodified-Since in POST, PUT, and DELETE

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -693,11 +693,20 @@ jQuery.extend({
 		// Set the If-Modified-Since and/or If-None-Match header, if in ifModified mode.
 		if ( s.ifModified ) {
 			ifModifiedKey = ifModifiedKey || s.url;
-			if ( jQuery.lastModified[ ifModifiedKey ] ) {
-				jqXHR.setRequestHeader( "If-Modified-Since", jQuery.lastModified[ ifModifiedKey ] );
+			if ( jQuery.lastModified[ifModifiedKey] ) {
+				// Set appropriate If-Modified-Since request header depending on POST or GET
+				if (s.type === "POST" || type === "PUT" || type === "DELETE")
+					xhr.setRequestHeader("If-Unmodified-Since", jQuery.lastModified[ifModifiedKey]);
+				else
+					xhr.setRequestHeader("If-Modified-Since", jQuery.lastModified[ifModifiedKey]);
 			}
-			if ( jQuery.etag[ ifModifiedKey ] ) {
-				jqXHR.setRequestHeader( "If-None-Match", jQuery.etag[ ifModifiedKey ] );
+
+			if ( jQuery.etag[ifModifiedKey] ) {
+				// Set appropriate If-None-Match request header depending on POST or GET
+				if (type === "POST" || type === "PUT" || type === "DELETE")
+					xhr.setRequestHeader("If-Match", jQuery.etag[ifModifiedKey]);
+				else
+					xhr.setRequestHeader("If-None-Match", jQuery.etag[ifModifiedKey]);
 			}
 		}
 


### PR DESCRIPTION
When using the ifModified attribute in AJAX requests to call for new data is an excellent way of implementing cache control, however this change adds support for POST and other methods that pushes changes to server files only if they have haven't been changed since the last retrieval.
