### PR TITLE
Add jQuery.isPlainObject check to ensure constructed property values are not misinterpretted as objects. Fixes #10466

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -818,7 +818,7 @@ function buildParams( prefix, obj, traditional, add ) {
 			}
 		});
 
-	} else if ( !traditional && obj != null && ( typeof obj === "object" && jQuery.isPlainObject( obj ) ) ) {
+	} else if ( !traditional && jQuery.isPlainObject( obj ) ) {
 		// Serialize object item.
 		for ( var name in obj ) {
 			buildParams( prefix + "[" + name + "]", obj[ name ], traditional, add );

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -1032,13 +1032,16 @@ test("jQuery.param()", function() {
 });
 
 test("jQuery.param() Constructed prop values", function() {
-	expect(2);
+	expect(3);
 
 	var params = {"test": new String("foo") };
-	equal( jQuery.param( params, false ), "test=foo", "Do not mistake String() for a plain object" );
+	equal( jQuery.param( params, false ), "test=foo", "Do not mistake new String() for a plain object" );
 
 	params = {"test": new Number(5) };
-	equal( jQuery.param( params, false ), "test=5", "Do not mistake Number() for a plain object" );
+	equal( jQuery.param( params, false ), "test=5", "Do not mistake new Number() for a plain object" );
+
+	params = {"test": new Date() };
+	ok( jQuery.param( params, false ), "(Non empty string returned) Do not mistake new Date() for a plain object" );
 });
 
 test("synchronous request", function() {


### PR DESCRIPTION
Add jQuery.isPlainObject check to ensure constructed property values are not misinterpretted as objects. Fixes #10466

http://bugs.jquery.com/ticket/10466
