### PR TITLE
RemoveAttr fix for IE6-7 

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -7,6 +7,7 @@ var rclass = /[\n\t\r]/g,
 	rfocusable = /^(?:button|input|object|select|textarea)$/i,
 	rclickable = /^a(?:rea)?$/i,
 	rboolean = /^(?:autofocus|autoplay|async|checked|controls|defer|disabled|hidden|loop|multiple|open|readonly|required|scoped|selected)$/i,
+	getSetAttribute = jQuery.support.getSetAttribute,
 	nodeHook, boolHook, fixSpecified;
 
 jQuery.fn.extend({
@@ -356,8 +357,13 @@ jQuery.extend({
 			for ( ; i < l; i++ ) {
 				name = attrNames[ i ].toLowerCase();
 
-				// See #9699 for explanation of this approach (setting first, then removal)
-				jQuery.attr( elem, name, "" );
+				if ( !getSetAttribute ) {
+					name = jQuery.propFix[ name ] || name;
+				} else {
+					// See #9699 for explanation of this approach (setting first, then removal)
+					jQuery.attr( elem, name, "" );
+				}
+
 				elem.removeAttribute( name );
 
 				// Set corresponding property to false for boolean attributes
@@ -510,7 +516,7 @@ boolHook = {
 };
 
 // IE6/7 do not support getting/setting some attributes with get/setAttribute
-if ( !jQuery.support.getSetAttribute ) {
+if ( !getSetAttribute ) {
 
 	fixSpecified = {
 		name: true,

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -535,21 +535,23 @@ test("prop(String, Object)", function() {
 });
 
 test("removeAttr(Multi String)", function() {
-	expect(8);
+	expect(12);
 
-	var div = jQuery("<div id='a' alt='b' title='c' rel='d'></div>"),
+	var div = jQuery("<div id='a' alt='b' title='c' rel='d' class='e' contenteditable='true'></div>"),
 		tests = {
 			id: "a",
 			alt: "b",
 			title: "c",
-			rel: "d"
+			rel: "d",
+			"class": "e",
+			contentEditable: "true"
 		};
 
 	jQuery.each( tests, function( key, val ) {
 		equal( div.attr(key), val, "Attribute `" + key + "` exists, and has a value of `" + val + "`" );
 	});
 
-	div.removeAttr( "id alt title rel" );
+	div.removeAttr( "id alt title rel class contentEditable" );
 
 	jQuery.each( tests, function( key, val ) {
 		equal( div.attr(key), undefined, "Attribute `" + key + "` was removed" );


### PR DESCRIPTION
For http://bugs.jquery.com/ticket/10482. 
Dont understand why i cant remove attributes such as "class" , "contenteditable" and etc, in IE6-7, In new jQuery. Seems inconsistent to me.
