### PR TITLE
Fix #9945. Swap parent elements visibility recursively to compute real width. 

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -146,19 +146,40 @@ jQuery.extend({
 	// A method for quickly swapping in/out CSS properties to get correct calculations
 	swap: function( elem, options, callback ) {
 		var old = {};
+		var elements = [];
 
-		// Remember the old values, and insert the new ones
-		for ( var name in options ) {
-			old[ name ] = elem.style[ name ];
-			elem.style[ name ] = options[ name ];
+
+		if( typeof arguments[3] !== undefined && arguments[3]){ 
+			elements = jQuery(elem).parents().filter(':not(body)').filter(':not(html)');
+			elements.splice(0,0, elem);
+		} else {
+			elements = elem;
 		}
+
+		jQuery.each(elements, function(i,o){
+			old[i] = {};
+			var swap_options = options;
+
+			// only apply position absolute to the highest level element
+			if ( i < jQuery(elements).size() - 1 && jQuery.inArray('')) {
+				swap_options['position'] = '';
+			}
+
+			// Remember the old values, and insert the new ones
+			for ( var name in swap_options ) {
+				old[i][ name ] = o.style[ name ];
+				o.style[ name ] = options[ name ];
+			}
+		});
 
 		callback.call( elem );
 
-		// Revert the old values
-		for ( name in options ) {
-			elem.style[ name ] = old[ name ];
-		}
+		//Revert the old values
+		jQuery.each(elements, function(i,o){
+			for ( var name in options ) {
+				o.style[ name ] = old[i][ name ];
+			}
+		});
 	}
 });
 
@@ -176,7 +197,7 @@ jQuery.each(["height", "width"], function( i, name ) {
 				} else {
 					jQuery.swap( elem, cssShow, function() {
 						val = getWH( elem, name, extra );
-					});
+					}, true);
 				}
 
 				return val;

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -511,3 +511,31 @@ test("Do not append px to 'fill-opacity' #9548", 1, function() {
 	});
 
 });
+
+test("Wrong width on percentage width elements in hidden divs #9945", function() {
+    	var $select = jQuery( '<select>' )
+    		.append( jQuery( '<option>Option 1</option>' ) )
+    		.css( {'width': '94%', 'border' : '0'});
+    	var $div_container = jQuery( '<div>' )
+    		.appendTo(document.body)
+    		.css( 'display', 'none')
+    		.append( jQuery( '<div>' ).append( $select ) );
+
+
+    	var hidden_widths = [
+                            $select.width(), 
+                            $select.css("width")
+    	                    ];
+    	
+    	$div_container.show();
+
+    	var shown_widths = [
+                            $select.width(), 
+                            $select.css("width")
+    	                    ];
+    		
+	equal( hidden_widths[0], shown_widths[0], 'the $select.width() should be the same if hidden or not' );
+	equal( hidden_widths[1], shown_widths[1], 'the $select.css("width") should be the same if hidden or not' );
+
+	$div_container.remove();
+});


### PR DESCRIPTION
Swap parent elements visibility recursively to compute real width of the element. Fixes #9945
