### PR TITLE
Fixes jQuery.fragments cache and adds tests. Fixes #10682

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -480,7 +480,7 @@ jQuery.buildFragment = function( args, nodes, scripts ) {
 	// Lastly, IE6,7,8 will not correctly reuse cached fragments that were created from unknown elems #10501
 	if ( args.length === 1 && typeof first === "string" && first.length < 512 && doc === document &&
 		first.charAt(0) === "<" && !rnocache.test( first ) &&
-		(jQuery.support.checkClone || !rchecked.test( first )) &&
+		(jQuery.support.checkClone || !rchecked.test( first )) ||
 		(!jQuery.support.unknownElems && rnoshimcache.test( first )) ) {
 
 		cacheable = true;

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -1531,3 +1531,51 @@ test("jQuery.clone - no exceptions for object elements #9587", function() {
 		ok( false, e.message );
 	}
 });
+
+test("jQuery.fragments cache expectations", function() {
+
+	expect( 10 );
+
+	jQuery.fragments = {};
+
+	function fragmentCacheSize() {
+		var n = 0, c;
+
+		for ( c in jQuery.fragments ) {
+			n++;
+		}
+		return n;
+	}
+
+	jQuery("<li></li>");
+	jQuery("<li>?</li>");
+	jQuery("<li>whip</li>");
+	jQuery("<li>it</li>");
+	jQuery("<li>good</li>");
+	jQuery("<div></div>");
+	jQuery("<div><div><span></span></div></div>");
+	jQuery("<tr><td></td></tr>");
+	jQuery("<tr><td></tr>");
+	jQuery("<li>aaa</li>");
+	jQuery("<ul><li>?</li></ul>");
+	jQuery("<div><p>arf</p>nnn</div>");
+	jQuery("<div><p>dog</p>?</div>");
+	jQuery("<span><span>");
+
+	equal( fragmentCacheSize(), 12, "12 entries exist in jQuery.fragments, 1" );
+
+	jQuery.each( [
+		"<tr><td></td></tr>",
+		"<ul><li>?</li></ul>",
+		"<div><p>dog</p>?</div>",
+		"<span><span>"
+	], function( i, frag ) {
+
+		jQuery( frag );
+
+		equal( jQuery.fragments[ frag ].nodeType, 11, "Second call with " + frag + " creates a cached DocumentFragment, has nodeType 11" );
+		ok( jQuery.fragments[ frag ].childNodes.length, "Second call with " + frag + " creates a cached DocumentFragment, has childNodes with length" );
+	});
+
+	equal( fragmentCacheSize(), 12, "12 entries exist in jQuery.fragments, 2" );
+});


### PR DESCRIPTION
This patch depends on PR#577 - https://github.com/jquery/jquery/pull/577
