### PR TITLE
clone does not work for checkboxes on IE9 correctly, your tests were faulty

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -431,6 +431,8 @@ function cloneFixAttributes( src, dest ) {
 		// a checked appearance if the defaultChecked value isn't also set
 		if ( src.checked ) {
 			dest.defaultChecked = dest.checked = src.checked;
+			// IE9 does not allow checked to be set via .checked, must be set using setAttribute
+			if (dest.setAttribute && src.getAttribute) { dest.setAttribute('checked', src.getAttribute('checked')); }
 		}
 
 		// IE6-7 get confused and end up setting the value of a cloned

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -1112,8 +1112,8 @@ test("clone()", function() {
 	equal( jQuery("body").clone().children()[0].id, "qunit-header", "Make sure cloning body works" );
 });
 
-test("clone(form element) (Bug #3879, #6655)", function() {
-	expect(5);
+test("clone(form element) (Bug #3879, #6655, #10550)", function() {
+	expect(6);
 	var element = jQuery("<select><option>Foo</option><option selected>Bar</option></select>");
 
 	equals( element.clone().find("option:selected").val(), element.find("option:selected").val(), "Selected option cloned correctly" );
@@ -1123,6 +1123,11 @@ test("clone(form element) (Bug #3879, #6655)", function() {
 
 	equals( clone.is(":checked"), element.is(":checked"), "Checked input cloned correctly" );
 	equals( clone[0].defaultValue, "foo", "Checked input defaultValue cloned correctly" );
+
+	element = jQuery("<input type='checkbox' value='foo' checked='checked'>");
+	clone = element.clone();
+
+	equals( clone[0].getAttribute('checked'), element[0].getAttribute('checked'), "Checked input cloned correctly with getAttribute for IE9");
 
 	// defaultChecked also gets set now due to setAttribute in attr, is this check still valid?
 	// equals( clone[0].defaultChecked, !jQuery.support.noCloneChecked, "Checked input defaultChecked cloned correctly" );


### PR DESCRIPTION
Please see bug report at http://bugs.jquery.com/ticket/10550
