### PR TITLE
New method for validating JSON strings

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -32,12 +32,6 @@ var jQuery = function( selector, context ) {
 	// Match a standalone tag
 	rsingleTag = /^<(\w+)\s*\/?>(?:<\/\1>)?$/,
 
-	// JSON RegExp
-	rvalidchars = /^[\],:{}\s]*$/,
-	rvalidescape = /\\(?:["\\\/bfnrt]|u[0-9a-fA-F]{4})/g,
-	rvalidtokens = /"[^"\\\n\r]*"|true|false|null|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?/g,
-	rvalidbraces = /(?:^|:|,)(?:\s*\[)+/g,
-
 	// Useragent RegExp
 	rwebkit = /(webkit)[ \/]([\w.]+)/,
 	ropera = /(opera)(?:.*version)?[ \/]([\w.]+)/,


### PR DESCRIPTION
The old method for validating JSON is inaccurate and buggy. For example, jQuery.parseJSON("{,}") passes the existing test, and results in a syntax error when trying to eval it. This proposed method actually matches the string against the JSON grammar rather than using a shaky heuristic. This comes at little performance cost, since most of the time spent in this branch of the function is in eval() anyway.
