### PR TITLE
Minor tweaks

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -157,8 +157,8 @@ jQuery.support = (function() {
 	if ( body ) {
 		jQuery.extend( testElementStyle, {
 			position: "absolute",
-			left: "-999em",
-			top: "-999em"
+			left: "-999px",
+			top: "-999px"
 		});
 	}
 	for ( i in testElementStyle ) {


### PR DESCRIPTION
About the comment: `document.getElementsByTagName('body')[0]` is `undefined` in frameset documents, while `document.body` isn’t. Here’s a quick test to confirm it:

```
data:text/html;charset=utf-8,<!DOCTYPE%20html><html><title>Test</title><frameset><frame%20src=foo%20><frame%20src=bar%20></frameset></html>
```

Then, in your console: `document.body === document.getElementsByTagName('body')[0]; // false`
