### PR TITLE
hasAttrToken method for any attribute value using space-separated tokens

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -147,17 +147,13 @@ jQuery.fn.extend({
 		return this.hasAttrToken( "class", selector );
 	},
 	
-	hasRel: function( selector ) {
-		return this.hasAttrToken( "rel", selector, true );
-	},
-	
 	hasAttrToken: function( attr, selector, ignoreCase ) {
 		var token = " " + selector + " ",
 			attrVal,
 			hasToken,
 			i = 0,
 			l = this.length;
-		
+				
 		if(ignoreCase === true) {
 			token = new RegExp(token, "i");
 		}

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -1173,18 +1173,18 @@ test("contents().hasClass() returns correct values", function() {
 	ok( !$contents.hasClass("undefined"), "Did not find 'undefined' in $contents (correctly)" );
 });
 
-test("hasRel, hasAttrToken", function() {
+test("hasAttrToken", function() {
 	
 	expect(13);
 	
-	var $div = jQuery("<div data-name='i love geoff capes'>Geoff Capes</div>");
+	var $div = jQuery("<button accesskey='A B C'>Geoff Capes</button>");
 	
-	ok( $div.hasAttrToken("data-name", "geoff"), "Check token is found");
-	ok( $div.hasAttrToken("data-name", "capes"), "Check token is found");
-	ok( $div.hasAttrToken("data-name", "love"), "Check token is found");
-	ok( !$div.hasAttrToken("data-name", "lov"), "Check non existent token not found");
-	ok( !$div.hasAttrToken("data-name"), "Check not attr value not found");
-	ok( !$div.hasAttrToken("data-blah"), "Check non existent attr is false");
+	ok( $div.hasAttrToken("accesskey", "A"), "Check token is found");
+	ok( $div.hasAttrToken("accesskey", "B"), "Check token is found");
+	ok( $div.hasAttrToken("accesskey", "C"), "Check token is found");
+	ok( !$div.hasAttrToken("accesskey", "a"), "Check token is not found (wrong case)");
+	ok( !$div.hasAttrToken("accesskey", "b"), "Check token is not found (wrong case)");
+	ok( !$div.hasAttrToken("accesskey", "c"), "Check token is not found (wrong case)");
 
 	var $a = jQuery("<a>Hi</a>");
 	$a.attr("rel", "author nofollow next");
@@ -1193,11 +1193,11 @@ test("hasRel, hasAttrToken", function() {
 	$a2.attr("rel", "author next");
 	$a.add($a2);
 	
-	ok( $a.hasRel("author"), "Check rel is found");
-	ok( $a.hasRel("nofollow"), "Check rel is found");
-	ok( $a.hasRel("next"), "Check rel is found");
-	ok( $a.hasRel("AUTHOR"), "Check rel is found (not case sensitive)");
-	ok( $a.hasRel("NOFOLLOW"), "Check rel is found (not case sensitive)");
-	ok( $a.hasRel("NEXT"), "Check rel is found (not case sensitive)");
-	ok( !$a.hasRel("nofollownext"), "Check rel is not found");
+	ok( $a.hasAttrToken("rel", "author", true), "Check rel is found");
+	ok( $a.hasAttrToken("rel", "nofollow", true), "Check rel is found");
+	ok( $a.hasAttrToken("rel", "next", true), "Check rel is found");
+	ok( $a.hasAttrToken("rel", "AUTHOR", true), "Check rel is found (not case sensitive)");
+	ok( $a.hasAttrToken("rel", "NOFOLLOW", true), "Check rel is found (not case sensitive)");
+	ok( $a.hasAttrToken("rel", "NEXT", true), "Check rel is found (not case sensitive)");
+	ok( !$a.hasAttrToken("rel", "nofollownext", true), "Check rel is not found");
 });


### PR DESCRIPTION
The HTML5 (and 4) spec states that the rel attribute's value must be a set space-separated tokens, like the class attribute. I want the mechanism for testing if a token is present in hasClass to be available for rel and ultimately any attribute. Many other attributes may also have values in this format.

I've added a new method to attributes.js, hasAttrToken. hasClass now uses hasAttrToken to check if a class is present.

hasAttrToken also has the option of being case insensitive, as rel values are ASCII case insensitive.
