### PR TITLE
Fix #10202. Don't modify data property in ajax, regression from #9682.

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -664,10 +664,10 @@ jQuery.extend({
 		if ( !s.hasContent ) {
 
 			// If data is available, append data to url
-			if ( s.data ) {
+			// Only append once, do not re-append if data is already in url
+			var dataAppendedToUrl = ( new RegExp( "(&|\\?)" + s.data + "(&|$)" ) ).test( s.url );
+			if ( s.data && !dataAppendedToUrl ) {
 				s.url += ( rquery.test( s.url ) ? "&" : "?" ) + s.data;
-				// #9682: remove data so that it's not used in an eventual retry
-				delete s.data;
 			}
 
 			// Get ifModifiedKey before adding the anti-cache parameter

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -323,7 +323,7 @@ test("jQuery.ajax() - responseText on error", function() {
 
 test(".ajax() - retry with jQuery.ajax( this )", function() {
 
-	expect( 2 );
+	expect( 3 );
 
 	stop();
 
@@ -346,6 +346,7 @@ test(".ajax() - retry with jQuery.ajax( this )", function() {
 							previousUrl = this.url;
 						} else {
 							strictEqual( this.url , previousUrl, "url parameters are not re-appended" );
+							strictEqual( this.data, "x=1", "data is not modified" );
 							start();
 							return false;
 						}


### PR DESCRIPTION
This fixes a regression (see [#10202](http://bugs.jquery.com/ticket/10202) for discussion), which was introduced in [#9862](http://bugs.jquery.com/ticket/9682) (present in v1.6.3 and 1.6.4). I included a test and a fix.
