### PR TITLE
A fix for Ticket #9217 - jQuery crashing in IE.

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -600,7 +600,9 @@ jQuery.extend( jQuery.fx, {
 			if ( fx.elem.style && fx.elem.style[ fx.prop ] != null ) {
 				fx.elem.style[ fx.prop ] = fx.now + fx.unit;
 			} else {
-				fx.elem[ fx.prop ] = fx.now;
+				try {
+					fx.elem[ fx.prop ] = fx.now;
+				} catch (e) { }
 			}
 		}
 	}


### PR DESCRIPTION
This ticket describes a jquery crash in IE when an element being
animated is removed. Unfortunately, this fix uses a try/catch -
probably due to my lack of knowledge of the internals of IE.

From what I can infer, when an element is switched out from under
javascript, it is an error to write to scrollTop; the only way to
know whether it is an error to write to a field as far as I know
is to write to it: thus the try/catch.
