### PR TITLE
Uses literal array instead of concat and splitting

### DIFF
--- a/src/offset.js
+++ b/src/offset.js
@@ -120,11 +120,13 @@ if ( "getBoundingClientRect" in document.documentElement ) {
 
 jQuery.offset = {};
 
-jQuery.each(
-	( "doesAddBorderForTableAndCells doesNotAddBorder " +
-		"doesNotIncludeMarginInBodyOffset subtractsBorderForOverflowNotVisible " +
-		"supportsFixedPosition" ).split(" "), function( i, prop ) {
-
+jQuery.each([
+	"doesAddBorderForTableAndCells",
+	"doesNotAddBorder",
+	"doesNotIncludeMarginInBodyOffset",
+	"subtractsBorderForOverflowNotVisible",
+	"supportsFixedPosition"
+], function( i, prop ) {
 	jQuery.offset[ prop ] = jQuery.support[ prop ];
 });
 


### PR DESCRIPTION
This is petty, I know, but a literal array does take up less space in this instance. 
