### PR TITLE
Fixes coniditional path for tr, td defaultDisplay() calls. Fixes #10416

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -38,7 +38,7 @@ jQuery.fn.extend({
 					// Set elements which have been overridden with display: none
 					// in a stylesheet to whatever the default browser style is
 					// for such an element
-					if ( display === "none" || (display === ""  && jQuery.css( elem, "display" ) === "none" ) ) {
+					if ( display === "none" || ( display === ""  && jQuery.css( elem, "display" ) === "none" ) ) {
 						jQuery._data(elem, "olddisplay", defaultDisplay(elem.nodeName));
 					}
 				}

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -194,12 +194,12 @@ test("defaultDisplay() correctly determines tr, td display #10416", function() {
 	var tr = "<tr></tr>",
 			td = "<td>new</td>";
 
-	jQuery(tr).append(td).appendTo("#table");
-	jQuery(tr).hide().append(td).appendTo("#table").show();
+	jQuery( tr ).append( td ).appendTo( "#table" );
+	jQuery( tr ).hide().append( td ).appendTo( "#table" ).show();
 
 	equal(
-		jQuery("table").find("tr").eq(1).css("display"),
-		jQuery("table").find("tr").eq(0).css("display"),
+		jQuery( "#table" ).find( "tr" ).eq( 1 ).css( "display" ),
+		jQuery( "#table" ).find( "tr" ).eq( 0 ).css( "display" ),
 		"defaultDisplay() returns correct tr display values"
 	);
 });


### PR DESCRIPTION
Submitting for review.

Tested
- FF3.6.x,7
- Chrome 14
- Safari 5.1
- IE 7
- Opera 11.51

Need help with IE6,8,9... Issues with Browserstack preventing testing
