### PR TITLE
.stop( [queue,] clearQueue, gotoEnd )

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -248,7 +248,12 @@ jQuery.fn.extend({
 			this.queue( optall.queue, doAnimation );
 	},
 
-	stop: function( clearQueue, gotoEnd, type ) {
+	stop: function( type, clearQueue, gotoEnd ) {
+		if ( typeof type !== "string" ) {
+			gotoEnd = clearQueue;
+			clearQueue = type;
+			type = undefined;
+		}
 		if ( clearQueue && type !== false ) {
 			this.queue( type || "fx", [] );
 		}

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -659,7 +659,7 @@ test("stop(clearQueue, gotoEnd)", function() {
 	}, 100);
 });
 
-asyncTest( "stop( ..., ..., queue ) - Stop single queues", function() {
+asyncTest( "stop( queue, ..., ... ) - Stop single queues", function() {
 	expect( 3 );
 	var foo = jQuery( "#foo" ),
 		saved;
@@ -681,7 +681,7 @@ asyncTest( "stop( ..., ..., queue ) - Stop single queues", function() {
 	},{
 		duration: 1000,
 		queue: "height"
-	}).dequeue( "height" ).stop( false, true, "height" );
+	}).dequeue( "height" ).stop( "height", false, true );
 
 	equals( foo.height(), 400, "Height was stopped with gotoEnd" );
 
@@ -690,7 +690,7 @@ asyncTest( "stop( ..., ..., queue ) - Stop single queues", function() {
 	},{
 		duration: 1000,
 		queue: "height"
-	}).dequeue( "height" ).stop( false, false, "height" );
+	}).dequeue( "height" ).stop( "height", false, false );
 	saved = foo.height();
 });
 


### PR DESCRIPTION
putting the queueName parameter at the front instead of the end.  accepts strings.
