### PR TITLE
Patch for ticket #9830

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -402,7 +402,7 @@ jQuery.extend({
 					return nodeHook.get( elem, name );
 				}
 				return name in elem ?
-					elem.value :
+					elem.getAttribute( "value" ) || elem.value :
 					null;
 			},
 			set: function( elem, value, name ) {


### PR DESCRIPTION
Fixed with jollysonali jyli7. We made the adjustment in line #404 of attributes.js. The attrHooks' get function sends back the getAttribute value of the element if present. If it's not present, it defaults to the current value of the element. 

Let us know if you have any feedback, thank you! 
