### PR TITLE
Fixes #10287: AJAX: Implemention of ifModified attribute for pushing changes to server

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -693,16 +693,6 @@ jQuery.extend({
 		// Set the If-Modified-Since and/or If-None-Match header, if in ifModified mode.
 		if ( s.ifModified ) {
 			ifModifiedKey = ifModifiedKey || s.url;
-			if ( jQuery.lastModified[ ifModifiedKey ] ) {
-				jqXHR.setRequestHeader( "If-Modified-Since", jQuery.lastModified[ ifModifiedKey ] );
-			}
-			if ( jQuery.etag[ ifModifiedKey ] ) {
-				jqXHR.setRequestHeader( "If-None-Match", jQuery.etag[ ifModifiedKey ] );
-			}
-		}
-		// Set the If-Modified-Since and/or If-None-Match header, if in ifModified mode.
-		if ( s.ifModified ) {
-			ifModifiedKey = ifModifiedKey || s.url;
 			if ( jQuery.lastModified[ifModifiedKey] ) {
 				// Set appropriate If-Modified-Since request header depending on POST or GET
 				if ( s.type === "POST" || s.type === "PUT" || s.type === "DELETE" )


### PR DESCRIPTION
Hope I did this right lol.

Implements If-Match, and If-Unmodified-Since request headers under POST, POST and DELETE types since If-Modified-Since and If-None-Match are mainly retrieval operations. 

http://bugs.jquery.com/ticket/10287
