### PR TITLE
Fix #7641: .animate() should accept "auto" and "" (empty string) values

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -199,7 +199,16 @@ jQuery.fn.extend({
 				e = new jQuery.fx( this, opt, p );
 				val = prop[ p ];
 
-				if ( rfxtypes.test( val ) ) {
+				if ( val === "auto" || val === "" ) {
+					// We need to compute ending value
+					start = e.cur();
+					jQuery.style( this, p, val );
+					end = e.cur();
+					jQuery.style( this, p, start );
+
+					e.custom( start, end, jQuery.cssNumber[ p ] ? "" : "px", val );
+
+				} else if ( rfxtypes.test( val ) ) {
 					// Tracks whether to show or hide based on private
 					// data attached to the element
 					method = jQuery._data( this, "toggle" + p ) || (val === "toggle" ? hidden ? "show" : "hide" : 0);
@@ -394,13 +403,14 @@ jQuery.fx.prototype = {
 	},
 
 	// Start an animation from one number to another
-	custom: function( from, to, unit ) {
+	custom: function( from, to, unit, eventual ) {
 		var self = this,
 			fx = jQuery.fx;
 
 		this.startTime = fxNow || createFxNow();
 		this.end = to;
 		this.now = this.start = from;
+		this.eventual = eventual;
 		this.pos = this.state = 0;
 		this.unit = unit || this.unit || ( jQuery.cssNumber[ this.prop ] ? "" : "px" );
 
@@ -463,6 +473,11 @@ jQuery.fx.prototype = {
 			this.now = this.end;
 			this.pos = this.state = 1;
 			this.update();
+
+			if ( this.eventual !== undefined ) {
+				// Set final value to null or auto
+				jQuery.style( this.elem, this.prop, this.eventual );
+			}
 
 			options.animatedProperties[ this.prop ] = true;
 

--- a/test/data/testsuite.css
+++ b/test/data/testsuite.css
@@ -123,3 +123,6 @@ body, div { background: url(http://static.jquery.com/files/rocker/images/logo_jq
 
 /* #6652 REMOVE FILTER:ALPHA(OPACITY=100) AFTER ANIMATION */
 #t6652 div { filter: alpha(opacity=50); }
+
+/* #7641 and #9482 animate to auto and null values */
+#qunit-fixture .autoNull { width: 50px; height: 10px; }

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -1153,3 +1153,37 @@ test("callbacks should fire in correct order (#9100)", function() {
 				}
 			});
 });
+
+test( "animate to auto and \"\" (empty string) values (#7641)", function() {
+	expect(8);
+	stop();
+
+	var $div = jQuery( "<div class='autoNull' style='width: 100px;'></div>" ).appendTo("#qunit-fixture"),
+		$span = jQuery( "<span class='autoNull' style='width: 100px;'></span>" ).appendTo("#qunit-fixture");
+	jQuery("#qunit-fixture").css({
+		width: "120px",
+		height: "120px"
+	});
+
+	$div.animate( {width: "auto"}, 13, function() {
+		ok( $div.width() > 100, "computed width of a block element is larger than 100 when width is auto" );
+		equal( jQuery.style( $div[0], "width" ), "auto", "after the animation to auto, the inline width is auto" );
+
+		$div.animate( {width: ""}, 13, function() {
+			equal( $div.width(), 50, "computed width of a block element is equal to its CSS width" );
+			ok( !jQuery.style( $div[0], "width" ), "after the animation to \"\", there is no inline width" );
+		});
+	});
+
+	$span.animate( {width: "auto"}, 13, function() {
+		var width = $span.width();
+		equal( width, 0, "computed width of an inline element is 0 when width is auto" );
+		equal( jQuery.style( $span[0], "width" ), "auto", "after the animation to auto, the inline width is auto" );
+
+		$span.animate( {width: ""}, 13, function() {
+			equal( $span.width(), 50, "computed width of an inline element is equal to its CSS width" );
+			ok( !jQuery.style( $span[0], "width" ), "after the animation to \"\", there is no inline width" );
+			start();
+		});
+	});
+});


### PR DESCRIPTION
This PR fixes a "patchwelcome" bug in 10 short lines of code.
Unit-tests included.  

http://bugs.jquery.com/ticket/7641 (was "patchwelcome", I just reopened it)
