### PR TITLE
only check for not null in unit tests... fixes #8388.

### DIFF
--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -505,7 +505,7 @@ test("widows & orphans #8936", function () {
 test("can't get css for disconnected in IE<9, see #10254 and #8388", function() {
 	expect( 2 );
 	var span = jQuery( "<span/>" ).css( "background-image", "url(http://static.jquery.com/files/rocker/images/logo_jquery_215x53.gif)" );
-	equal( span.css( "background-image" ), "url(http://static.jquery.com/files/rocker/images/logo_jquery_215x53.gif)", "can't get background-image in IE<9, see #10254" );
+	notEqual( span.css( "background-image" ), null, "can't get background-image in IE<9, see #10254" );
 
 	var div = jQuery( "<div/>" ).css( "top", 10 );
 	equal( div.css( "top" ), "10px", "can't get top in IE<9, see #8388" );


### PR DESCRIPTION
in Opera, currentStyle works for disconnected nodes, and uses computed values, so we can't
expect the exact url() string we set.

Sorry for the additional PR... I should have caught this during testing.
