### PR TITLE
#10531: Remove `layerX` and `layerY`

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -486,7 +486,7 @@ jQuery.event = {
 	},
 
 	mouseHooks: {
-		props: "button buttons clientX clientY fromElement layerX layerY offsetX offsetY pageX pageY screenX screenY toElement wheelDelta".split(" "),
+		props: "button buttons clientX clientY fromElement offsetX offsetY pageX pageY screenX screenY toElement wheelDelta".split(" "),
 		filter: function( event, original ) {
 			var eventDoc, doc, body,
 				button = original.button,


### PR DESCRIPTION
Don’t copy the `layerX` and `layerY` event properties over to jQuery event objects. [Fixes #10531.](http://bugs.jquery.com/ticket/10531)
