### PR TITLE
fixes #10691, remove all instances of equals() and same() in unit tests

### DIFF
--- a/test/data/testinit.js
+++ b/test/data/testinit.js
@@ -41,7 +41,7 @@ function t(a,b,c) {
 		s += (s && ",") + '"' + f[i].id + '"';
 	}
 
-	same(f, q.apply(q,c), a + " (" + b + ")");
+	deepEqual(f, q.apply(q,c), a + " (" + b + ")");
 }
 
 var fireNative;
@@ -102,19 +102,19 @@ function url(value) {
 		// Because QUnit doesn't have a mechanism for retrieving the number of expected assertions for a test,
 		// if we unconditionally assert any of these, the test will fail with too many assertions :|
 		if ( cacheLength !== oldCacheLength ) {
-			equals( cacheLength, oldCacheLength, "No unit tests leak memory in jQuery.cache" );
+			equal( cacheLength, oldCacheLength, "No unit tests leak memory in jQuery.cache" );
 			oldCacheLength = cacheLength;
 		}
 		if ( fragmentsLength !== oldFragmentsLength ) {
-			equals( fragmentsLength, oldFragmentsLength, "No unit tests leak memory in jQuery.fragments" );
+			equal( fragmentsLength, oldFragmentsLength, "No unit tests leak memory in jQuery.fragments" );
 			oldFragmentsLength = fragmentsLength;
 		}
 		if ( jQuery.timers.length !== oldTimersLength ) {
-			equals( jQuery.timers.length, oldTimersLength, "No timers are still running" );
+			equal( jQuery.timers.length, oldTimersLength, "No timers are still running" );
 			oldTimersLength = jQuery.timers.length;
 		}
 		if ( jQuery.active !== oldActive ) {
-			equals( jQuery.active, 0, "No AJAX requests are still active" );
+			equal( jQuery.active, 0, "No AJAX requests are still active" );
 			oldActive = jQuery.active;
 		}
 	}

--- a/test/data/testrunner.js
+++ b/test/data/testrunner.js
@@ -25,9 +25,3 @@ jQuery.noConflict(); // Allow the test to run with other libs or jQuery's.
 
 	document.write("<scr" + "ipt src='http://swarm.jquery.org/js/inject.js?" + (new Date).getTime() + "'></scr" + "ipt>");
 })();
-
-// QUnit Aliases
-(function() {
-	window.equals = window.equal;
-	window.same = window.deepEqual;	
-})();

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -474,7 +474,7 @@ test(".ajax() - protocol-less urls", function() {
 	jQuery.ajax({
 		url: "//somedomain.com",
 		beforeSend: function( xhr, settings ) {
-			equals(settings.url, location.protocol + "//somedomain.com", "Make sure that the protocol is added.");
+			equal(settings.url, location.protocol + "//somedomain.com", "Make sure that the protocol is added.");
 			return false;
 		}
 	});
@@ -486,7 +486,7 @@ test(".ajax() - hash", function() {
 	jQuery.ajax({
 		url: "data/name.html#foo",
 		beforeSend: function( xhr, settings ) {
-			equals(settings.url, "data/name.html", "Make sure that the URL is trimmed.");
+			equal(settings.url, "data/name.html", "Make sure that the URL is trimmed.");
 			return false;
 		}
 	});
@@ -494,7 +494,7 @@ test(".ajax() - hash", function() {
 	jQuery.ajax({
 		url: "data/name.html?abc#foo",
 		beforeSend: function( xhr, settings ) {
-		equals(settings.url, "data/name.html?abc", "Make sure that the URL is trimmed.");
+		equal(settings.url, "data/name.html?abc", "Make sure that the URL is trimmed.");
 			return false;
 		}
 	});
@@ -503,7 +503,7 @@ test(".ajax() - hash", function() {
 		url: "data/name.html?abc#foo",
 		data: { "test": 123 },
 		beforeSend: function( xhr, settings ) {
-			equals(settings.url, "data/name.html?abc&test=123", "Make sure that the URL is trimmed.");
+			equal(settings.url, "data/name.html?abc&test=123", "Make sure that the URL is trimmed.");
 			return false;
 		}
 	});
@@ -619,10 +619,10 @@ test("jQuery.ajax() - abort", function() {
 		complete: function(){ ok(true, "complete"); }
 	});
 
-	equals( xhr.readyState, 1, "XHR readyState indicates successful dispatch" );
+	equal( xhr.readyState, 1, "XHR readyState indicates successful dispatch" );
 
 	xhr.abort();
-	equals( xhr.readyState, 0, "XHR readyState indicates successful abortion" );
+	equal( xhr.readyState, 0, "XHR readyState indicates successful abortion" );
 });
 
 test("Ajax events with context", function() {
@@ -632,18 +632,18 @@ test("Ajax events with context", function() {
 	var context = document.createElement("div");
 
 	function event(e){
-		equals( this, context, e.type );
+		equal( this, context, e.type );
 	}
 
 	function callback(msg){
 		return function(){
-			equals( this, context, "context is preserved on callback " + msg );
+			equal( this, context, "context is preserved on callback " + msg );
 		};
 	}
 
 	function nocallback(msg){
 		return function(){
-			equals( typeof this.url, "string", "context is settings on callback " + msg );
+			equal( typeof this.url, "string", "context is settings on callback " + msg );
 		};
 	}
 
@@ -705,7 +705,7 @@ test("jQuery.ajax context modification", function() {
 		}
 	});
 
-	equals( obj.test, "foo", "Make sure the original object is maintained." );
+	equal( obj.test, "foo", "Make sure the original object is maintained." );
 });
 
 test("jQuery.ajax context modification through ajaxSetup", function() {
@@ -787,9 +787,9 @@ test("jQuery.ajax - xml: non-namespace elements inside namespaced elements", fun
 	  url: url("data/with_fries.xml"),
 	  dataType: "xml",
 	  success: function(resp) {
-		equals( jQuery("properties", resp).length, 1, "properties in responseXML" );
-		equals( jQuery("jsconf", resp).length, 1, "jsconf in responseXML" );
-		equals( jQuery("thing", resp).length, 2, "things in responseXML" );
+		equal( jQuery("properties", resp).length, 1, "properties in responseXML" );
+		equal( jQuery("jsconf", resp).length, 1, "jsconf in responseXML" );
+		equal( jQuery("thing", resp).length, 2, "things in responseXML" );
 		start();
 	  }
 	});
@@ -802,9 +802,9 @@ test("jQuery.ajax - xml: non-namespace elements inside namespaced elements (over
 	  url: url("data/with_fries_over_jsonp.php"),
 	  dataType: "jsonp xml",
 	  success: function(resp) {
-		equals( jQuery("properties", resp).length, 1, "properties in responseXML" );
-		equals( jQuery("jsconf", resp).length, 1, "jsconf in responseXML" );
-		equals( jQuery("thing", resp).length, 2, "things in responseXML" );
+		equal( jQuery("properties", resp).length, 1, "properties in responseXML" );
+		equal( jQuery("jsconf", resp).length, 1, "jsconf in responseXML" );
+		equal( jQuery("thing", resp).length, 2, "things in responseXML" );
 		start();
 	  },
 	  error: function(_1,_2,error) {
@@ -910,8 +910,8 @@ test("jQuery.ajax - dataType html", function() {
 	stop();
 
 	var verifyEvaluation = function() {
-		equals( testFoo, "foo", "Check if script was evaluated for datatype html" );
-		equals( foobar, "bar", "Check if script src was evaluated for datatype html" );
+		equal( testFoo, "foo", "Check if script was evaluated for datatype html" );
+		equal( foobar, "bar", "Check if script src was evaluated for datatype html" );
 
 		start();
 	};
@@ -936,28 +936,28 @@ test("serialize()", function() {
 		"<input type='number' id='html5number' name='number' value='43' />"
 	);
 
-	equals( jQuery("#form").serialize(),
+	equal( jQuery("#form").serialize(),
 		"action=Test&radio2=on&check=on&hidden=&foo%5Bbar%5D=&name=name&search=search&email=dave%40jquery.com&number=43&select1=&select2=3&select3=1&select3=2&select5=3",
 		"Check form serialization as query string");
 
-	equals( jQuery("#form :input").serialize(),
+	equal( jQuery("#form :input").serialize(),
 		"action=Test&radio2=on&check=on&hidden=&foo%5Bbar%5D=&name=name&search=search&email=dave%40jquery.com&number=43&select1=&select2=3&select3=1&select3=2&select5=3",
 		"Check input serialization as query string");
 
-	equals( jQuery("#testForm").serialize(),
+	equal( jQuery("#testForm").serialize(),
 		"T3=%3F%0D%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My+Name=me&S1=abc&S3=YES&S4=",
 		"Check form serialization as query string");
 
-	equals( jQuery("#testForm :input").serialize(),
+	equal( jQuery("#testForm :input").serialize(),
 		"T3=%3F%0D%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My+Name=me&S1=abc&S3=YES&S4=",
 		"Check input serialization as query string");
 
-	equals( jQuery("#form, #testForm").serialize(),
+	equal( jQuery("#form, #testForm").serialize(),
 		"action=Test&radio2=on&check=on&hidden=&foo%5Bbar%5D=&name=name&search=search&email=dave%40jquery.com&number=43&select1=&select2=3&select3=1&select3=2&select5=3&T3=%3F%0D%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My+Name=me&S1=abc&S3=YES&S4=",
 		"Multiple form serialization as query string");
 
   /* Temporarily disabled. Opera 10 has problems with form serialization.
-	equals( jQuery("#form, #testForm :input").serialize(),
+	equal( jQuery("#form, #testForm :input").serialize(),
 		"action=Test&radio2=on&check=on&hidden=&foo%5Bbar%5D=&name=name&search=search&email=dave%40jquery.com&number=43&select1=&select2=3&select3=1&select3=2&T3=%3F%0D%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My+Name=me&S1=abc&S3=YES&S4=",
 		"Mixed form/input serialization as query string");
 	*/
@@ -967,68 +967,68 @@ test("serialize()", function() {
 test("jQuery.param()", function() {
 	expect(21);
 
-	equals( !jQuery.ajaxSettings.traditional, true, "traditional flag, falsy by default" );
+	equal( !jQuery.ajaxSettings.traditional, true, "traditional flag, falsy by default" );
 
 	var params = {foo:"bar", baz:42, quux:"All your base are belong to us"};
-	equals( jQuery.param(params), "foo=bar&baz=42&quux=All+your+base+are+belong+to+us", "simple" );
+	equal( jQuery.param(params), "foo=bar&baz=42&quux=All+your+base+are+belong+to+us", "simple" );
 
 	params = {someName: [1, 2, 3], regularThing: "blah" };
-	equals( jQuery.param(params), "someName%5B%5D=1&someName%5B%5D=2&someName%5B%5D=3&regularThing=blah", "with array" );
+	equal( jQuery.param(params), "someName%5B%5D=1&someName%5B%5D=2&someName%5B%5D=3&regularThing=blah", "with array" );
 
 	params = {foo: ["a", "b", "c"]};
-	equals( jQuery.param(params), "foo%5B%5D=a&foo%5B%5D=b&foo%5B%5D=c", "with array of strings" );
+	equal( jQuery.param(params), "foo%5B%5D=a&foo%5B%5D=b&foo%5B%5D=c", "with array of strings" );
 
 	params = {foo: ["baz", 42, "All your base are belong to us"] };
-	equals( jQuery.param(params), "foo%5B%5D=baz&foo%5B%5D=42&foo%5B%5D=All+your+base+are+belong+to+us", "more array" );
+	equal( jQuery.param(params), "foo%5B%5D=baz&foo%5B%5D=42&foo%5B%5D=All+your+base+are+belong+to+us", "more array" );
 
 	params = {foo: { bar: "baz", beep: 42, quux: "All your base are belong to us" } };
-	equals( jQuery.param(params), "foo%5Bbar%5D=baz&foo%5Bbeep%5D=42&foo%5Bquux%5D=All+your+base+are+belong+to+us", "even more arrays" );
+	equal( jQuery.param(params), "foo%5Bbar%5D=baz&foo%5Bbeep%5D=42&foo%5Bquux%5D=All+your+base+are+belong+to+us", "even more arrays" );
 
 	params = { a:[1,2], b:{ c:3, d:[4,5], e:{ x:[6], y:7, z:[8,9] }, f:true, g:false, h:undefined }, i:[10,11], j:true, k:false, l:[undefined,0], m:"cowboy hat?" };
-	equals( decodeURIComponent( jQuery.param(params) ), "a[]=1&a[]=2&b[c]=3&b[d][]=4&b[d][]=5&b[e][x][]=6&b[e][y]=7&b[e][z][]=8&b[e][z][]=9&b[f]=true&b[g]=false&b[h]=undefined&i[]=10&i[]=11&j=true&k=false&l[]=undefined&l[]=0&m=cowboy+hat?", "huge structure" );
+	equal( decodeURIComponent( jQuery.param(params) ), "a[]=1&a[]=2&b[c]=3&b[d][]=4&b[d][]=5&b[e][x][]=6&b[e][y]=7&b[e][z][]=8&b[e][z][]=9&b[f]=true&b[g]=false&b[h]=undefined&i[]=10&i[]=11&j=true&k=false&l[]=undefined&l[]=0&m=cowboy+hat?", "huge structure" );
 
 	params = { a: [ 0, [ 1, 2 ], [ 3, [ 4, 5 ], [ 6 ] ], { b: [ 7, [ 8, 9 ], [ { c: 10, d: 11 } ], [ [ 12 ] ], [ [ [ 13 ] ] ], { e: { f: { g: [ 14, [ 15 ] ] } } }, 16 ] }, 17 ] };
-	equals( decodeURIComponent( jQuery.param(params) ), "a[]=0&a[1][]=1&a[1][]=2&a[2][]=3&a[2][1][]=4&a[2][1][]=5&a[2][2][]=6&a[3][b][]=7&a[3][b][1][]=8&a[3][b][1][]=9&a[3][b][2][0][c]=10&a[3][b][2][0][d]=11&a[3][b][3][0][]=12&a[3][b][4][0][0][]=13&a[3][b][5][e][f][g][]=14&a[3][b][5][e][f][g][1][]=15&a[3][b][]=16&a[]=17", "nested arrays" );
+	equal( decodeURIComponent( jQuery.param(params) ), "a[]=0&a[1][]=1&a[1][]=2&a[2][]=3&a[2][1][]=4&a[2][1][]=5&a[2][2][]=6&a[3][b][]=7&a[3][b][1][]=8&a[3][b][1][]=9&a[3][b][2][0][c]=10&a[3][b][2][0][d]=11&a[3][b][3][0][]=12&a[3][b][4][0][0][]=13&a[3][b][5][e][f][g][]=14&a[3][b][5][e][f][g][1][]=15&a[3][b][]=16&a[]=17", "nested arrays" );
 
 	params = { a:[1,2], b:{ c:3, d:[4,5], e:{ x:[6], y:7, z:[8,9] }, f:true, g:false, h:undefined }, i:[10,11], j:true, k:false, l:[undefined,0], m:"cowboy hat?" };
-	equals( jQuery.param(params,true), "a=1&a=2&b=%5Bobject+Object%5D&i=10&i=11&j=true&k=false&l=undefined&l=0&m=cowboy+hat%3F", "huge structure, forced traditional" );
+	equal( jQuery.param(params,true), "a=1&a=2&b=%5Bobject+Object%5D&i=10&i=11&j=true&k=false&l=undefined&l=0&m=cowboy+hat%3F", "huge structure, forced traditional" );
 
-	equals( decodeURIComponent( jQuery.param({ a: [1,2,3], "b[]": [4,5,6], "c[d]": [7,8,9], e: { f: [10], g: [11,12], h: 13 } }) ), "a[]=1&a[]=2&a[]=3&b[]=4&b[]=5&b[]=6&c[d][]=7&c[d][]=8&c[d][]=9&e[f][]=10&e[g][]=11&e[g][]=12&e[h]=13", "Make sure params are not double-encoded." );
+	equal( decodeURIComponent( jQuery.param({ a: [1,2,3], "b[]": [4,5,6], "c[d]": [7,8,9], e: { f: [10], g: [11,12], h: 13 } }) ), "a[]=1&a[]=2&a[]=3&b[]=4&b[]=5&b[]=6&c[d][]=7&c[d][]=8&c[d][]=9&e[f][]=10&e[g][]=11&e[g][]=12&e[h]=13", "Make sure params are not double-encoded." );
 
 	// #7945
-	equals( jQuery.param({"jquery": "1.4.2"}), "jquery=1.4.2", "Check that object with a jQuery property get serialized correctly" );
+	equal( jQuery.param({"jquery": "1.4.2"}), "jquery=1.4.2", "Check that object with a jQuery property get serialized correctly" );
 
 	jQuery.ajaxSetup({ traditional: true });
 
 	var params = {foo:"bar", baz:42, quux:"All your base are belong to us"};
-	equals( jQuery.param(params), "foo=bar&baz=42&quux=All+your+base+are+belong+to+us", "simple" );
+	equal( jQuery.param(params), "foo=bar&baz=42&quux=All+your+base+are+belong+to+us", "simple" );
 
 	params = {someName: [1, 2, 3], regularThing: "blah" };
-	equals( jQuery.param(params), "someName=1&someName=2&someName=3&regularThing=blah", "with array" );
+	equal( jQuery.param(params), "someName=1&someName=2&someName=3&regularThing=blah", "with array" );
 
 	params = {foo: ["a", "b", "c"]};
-	equals( jQuery.param(params), "foo=a&foo=b&foo=c", "with array of strings" );
+	equal( jQuery.param(params), "foo=a&foo=b&foo=c", "with array of strings" );
 
 	params = {"foo[]":["baz", 42, "All your base are belong to us"]};
-	equals( jQuery.param(params), "foo%5B%5D=baz&foo%5B%5D=42&foo%5B%5D=All+your+base+are+belong+to+us", "more array" );
+	equal( jQuery.param(params), "foo%5B%5D=baz&foo%5B%5D=42&foo%5B%5D=All+your+base+are+belong+to+us", "more array" );
 
 	params = {"foo[bar]":"baz", "foo[beep]":42, "foo[quux]":"All your base are belong to us"};
-	equals( jQuery.param(params), "foo%5Bbar%5D=baz&foo%5Bbeep%5D=42&foo%5Bquux%5D=All+your+base+are+belong+to+us", "even more arrays" );
+	equal( jQuery.param(params), "foo%5Bbar%5D=baz&foo%5Bbeep%5D=42&foo%5Bquux%5D=All+your+base+are+belong+to+us", "even more arrays" );
 
 	params = { a:[1,2], b:{ c:3, d:[4,5], e:{ x:[6], y:7, z:[8,9] }, f:true, g:false, h:undefined }, i:[10,11], j:true, k:false, l:[undefined,0], m:"cowboy hat?" };
-	equals( jQuery.param(params), "a=1&a=2&b=%5Bobject+Object%5D&i=10&i=11&j=true&k=false&l=undefined&l=0&m=cowboy+hat%3F", "huge structure" );
+	equal( jQuery.param(params), "a=1&a=2&b=%5Bobject+Object%5D&i=10&i=11&j=true&k=false&l=undefined&l=0&m=cowboy+hat%3F", "huge structure" );
 
 	params = { a: [ 0, [ 1, 2 ], [ 3, [ 4, 5 ], [ 6 ] ], { b: [ 7, [ 8, 9 ], [ { c: 10, d: 11 } ], [ [ 12 ] ], [ [ [ 13 ] ] ], { e: { f: { g: [ 14, [ 15 ] ] } } }, 16 ] }, 17 ] };
-	equals( jQuery.param(params), "a=0&a=1%2C2&a=3%2C4%2C5%2C6&a=%5Bobject+Object%5D&a=17", "nested arrays (not possible when jQuery.param.traditional == true)" );
+	equal( jQuery.param(params), "a=0&a=1%2C2&a=3%2C4%2C5%2C6&a=%5Bobject+Object%5D&a=17", "nested arrays (not possible when jQuery.param.traditional == true)" );
 
 	params = { a:[1,2], b:{ c:3, d:[4,5], e:{ x:[6], y:7, z:[8,9] }, f:true, g:false, h:undefined }, i:[10,11], j:true, k:false, l:[undefined,0], m:"cowboy hat?" };
-	equals( decodeURIComponent( jQuery.param(params,false) ), "a[]=1&a[]=2&b[c]=3&b[d][]=4&b[d][]=5&b[e][x][]=6&b[e][y]=7&b[e][z][]=8&b[e][z][]=9&b[f]=true&b[g]=false&b[h]=undefined&i[]=10&i[]=11&j=true&k=false&l[]=undefined&l[]=0&m=cowboy+hat?", "huge structure, forced not traditional" );
+	equal( decodeURIComponent( jQuery.param(params,false) ), "a[]=1&a[]=2&b[c]=3&b[d][]=4&b[d][]=5&b[e][x][]=6&b[e][y]=7&b[e][z][]=8&b[e][z][]=9&b[f]=true&b[g]=false&b[h]=undefined&i[]=10&i[]=11&j=true&k=false&l[]=undefined&l[]=0&m=cowboy+hat?", "huge structure, forced not traditional" );
 
 	params = { param1: null };
-	equals( jQuery.param(params,false), "param1=null", "Make sure that null params aren't traversed." );
+	equal( jQuery.param(params,false), "param1=null", "Make sure that null params aren't traversed." );
 
 	params = {"test": {"length": 3, "foo": "bar"} };
-	equals( jQuery.param( params, false ), "test%5Blength%5D=3&test%5Bfoo%5D=bar", "Sub-object with a length property" );
+	equal( jQuery.param( params, false ), "test%5Blength%5D=3&test%5Bfoo%5D=bar", "Sub-object with a length property" );
 });
 
 test("synchronous request", function() {
@@ -1059,8 +1059,8 @@ test("pass-through request object", function() {
 		errorEx += ": " + xml.status;
 	});
 	jQuery("#foo").one("ajaxStop", function () {
-		equals(successCount, 5, "Check all ajax calls successful");
-		equals(errorCount, 0, "Check no ajax errors (status" + errorEx + ")");
+		equal(successCount, 5, "Check all ajax calls successful");
+		equal(errorCount, 0, "Check no ajax errors (status" + errorEx + ")");
 		jQuery("#foo").unbind("ajaxError");
 
 		start();
@@ -1090,7 +1090,7 @@ test("ajax cache", function () {
 			}
 			oldOne = ret[1];
 		}
-		equals(i, 1, "Test to make sure only one 'no-cache' parameter is there");
+		equal(i, 1, "Test to make sure only one 'no-cache' parameter is there");
 		ok(oldOne != "tobereplaced555", "Test to be sure parameter (if it was there) was replaced");
 		if(++count == 6)
 			start();
@@ -1143,7 +1143,7 @@ test("load('url selector')", function() {
 	expect(1);
 	stop(); // check if load can be called with only url
 	jQuery("#first").load("data/test3.html div.user", function(){
-		equals( jQuery(this).children("div").length, 2, "Verify that specific elements were injected" );
+		equal( jQuery(this).children("div").length, 2, "Verify that specific elements were injected" );
 		start();
 	});
 });
@@ -1153,7 +1153,7 @@ test("load(String, Function) with ajaxSetup on dataType json, see #2046", functi
 	stop();
 	jQuery.ajaxSetup({ dataType: "json" });
 	jQuery("#first").ajaxComplete(function (e, xml, s) {
-		equals( s.dataType, "html", "Verify the load() dataType was html" );
+		equal( s.dataType, "html", "Verify the load() dataType was html" );
 		jQuery("#first").unbind("ajaxComplete");
 		jQuery.ajaxSetup({ dataType: "" });
 		start();
@@ -1175,15 +1175,15 @@ test("load(String, Function) - check scripts", function() {
 	stop();
 
 	var verifyEvaluation = function() {
-		equals( foobar, "bar", "Check if script src was evaluated after load" );
-		equals( jQuery("#ap").html(), "bar", "Check if script evaluation has modified DOM");
+		equal( foobar, "bar", "Check if script src was evaluated after load" );
+		equal( jQuery("#ap").html(), "bar", "Check if script evaluation has modified DOM");
 
 		start();
 	};
 	jQuery("#first").load(url("data/test.html"), function() {
 		ok( jQuery("#first").html().match(/^html text/), "Check content after loading html" );
-		equals( jQuery("#foo").html(), "foo", "Check if script evaluation has modified DOM");
-		equals( testFoo, "foo", "Check if script was evaluated after load" );
+		equal( jQuery("#foo").html(), "foo", "Check if script evaluation has modified DOM");
+		equal( testFoo, "foo", "Check if script was evaluated after load" );
 		setTimeout(verifyEvaluation, 600);
 	});
 });
@@ -1193,8 +1193,8 @@ test("load(String, Function) - check file with only a script tag", function() {
 	stop();
 
 	jQuery("#first").load(url("data/test2.html"), function() {
-		equals( jQuery("#foo").html(), "foo", "Check if script evaluation has modified DOM");
-		equals( testFoo, "foo", "Check if script was evaluated after load" );
+		equal( jQuery("#foo").html(), "foo", "Check if script evaluation has modified DOM");
+		equal( testFoo, "foo", "Check if script was evaluated after load" );
 
 		start();
 	});
@@ -1218,8 +1218,8 @@ test("load(String, Object, Function)", function() {
 
 	jQuery("<div />").load(url("data/params_html.php"), { foo: 3, bar: "ok" }, function() {
 		var $post = jQuery(this).find("#post");
-		equals( $post.find("#foo").text(), "3", "Check if a hash of data is passed correctly");
-		equals( $post.find("#bar").text(), "ok", "Check if a hash of data is passed correctly");
+		equal( $post.find("#foo").text(), "3", "Check if a hash of data is passed correctly");
+		equal( $post.find("#bar").text(), "ok", "Check if a hash of data is passed correctly");
 		start();
 	});
 });
@@ -1230,8 +1230,8 @@ test("load(String, String, Function)", function() {
 
 	jQuery("<div />").load(url("data/params_html.php"), "foo=3&bar=ok", function() {
 		var $get = jQuery(this).find("#get");
-		equals( $get.find("#foo").text(), "3", "Check if a string of data is passed correctly");
-		equals( $get.find("#bar").text(), "ok", "Check if a	 of data is passed correctly");
+		equal( $get.find("#foo").text(), "3", "Check if a string of data is passed correctly");
+		equal( $get.find("#bar").text(), "ok", "Check if a	 of data is passed correctly");
 		start();
 	});
 });
@@ -1259,8 +1259,8 @@ test("jQuery.get(String, Hash, Function) - parse xml and use text() on nodes", f
 		jQuery("tab", xml).each(function() {
 			content.push(jQuery(this).text());
 		});
-		equals( content[0], "blabla", "Check first tab");
-		equals( content[1], "blublu", "Check second tab");
+		equal( content[0], "blabla", "Check first tab");
+		equal( content[1], "blublu", "Check second tab");
 		start();
 	});
 });
@@ -1269,7 +1269,7 @@ test("jQuery.getScript(String, Function) - with callback", function() {
 	expect(3);
 	stop();
 	jQuery.getScript(url("data/test.js"), function( data, _, jqXHR ) {
-		equals( foobar, "bar", "Check if script was evaluated" );
+		equal( foobar, "bar", "Check if script was evaluated" );
 		strictEqual( data, jqXHR.responseText, "Same-domain script requests returns the source of the script (#8082)" );
 		setTimeout(start, 100);
 	});
@@ -1574,7 +1574,7 @@ test("jQuery.ajax() - script, Remote with POST", function() {
 		dataType: "script",
 		success: function(data, status){
 			ok( foobar, "Script results returned (POST, no callback)" );
-			equals( status, "success", "Script results returned (POST, no callback)" );
+			equal( status, "success", "Script results returned (POST, no callback)" );
 			start();
 		},
 		error: function(xhr) {
@@ -1615,7 +1615,7 @@ test("jQuery.ajax() - malformed JSON", function() {
 			start();
 		},
 		error: function(xhr, msg, detailedMsg) {
-			equals( "parsererror", msg, "A parse error occurred." );
+			equal( "parsererror", msg, "A parse error occurred." );
 			ok( /^(Invalid|SyntaxError|exception)/i.test(detailedMsg), "Detailed parsererror message provided" );
 	  		start();
 		}
@@ -1654,10 +1654,10 @@ test("jQuery.ajax() - json by content-type", function() {
 		data: { header: "json", json: "array" },
 		success: function( json ) {
 	  		ok( json.length >= 2, "Check length");
-	  		equals( json[0].name, "John", "Check JSON: first, name" );
-	  		equals( json[0].age, 21, "Check JSON: first, age" );
-	  		equals( json[1].name, "Peter", "Check JSON: second, name" );
-	  		equals( json[1].age, 25, "Check JSON: second, age" );
+	  		equal( json[0].name, "John", "Check JSON: first, name" );
+	  		equal( json[0].age, 21, "Check JSON: first, age" );
+	  		equal( json[1].name, "Peter", "Check JSON: second, name" );
+	  		equal( json[1].age, 25, "Check JSON: second, age" );
 	  		start();
 		}
 	});
@@ -1675,13 +1675,13 @@ test("jQuery.ajax() - json by content-type disabled with options", function() {
 			json: false
 		},
 		success: function( text ) {
-			equals( typeof text , "string" , "json wasn't auto-determined" );
+			equal( typeof text , "string" , "json wasn't auto-determined" );
 			var json = jQuery.parseJSON( text );
 	  		ok( json.length >= 2, "Check length");
-	  		equals( json[0].name, "John", "Check JSON: first, name" );
-	  		equals( json[0].age, 21, "Check JSON: first, age" );
-	  		equals( json[1].name, "Peter", "Check JSON: second, name" );
-	  		equals( json[1].age, 25, "Check JSON: second, age" );
+	  		equal( json[0].name, "John", "Check JSON: first, name" );
+	  		equal( json[0].age, 21, "Check JSON: first, age" );
+	  		equal( json[1].name, "Peter", "Check JSON: second, name" );
+	  		equal( json[1].age, 25, "Check JSON: second, age" );
 	  		start();
 		}
 	});
@@ -1692,10 +1692,10 @@ test("jQuery.getJSON(String, Hash, Function) - JSON array", function() {
 	stop();
 	jQuery.getJSON(url("data/json.php"), {json: "array"}, function(json) {
 	  ok( json.length >= 2, "Check length");
-	  equals( json[0].name, "John", "Check JSON: first, name" );
-	  equals( json[0].age, 21, "Check JSON: first, age" );
-	  equals( json[1].name, "Peter", "Check JSON: second, name" );
-	  equals( json[1].age, 25, "Check JSON: second, age" );
+	  equal( json[0].name, "John", "Check JSON: first, name" );
+	  equal( json[0].age, 21, "Check JSON: first, age" );
+	  equal( json[1].name, "Peter", "Check JSON: second, name" );
+	  equal( json[1].age, 25, "Check JSON: second, age" );
 	  start();
 	});
 });
@@ -1705,8 +1705,8 @@ test("jQuery.getJSON(String, Function) - JSON object", function() {
 	stop();
 	jQuery.getJSON(url("data/json.php"), function(json) {
 	  if (json && json.data) {
-		  equals( json.data.lang, "en", "Check JSON: lang" );
-		  equals( json.data.length, 25, "Check JSON: length" );
+		  equal( json.data.lang, "en", "Check JSON: lang" );
+		  equal( json.data.length, 25, "Check JSON: length" );
 	  }
 	  start();
 	});
@@ -1726,7 +1726,7 @@ test("jQuery.getJSON - Using Native JSON", function() {
 	stop();
 	jQuery.getJSON(url("data/json.php"), function(json) {
 		window.JSON = old;
-		equals( json, true, "Verifying return value" );
+		equal( json, true, "Verifying return value" );
 		start();
 	});
 });
@@ -1738,8 +1738,8 @@ test("jQuery.getJSON(String, Function) - JSON object with absolute url to local 
 
 	stop();
 	jQuery.getJSON(url(base + "data/json.php"), function(json) {
-	  equals( json.data.lang, "en", "Check JSON: lang" );
-	  equals( json.data.length, 25, "Check JSON: length" );
+	  equal( json.data.lang, "en", "Check JSON: lang" );
+	  equal( json.data.length, 25, "Check JSON: length" );
 	  start();
 	});
 });
@@ -1750,8 +1750,8 @@ test("jQuery.post - data", 3, function() {
 	jQuery.when(
 		jQuery.post( url( "data/name.php" ), { xml: "5-2", length: 3 }, function( xml ) {
 			jQuery( "math", xml ).each(function() {
-				equals( jQuery( "calculation", this ).text(), "5-2", "Check for XML" );
-				equals( jQuery( "result", this ).text(), "3", "Check for XML" );
+				equal( jQuery( "calculation", this ).text(), "5-2", "Check for XML" );
+				equal( jQuery( "result", this ).text(), "3", "Check for XML" );
 			});
 		}),
 
@@ -1781,16 +1781,16 @@ test("jQuery.post(String, Hash, Function) - simple with xml", function() {
 
 	jQuery.post(url("data/name.php"), {xml: "5-2"}, function(xml){
 	  jQuery("math", xml).each(function() {
-			equals( jQuery("calculation", this).text(), "5-2", "Check for XML" );
-			equals( jQuery("result", this).text(), "3", "Check for XML" );
+			equal( jQuery("calculation", this).text(), "5-2", "Check for XML" );
+			equal( jQuery("result", this).text(), "3", "Check for XML" );
 		 });
 	  if ( ++done === 2 ) start();
 	});
 
 	jQuery.post(url("data/name.php?xml=5-2"), {}, function(xml){
 	  jQuery("math", xml).each(function() {
-			equals( jQuery("calculation", this).text(), "5-2", "Check for XML" );
-			equals( jQuery("result", this).text(), "3", "Check for XML" );
+			equal( jQuery("calculation", this).text(), "5-2", "Check for XML" );
+			equal( jQuery("result", this).text(), "3", "Check for XML" );
 		 });
 	  if ( ++done === 2 ) start();
 	});
@@ -1859,7 +1859,7 @@ test("jQuery.ajax - simple get", function() {
 	  type: "GET",
 	  url: url("data/name.php?name=foo"),
 	  success: function(msg){
-		equals( msg, "bar", "Check for GET" );
+		equal( msg, "bar", "Check for GET" );
 		start();
 	  }
 	});
@@ -1873,7 +1873,7 @@ test("jQuery.ajax - simple post", function() {
 	  url: url("data/name.php"),
 	  data: "name=peter",
 	  success: function(msg){
-		equals( msg, "pan", "Check for POST" );
+		equal( msg, "pan", "Check for POST" );
 		start();
 	  }
 	});
@@ -1885,7 +1885,7 @@ test("ajaxSetup()", function() {
 	jQuery.ajaxSetup({
 		url: url("data/name.php?name=foo"),
 		success: function(msg){
-			equals( msg, "bar", "Check for GET" );
+			equal( msg, "bar", "Check for GET" );
 			start();
 		}
 	});
@@ -1900,7 +1900,7 @@ test("custom timeout does not set error message when timeout occurs, see #970", 
 		timeout: 500,
 		error: function(request, status) {
 			ok( status != null, "status shouldn't be null in error handler" );
-			equals( "timeout", status );
+			equal( "timeout", status );
 			start();
 		}
 	});
@@ -1917,7 +1917,7 @@ test("data option: evaluate function values (#2806)", function() {
 			}
 		},
 		success: function(result) {
-			equals( result, "key=value" );
+			equal( result, "key=value" );
 			start();
 		}
 	});
@@ -1930,7 +1930,7 @@ test("data option: empty bodies for non-GET requests", function() {
 		data: undefined,
 		type: "post",
 		success: function(result) {
-			equals( result, "" );
+			equal( result, "" );
 			start();
 		}
 	});
@@ -1952,7 +1952,7 @@ jQuery.each( { " (cache)": true, " (no cache)": false }, function( label, cache 
 			ifModified: true,
 			cache: cache,
 			success: function(data, status) {
-				equals(status, "success" );
+				equal(status, "success" );
 
 				jQuery.ajax({
 					url: url,
@@ -1963,7 +1963,7 @@ jQuery.each( { " (cache)": true, " (no cache)": false }, function( label, cache 
 							ok(jQuery.browser.opera, "Opera is incapable of doing .setRequestHeader('If-Modified-Since').");
 							ok(jQuery.browser.opera, "Opera is incapable of doing .setRequestHeader('If-Modified-Since').");
 						} else {
-							equals(status, "notmodified");
+							equal(status, "notmodified");
 							ok(data == null, "response body should be empty");
 						}
 						start();
@@ -1979,7 +1979,7 @@ jQuery.each( { " (cache)": true, " (no cache)": false }, function( label, cache 
 				});
 			},
 			error: function() {
-				equals(false, "error");
+				equal(false, "error");
 				// Do this because opera simply refuses to implement 304 handling :(
 				// A feature-driven way of detecting this would be appreciated
 				// See: http://gist.github.com/599419
@@ -2001,7 +2001,7 @@ jQuery.each( { " (cache)": true, " (no cache)": false }, function( label, cache 
 			ifModified: true,
 			cache: cache,
 			success: function(data, status) {
-				equals(status, "success" );
+				equal(status, "success" );
 
 				jQuery.ajax({
 					url: url,
@@ -2012,7 +2012,7 @@ jQuery.each( { " (cache)": true, " (no cache)": false }, function( label, cache 
 							ok(jQuery.browser.opera, "Opera is incapable of doing .setRequestHeader('If-None-Match').");
 							ok(jQuery.browser.opera, "Opera is incapable of doing .setRequestHeader('If-None-Match').");
 						} else {
-							equals(status, "notmodified");
+							equal(status, "notmodified");
 							ok(data == null, "response body should be empty");
 						}
 						start();

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -36,21 +36,21 @@ test("jQuery.propFix integrity test", function() {
 test("attr(String)", function() {
 	expect(46);
 
-	equals( jQuery("#text1").attr("type"), "text", "Check for type attribute" );
-	equals( jQuery("#radio1").attr("type"), "radio", "Check for type attribute" );
-	equals( jQuery("#check1").attr("type"), "checkbox", "Check for type attribute" );
-	equals( jQuery("#simon1").attr("rel"), "bookmark", "Check for rel attribute" );
-	equals( jQuery("#google").attr("title"), "Google!", "Check for title attribute" );
-	equals( jQuery("#mark").attr("hreflang"), "en", "Check for hreflang attribute" );
-	equals( jQuery("#en").attr("lang"), "en", "Check for lang attribute" );
-	equals( jQuery("#simon").attr("class"), "blog link", "Check for class attribute" );
-	equals( jQuery("#name").attr("name"), "name", "Check for name attribute" );
-	equals( jQuery("#text1").attr("name"), "action", "Check for name attribute" );
+	equal( jQuery("#text1").attr("type"), "text", "Check for type attribute" );
+	equal( jQuery("#radio1").attr("type"), "radio", "Check for type attribute" );
+	equal( jQuery("#check1").attr("type"), "checkbox", "Check for type attribute" );
+	equal( jQuery("#simon1").attr("rel"), "bookmark", "Check for rel attribute" );
+	equal( jQuery("#google").attr("title"), "Google!", "Check for title attribute" );
+	equal( jQuery("#mark").attr("hreflang"), "en", "Check for hreflang attribute" );
+	equal( jQuery("#en").attr("lang"), "en", "Check for lang attribute" );
+	equal( jQuery("#simon").attr("class"), "blog link", "Check for class attribute" );
+	equal( jQuery("#name").attr("name"), "name", "Check for name attribute" );
+	equal( jQuery("#text1").attr("name"), "action", "Check for name attribute" );
 	ok( jQuery("#form").attr("action").indexOf("formaction") >= 0, "Check for action attribute" );
-	equals( jQuery("#text1").attr("value", "t").attr("value"), "t", "Check setting the value attribute" );
-	equals( jQuery("<div value='t'></div>").attr("value"), "t", "Check setting custom attr named 'value' on a div" );
-	equals( jQuery("#form").attr("blah", "blah").attr("blah"), "blah", "Set non-existant attribute on a form" );
-	equals( jQuery("#foo").attr("height"), undefined, "Non existent height attribute should return undefined" );
+	equal( jQuery("#text1").attr("value", "t").attr("value"), "t", "Check setting the value attribute" );
+	equal( jQuery("<div value='t'></div>").attr("value"), "t", "Check setting custom attr named 'value' on a div" );
+	equal( jQuery("#form").attr("blah", "blah").attr("blah"), "blah", "Set non-existant attribute on a form" );
+	equal( jQuery("#foo").attr("height"), undefined, "Non existent height attribute should return undefined" );
 
 	// [7472] & [3113] (form contains an input with name="action" or name="id")
 	var extras = jQuery("<input name='id' name='name' /><input id='target' name='target' />").appendTo("#testForm");
@@ -59,20 +59,20 @@ test("attr(String)", function() {
 	equal( jQuery("#testForm").attr("target", "newTarget").attr("target"), "newTarget", "Set target successfully on a form" );
 	equal( jQuery("#testForm").removeAttr("id").attr("id"), undefined, "Retrieving id does not equal the input with name=id after id is removed [#7472]" );
 	// Bug #3685 (form contains input with name="name")
-	equals( jQuery("#testForm").attr("name"), undefined, "Retrieving name does not retrieve input with name=name" );
+	equal( jQuery("#testForm").attr("name"), undefined, "Retrieving name does not retrieve input with name=name" );
 	extras.remove();
 
-	equals( jQuery("#text1").attr("maxlength"), "30", "Check for maxlength attribute" );
-	equals( jQuery("#text1").attr("maxLength"), "30", "Check for maxLength attribute" );
-	equals( jQuery("#area1").attr("maxLength"), "30", "Check for maxLength attribute" );
+	equal( jQuery("#text1").attr("maxlength"), "30", "Check for maxlength attribute" );
+	equal( jQuery("#text1").attr("maxLength"), "30", "Check for maxLength attribute" );
+	equal( jQuery("#area1").attr("maxLength"), "30", "Check for maxLength attribute" );
 
 	// using innerHTML in IE causes href attribute to be serialized to the full path
 	jQuery("<a/>").attr({ "id": "tAnchor5", "href": "#5" }).appendTo("#qunit-fixture");
-	equals( jQuery("#tAnchor5").attr("href"), "#5", "Check for non-absolute href (an anchor)" );
+	equal( jQuery("#tAnchor5").attr("href"), "#5", "Check for non-absolute href (an anchor)" );
 
 	// list attribute is readonly by default in browsers that support it
 	jQuery("#list-test").attr("list", "datalist");
-	equals( jQuery("#list-test").attr("list"), "datalist", "Check setting list attribute" );
+	equal( jQuery("#list-test").attr("list"), "datalist", "Check setting list attribute" );
 
 	// Related to [5574] and [5683]
 	var body = document.body, $body = jQuery(body);
@@ -80,10 +80,10 @@ test("attr(String)", function() {
 	strictEqual( $body.attr("foo"), undefined, "Make sure that a non existent attribute returns undefined" );
 
 	body.setAttribute("foo", "baz");
-	equals( $body.attr("foo"), "baz", "Make sure the dom attribute is retrieved when no expando is found" );
+	equal( $body.attr("foo"), "baz", "Make sure the dom attribute is retrieved when no expando is found" );
 
 	$body.attr("foo","cool");
-	equals( $body.attr("foo"), "cool", "Make sure that setting works well when both expando and dom attribute are available" );
+	equal( $body.attr("foo"), "cool", "Make sure that setting works well when both expando and dom attribute are available" );
 
 	body.removeAttribute("foo"); // Cleanup
 
@@ -94,8 +94,8 @@ test("attr(String)", function() {
 	equal( jQuery( option ).attr("selected"), "selected", "Make sure that a single option is selected, even when in an optgroup." );
 
 	var $img = jQuery("<img style='display:none' width='215' height='53' src='http://static.jquery.com/files/rocker/images/logo_jquery_215x53.gif'/>").appendTo("body");
-	equals( $img.attr("width"), "215", "Retrieve width attribute an an element with display:none." );
-	equals( $img.attr("height"), "53", "Retrieve height attribute an an element with display:none." );
+	equal( $img.attr("width"), "215", "Retrieve width attribute an an element with display:none." );
+	equal( $img.attr("height"), "53", "Retrieve height attribute an an element with display:none." );
 
 	// Check for style support
 	ok( !!~jQuery("#dl").attr("style").indexOf("position"), "Check style attribute getter, also normalize css props to lowercase" );
@@ -103,12 +103,12 @@ test("attr(String)", function() {
 
 	// Check value on button element (#1954)
 	var $button = jQuery("<button value='foobar'>text</button>").insertAfter("#button");
-	equals( $button.attr("value"), "foobar", "Value retrieval on a button does not return innerHTML" );
-	equals( $button.attr("value", "baz").html(), "text", "Setting the value does not change innerHTML" );
+	equal( $button.attr("value"), "foobar", "Value retrieval on a button does not return innerHTML" );
+	equal( $button.attr("value", "baz").html(), "text", "Setting the value does not change innerHTML" );
 
 	// Attributes with a colon on a table element (#1591)
-	equals( jQuery("#table").attr("test:attrib"), undefined, "Retrieving a non-existent attribute on a table with a colon does not throw an error." );
-	equals( jQuery("#table").attr("test:attrib", "foobar").attr("test:attrib"), "foobar", "Setting an attribute on a table with a colon does not throw an error." );
+	equal( jQuery("#table").attr("test:attrib"), undefined, "Retrieving a non-existent attribute on a table with a colon does not throw an error." );
+	equal( jQuery("#table").attr("test:attrib", "foobar").attr("test:attrib"), "foobar", "Setting an attribute on a table with a colon does not throw an error." );
 
 	var $form = jQuery("<form class='something'></form>").appendTo("#qunit-fixture");
 	equal( $form.attr("class"), "something", "Retrieve the class attribute on a form." );
@@ -142,8 +142,8 @@ if ( !isLocal ) {
 
 test("attr(String, Function)", function() {
 	expect(2);
-	equals( jQuery("#text1").attr("value", function() { return this.id; })[0].value, "text1", "Set value from id" );
-	equals( jQuery("#text1").attr("title", function(i) { return i; }).attr("title"), "0", "Set value with an index");
+	equal( jQuery("#text1").attr("value", function() { return this.id; })[0].value, "text1", "Set value from id" );
+	equal( jQuery("#text1").attr("title", function(i) { return i; }).attr("title"), "0", "Set value with an index");
 });
 
 test("attr(Hash)", function() {
@@ -153,8 +153,8 @@ test("attr(Hash)", function() {
 		if ( this.getAttribute("foo") != "baz" && this.getAttribute("zoo") != "ping" ) pass = false;
 	});
 	ok( pass, "Set Multiple Attributes" );
-	equals( jQuery("#text1").attr({value: function() { return this.id; }})[0].value, "text1", "Set attribute to computed value #1" );
-	equals( jQuery("#text1").attr({title: function(i) { return i; }}).attr("title"), "0", "Set attribute to computed value #2");
+	equal( jQuery("#text1").attr({value: function() { return this.id; }})[0].value, "text1", "Set attribute to computed value #1" );
+	equal( jQuery("#text1").attr({title: function(i) { return i; }}).attr("title"), "0", "Set attribute to computed value #2");
 });
 
 test("attr(String, Object)", function() {
@@ -170,43 +170,43 @@ test("attr(String, Object)", function() {
 		}
 	}
 
-	equals( fail, false, "Set Attribute, the #" + fail + " element didn't get the attribute 'foo'" );
+	equal( fail, false, "Set Attribute, the #" + fail + " element didn't get the attribute 'foo'" );
 
 	ok( jQuery("#foo").attr({ "width": null }), "Try to set an attribute to nothing" );
 
 	jQuery("#name").attr("name", "something");
-	equals( jQuery("#name").attr("name"), "something", "Set name attribute" );
+	equal( jQuery("#name").attr("name"), "something", "Set name attribute" );
 	jQuery("#name").attr("name", null);
-	equals( jQuery("#name").attr("name"), undefined, "Remove name attribute" );
+	equal( jQuery("#name").attr("name"), undefined, "Remove name attribute" );
 	var $input = jQuery("<input>", { name: "something", id: "specified" });
 	equal( $input.attr("name"), "something", "Check element creation gets/sets the name attribute." );
 	equal( $input.attr("id"), "specified", "Check element creation gets/sets the id attribute." );
 
 	jQuery("#check2").prop("checked", true).prop("checked", false).attr("checked", true);
-	equals( document.getElementById("check2").checked, true, "Set checked attribute" );
-	equals( jQuery("#check2").prop("checked"), true, "Set checked attribute" );
-	equals( jQuery("#check2").attr("checked"), "checked", "Set checked attribute" );
+	equal( document.getElementById("check2").checked, true, "Set checked attribute" );
+	equal( jQuery("#check2").prop("checked"), true, "Set checked attribute" );
+	equal( jQuery("#check2").attr("checked"), "checked", "Set checked attribute" );
 	jQuery("#check2").attr("checked", false);
-	equals( document.getElementById("check2").checked, false, "Set checked attribute" );
-	equals( jQuery("#check2").prop("checked"), false, "Set checked attribute" );
-	equals( jQuery("#check2").attr("checked"), undefined, "Set checked attribute" );
+	equal( document.getElementById("check2").checked, false, "Set checked attribute" );
+	equal( jQuery("#check2").prop("checked"), false, "Set checked attribute" );
+	equal( jQuery("#check2").attr("checked"), undefined, "Set checked attribute" );
 	jQuery("#text1").attr("readonly", true);
-	equals( document.getElementById("text1").readOnly, true, "Set readonly attribute" );
-	equals( jQuery("#text1").prop("readOnly"), true, "Set readonly attribute" );
-	equals( jQuery("#text1").attr("readonly"), "readonly", "Set readonly attribute" );
+	equal( document.getElementById("text1").readOnly, true, "Set readonly attribute" );
+	equal( jQuery("#text1").prop("readOnly"), true, "Set readonly attribute" );
+	equal( jQuery("#text1").attr("readonly"), "readonly", "Set readonly attribute" );
 	jQuery("#text1").attr("readonly", false);
-	equals( document.getElementById("text1").readOnly, false, "Set readonly attribute" );
-	equals( jQuery("#text1").prop("readOnly"), false, "Set readonly attribute" );
-	equals( jQuery("#text1").attr("readonly"), undefined, "Set readonly attribute" );
+	equal( document.getElementById("text1").readOnly, false, "Set readonly attribute" );
+	equal( jQuery("#text1").prop("readOnly"), false, "Set readonly attribute" );
+	equal( jQuery("#text1").attr("readonly"), undefined, "Set readonly attribute" );
 
 	jQuery("#check2").prop("checked", true);
-	equals( document.getElementById("check2").checked, true, "Set checked attribute" );
-	equals( jQuery("#check2").prop("checked"), true, "Set checked attribute" );
-	equals( jQuery("#check2").attr("checked"), "checked", "Set checked attribute" );
+	equal( document.getElementById("check2").checked, true, "Set checked attribute" );
+	equal( jQuery("#check2").prop("checked"), true, "Set checked attribute" );
+	equal( jQuery("#check2").attr("checked"), "checked", "Set checked attribute" );
 	jQuery("#check2").prop("checked", false);
-	equals( document.getElementById("check2").checked, false, "Set checked attribute" );
-	equals( jQuery("#check2").prop("checked"), false, "Set checked attribute" );
-	equals( jQuery("#check2").attr("checked"), undefined, "Set checked attribute" );
+	equal( document.getElementById("check2").checked, false, "Set checked attribute" );
+	equal( jQuery("#check2").prop("checked"), false, "Set checked attribute" );
+	equal( jQuery("#check2").attr("checked"), undefined, "Set checked attribute" );
 
 	jQuery("#check2").attr("checked", "checked");
 	equal( document.getElementById("check2").checked, true, "Set checked attribute with 'checked'" );
@@ -221,18 +221,18 @@ test("attr(String, Object)", function() {
 	equal( $radios.attr("checked"), $radios[0].checked ? "checked" : undefined, "Known booleans do not fall back to attribute presence (#10278)");
 
 	jQuery("#text1").prop("readOnly", true);
-	equals( document.getElementById("text1").readOnly, true, "Set readonly attribute" );
-	equals( jQuery("#text1").prop("readOnly"), true, "Set readonly attribute" );
-	equals( jQuery("#text1").attr("readonly"), "readonly", "Set readonly attribute" );
+	equal( document.getElementById("text1").readOnly, true, "Set readonly attribute" );
+	equal( jQuery("#text1").prop("readOnly"), true, "Set readonly attribute" );
+	equal( jQuery("#text1").attr("readonly"), "readonly", "Set readonly attribute" );
 	jQuery("#text1").prop("readOnly", false);
-	equals( document.getElementById("text1").readOnly, false, "Set readonly attribute" );
-	equals( jQuery("#text1").prop("readOnly"), false, "Set readonly attribute" );
-	equals( jQuery("#text1").attr("readonly"), undefined, "Set readonly attribute" );
+	equal( document.getElementById("text1").readOnly, false, "Set readonly attribute" );
+	equal( jQuery("#text1").prop("readOnly"), false, "Set readonly attribute" );
+	equal( jQuery("#text1").attr("readonly"), undefined, "Set readonly attribute" );
 
 	jQuery("#name").attr("maxlength", "5");
-	equals( document.getElementById("name").maxLength, 5, "Set maxlength attribute" );
+	equal( document.getElementById("name").maxLength, 5, "Set maxlength attribute" );
 	jQuery("#name").attr("maxLength", "10");
-	equals( document.getElementById("name").maxLength, 10, "Set maxlength attribute" );
+	equal( document.getElementById("name").maxLength, 10, "Set maxlength attribute" );
 
 	// HTML5 boolean attributes
 	var $text = jQuery("#text1").attr({
@@ -258,7 +258,7 @@ test("attr(String, Object)", function() {
 	$text.removeData("something").removeData("another").removeAttr("aria-disabled");
 
 	jQuery("#foo").attr("contenteditable", true);
-	equals( jQuery("#foo").attr("contenteditable"), "true", "Enumerated attributes are set properly" );
+	equal( jQuery("#foo").attr("contenteditable"), "true", "Enumerated attributes are set properly" );
 
 	var attributeNode = document.createAttribute("irrelevant"),
 		commentNode = document.createComment("some comment"),
@@ -280,27 +280,27 @@ test("attr(String, Object)", function() {
 	var table = jQuery("#table").append("<tr><td>cell</td></tr><tr><td>cell</td><td>cell</td></tr><tr><td>cell</td><td>cell</td></tr>"),
 		td = table.find("td:first");
 	td.attr("rowspan", "2");
-	equals( td[0].rowSpan, 2, "Check rowspan is correctly set" );
+	equal( td[0].rowSpan, 2, "Check rowspan is correctly set" );
 	td.attr("colspan", "2");
-	equals( td[0].colSpan, 2, "Check colspan is correctly set" );
+	equal( td[0].colSpan, 2, "Check colspan is correctly set" );
 	table.attr("cellspacing", "2");
-	equals( table[0].cellSpacing, "2", "Check cellspacing is correctly set" );
+	equal( table[0].cellSpacing, "2", "Check cellspacing is correctly set" );
 
-	equals( jQuery("#area1").attr("value"), "foobar", "Value attribute retrieves the property for backwards compatibility." );
+	equal( jQuery("#area1").attr("value"), "foobar", "Value attribute retrieves the property for backwards compatibility." );
 
 	// for #1070
 	jQuery("#name").attr("someAttr", "0");
-	equals( jQuery("#name").attr("someAttr"), "0", "Set attribute to a string of \"0\"" );
+	equal( jQuery("#name").attr("someAttr"), "0", "Set attribute to a string of \"0\"" );
 	jQuery("#name").attr("someAttr", 0);
-	equals( jQuery("#name").attr("someAttr"), "0", "Set attribute to the number 0" );
+	equal( jQuery("#name").attr("someAttr"), "0", "Set attribute to the number 0" );
 	jQuery("#name").attr("someAttr", 1);
-	equals( jQuery("#name").attr("someAttr"), "1", "Set attribute to the number 1" );
+	equal( jQuery("#name").attr("someAttr"), "1", "Set attribute to the number 1" );
 
 	// using contents will get comments regular, text, and comment nodes
 	var j = jQuery("#nonnodes").contents();
 
 	j.attr("name", "attrvalue");
-	equals( j.attr("name"), "attrvalue", "Check node,textnode,comment for attr" );
+	equal( j.attr("name"), "attrvalue", "Check node,textnode,comment for attr" );
 	j.removeAttr("name");
 
 	// Type
@@ -312,7 +312,7 @@ test("attr(String, Object)", function() {
 		thrown = true;
 	}
 	ok( thrown, "Exception thrown when trying to change type property" );
-	equals( type, jQuery("#check2").attr("type"), "Verify that you can't change the type of an input element" );
+	equal( type, jQuery("#check2").attr("type"), "Verify that you can't change the type of an input element" );
 
 	var check = document.createElement("input");
 	thrown = true;
@@ -322,7 +322,7 @@ test("attr(String, Object)", function() {
 		thrown = false;
 	}
 	ok( thrown, "Exception thrown when trying to change type property" );
-	equals( "checkbox", jQuery(check).attr("type"), "Verify that you can change the type of an input element that isn't in the DOM" );
+	equal( "checkbox", jQuery(check).attr("type"), "Verify that you can change the type of an input element that isn't in the DOM" );
 
 	check = jQuery("<input />");
 	thrown = true;
@@ -332,7 +332,7 @@ test("attr(String, Object)", function() {
 		thrown = false;
 	}
 	ok( thrown, "Exception thrown when trying to change type property" );
-	equals( "checkbox", check.attr("type"), "Verify that you can change the type of an input element that isn't in the DOM" );
+	equal( "checkbox", check.attr("type"), "Verify that you can change the type of an input element that isn't in the DOM" );
 
 	var button = jQuery("#button");
 	thrown = false;
@@ -342,16 +342,16 @@ test("attr(String, Object)", function() {
 		thrown = true;
 	}
 	ok( thrown, "Exception thrown when trying to change type property" );
-	equals( "button", button.attr("type"), "Verify that you can't change the type of a button element" );
+	equal( "button", button.attr("type"), "Verify that you can't change the type of a button element" );
 
 	var $radio = jQuery("<input>", { "value": "sup", "type": "radio" }).appendTo("#testForm");
-	equals( $radio.val(), "sup", "Value is not reset when type is set after value on a radio" );
+	equal( $radio.val(), "sup", "Value is not reset when type is set after value on a radio" );
 
 	// Setting attributes on svg elements (bug #3116)
 	var $svg = jQuery("<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' version='1.1' baseProfile='full' width='200' height='200'>"
 		+ "<circle cx='200' cy='200' r='150' />"
 	+ "</svg>").appendTo("body");
-	equals( $svg.attr("cx", 100).attr("cx"), "100", "Set attribute on svg element" );
+	equal( $svg.attr("cx", 100).attr("cx"), "100", "Set attribute on svg element" );
 	$svg.remove();
 });
 
@@ -363,16 +363,16 @@ test("attr(jquery_method)", function(){
 
 	// one at a time
 	$elem.attr({html: "foo"}, true);
-	equals( elem.innerHTML, "foo", "attr(html)");
+	equal( elem.innerHTML, "foo", "attr(html)");
 
 	$elem.attr({text: "bar"}, true);
-	equals( elem.innerHTML, "bar", "attr(text)");
+	equal( elem.innerHTML, "bar", "attr(text)");
 
 	$elem.attr({css: {color: "red"}}, true);
 	ok( /^(#ff0000|red)$/i.test(elem.style.color), "attr(css)");
 
 	$elem.attr({height: 10}, true);
-	equals( elem.style.height, "10px", "attr(height)");
+	equal( elem.style.height, "10px", "attr(height)");
 
 	// Multiple attributes
 
@@ -381,9 +381,9 @@ test("attr(jquery_method)", function(){
 		css:{ paddingLeft:1, paddingRight:1 }
 	}, true);
 
-	equals( elem.style.width, "10px", "attr({...})");
-	equals( elem.style.paddingLeft, "1px", "attr({...})");
-	equals( elem.style.paddingRight, "1px", "attr({...})");
+	equal( elem.style.width, "10px", "attr({...})");
+	equal( elem.style.paddingLeft, "1px", "attr({...})");
+	equal( elem.style.paddingRight, "1px", "attr({...})");
 });
 
 if ( !isLocal ) {
@@ -395,8 +395,8 @@ if ( !isLocal ) {
 			jQuery( "tab", xml ).each(function() {
 				titles.push( jQuery(this).attr("title") );
 			});
-			equals( titles[0], "Location", "attr() in XML context: Check first title" );
-			equals( titles[1], "Users", "attr() in XML context: Check second title" );
+			equal( titles[0], "Location", "attr() in XML context: Check first title" );
+			equal( titles[1], "Users", "attr() in XML context: Check second title" );
 			start();
 		});
 	});
@@ -406,55 +406,55 @@ test("attr('tabindex')", function() {
 	expect(8);
 
 	// elements not natively tabbable
-	equals(jQuery("#listWithTabIndex").attr("tabindex"), 5, "not natively tabbable, with tabindex set to 0");
-	equals(jQuery("#divWithNoTabIndex").attr("tabindex"), undefined, "not natively tabbable, no tabindex set");
+	equal(jQuery("#listWithTabIndex").attr("tabindex"), 5, "not natively tabbable, with tabindex set to 0");
+	equal(jQuery("#divWithNoTabIndex").attr("tabindex"), undefined, "not natively tabbable, no tabindex set");
 
 	// anchor with href
-	equals(jQuery("#linkWithNoTabIndex").attr("tabindex"), 0, "anchor with href, no tabindex set");
-	equals(jQuery("#linkWithTabIndex").attr("tabindex"), 2, "anchor with href, tabindex set to 2");
-	equals(jQuery("#linkWithNegativeTabIndex").attr("tabindex"), -1, "anchor with href, tabindex set to -1");
+	equal(jQuery("#linkWithNoTabIndex").attr("tabindex"), 0, "anchor with href, no tabindex set");
+	equal(jQuery("#linkWithTabIndex").attr("tabindex"), 2, "anchor with href, tabindex set to 2");
+	equal(jQuery("#linkWithNegativeTabIndex").attr("tabindex"), -1, "anchor with href, tabindex set to -1");
 
 	// anchor without href
-	equals(jQuery("#linkWithNoHrefWithNoTabIndex").attr("tabindex"), undefined, "anchor without href, no tabindex set");
-	equals(jQuery("#linkWithNoHrefWithTabIndex").attr("tabindex"), 1, "anchor without href, tabindex set to 2");
-	equals(jQuery("#linkWithNoHrefWithNegativeTabIndex").attr("tabindex"), -1, "anchor without href, no tabindex set");
+	equal(jQuery("#linkWithNoHrefWithNoTabIndex").attr("tabindex"), undefined, "anchor without href, no tabindex set");
+	equal(jQuery("#linkWithNoHrefWithTabIndex").attr("tabindex"), 1, "anchor without href, tabindex set to 2");
+	equal(jQuery("#linkWithNoHrefWithNegativeTabIndex").attr("tabindex"), -1, "anchor without href, no tabindex set");
 });
 
 test("attr('tabindex', value)", function() {
 	expect(9);
 
 	var element = jQuery("#divWithNoTabIndex");
-	equals(element.attr("tabindex"), undefined, "start with no tabindex");
+	equal(element.attr("tabindex"), undefined, "start with no tabindex");
 
 	// set a positive string
 	element.attr("tabindex", "1");
-	equals(element.attr("tabindex"), 1, "set tabindex to 1 (string)");
+	equal(element.attr("tabindex"), 1, "set tabindex to 1 (string)");
 
 	// set a zero string
 	element.attr("tabindex", "0");
-	equals(element.attr("tabindex"), 0, "set tabindex to 0 (string)");
+	equal(element.attr("tabindex"), 0, "set tabindex to 0 (string)");
 
 	// set a negative string
 	element.attr("tabindex", "-1");
-	equals(element.attr("tabindex"), -1, "set tabindex to -1 (string)");
+	equal(element.attr("tabindex"), -1, "set tabindex to -1 (string)");
 
 	// set a positive number
 	element.attr("tabindex", 1);
-	equals(element.attr("tabindex"), 1, "set tabindex to 1 (number)");
+	equal(element.attr("tabindex"), 1, "set tabindex to 1 (number)");
 
 	// set a zero number
 	element.attr("tabindex", 0);
-	equals(element.attr("tabindex"), 0, "set tabindex to 0 (number)");
+	equal(element.attr("tabindex"), 0, "set tabindex to 0 (number)");
 
 	// set a negative number
 	element.attr("tabindex", -1);
-	equals(element.attr("tabindex"), -1, "set tabindex to -1 (number)");
+	equal(element.attr("tabindex"), -1, "set tabindex to -1 (number)");
 
 	element = jQuery("#linkWithTabIndex");
-	equals(element.attr("tabindex"), 2, "start with tabindex 2");
+	equal(element.attr("tabindex"), 2, "start with tabindex 2");
 
 	element.attr("tabindex", -1);
-	equals(element.attr("tabindex"), -1, "set negative tabindex");
+	equal(element.attr("tabindex"), -1, "set negative tabindex");
 });
 
 test("removeAttr(String)", function() {
@@ -484,32 +484,32 @@ test("removeAttr(String)", function() {
 test("prop(String, Object)", function() {
 	expect(31);
 
-	equals( jQuery("#text1").prop("value"), "Test", "Check for value attribute" );
-	equals( jQuery("#text1").prop("value", "Test2").prop("defaultValue"), "Test", "Check for defaultValue attribute" );
-	equals( jQuery("#select2").prop("selectedIndex"), 3, "Check for selectedIndex attribute" );
-	equals( jQuery("#foo").prop("nodeName").toUpperCase(), "DIV", "Check for nodeName attribute" );
-	equals( jQuery("#foo").prop("tagName").toUpperCase(), "DIV", "Check for tagName attribute" );
-	equals( jQuery("<option/>").prop("selected"), false, "Check selected attribute on disconnected element." );
+	equal( jQuery("#text1").prop("value"), "Test", "Check for value attribute" );
+	equal( jQuery("#text1").prop("value", "Test2").prop("defaultValue"), "Test", "Check for defaultValue attribute" );
+	equal( jQuery("#select2").prop("selectedIndex"), 3, "Check for selectedIndex attribute" );
+	equal( jQuery("#foo").prop("nodeName").toUpperCase(), "DIV", "Check for nodeName attribute" );
+	equal( jQuery("#foo").prop("tagName").toUpperCase(), "DIV", "Check for tagName attribute" );
+	equal( jQuery("<option/>").prop("selected"), false, "Check selected attribute on disconnected element." );
 
-	equals( jQuery("#listWithTabIndex").prop("tabindex"), 5, "Check retrieving tabindex" );
+	equal( jQuery("#listWithTabIndex").prop("tabindex"), 5, "Check retrieving tabindex" );
 	jQuery("#text1").prop("readonly", true);
-	equals( document.getElementById("text1").readOnly, true, "Check setting readOnly property with 'readonly'" );
-	equals( jQuery("#label-for").prop("for"), "action", "Check retrieving htmlFor" );
+	equal( document.getElementById("text1").readOnly, true, "Check setting readOnly property with 'readonly'" );
+	equal( jQuery("#label-for").prop("for"), "action", "Check retrieving htmlFor" );
 	jQuery("#text1").prop("class", "test");
-	equals( document.getElementById("text1").className, "test", "Check setting className with 'class'" );
-	equals( jQuery("#text1").prop("maxlength"), 30, "Check retrieving maxLength" );
+	equal( document.getElementById("text1").className, "test", "Check setting className with 'class'" );
+	equal( jQuery("#text1").prop("maxlength"), 30, "Check retrieving maxLength" );
 	jQuery("#table").prop("cellspacing", 1);
-	equals( jQuery("#table").prop("cellSpacing"), "1", "Check setting and retrieving cellSpacing" );
+	equal( jQuery("#table").prop("cellSpacing"), "1", "Check setting and retrieving cellSpacing" );
 	jQuery("#table").prop("cellpadding", 1);
-	equals( jQuery("#table").prop("cellPadding"), "1", "Check setting and retrieving cellPadding" );
+	equal( jQuery("#table").prop("cellPadding"), "1", "Check setting and retrieving cellPadding" );
 	jQuery("#table").prop("rowspan", 1);
-	equals( jQuery("#table").prop("rowSpan"), 1, "Check setting and retrieving rowSpan" );
+	equal( jQuery("#table").prop("rowSpan"), 1, "Check setting and retrieving rowSpan" );
 	jQuery("#table").prop("colspan", 1);
-	equals( jQuery("#table").prop("colSpan"), 1, "Check setting and retrieving colSpan" );
+	equal( jQuery("#table").prop("colSpan"), 1, "Check setting and retrieving colSpan" );
 	jQuery("#table").prop("usemap", 1);
-	equals( jQuery("#table").prop("useMap"), 1, "Check setting and retrieving useMap" );
+	equal( jQuery("#table").prop("useMap"), 1, "Check setting and retrieving useMap" );
 	jQuery("#table").prop("frameborder", 1);
-	equals( jQuery("#table").prop("frameBorder"), 1, "Check setting and retrieving frameBorder" );
+	equal( jQuery("#table").prop("frameBorder"), 1, "Check setting and retrieving frameBorder" );
 	QUnit.reset();
 
 	var body = document.body,
@@ -517,7 +517,7 @@ test("prop(String, Object)", function() {
 
 	ok( $body.prop("nextSibling") === null, "Make sure a null expando returns null" );
 	body.foo = "bar";
-	equals( $body.prop("foo"), "bar", "Make sure the expando is preferred over the dom attribute" );
+	equal( $body.prop("foo"), "bar", "Make sure the expando is preferred over the dom attribute" );
 	body.foo = undefined;
 	ok( $body.prop("foo") === undefined, "Make sure the expando is preferred over the dom attribute, even if undefined" );
 
@@ -525,8 +525,8 @@ test("prop(String, Object)", function() {
 	optgroup.appendChild( option );
 	select.appendChild( optgroup );
 
-	equals( jQuery(option).prop("selected"), true, "Make sure that a single option is selected, even when in an optgroup." );
-	equals( jQuery(document).prop("nodeName"), "#document", "prop works correctly on document nodes (bug #7451)." );
+	equal( jQuery(option).prop("selected"), true, "Make sure that a single option is selected, even when in an optgroup." );
+	equal( jQuery(document).prop("nodeName"), "#document", "prop works correctly on document nodes (bug #7451)." );
 
 	var attributeNode = document.createAttribute("irrelevant"),
 		commentNode = document.createComment("some comment"),
@@ -574,55 +574,55 @@ test("prop('tabindex')", function() {
 	expect(8);
 
 	// elements not natively tabbable
-	equals(jQuery("#listWithTabIndex").prop("tabindex"), 5, "not natively tabbable, with tabindex set to 0");
-	equals(jQuery("#divWithNoTabIndex").prop("tabindex"), undefined, "not natively tabbable, no tabindex set");
+	equal(jQuery("#listWithTabIndex").prop("tabindex"), 5, "not natively tabbable, with tabindex set to 0");
+	equal(jQuery("#divWithNoTabIndex").prop("tabindex"), undefined, "not natively tabbable, no tabindex set");
 
 	// anchor with href
-	equals(jQuery("#linkWithNoTabIndex").prop("tabindex"), 0, "anchor with href, no tabindex set");
-	equals(jQuery("#linkWithTabIndex").prop("tabindex"), 2, "anchor with href, tabindex set to 2");
-	equals(jQuery("#linkWithNegativeTabIndex").prop("tabindex"), -1, "anchor with href, tabindex set to -1");
+	equal(jQuery("#linkWithNoTabIndex").prop("tabindex"), 0, "anchor with href, no tabindex set");
+	equal(jQuery("#linkWithTabIndex").prop("tabindex"), 2, "anchor with href, tabindex set to 2");
+	equal(jQuery("#linkWithNegativeTabIndex").prop("tabindex"), -1, "anchor with href, tabindex set to -1");
 
 	// anchor without href
-	equals(jQuery("#linkWithNoHrefWithNoTabIndex").prop("tabindex"), undefined, "anchor without href, no tabindex set");
-	equals(jQuery("#linkWithNoHrefWithTabIndex").prop("tabindex"), 1, "anchor without href, tabindex set to 2");
-	equals(jQuery("#linkWithNoHrefWithNegativeTabIndex").prop("tabindex"), -1, "anchor without href, no tabindex set");
+	equal(jQuery("#linkWithNoHrefWithNoTabIndex").prop("tabindex"), undefined, "anchor without href, no tabindex set");
+	equal(jQuery("#linkWithNoHrefWithTabIndex").prop("tabindex"), 1, "anchor without href, tabindex set to 2");
+	equal(jQuery("#linkWithNoHrefWithNegativeTabIndex").prop("tabindex"), -1, "anchor without href, no tabindex set");
 });
 
 test("prop('tabindex', value)", function() {
 	expect(9);
 
 	var element = jQuery("#divWithNoTabIndex");
-	equals(element.prop("tabindex"), undefined, "start with no tabindex");
+	equal(element.prop("tabindex"), undefined, "start with no tabindex");
 
 	// set a positive string
 	element.prop("tabindex", "1");
-	equals(element.prop("tabindex"), 1, "set tabindex to 1 (string)");
+	equal(element.prop("tabindex"), 1, "set tabindex to 1 (string)");
 
 	// set a zero string
 	element.prop("tabindex", "0");
-	equals(element.prop("tabindex"), 0, "set tabindex to 0 (string)");
+	equal(element.prop("tabindex"), 0, "set tabindex to 0 (string)");
 
 	// set a negative string
 	element.prop("tabindex", "-1");
-	equals(element.prop("tabindex"), -1, "set tabindex to -1 (string)");
+	equal(element.prop("tabindex"), -1, "set tabindex to -1 (string)");
 
 	// set a positive number
 	element.prop("tabindex", 1);
-	equals(element.prop("tabindex"), 1, "set tabindex to 1 (number)");
+	equal(element.prop("tabindex"), 1, "set tabindex to 1 (number)");
 
 	// set a zero number
 	element.prop("tabindex", 0);
-	equals(element.prop("tabindex"), 0, "set tabindex to 0 (number)");
+	equal(element.prop("tabindex"), 0, "set tabindex to 0 (number)");
 
 	// set a negative number
 	element.prop("tabindex", -1);
-	equals(element.prop("tabindex"), -1, "set tabindex to -1 (number)");
+	equal(element.prop("tabindex"), -1, "set tabindex to -1 (number)");
 
 	element = jQuery("#linkWithTabIndex");
-	equals(element.prop("tabindex"), 2, "start with tabindex 2");
+	equal(element.prop("tabindex"), 2, "start with tabindex 2");
 
 	element.prop("tabindex", -1);
-	equals(element.prop("tabindex"), -1, "set negative tabindex");
+	equal(element.prop("tabindex"), -1, "set negative tabindex");
 });
 
 test("removeProp(String)", function() {
@@ -650,71 +650,71 @@ test("val()", function() {
 	expect(26);
 
 	document.getElementById("text1").value = "bla";
-	equals( jQuery("#text1").val(), "bla", "Check for modified value of input element" );
+	equal( jQuery("#text1").val(), "bla", "Check for modified value of input element" );
 
 	QUnit.reset();
 
-	equals( jQuery("#text1").val(), "Test", "Check for value of input element" );
+	equal( jQuery("#text1").val(), "Test", "Check for value of input element" );
 	// ticket #1714 this caused a JS error in IE
-	equals( jQuery("#first").val(), "", "Check a paragraph element to see if it has a value" );
+	equal( jQuery("#first").val(), "", "Check a paragraph element to see if it has a value" );
 	ok( jQuery([]).val() === undefined, "Check an empty jQuery object will return undefined from val" );
 
-	equals( jQuery("#select2").val(), "3", "Call val() on a single=\"single\" select" );
+	equal( jQuery("#select2").val(), "3", "Call val() on a single=\"single\" select" );
 
-	same( jQuery("#select3").val(), ["1", "2"], "Call val() on a multiple=\"multiple\" select" );
+	deepEqual( jQuery("#select3").val(), ["1", "2"], "Call val() on a multiple=\"multiple\" select" );
 
-	equals( jQuery("#option3c").val(), "2", "Call val() on a option element with value" );
+	equal( jQuery("#option3c").val(), "2", "Call val() on a option element with value" );
 
-	equals( jQuery("#option3a").val(), "", "Call val() on a option element with empty value" );
+	equal( jQuery("#option3a").val(), "", "Call val() on a option element with empty value" );
 
-	equals( jQuery("#option3e").val(), "no value", "Call val() on a option element with no value attribute" );
+	equal( jQuery("#option3e").val(), "no value", "Call val() on a option element with no value attribute" );
 
-	equals( jQuery("#option3a").val(), "", "Call val() on a option element with no value attribute" );
+	equal( jQuery("#option3a").val(), "", "Call val() on a option element with no value attribute" );
 
 	jQuery("#select3").val("");
-	same( jQuery("#select3").val(), [""], "Call val() on a multiple=\"multiple\" select" );
+	deepEqual( jQuery("#select3").val(), [""], "Call val() on a multiple=\"multiple\" select" );
 
-	same( jQuery("#select4").val(), [], "Call val() on multiple=\"multiple\" select with all disabled options" );
+	deepEqual( jQuery("#select4").val(), [], "Call val() on multiple=\"multiple\" select with all disabled options" );
 
 	jQuery("#select4 optgroup").add("#select4 > [disabled]").attr("disabled", false);
-	same( jQuery("#select4").val(), ["2", "3"], "Call val() on multiple=\"multiple\" select with some disabled options" );
+	deepEqual( jQuery("#select4").val(), ["2", "3"], "Call val() on multiple=\"multiple\" select with some disabled options" );
 
 	jQuery("#select4").attr("disabled", true);
-	same( jQuery("#select4").val(), ["2", "3"], "Call val() on disabled multiple=\"multiple\" select" );
+	deepEqual( jQuery("#select4").val(), ["2", "3"], "Call val() on disabled multiple=\"multiple\" select" );
 
-	equals( jQuery("#select5").val(), "3", "Check value on ambiguous select." );
+	equal( jQuery("#select5").val(), "3", "Check value on ambiguous select." );
 
 	jQuery("#select5").val(1);
-	equals( jQuery("#select5").val(), "1", "Check value on ambiguous select." );
+	equal( jQuery("#select5").val(), "1", "Check value on ambiguous select." );
 
 	jQuery("#select5").val(3);
-	equals( jQuery("#select5").val(), "3", "Check value on ambiguous select." );
+	equal( jQuery("#select5").val(), "3", "Check value on ambiguous select." );
 
 	var checks = jQuery("<input type='checkbox' name='test' value='1'/><input type='checkbox' name='test' value='2'/><input type='checkbox' name='test' value=''/><input type='checkbox' name='test'/>").appendTo("#form");
 
-	same( checks.serialize(), "", "Get unchecked values." );
+	deepEqual( checks.serialize(), "", "Get unchecked values." );
 
-	equals( checks.eq(3).val(), "on", "Make sure a value of 'on' is provided if none is specified." );
+	equal( checks.eq(3).val(), "on", "Make sure a value of 'on' is provided if none is specified." );
 
 	checks.val([ "2" ]);
-	same( checks.serialize(), "test=2", "Get a single checked value." );
+	deepEqual( checks.serialize(), "test=2", "Get a single checked value." );
 
 	checks.val([ "1", "" ]);
-	same( checks.serialize(), "test=1&test=", "Get multiple checked values." );
+	deepEqual( checks.serialize(), "test=1&test=", "Get multiple checked values." );
 
 	checks.val([ "", "2" ]);
-	same( checks.serialize(), "test=2&test=", "Get multiple checked values." );
+	deepEqual( checks.serialize(), "test=2&test=", "Get multiple checked values." );
 
 	checks.val([ "1", "on" ]);
-	same( checks.serialize(), "test=1&test=on", "Get multiple checked values." );
+	deepEqual( checks.serialize(), "test=1&test=on", "Get multiple checked values." );
 
 	checks.remove();
 
 	var $button = jQuery("<button value='foobar'>text</button>").insertAfter("#button");
-	equals( $button.val(), "foobar", "Value retrieval on a button does not return innerHTML" );
-	equals( $button.val("baz").html(), "text", "Setting the value does not change innerHTML" );
+	equal( $button.val(), "foobar", "Value retrieval on a button does not return innerHTML" );
+	equal( $button.val("baz").html(), "text", "Setting the value does not change innerHTML" );
 
-	equals( jQuery("<option/>").val("test").attr("value"), "test", "Setting value sets the value attribute" );
+	equal( jQuery("<option/>").val("test").attr("value"), "test", "Setting value sets the value attribute" );
 });
 
 if ( "value" in document.createElement("meter") &&
@@ -746,32 +746,32 @@ var testVal = function(valueObj) {
 
 	QUnit.reset();
 	jQuery("#text1").val(valueObj( "test" ));
-	equals( document.getElementById("text1").value, "test", "Check for modified (via val(String)) value of input element" );
+	equal( document.getElementById("text1").value, "test", "Check for modified (via val(String)) value of input element" );
 
 	jQuery("#text1").val(valueObj( undefined ));
-	equals( document.getElementById("text1").value, "", "Check for modified (via val(undefined)) value of input element" );
+	equal( document.getElementById("text1").value, "", "Check for modified (via val(undefined)) value of input element" );
 
 	jQuery("#text1").val(valueObj( 67 ));
-	equals( document.getElementById("text1").value, "67", "Check for modified (via val(Number)) value of input element" );
+	equal( document.getElementById("text1").value, "67", "Check for modified (via val(Number)) value of input element" );
 
 	jQuery("#text1").val(valueObj( null ));
-	equals( document.getElementById("text1").value, "", "Check for modified (via val(null)) value of input element" );
+	equal( document.getElementById("text1").value, "", "Check for modified (via val(null)) value of input element" );
 
 	var $select1 = jQuery("#select1");
 	$select1.val(valueObj( "3" ));
-	equals( $select1.val(), "3", "Check for modified (via val(String)) value of select element" );
+	equal( $select1.val(), "3", "Check for modified (via val(String)) value of select element" );
 
 	$select1.val(valueObj( 2 ));
-	equals( $select1.val(), "2", "Check for modified (via val(Number)) value of select element" );
+	equal( $select1.val(), "2", "Check for modified (via val(Number)) value of select element" );
 
 	$select1.append("<option value='4'>four</option>");
 	$select1.val(valueObj( 4 ));
-	equals( $select1.val(), "4", "Should be possible to set the val() to a newly created option" );
+	equal( $select1.val(), "4", "Should be possible to set the val() to a newly created option" );
 
 	// using contents will get comments regular, text, and comment nodes
 	var j = jQuery("#nonnodes").contents();
 	j.val(valueObj( "asdf" ));
-	equals( j.val(), "asdf", "Check node,textnode,comment with val()" );
+	equal( j.val(), "asdf", "Check node,textnode,comment with val()" );
 	j.removeAttr("value");
 }
 
@@ -802,49 +802,49 @@ test("val(Function) with incoming value", function() {
 	var oldVal = jQuery("#text1").val();
 
 	jQuery("#text1").val(function(i, val) {
-		equals( val, oldVal, "Make sure the incoming value is correct." );
+		equal( val, oldVal, "Make sure the incoming value is correct." );
 		return "test";
 	});
 
-	equals( document.getElementById("text1").value, "test", "Check for modified (via val(String)) value of input element" );
+	equal( document.getElementById("text1").value, "test", "Check for modified (via val(String)) value of input element" );
 
 	oldVal = jQuery("#text1").val();
 
 	jQuery("#text1").val(function(i, val) {
-		equals( val, oldVal, "Make sure the incoming value is correct." );
+		equal( val, oldVal, "Make sure the incoming value is correct." );
 		return 67;
 	});
 
-	equals( document.getElementById("text1").value, "67", "Check for modified (via val(Number)) value of input element" );
+	equal( document.getElementById("text1").value, "67", "Check for modified (via val(Number)) value of input element" );
 
 	oldVal = jQuery("#select1").val();
 
 	jQuery("#select1").val(function(i, val) {
-		equals( val, oldVal, "Make sure the incoming value is correct." );
+		equal( val, oldVal, "Make sure the incoming value is correct." );
 		return "3";
 	});
 
-	equals( jQuery("#select1").val(), "3", "Check for modified (via val(String)) value of select element" );
+	equal( jQuery("#select1").val(), "3", "Check for modified (via val(String)) value of select element" );
 
 	oldVal = jQuery("#select1").val();
 
 	jQuery("#select1").val(function(i, val) {
-		equals( val, oldVal, "Make sure the incoming value is correct." );
+		equal( val, oldVal, "Make sure the incoming value is correct." );
 		return 2;
 	});
 
-	equals( jQuery("#select1").val(), "2", "Check for modified (via val(Number)) value of select element" );
+	equal( jQuery("#select1").val(), "2", "Check for modified (via val(Number)) value of select element" );
 
 	jQuery("#select1").append("<option value='4'>four</option>");
 
 	oldVal = jQuery("#select1").val();
 
 	jQuery("#select1").val(function(i, val) {
-		equals( val, oldVal, "Make sure the incoming value is correct." );
+		equal( val, oldVal, "Make sure the incoming value is correct." );
 		return 4;
 	});
 
-	equals( jQuery("#select1").val(), "4", "Should be possible to set the val() to a newly created option" );
+	equal( jQuery("#select1").val(), "4", "Should be possible to set the val() to a newly created option" );
 });
 
 // testing if a form.reset() breaks a subsequent call to a select element's .val() (in IE only)
@@ -861,7 +861,7 @@ test("val(select) after form.reset() (Bug #2551)", function() {
 	equal( jQuery("#kkk").val(), "cf", "Check value of select after form reset." );
 
 	// re-verify the multi-select is not broken (after form.reset) by our fix for single-select
-	same( jQuery("#select3").val(), ["1", "2"], "Call val() on a multiple=\"multiple\" select" );
+	deepEqual( jQuery("#select3").val(), ["1", "2"], "Call val() on a multiple=\"multiple\" select" );
 
 	jQuery("#kk").remove();
 });
@@ -887,15 +887,15 @@ var testAddClass = function(valueObj) {
 	div = jQuery("<div/>");
 
 	div.addClass( valueObj("test") );
-	equals( div.attr("class"), "test", "Make sure there's no extra whitespace." );
+	equal( div.attr("class"), "test", "Make sure there's no extra whitespace." );
 
 	div.attr("class", " foo");
 	div.addClass( valueObj("test") );
-	equals( div.attr("class"), "foo test", "Make sure there's no extra whitespace." );
+	equal( div.attr("class"), "foo test", "Make sure there's no extra whitespace." );
 
 	div.attr("class", "foo");
 	div.addClass( valueObj("bar baz") );
-	equals( div.attr("class"), "foo bar baz", "Make sure there isn't too much trimming." );
+	equal( div.attr("class"), "foo bar baz", "Make sure there isn't too much trimming." );
 
 	div.removeClass();
 	div.addClass( valueObj("foo") ).addClass( valueObj("foo") );
@@ -927,7 +927,7 @@ test("addClass(Function) with incoming value", function() {
 
 	div.addClass(function(i, val) {
 		if ( this.id !== "_firebugConsole") {
-			equals( val, old[i], "Make sure the incoming value is correct." );
+			equal( val, old[i], "Make sure the incoming value is correct." );
 			return "test";
 		}
 	});
@@ -975,12 +975,12 @@ var testRemoveClass = function(valueObj) {
 	div.className = " test foo ";
 
 	jQuery(div).removeClass( valueObj("foo") );
-	equals( div.className, "test", "Make sure remaining className is trimmed." );
+	equal( div.className, "test", "Make sure remaining className is trimmed." );
 
 	div.className = " test ";
 
 	jQuery(div).removeClass( valueObj("test") );
-	equals( div.className, "", "Make sure there is nothing left after everything is removed." );
+	equal( div.className, "", "Make sure there is nothing left after everything is removed." );
 };
 
 test("removeClass(String) - simple", function() {
@@ -1000,7 +1000,7 @@ test("removeClass(Function) with incoming value", function() {
 
 	$divs.removeClass(function(i, val) {
 		if ( this.id !== "_firebugConsole" ) {
-			equals( val, old[i], "Make sure the incoming value is correct." );
+			equal( val, old[i], "Make sure the incoming value is correct." );
 			return "test";
 		}
 	});
@@ -1127,17 +1127,17 @@ test("addClass, removeClass, hasClass", function() {
 	var jq = jQuery("<p>Hi</p>"), x = jq[0];
 
 	jq.addClass("hi");
-	equals( x.className, "hi", "Check single added class" );
+	equal( x.className, "hi", "Check single added class" );
 
 	jq.addClass("foo bar");
-	equals( x.className, "hi foo bar", "Check more added classes" );
+	equal( x.className, "hi foo bar", "Check more added classes" );
 
 	jq.removeClass();
-	equals( x.className, "", "Remove all classes" );
+	equal( x.className, "", "Remove all classes" );
 
 	jq.addClass("hi foo bar");
 	jq.removeClass("foo");
-	equals( x.className, "hi bar", "Check removal of one class" );
+	equal( x.className, "hi bar", "Check removal of one class" );
 
 	ok( jq.hasClass("hi"), "Check has1" );
 	ok( jq.hasClass("bar"), "Check has2" );

--- a/test/unit/callbacks.js
+++ b/test/unit/callbacks.js
@@ -69,7 +69,7 @@ jQuery.each( tests, function( flags, resultString ) {
 				output = "X";
 				cblist = jQuery.Callbacks( flags );
 				cblist.add(function() {
-					equals( this, window, "Basic binding and firing (context)" );
+					equal( this, window, "Basic binding and firing (context)" );
 					output += Array.prototype.join.call( arguments, "" );
 				});
 				cblist.fireWith( window, [ "A", "B" ] );
@@ -79,7 +79,7 @@ jQuery.each( tests, function( flags, resultString ) {
 				output = "";
 				cblist = jQuery.Callbacks( flags );
 				cblist.add(function() {
-					equals( this, window, "fireWith with no arguments (context is window)" );
+					equal( this, window, "fireWith with no arguments (context is window)" );
 					strictEqual( arguments.length, 0, "fireWith with no arguments (no arguments)" );
 				});
 				cblist.fireWith();

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -16,21 +16,21 @@ test("jQuery()", function() {
 
 	// Basic constructor's behavior
 
-	equals( jQuery().length, 0, "jQuery() === jQuery([])" );
-	equals( jQuery(undefined).length, 0, "jQuery(undefined) === jQuery([])" );
-	equals( jQuery(null).length, 0, "jQuery(null) === jQuery([])" );
-	equals( jQuery("").length, 0, "jQuery('') === jQuery([])" );
-	equals( jQuery("#").length, 0, "jQuery('#') === jQuery([])" );
+	equal( jQuery().length, 0, "jQuery() === jQuery([])" );
+	equal( jQuery(undefined).length, 0, "jQuery(undefined) === jQuery([])" );
+	equal( jQuery(null).length, 0, "jQuery(null) === jQuery([])" );
+	equal( jQuery("").length, 0, "jQuery('') === jQuery([])" );
+	equal( jQuery("#").length, 0, "jQuery('#') === jQuery([])" );
 
 	var obj = jQuery("div");
-	equals( jQuery(obj).selector, "div", "jQuery(jQueryObj) == jQueryObj" );
+	equal( jQuery(obj).selector, "div", "jQuery(jQueryObj) == jQueryObj" );
 
 		// can actually yield more than one, when iframes are included, the window is an array as well
-	equals( jQuery(window).length, 1, "Correct number of elements generated for jQuery(window)" );
+	equal( jQuery(window).length, 1, "Correct number of elements generated for jQuery(window)" );
 
 
 	var main = jQuery("#qunit-fixture");
-	same( jQuery("div p", main).get(), q("sndp", "en", "sap"), "Basic selector with jQuery object as context" );
+	deepEqual( jQuery("div p", main).get(), q("sndp", "en", "sap"), "Basic selector with jQuery object as context" );
 
 /*
 	// disabled since this test was doing nothing. i tried to fix it but i'm not sure
@@ -38,7 +38,7 @@ test("jQuery()", function() {
 	// make sure this is handled
 	var crlfContainer = jQuery('<p>\r\n</p>');
 	var x = crlfContainer.contents().get(0).nodeValue;
-	equals( x, what???, "Check for \\r and \\n in jQuery()" );
+	equal( x, what???, "Check for \\r and \\n in jQuery()" );
 */
 
 	/* // Disabled until we add this functionality in
@@ -51,18 +51,18 @@ test("jQuery()", function() {
 	ok( pass, "jQuery('&lt;tag&gt;') needs optional document parameter to ease cross-frame DOM wrangling, see #968" );*/
 
 	var code = jQuery("<code/>");
-	equals( code.length, 1, "Correct number of elements generated for code" );
-	equals( code.parent().length, 0, "Make sure that the generated HTML has no parent." );
+	equal( code.length, 1, "Correct number of elements generated for code" );
+	equal( code.parent().length, 0, "Make sure that the generated HTML has no parent." );
 	var img = jQuery("<img/>");
-	equals( img.length, 1, "Correct number of elements generated for img" );
-	equals( img.parent().length, 0, "Make sure that the generated HTML has no parent." );
+	equal( img.length, 1, "Correct number of elements generated for img" );
+	equal( img.parent().length, 0, "Make sure that the generated HTML has no parent." );
 	var div = jQuery("<div/><hr/><code/><b/>");
-	equals( div.length, 4, "Correct number of elements generated for div hr code b" );
-	equals( div.parent().length, 0, "Make sure that the generated HTML has no parent." );
+	equal( div.length, 4, "Correct number of elements generated for div hr code b" );
+	equal( div.parent().length, 0, "Make sure that the generated HTML has no parent." );
 
-	equals( jQuery([1,2,3]).get(1), 2, "Test passing an array to the factory" );
+	equal( jQuery([1,2,3]).get(1), 2, "Test passing an array to the factory" );
 
-	equals( jQuery(document.body).get(0), jQuery("body").get(0), "Test passing an html node to the factory" );
+	equal( jQuery(document.body).get(0), jQuery("body").get(0), "Test passing an html node to the factory" );
 
 	var exec = false;
 
@@ -75,13 +75,13 @@ test("jQuery()", function() {
 		id: "test3"
 	});
 
-	equals( elem[0].style.width, "10px", "jQuery() quick setter width");
-	equals( elem[0].style.paddingLeft, "1px", "jQuery quick setter css");
-	equals( elem[0].style.paddingRight, "1px", "jQuery quick setter css");
-	equals( elem[0].childNodes.length, 1, "jQuery quick setter text");
-	equals( elem[0].firstChild.nodeValue, "test", "jQuery quick setter text");
-	equals( elem[0].className, "test2", "jQuery() quick setter class");
-	equals( elem[0].id, "test3", "jQuery() quick setter id");
+	equal( elem[0].style.width, "10px", "jQuery() quick setter width");
+	equal( elem[0].style.paddingLeft, "1px", "jQuery quick setter css");
+	equal( elem[0].style.paddingRight, "1px", "jQuery quick setter css");
+	equal( elem[0].childNodes.length, 1, "jQuery quick setter text");
+	equal( elem[0].firstChild.nodeValue, "test", "jQuery quick setter text");
+	equal( elem[0].className, "test2", "jQuery() quick setter class");
+	equal( elem[0].id, "test3", "jQuery() quick setter id");
 
 	exec = true;
 	elem.click();
@@ -92,21 +92,21 @@ test("jQuery()", function() {
 	for ( var i = 0; i < 3; ++i ) {
 		elem = jQuery("<input type='text' value='TEST' />");
 	}
-	equals( elem[0].defaultValue, "TEST", "Ensure cached nodes are cloned properly (Bug #6655)" );
+	equal( elem[0].defaultValue, "TEST", "Ensure cached nodes are cloned properly (Bug #6655)" );
 
 	// manually clean up detached elements
 	elem.remove();
 
-	equals( jQuery(" <div/> ").length, 1, "Make sure whitespace is trimmed." );
-	equals( jQuery(" a<div/>b ").length, 1, "Make sure whitespace and other characters are trimmed." );
+	equal( jQuery(" <div/> ").length, 1, "Make sure whitespace is trimmed." );
+	equal( jQuery(" a<div/>b ").length, 1, "Make sure whitespace and other characters are trimmed." );
 
 	var long = "";
 	for ( var i = 0; i < 128; i++ ) {
 		long += "12345678";
 	}
 
-	equals( jQuery(" <div>" + long + "</div> ").length, 1, "Make sure whitespace is trimmed on long strings." );
-	equals( jQuery(" a<div>" + long + "</div>b ").length, 1, "Make sure whitespace and other characters are trimmed on long strings." );
+	equal( jQuery(" <div>" + long + "</div> ").length, 1, "Make sure whitespace is trimmed on long strings." );
+	equal( jQuery(" a<div>" + long + "</div>b ").length, 1, "Make sure whitespace and other characters are trimmed on long strings." );
 });
 
 test("selector state", function() {
@@ -115,68 +115,68 @@ test("selector state", function() {
 	var test;
 
 	test = jQuery(undefined);
-	equals( test.selector, "", "Empty jQuery Selector" );
-	equals( test.context, undefined, "Empty jQuery Context" );
+	equal( test.selector, "", "Empty jQuery Selector" );
+	equal( test.context, undefined, "Empty jQuery Context" );
 
 	test = jQuery(document);
-	equals( test.selector, "", "Document Selector" );
-	equals( test.context, document, "Document Context" );
+	equal( test.selector, "", "Document Selector" );
+	equal( test.context, document, "Document Context" );
 
 	test = jQuery(document.body);
-	equals( test.selector, "", "Body Selector" );
-	equals( test.context, document.body, "Body Context" );
+	equal( test.selector, "", "Body Selector" );
+	equal( test.context, document.body, "Body Context" );
 
 	test = jQuery("#qunit-fixture");
-	equals( test.selector, "#qunit-fixture", "#qunit-fixture Selector" );
-	equals( test.context, document, "#qunit-fixture Context" );
+	equal( test.selector, "#qunit-fixture", "#qunit-fixture Selector" );
+	equal( test.context, document, "#qunit-fixture Context" );
 
 	test = jQuery("#notfoundnono");
-	equals( test.selector, "#notfoundnono", "#notfoundnono Selector" );
-	equals( test.context, document, "#notfoundnono Context" );
+	equal( test.selector, "#notfoundnono", "#notfoundnono Selector" );
+	equal( test.context, document, "#notfoundnono Context" );
 
 	test = jQuery("#qunit-fixture", document);
-	equals( test.selector, "#qunit-fixture", "#qunit-fixture Selector" );
-	equals( test.context, document, "#qunit-fixture Context" );
+	equal( test.selector, "#qunit-fixture", "#qunit-fixture Selector" );
+	equal( test.context, document, "#qunit-fixture Context" );
 
 	test = jQuery("#qunit-fixture", document.body);
-	equals( test.selector, "#qunit-fixture", "#qunit-fixture Selector" );
-	equals( test.context, document.body, "#qunit-fixture Context" );
+	equal( test.selector, "#qunit-fixture", "#qunit-fixture Selector" );
+	equal( test.context, document.body, "#qunit-fixture Context" );
 
 	// Test cloning
 	test = jQuery(test);
-	equals( test.selector, "#qunit-fixture", "#qunit-fixture Selector" );
-	equals( test.context, document.body, "#qunit-fixture Context" );
+	equal( test.selector, "#qunit-fixture", "#qunit-fixture Selector" );
+	equal( test.context, document.body, "#qunit-fixture Context" );
 
 	test = jQuery(document.body).find("#qunit-fixture");
-	equals( test.selector, "#qunit-fixture", "#qunit-fixture find Selector" );
-	equals( test.context, document.body, "#qunit-fixture find Context" );
+	equal( test.selector, "#qunit-fixture", "#qunit-fixture find Selector" );
+	equal( test.context, document.body, "#qunit-fixture find Context" );
 
 	test = jQuery("#qunit-fixture").filter("div");
-	equals( test.selector, "#qunit-fixture.filter(div)", "#qunit-fixture filter Selector" );
-	equals( test.context, document, "#qunit-fixture filter Context" );
+	equal( test.selector, "#qunit-fixture.filter(div)", "#qunit-fixture filter Selector" );
+	equal( test.context, document, "#qunit-fixture filter Context" );
 
 	test = jQuery("#qunit-fixture").not("div");
-	equals( test.selector, "#qunit-fixture.not(div)", "#qunit-fixture not Selector" );
-	equals( test.context, document, "#qunit-fixture not Context" );
+	equal( test.selector, "#qunit-fixture.not(div)", "#qunit-fixture not Selector" );
+	equal( test.context, document, "#qunit-fixture not Context" );
 
 	test = jQuery("#qunit-fixture").filter("div").not("div");
-	equals( test.selector, "#qunit-fixture.filter(div).not(div)", "#qunit-fixture filter, not Selector" );
-	equals( test.context, document, "#qunit-fixture filter, not Context" );
+	equal( test.selector, "#qunit-fixture.filter(div).not(div)", "#qunit-fixture filter, not Selector" );
+	equal( test.context, document, "#qunit-fixture filter, not Context" );
 
 	test = jQuery("#qunit-fixture").filter("div").not("div").end();
-	equals( test.selector, "#qunit-fixture.filter(div)", "#qunit-fixture filter, not, end Selector" );
-	equals( test.context, document, "#qunit-fixture filter, not, end Context" );
+	equal( test.selector, "#qunit-fixture.filter(div)", "#qunit-fixture filter, not, end Selector" );
+	equal( test.context, document, "#qunit-fixture filter, not, end Context" );
 
 	test = jQuery("#qunit-fixture").parent("body");
-	equals( test.selector, "#qunit-fixture.parent(body)", "#qunit-fixture parent Selector" );
-	equals( test.context, document, "#qunit-fixture parent Context" );
+	equal( test.selector, "#qunit-fixture.parent(body)", "#qunit-fixture parent Selector" );
+	equal( test.context, document, "#qunit-fixture parent Context" );
 
 	test = jQuery("#qunit-fixture").eq(0);
-	equals( test.selector, "#qunit-fixture.slice(0,1)", "#qunit-fixture eq Selector" );
-	equals( test.context, document, "#qunit-fixture eq Context" );
+	equal( test.selector, "#qunit-fixture.slice(0,1)", "#qunit-fixture eq Selector" );
+	equal( test.context, document, "#qunit-fixture eq Context" );
 
 	var d = "<div />";
-	equals(
+	equal(
 		jQuery(d).appendTo(jQuery(d)).selector,
 		jQuery(d).appendTo(d).selector,
 		"manipulation methods make same selector for jQuery objects"
@@ -215,8 +215,8 @@ test("browser", function() {
 			var parts = this.split("\t");
 			if ( parts[2] ) {
 				var ua = jQuery.uaMatch( parts[2] );
-				equals( ua.browser, parts[0], "Checking browser for " + parts[2] );
-				equals( ua.version, parts[1], "Checking version string for " + parts[2] );
+				equal( ua.browser, parts[0], "Checking browser for " + parts[2] );
+				equal( ua.version, parts[1], "Checking version string for " + parts[2] );
 			}
 		});
 
@@ -228,7 +228,7 @@ test("browser", function() {
 test("amdModule", function() {
 	expect(1);
 
-	equals( jQuery, amdDefined, "Make sure defined module matches jQuery" );
+	equal( jQuery, amdDefined, "Make sure defined module matches jQuery" );
 });
 
 test("noConflict", function() {
@@ -236,15 +236,15 @@ test("noConflict", function() {
 
 	var $$ = jQuery;
 
-	equals( jQuery, jQuery.noConflict(), "noConflict returned the jQuery object" );
-	equals( jQuery, $$, "Make sure jQuery wasn't touched." );
-	equals( $, original$, "Make sure $ was reverted." );
+	equal( jQuery, jQuery.noConflict(), "noConflict returned the jQuery object" );
+	equal( jQuery, $$, "Make sure jQuery wasn't touched." );
+	equal( $, original$, "Make sure $ was reverted." );
 
 	jQuery = $ = $$;
 
-	equals( jQuery.noConflict(true), $$, "noConflict returned the jQuery object" );
-	equals( jQuery, originaljQuery, "Make sure jQuery was reverted." );
-	equals( $, original$, "Make sure $ was reverted." );
+	equal( jQuery.noConflict(true), $$, "noConflict returned the jQuery object" );
+	equal( jQuery, originaljQuery, "Make sure jQuery was reverted." );
+	equal( $, original$, "Make sure $ was reverted." );
 	ok( $$("#qunit-fixture").html("test"), "Make sure that jQuery still works." );
 
 	jQuery = $$;
@@ -255,44 +255,44 @@ test("trim", function() {
 
 	var nbsp = String.fromCharCode(160);
 
-	equals( jQuery.trim("hello  "), "hello", "trailing space" );
-	equals( jQuery.trim("  hello"), "hello", "leading space" );
-	equals( jQuery.trim("  hello   "), "hello", "space on both sides" );
-	equals( jQuery.trim("  " + nbsp + "hello  " + nbsp + " "), "hello", "&nbsp;" );
+	equal( jQuery.trim("hello  "), "hello", "trailing space" );
+	equal( jQuery.trim("  hello"), "hello", "leading space" );
+	equal( jQuery.trim("  hello   "), "hello", "space on both sides" );
+	equal( jQuery.trim("  " + nbsp + "hello  " + nbsp + " "), "hello", "&nbsp;" );
 
-	equals( jQuery.trim(), "", "Nothing in." );
-	equals( jQuery.trim( undefined ), "", "Undefined" );
-	equals( jQuery.trim( null ), "", "Null" );
-	equals( jQuery.trim( 5 ), "5", "Number" );
-	equals( jQuery.trim( false ), "false", "Boolean" );
+	equal( jQuery.trim(), "", "Nothing in." );
+	equal( jQuery.trim( undefined ), "", "Undefined" );
+	equal( jQuery.trim( null ), "", "Null" );
+	equal( jQuery.trim( 5 ), "5", "Number" );
+	equal( jQuery.trim( false ), "false", "Boolean" );
 });
 
 test("type", function() {
 	expect(23);
 
-	equals( jQuery.type(null), "null", "null" );
-	equals( jQuery.type(undefined), "undefined", "undefined" );
-	equals( jQuery.type(true), "boolean", "Boolean" );
-	equals( jQuery.type(false), "boolean", "Boolean" );
-	equals( jQuery.type(Boolean(true)), "boolean", "Boolean" );
-	equals( jQuery.type(0), "number", "Number" );
-	equals( jQuery.type(1), "number", "Number" );
-	equals( jQuery.type(Number(1)), "number", "Number" );
-	equals( jQuery.type(""), "string", "String" );
-	equals( jQuery.type("a"), "string", "String" );
-	equals( jQuery.type(String("a")), "string", "String" );
-	equals( jQuery.type({}), "object", "Object" );
-	equals( jQuery.type(/foo/), "regexp", "RegExp" );
-	equals( jQuery.type(new RegExp("asdf")), "regexp", "RegExp" );
-	equals( jQuery.type([1]), "array", "Array" );
-	equals( jQuery.type(new Date()), "date", "Date" );
-	equals( jQuery.type(new Function("return;")), "function", "Function" );
-	equals( jQuery.type(function(){}), "function", "Function" );
-	equals( jQuery.type(window), "object", "Window" );
-	equals( jQuery.type(document), "object", "Document" );
-	equals( jQuery.type(document.body), "object", "Element" );
-	equals( jQuery.type(document.createTextNode("foo")), "object", "TextNode" );
-	equals( jQuery.type(document.getElementsByTagName("*")), "object", "NodeList" );
+	equal( jQuery.type(null), "null", "null" );
+	equal( jQuery.type(undefined), "undefined", "undefined" );
+	equal( jQuery.type(true), "boolean", "Boolean" );
+	equal( jQuery.type(false), "boolean", "Boolean" );
+	equal( jQuery.type(Boolean(true)), "boolean", "Boolean" );
+	equal( jQuery.type(0), "number", "Number" );
+	equal( jQuery.type(1), "number", "Number" );
+	equal( jQuery.type(Number(1)), "number", "Number" );
+	equal( jQuery.type(""), "string", "String" );
+	equal( jQuery.type("a"), "string", "String" );
+	equal( jQuery.type(String("a")), "string", "String" );
+	equal( jQuery.type({}), "object", "Object" );
+	equal( jQuery.type(/foo/), "regexp", "RegExp" );
+	equal( jQuery.type(new RegExp("asdf")), "regexp", "RegExp" );
+	equal( jQuery.type([1]), "array", "Array" );
+	equal( jQuery.type(new Date()), "date", "Date" );
+	equal( jQuery.type(new Function("return;")), "function", "Function" );
+	equal( jQuery.type(function(){}), "function", "Function" );
+	equal( jQuery.type(window), "object", "Window" );
+	equal( jQuery.type(document), "object", "Document" );
+	equal( jQuery.type(document.body), "object", "Element" );
+	equal( jQuery.type(document.createTextNode("foo")), "object", "TextNode" );
+	equal( jQuery.type(document.getElementsByTagName("*")), "object", "NodeList" );
 });
 
 test("isPlainObject", function() {
@@ -475,23 +475,23 @@ test( "isNumeric", function() {
 	ok( t(3.1415), "Positive floating point number");
 	ok( t(8e5), "Exponential notation");
 	ok( t("123e-2"), "Exponential notation string");
-	equals( t(""), false, "Empty string");
-	equals( t("        "), false, "Whitespace characters string");
-	equals( t("\t\t"), false, "Tab characters string");
-	equals( t("abcdefghijklm1234567890"), false, "Alphanumeric character string");
-	equals( t("xabcdefx"), false, "Non-numeric character string");
-	equals( t(true), false, "Boolean true literal");
-	equals( t(false), false, "Boolean false literal");
-	equals( t("bcfed5.2"), false, "Number with preceding non-numeric characters");
-	equals( t("7.2acdgs"), false, "Number with trailling non-numeric characters");
-	equals( t(undefined), false, "Undefined value");
-	equals( t(null), false, "Null value");
-	equals( t(NaN), false, "NaN value");
-	equals( t(Infinity), false, "Infinity primitive");
-	equals( t(Number.POSITIVE_INFINITY), false, "Positive Infinity");
-	equals( t(Number.NEGATIVE_INFINITY), false, "Negative Infinity");
-	equals( t({}), false, "Empty object");
-	equals( t(function(){} ), false, "Instance of a function");
+	equal( t(""), false, "Empty string");
+	equal( t("        "), false, "Whitespace characters string");
+	equal( t("\t\t"), false, "Tab characters string");
+	equal( t("abcdefghijklm1234567890"), false, "Alphanumeric character string");
+	equal( t("xabcdefx"), false, "Non-numeric character string");
+	equal( t(true), false, "Boolean true literal");
+	equal( t(false), false, "Boolean false literal");
+	equal( t("bcfed5.2"), false, "Number with preceding non-numeric characters");
+	equal( t("7.2acdgs"), false, "Number with trailling non-numeric characters");
+	equal( t(undefined), false, "Undefined value");
+	equal( t(null), false, "Null value");
+	equal( t(NaN), false, "NaN value");
+	equal( t(Infinity), false, "Infinity primitive");
+	equal( t(Number.POSITIVE_INFINITY), false, "Positive Infinity");
+	equal( t(Number.NEGATIVE_INFINITY), false, "Negative Infinity");
+	equal( t({}), false, "Empty object");
+	equal( t(function(){} ), false, "Instance of a function");
 });
 
 test("isXMLDoc - HTML", function() {
@@ -583,11 +583,11 @@ test("jQuery('html')", function() {
 
 	// Test multi-line HTML
 	var div = jQuery("<div>\r\nsome text\n<p>some p</p>\nmore text\r\n</div>")[0];
-	equals( div.nodeName.toUpperCase(), "DIV", "Make sure we're getting a div." );
-	equals( div.firstChild.nodeType, 3, "Text node." );
-	equals( div.lastChild.nodeType, 3, "Text node." );
-	equals( div.childNodes[1].nodeType, 1, "Paragraph." );
-	equals( div.childNodes[1].firstChild.nodeType, 3, "Paragraph text." );
+	equal( div.nodeName.toUpperCase(), "DIV", "Make sure we're getting a div." );
+	equal( div.firstChild.nodeType, 3, "Text node." );
+	equal( div.lastChild.nodeType, 3, "Text node." );
+	equal( div.childNodes[1].nodeType, 1, "Paragraph." );
+	equal( div.childNodes[1].firstChild.nodeType, 3, "Paragraph text." );
 
 	QUnit.reset();
 	ok( jQuery("<link rel='stylesheet'/>")[0], "Creating a link" );
@@ -613,9 +613,9 @@ test("jQuery('html')", function() {
 	}
 	html.push("</ul>");
 	html = jQuery(html.join(""))[0];
-	equals( html.nodeName.toUpperCase(), "UL");
-	equals( html.firstChild.nodeName.toUpperCase(), "LI");
-	equals( html.childNodes.length, 50000 );
+	equal( html.nodeName.toUpperCase(), "UL");
+	equal( html.firstChild.nodeName.toUpperCase(), "LI");
+	equal( html.childNodes.length, 50000 );
 });
 
 test("jQuery('html', context)", function() {
@@ -623,7 +623,7 @@ test("jQuery('html', context)", function() {
 
 	var $div = jQuery("<div/>")[0];
 	var $span = jQuery("<span/>", $div);
-	equals($span.length, 1, "Verify a span created with a div context works, #1763");
+	equal($span.length, 1, "Verify a span created with a div context works, #1763");
 });
 
 if ( !isLocal ) {
@@ -633,9 +633,9 @@ test("jQuery(selector, xml).text(str) - Loaded via XML document", function() {
 	jQuery.get("data/dashboard.xml", function(xml) {
 		// tests for #1419 where IE was a problem
 		var tab = jQuery("tab", xml).eq(0);
-		equals( tab.text(), "blabla", "Verify initial text correct" );
+		equal( tab.text(), "blabla", "Verify initial text correct" );
 		tab.text("newtext");
-		equals( tab.text(), "newtext", "Verify new text correct" );
+		equal( tab.text(), "newtext", "Verify new text correct" );
 		start();
 	});
 });
@@ -643,32 +643,32 @@ test("jQuery(selector, xml).text(str) - Loaded via XML document", function() {
 
 test("end()", function() {
 	expect(3);
-	equals( "Yahoo", jQuery("#yahoo").parent().end().text(), "Check for end" );
+	equal( "Yahoo", jQuery("#yahoo").parent().end().text(), "Check for end" );
 	ok( jQuery("#yahoo").end(), "Check for end with nothing to end" );
 
 	var x = jQuery("#yahoo");
 	x.parent();
-	equals( "Yahoo", jQuery("#yahoo").text(), "Check for non-destructive behaviour" );
+	equal( "Yahoo", jQuery("#yahoo").text(), "Check for non-destructive behaviour" );
 });
 
 test("length", function() {
 	expect(1);
-	equals( jQuery("#qunit-fixture p").length, 6, "Get Number of Elements Found" );
+	equal( jQuery("#qunit-fixture p").length, 6, "Get Number of Elements Found" );
 });
 
 test("size()", function() {
 	expect(1);
-	equals( jQuery("#qunit-fixture p").size(), 6, "Get Number of Elements Found" );
+	equal( jQuery("#qunit-fixture p").size(), 6, "Get Number of Elements Found" );
 });
 
 test("get()", function() {
 	expect(1);
-	same( jQuery("#qunit-fixture p").get(), q("firstp","ap","sndp","en","sap","first"), "Get All Elements" );
+	deepEqual( jQuery("#qunit-fixture p").get(), q("firstp","ap","sndp","en","sap","first"), "Get All Elements" );
 });
 
 test("toArray()", function() {
 	expect(1);
-	same( jQuery("#qunit-fixture p").toArray(),
+	deepEqual( jQuery("#qunit-fixture p").toArray(),
 		q("firstp","ap","sndp","en","sap","first"),
 		"Convert jQuery object to an Array" )
 })
@@ -711,13 +711,13 @@ test("inArray()", function() {
 
 test("get(Number)", function() {
 	expect(2);
-	equals( jQuery("#qunit-fixture p").get(0), document.getElementById("firstp"), "Get A Single Element" );
+	equal( jQuery("#qunit-fixture p").get(0), document.getElementById("firstp"), "Get A Single Element" );
 	strictEqual( jQuery("#firstp").get(1), undefined, "Try get with index larger elements count" );
 });
 
 test("get(-Number)",function() {
 	expect(2);
-	equals( jQuery("p").get(-1), document.getElementById("first"), "Get a single element with negative index" );
+	equal( jQuery("p").get(-1), document.getElementById("first"), "Get a single element with negative index" );
 	strictEqual( jQuery("#firstp").get(-2), undefined, "Try get with index negative index larger then elements count" );
 })
 
@@ -737,14 +737,14 @@ test("slice()", function() {
 
 	var $links = jQuery("#ap a");
 
-	same( $links.slice(1,2).get(), q("groups"), "slice(1,2)" );
-	same( $links.slice(1).get(), q("groups", "anchor1", "mark"), "slice(1)" );
-	same( $links.slice(0,3).get(), q("google", "groups", "anchor1"), "slice(0,3)" );
-	same( $links.slice(-1).get(), q("mark"), "slice(-1)" );
+	deepEqual( $links.slice(1,2).get(), q("groups"), "slice(1,2)" );
+	deepEqual( $links.slice(1).get(), q("groups", "anchor1", "mark"), "slice(1)" );
+	deepEqual( $links.slice(0,3).get(), q("google", "groups", "anchor1"), "slice(0,3)" );
+	deepEqual( $links.slice(-1).get(), q("mark"), "slice(-1)" );
 
-	same( $links.eq(1).get(), q("groups"), "eq(1)" );
-	same( $links.eq("2").get(), q("anchor1"), "eq('2')" );
-	same( $links.eq(-1).get(), q("mark"), "eq(-1)" );
+	deepEqual( $links.eq(1).get(), q("groups"), "eq(1)" );
+	deepEqual( $links.eq("2").get(), q("anchor1"), "eq('2')" );
+	deepEqual( $links.eq(-1).get(), q("mark"), "eq(-1)" );
 });
 
 test("first()/last()", function() {
@@ -752,17 +752,17 @@ test("first()/last()", function() {
 
 	var $links = jQuery("#ap a"), $none = jQuery("asdf");
 
-	same( $links.first().get(), q("google"), "first()" );
-	same( $links.last().get(), q("mark"), "last()" );
+	deepEqual( $links.first().get(), q("google"), "first()" );
+	deepEqual( $links.last().get(), q("mark"), "last()" );
 
-	same( $none.first().get(), [], "first() none" );
-	same( $none.last().get(), [], "last() none" );
+	deepEqual( $none.first().get(), [], "first() none" );
+	deepEqual( $none.last().get(), [], "last() none" );
 });
 
 test("map()", function() {
 	expect(8);
 
-	same(
+	deepEqual(
 		jQuery("#ap").map(function(){
 			return jQuery(this).find("a").get();
 		}).get(),
@@ -770,7 +770,7 @@ test("map()", function() {
 		"Array Map"
 	);
 
-	same(
+	deepEqual(
 		jQuery("#ap > a").map(function(){
 			return this.parentNode;
 		}).get(),
@@ -782,35 +782,35 @@ test("map()", function() {
 	var keys = jQuery.map( {a:1,b:2}, function( v, k ){
 		return k;
 	});
-	equals( keys.join(""), "ab", "Map the keys from a hash to an array" );
+	equal( keys.join(""), "ab", "Map the keys from a hash to an array" );
 
 	var values = jQuery.map( {a:1,b:2}, function( v, k ){
 		return v;
 	});
-	equals( values.join(""), "12", "Map the values from a hash to an array" );
+	equal( values.join(""), "12", "Map the values from a hash to an array" );
 
 	// object with length prop
 	var values = jQuery.map( {a:1,b:2, length:3}, function( v, k ){
 		return v;
 	});
-	equals( values.join(""), "123", "Map the values from a hash with a length property to an array" );
+	equal( values.join(""), "123", "Map the values from a hash with a length property to an array" );
 
 	var scripts = document.getElementsByTagName("script");
 	var mapped = jQuery.map( scripts, function( v, k ){
 		return v;
 	});
-	equals( mapped.length, scripts.length, "Map an array(-like) to a hash" );
+	equal( mapped.length, scripts.length, "Map an array(-like) to a hash" );
 
 	var nonsense = document.getElementsByTagName("asdf");
 	var mapped = jQuery.map( nonsense, function( v, k ){
 		return v;
 	});
-	equals( mapped.length, nonsense.length, "Map an empty array(-like) to a hash" );
+	equal( mapped.length, nonsense.length, "Map an empty array(-like) to a hash" );
 
 	var flat = jQuery.map( Array(4), function( v, k ){
 		return k % 2 ? k : [k,k,k];//try mixing array and regular returns
 	});
-	equals( flat.join(""), "00012223", "try the new flatten technique(#2616)" );
+	equal( flat.join(""), "00012223", "try the new flatten technique(#2616)" );
 });
 
 test("jQuery.merge()", function() {
@@ -818,20 +818,20 @@ test("jQuery.merge()", function() {
 
 	var parse = jQuery.merge;
 
-	same( parse([],[]), [], "Empty arrays" );
+	deepEqual( parse([],[]), [], "Empty arrays" );
 
-	same( parse([1],[2]), [1,2], "Basic" );
-	same( parse([1,2],[3,4]), [1,2,3,4], "Basic" );
+	deepEqual( parse([1],[2]), [1,2], "Basic" );
+	deepEqual( parse([1,2],[3,4]), [1,2,3,4], "Basic" );
 
-	same( parse([1,2],[]), [1,2], "Second empty" );
-	same( parse([],[1,2]), [1,2], "First empty" );
+	deepEqual( parse([1,2],[]), [1,2], "Second empty" );
+	deepEqual( parse([],[1,2]), [1,2], "First empty" );
 
 	// Fixed at [5998], #3641
-	same( parse([-2,-1], [0,1,2]), [-2,-1,0,1,2], "Second array including a zero (falsy)");
+	deepEqual( parse([-2,-1], [0,1,2]), [-2,-1,0,1,2], "Second array including a zero (falsy)");
 
 	// After fixing #5527
-	same( parse([], [null, undefined]), [null, undefined], "Second array including null and undefined values");
-	same( parse({length:0}, [1,2]), {length:2, 0:1, 1:2}, "First array like");
+	deepEqual( parse([], [null, undefined]), [null, undefined], "Second array including null and undefined values");
+	deepEqual( parse({length:0}, [1,2]), {length:2, 0:1, 1:2}, "First array like");
 });
 
 test("jQuery.extend(Object, Object)", function() {
@@ -850,17 +850,17 @@ test("jQuery.extend(Object, Object)", function() {
 		nestedarray = { arr: arr };
 
 	jQuery.extend(settings, options);
-	same( settings, merged, "Check if extended: settings must be extended" );
-	same( options, optionsCopy, "Check if not modified: options must not be modified" );
+	deepEqual( settings, merged, "Check if extended: settings must be extended" );
+	deepEqual( options, optionsCopy, "Check if not modified: options must not be modified" );
 
 	jQuery.extend(settings, null, options);
-	same( settings, merged, "Check if extended: settings must be extended" );
-	same( options, optionsCopy, "Check if not modified: options must not be modified" );
+	deepEqual( settings, merged, "Check if extended: settings must be extended" );
+	deepEqual( options, optionsCopy, "Check if not modified: options must not be modified" );
 
 	jQuery.extend(true, deep1, deep2);
-	same( deep1.foo, deepmerged.foo, "Check if foo: settings must be extended" );
-	same( deep2.foo, deep2copy.foo, "Check if not deep2: options must not be modified" );
-	equals( deep1.foo2, document, "Make sure that a deep clone was not attempted on the document" );
+	deepEqual( deep1.foo, deepmerged.foo, "Check if foo: settings must be extended" );
+	deepEqual( deep2.foo, deep2copy.foo, "Check if not deep2: options must not be modified" );
+	equal( deep1.foo2, document, "Make sure that a deep clone was not attempted on the document" );
 
 	ok( jQuery.extend(true, {}, nestedarray).arr !== arr, "Deep extend of object must clone child array" );
 
@@ -871,12 +871,12 @@ test("jQuery.extend(Object, Object)", function() {
 	var empty = {};
 	var optionsWithLength = { foo: { length: -1 } };
 	jQuery.extend(true, empty, optionsWithLength);
-	same( empty.foo, optionsWithLength.foo, "The length property must copy correctly" );
+	deepEqual( empty.foo, optionsWithLength.foo, "The length property must copy correctly" );
 
 	empty = {};
 	var optionsWithDate = { foo: { date: new Date } };
 	jQuery.extend(true, empty, optionsWithDate);
-	same( empty.foo, optionsWithDate.foo, "Dates copy correctly" );
+	deepEqual( empty.foo, optionsWithDate.foo, "Dates copy correctly" );
 
 	var myKlass = function() {};
 	var customObject = new myKlass();
@@ -907,10 +907,10 @@ test("jQuery.extend(Object, Object)", function() {
 	var target = {};
 	var recursive = { foo:target, bar:5 };
 	jQuery.extend(true, target, recursive);
-	same( target, { bar:5 }, "Check to make sure a recursive obj doesn't go never-ending loop by not copying it over" );
+	deepEqual( target, { bar:5 }, "Check to make sure a recursive obj doesn't go never-ending loop by not copying it over" );
 
 	var ret = jQuery.extend(true, { foo: [] }, { foo: [0] } ); // 1907
-	equals( ret.foo.length, 1, "Check to make sure a value with coersion 'false' copies over when necessary to fix #1907" );
+	equal( ret.foo.length, 1, "Check to make sure a value with coersion 'false' copies over when necessary to fix #1907" );
 
 	var ret = jQuery.extend(true, { foo: "1,2,3" }, { foo: [1, 2, 3] } );
 	ok( typeof ret.foo != "string", "Check to make sure values equal with coersion (but not actually equal) overwrite correctly" );
@@ -920,11 +920,11 @@ test("jQuery.extend(Object, Object)", function() {
 
 	var obj = { foo:null };
 	jQuery.extend(true, obj, { foo:"notnull" } );
-	equals( obj.foo, "notnull", "Make sure a null value can be overwritten" );
+	equal( obj.foo, "notnull", "Make sure a null value can be overwritten" );
 
 	function func() {}
 	jQuery.extend(func, { key: "value" } );
-	equals( func.key, "value", "Verify a function can be extended" );
+	equal( func.key, "value", "Verify a function can be extended" );
 
 	var defaults = { xnumber1: 5, xnumber2: 7, xstring1: "peter", xstring2: "pan" },
 		defaultsCopy = { xnumber1: 5, xnumber2: 7, xstring1: "peter", xstring2: "pan" },
@@ -935,118 +935,118 @@ test("jQuery.extend(Object, Object)", function() {
 		merged2 = { xnumber1: 5, xnumber2: 1, xstring1: "peter", xstring2: "xx", xxx: "newstringx" };
 
 	var settings = jQuery.extend({}, defaults, options1, options2);
-	same( settings, merged2, "Check if extended: settings must be extended" );
-	same( defaults, defaultsCopy, "Check if not modified: options1 must not be modified" );
-	same( options1, options1Copy, "Check if not modified: options1 must not be modified" );
-	same( options2, options2Copy, "Check if not modified: options2 must not be modified" );
+	deepEqual( settings, merged2, "Check if extended: settings must be extended" );
+	deepEqual( defaults, defaultsCopy, "Check if not modified: options1 must not be modified" );
+	deepEqual( options1, options1Copy, "Check if not modified: options1 must not be modified" );
+	deepEqual( options2, options2Copy, "Check if not modified: options2 must not be modified" );
 });
 
 test("jQuery.each(Object,Function)", function() {
 	expect(14);
 	jQuery.each( [0,1,2], function(i, n){
-		equals( i, n, "Check array iteration" );
+		equal( i, n, "Check array iteration" );
 	});
 
 	jQuery.each( [5,6,7], function(i, n){
-		equals( i, n - 5, "Check array iteration" );
+		equal( i, n - 5, "Check array iteration" );
 	});
 
 	jQuery.each( { name: "name", lang: "lang" }, function(i, n){
-		equals( i, n, "Check object iteration" );
+		equal( i, n, "Check object iteration" );
 	});
 
 	var total = 0;
 	jQuery.each([1,2,3], function(i,v){ total += v; });
-	equals( total, 6, "Looping over an array" );
+	equal( total, 6, "Looping over an array" );
 	total = 0;
 	jQuery.each([1,2,3], function(i,v){ total += v; if ( i == 1 ) return false; });
-	equals( total, 3, "Looping over an array, with break" );
+	equal( total, 3, "Looping over an array, with break" );
 	total = 0;
 	jQuery.each({"a":1,"b":2,"c":3}, function(i,v){ total += v; });
-	equals( total, 6, "Looping over an object" );
+	equal( total, 6, "Looping over an object" );
 	total = 0;
 	jQuery.each({"a":3,"b":3,"c":3}, function(i,v){ total += v; return false; });
-	equals( total, 3, "Looping over an object, with break" );
+	equal( total, 3, "Looping over an object, with break" );
 
 	var f = function(){};
 	f.foo = "bar";
 	jQuery.each(f, function(i){
 		f[i] = "baz";
 	});
-	equals( "baz", f.foo, "Loop over a function" );
+	equal( "baz", f.foo, "Loop over a function" );
 
 	var stylesheet_count = 0;
 	jQuery.each(document.styleSheets, function(i){
 		stylesheet_count++;
 	});
-	equals(stylesheet_count, 2, "should not throw an error in IE while looping over document.styleSheets and return proper amount");
+	equal(stylesheet_count, 2, "should not throw an error in IE while looping over document.styleSheets and return proper amount");
 
 });
 
 test("jQuery.makeArray", function(){
 	expect(17);
 
-	equals( jQuery.makeArray(jQuery("html>*"))[0].nodeName.toUpperCase(), "HEAD", "Pass makeArray a jQuery object" );
+	equal( jQuery.makeArray(jQuery("html>*"))[0].nodeName.toUpperCase(), "HEAD", "Pass makeArray a jQuery object" );
 
-	equals( jQuery.makeArray(document.getElementsByName("PWD")).slice(0,1)[0].name, "PWD", "Pass makeArray a nodelist" );
+	equal( jQuery.makeArray(document.getElementsByName("PWD")).slice(0,1)[0].name, "PWD", "Pass makeArray a nodelist" );
 
-	equals( (function(){ return jQuery.makeArray(arguments); })(1,2).join(""), "12", "Pass makeArray an arguments array" );
+	equal( (function(){ return jQuery.makeArray(arguments); })(1,2).join(""), "12", "Pass makeArray an arguments array" );
 
-	equals( jQuery.makeArray([1,2,3]).join(""), "123", "Pass makeArray a real array" );
+	equal( jQuery.makeArray([1,2,3]).join(""), "123", "Pass makeArray a real array" );
 
-	equals( jQuery.makeArray().length, 0, "Pass nothing to makeArray and expect an empty array" );
+	equal( jQuery.makeArray().length, 0, "Pass nothing to makeArray and expect an empty array" );
 
-	equals( jQuery.makeArray( 0 )[0], 0 , "Pass makeArray a number" );
+	equal( jQuery.makeArray( 0 )[0], 0 , "Pass makeArray a number" );
 
-	equals( jQuery.makeArray( "foo" )[0], "foo", "Pass makeArray a string" );
+	equal( jQuery.makeArray( "foo" )[0], "foo", "Pass makeArray a string" );
 
-	equals( jQuery.makeArray( true )[0].constructor, Boolean, "Pass makeArray a boolean" );
+	equal( jQuery.makeArray( true )[0].constructor, Boolean, "Pass makeArray a boolean" );
 
-	equals( jQuery.makeArray( document.createElement("div") )[0].nodeName.toUpperCase(), "DIV", "Pass makeArray a single node" );
+	equal( jQuery.makeArray( document.createElement("div") )[0].nodeName.toUpperCase(), "DIV", "Pass makeArray a single node" );
 
-	equals( jQuery.makeArray( {length:2, 0:"a", 1:"b"} ).join(""), "ab", "Pass makeArray an array like map (with length)" );
+	equal( jQuery.makeArray( {length:2, 0:"a", 1:"b"} ).join(""), "ab", "Pass makeArray an array like map (with length)" );
 
 	ok( !!jQuery.makeArray( document.documentElement.childNodes ).slice(0,1)[0].nodeName, "Pass makeArray a childNodes array" );
 
 	// function, is tricky as it has length
-	equals( jQuery.makeArray( function(){ return 1;} )[0](), 1, "Pass makeArray a function" );
+	equal( jQuery.makeArray( function(){ return 1;} )[0](), 1, "Pass makeArray a function" );
 
 	//window, also has length
-	equals( jQuery.makeArray(window)[0], window, "Pass makeArray the window" );
+	equal( jQuery.makeArray(window)[0], window, "Pass makeArray the window" );
 
-	equals( jQuery.makeArray(/a/)[0].constructor, RegExp, "Pass makeArray a regex" );
+	equal( jQuery.makeArray(/a/)[0].constructor, RegExp, "Pass makeArray a regex" );
 
 	ok( jQuery.makeArray(document.getElementById("form")).length >= 13, "Pass makeArray a form (treat as elements)" );
 
 	// For #5610
-	same( jQuery.makeArray({length: "0"}), [], "Make sure object is coerced properly.");
-	same( jQuery.makeArray({length: "5"}), [], "Make sure object is coerced properly.");
+	deepEqual( jQuery.makeArray({length: "0"}), [], "Make sure object is coerced properly.");
+	deepEqual( jQuery.makeArray({length: "5"}), [], "Make sure object is coerced properly.");
 });
 
 test("jQuery.inArray", function(){
 	expect(3);
 
-	equals( jQuery.inArray( 0, false ), -1 , "Search in 'false' as array returns -1 and doesn't throw exception" );
+	equal( jQuery.inArray( 0, false ), -1 , "Search in 'false' as array returns -1 and doesn't throw exception" );
 
-	equals( jQuery.inArray( 0, null ), -1 , "Search in 'null' as array returns -1 and doesn't throw exception" );
+	equal( jQuery.inArray( 0, null ), -1 , "Search in 'null' as array returns -1 and doesn't throw exception" );
 
-	equals( jQuery.inArray( 0, undefined ), -1 , "Search in 'undefined' as array returns -1 and doesn't throw exception" );
+	equal( jQuery.inArray( 0, undefined ), -1 , "Search in 'undefined' as array returns -1 and doesn't throw exception" );
 });
 
 test("jQuery.isEmptyObject", function(){
 	expect(2);
 
-	equals(true, jQuery.isEmptyObject({}), "isEmptyObject on empty object literal" );
-	equals(false, jQuery.isEmptyObject({a:1}), "isEmptyObject on non-empty object literal" );
+	equal(true, jQuery.isEmptyObject({}), "isEmptyObject on empty object literal" );
+	equal(false, jQuery.isEmptyObject({a:1}), "isEmptyObject on non-empty object literal" );
 
 	// What about this ?
-	// equals(true, jQuery.isEmptyObject(null), "isEmptyObject on null" );
+	// equal(true, jQuery.isEmptyObject(null), "isEmptyObject on null" );
 });
 
 test("jQuery.proxy", function(){
 	expect(7);
 
-	var test = function(){ equals( this, thisObject, "Make sure that scope is set properly." ); };
+	var test = function(){ equal( this, thisObject, "Make sure that scope is set properly." ); };
 	var thisObject = { foo: "bar", method: test };
 
 	// Make sure normal works
@@ -1059,32 +1059,32 @@ test("jQuery.proxy", function(){
 	jQuery.proxy( thisObject, "method" )();
 
 	// Make sure it doesn't freak out
-	equals( jQuery.proxy( null, thisObject ), undefined, "Make sure no function was returned." );
+	equal( jQuery.proxy( null, thisObject ), undefined, "Make sure no function was returned." );
 
         // Partial application
-        var test2 = function( a ){ equals( a, "pre-applied", "Ensure arguments can be pre-applied." ); };
+        var test2 = function( a ){ equal( a, "pre-applied", "Ensure arguments can be pre-applied." ); };
         jQuery.proxy( test2, null, "pre-applied" )();
 
         // Partial application w/ normal arguments
-        var test3 = function( a, b ){ equals( b, "normal", "Ensure arguments can be pre-applied and passed as usual." ); };
+        var test3 = function( a, b ){ equal( b, "normal", "Ensure arguments can be pre-applied and passed as usual." ); };
         jQuery.proxy( test3, null, "pre-applied" )( "normal" );
 
 	// Test old syntax
-	var test4 = { meth: function( a ){ equals( a, "boom", "Ensure old syntax works." ); } };
+	var test4 = { meth: function( a ){ equal( a, "boom", "Ensure old syntax works." ); } };
 	jQuery.proxy( test4, "meth" )( "boom" );
 });
 
 test("jQuery.parseJSON", function(){
 	expect(8);
 
-	equals( jQuery.parseJSON(), null, "Nothing in, null out." );
-	equals( jQuery.parseJSON( null ), null, "Nothing in, null out." );
-	equals( jQuery.parseJSON( "" ), null, "Nothing in, null out." );
+	equal( jQuery.parseJSON(), null, "Nothing in, null out." );
+	equal( jQuery.parseJSON( null ), null, "Nothing in, null out." );
+	equal( jQuery.parseJSON( "" ), null, "Nothing in, null out." );
 
-	same( jQuery.parseJSON("{}"), {}, "Plain object parsing." );
-	same( jQuery.parseJSON("{\"test\":1}"), {"test":1}, "Plain object parsing." );
+	deepEqual( jQuery.parseJSON("{}"), {}, "Plain object parsing." );
+	deepEqual( jQuery.parseJSON("{\"test\":1}"), {"test":1}, "Plain object parsing." );
 
-	same( jQuery.parseJSON("\n{\"test\":1}"), {"test":1}, "Make sure leading whitespaces are handled." );
+	deepEqual( jQuery.parseJSON("\n{\"test\":1}"), {"test":1}, "Make sure leading whitespaces are handled." );
 
 	try {
 		jQuery.parseJSON("{a:1}");
@@ -1139,7 +1139,7 @@ test("jQuery.sub() - Static Methods", function(){
     //Test Simple Subclass
     ok(Subclass.topLevelMethod() === false, "Subclass.topLevelMethod thought debug was true");
     ok(Subclass.config.locale == "en_US", Subclass.config.locale + " is wrong!");
-    same(Subclass.config.test, undefined, "Subclass.config.test is set incorrectly");
+    deepEqual(Subclass.config.test, undefined, "Subclass.config.test is set incorrectly");
     equal(jQuery.ajax, Subclass.ajax, "The subclass failed to get all top level methods");
 
     //Create a SubSubclass
@@ -1148,7 +1148,7 @@ test("jQuery.sub() - Static Methods", function(){
     //Make Sure the SubSubclass inherited properly
     ok(SubSubclass.topLevelMethod() === false, "SubSubclass.topLevelMethod thought debug was true");
     ok(SubSubclass.config.locale == "en_US", SubSubclass.config.locale + " is wrong!");
-    same(SubSubclass.config.test, undefined, "SubSubclass.config.test is set incorrectly");
+    deepEqual(SubSubclass.config.test, undefined, "SubSubclass.config.test is set incorrectly");
     equal(jQuery.ajax, SubSubclass.ajax, "The subsubclass failed to get all top level methods");
 
     //Modify The Subclass and test the Modifications
@@ -1157,7 +1157,7 @@ test("jQuery.sub() - Static Methods", function(){
     SubSubclass.debug = true;
     SubSubclass.ajax = function() {return false;};
     ok(SubSubclass.topLevelMethod(), "SubSubclass.topLevelMethod thought debug was false");
-    same(SubSubclass(document).subClassMethod, Subclass.fn.subClassMethod, "Methods Differ!");
+    deepEqual(SubSubclass(document).subClassMethod, Subclass.fn.subClassMethod, "Methods Differ!");
     ok(SubSubclass.config.locale == "es_MX", SubSubclass.config.locale + " is wrong!");
     ok(SubSubclass.config.test == "worked", "SubSubclass.config.test is set incorrectly");
     notEqual(jQuery.ajax, SubSubclass.ajax, "The subsubclass failed to get all top level methods");
@@ -1165,8 +1165,8 @@ test("jQuery.sub() - Static Methods", function(){
     //This shows that the modifications to the SubSubClass did not bubble back up to it's superclass
     ok(Subclass.topLevelMethod() === false, "Subclass.topLevelMethod thought debug was true");
     ok(Subclass.config.locale == "en_US", Subclass.config.locale + " is wrong!");
-    same(Subclass.config.test, undefined, "Subclass.config.test is set incorrectly");
-    same(Subclass(document).subSubClassMethod, undefined, "subSubClassMethod set incorrectly");
+    deepEqual(Subclass.config.test, undefined, "Subclass.config.test is set incorrectly");
+    deepEqual(Subclass(document).subSubClassMethod, undefined, "subSubClassMethod set incorrectly");
     equal(jQuery.ajax, Subclass.ajax, "The subclass failed to get all top level methods");
 });
 
@@ -1211,27 +1211,27 @@ test("jQuery.sub() - .fn Methods", function(){
 
 				description = "(\""+selector+"\", "+context+")."+method+"("+(arg||"")+")";
 
-				same(
+				deepEqual(
 					jQuery(selector, context)[method](arg).subclassMethod, undefined,
 					"jQuery"+description+" doesn't have Subclass methods"
 				);
-				same(
+				deepEqual(
 					jQuery(selector, context)[method](arg).subclassSubclassMethod, undefined,
 					"jQuery"+description+" doesn't have SubclassSubclass methods"
 				);
-				same(
+				deepEqual(
 					Subclass(selector, context)[method](arg).subclassMethod, Subclass.fn.subclassMethod,
 					"Subclass"+description+" has Subclass methods"
 				);
-				same(
+				deepEqual(
 					Subclass(selector, context)[method](arg).subclassSubclassMethod, undefined,
 					"Subclass"+description+" doesn't have SubclassSubclass methods"
 				);
-				same(
+				deepEqual(
 					SubclassSubclass(selector, context)[method](arg).subclassMethod, Subclass.fn.subclassMethod,
 					"SubclassSubclass"+description+" has Subclass methods"
 				);
-				same(
+				deepEqual(
 					SubclassSubclass(selector, context)[method](arg).subclassSubclassMethod, SubclassSubclass.fn.subclassSubclassMethod,
 					"SubclassSubclass"+description+" has SubclassSubclass methods"
 				);

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -3,7 +3,7 @@ module("css", { teardown: moduleTeardown });
 test("css(String|Hash)", function() {
 	expect( 44 );
 
-	equals( jQuery("#qunit-fixture").css("display"), "block", "Check for css property \"display\"");
+	equal( jQuery("#qunit-fixture").css("display"), "block", "Check for css property \"display\"");
 
 	ok( jQuery("#nothiddendiv").is(":visible"), "Modifying CSS display: Assert element is visible");
 	jQuery("#nothiddendiv").css({display: "none"});
@@ -17,19 +17,19 @@ test("css(String|Hash)", function() {
 
 	// These should be "auto" (or some better value)
 	// temporarily provide "0px" for backwards compat
-	equals( div.css("width"), "0px", "Width on disconnected node." );
-	equals( div.css("height"), "0px", "Height on disconnected node." );
+	equal( div.css("width"), "0px", "Width on disconnected node." );
+	equal( div.css("height"), "0px", "Height on disconnected node." );
 
 	div.css({ width: 4, height: 4 });
 
-	equals( div.css("width"), "4px", "Width on disconnected node." );
-	equals( div.css("height"), "4px", "Height on disconnected node." );
+	equal( div.css("width"), "4px", "Width on disconnected node." );
+	equal( div.css("height"), "4px", "Height on disconnected node." );
 
 	var div2 = jQuery( "<div style='display:none;'><input type='text' style='height:20px;'/><textarea style='height:20px;'/><div style='height:20px;'></div></div>").appendTo("body");
 
-	equals( div2.find("input").css("height"), "20px", "Height on hidden input." );
-	equals( div2.find("textarea").css("height"), "20px", "Height on hidden textarea." );
-	equals( div2.find("div").css("height"), "20px", "Height on hidden textarea." );
+	equal( div2.find("input").css("height"), "20px", "Height on hidden input." );
+	equal( div2.find("textarea").css("height"), "20px", "Height on hidden textarea." );
+	equal( div2.find("div").css("height"), "20px", "Height on hidden textarea." );
 
 	div2.remove();
 
@@ -38,28 +38,28 @@ test("css(String|Hash)", function() {
 
 	var width = parseFloat(jQuery("#nothiddendiv").css("width")), height = parseFloat(jQuery("#nothiddendiv").css("height"));
 	jQuery("#nothiddendiv").css({ width: -1, height: -1 });
-	equals( parseFloat(jQuery("#nothiddendiv").css("width")), width, "Test negative width ignored");
-	equals( parseFloat(jQuery("#nothiddendiv").css("height")), height, "Test negative height ignored");
+	equal( parseFloat(jQuery("#nothiddendiv").css("width")), width, "Test negative width ignored");
+	equal( parseFloat(jQuery("#nothiddendiv").css("height")), height, "Test negative height ignored");
 
-	equals( jQuery("<div style='display: none;'>").css("display"), "none", "Styles on disconnected nodes");
+	equal( jQuery("<div style='display: none;'>").css("display"), "none", "Styles on disconnected nodes");
 
 	jQuery("#floatTest").css({"float": "right"});
-	equals( jQuery("#floatTest").css("float"), "right", "Modified CSS float using \"float\": Assert float is right");
+	equal( jQuery("#floatTest").css("float"), "right", "Modified CSS float using \"float\": Assert float is right");
 	jQuery("#floatTest").css({"font-size": "30px"});
-	equals( jQuery("#floatTest").css("font-size"), "30px", "Modified CSS font-size: Assert font-size is 30px");
+	equal( jQuery("#floatTest").css("font-size"), "30px", "Modified CSS font-size: Assert font-size is 30px");
 	jQuery.each("0,0.25,0.5,0.75,1".split(","), function(i, n) {
 		jQuery("#foo").css({opacity: n});
 
-		equals( jQuery("#foo").css("opacity"), parseFloat(n), "Assert opacity is " + parseFloat(n) + " as a String" );
+		equal( jQuery("#foo").css("opacity"), parseFloat(n), "Assert opacity is " + parseFloat(n) + " as a String" );
 		jQuery("#foo").css({opacity: parseFloat(n)});
-		equals( jQuery("#foo").css("opacity"), parseFloat(n), "Assert opacity is " + parseFloat(n) + " as a Number" );
+		equal( jQuery("#foo").css("opacity"), parseFloat(n), "Assert opacity is " + parseFloat(n) + " as a Number" );
 	});
 	jQuery("#foo").css({opacity: ""});
-	equals( jQuery("#foo").css("opacity"), "1", "Assert opacity is 1 when set to an empty String" );
+	equal( jQuery("#foo").css("opacity"), "1", "Assert opacity is 1 when set to an empty String" );
 
-	equals( jQuery("#empty").css("opacity"), "0", "Assert opacity is accessible via filter property set in stylesheet in IE" );
+	equal( jQuery("#empty").css("opacity"), "0", "Assert opacity is accessible via filter property set in stylesheet in IE" );
 	jQuery("#empty").css({ opacity: "1" });
-	equals( jQuery("#empty").css("opacity"), "1", "Assert opacity is taken from style attribute when set vs stylesheet in IE with filters" );
+	equal( jQuery("#empty").css("opacity"), "1", "Assert opacity is taken from style attribute when set vs stylesheet in IE with filters" );
 	jQuery.support.opacity ?
 		ok(true, "Requires the same number of tests"):
 		ok( ~jQuery("#empty")[0].currentStyle.filter.indexOf("gradient"), "Assert setting opacity doesn't overwrite other filters of the stylesheet in IE" );
@@ -67,16 +67,16 @@ test("css(String|Hash)", function() {
 	div = jQuery("#nothiddendiv");
 	var child = jQuery("#nothiddendivchild");
 
-	equals( parseInt(div.css("fontSize")), 16, "Verify fontSize px set." );
-	equals( parseInt(div.css("font-size")), 16, "Verify fontSize px set." );
-	equals( parseInt(child.css("fontSize")), 16, "Verify fontSize px set." );
-	equals( parseInt(child.css("font-size")), 16, "Verify fontSize px set." );
+	equal( parseInt(div.css("fontSize")), 16, "Verify fontSize px set." );
+	equal( parseInt(div.css("font-size")), 16, "Verify fontSize px set." );
+	equal( parseInt(child.css("fontSize")), 16, "Verify fontSize px set." );
+	equal( parseInt(child.css("font-size")), 16, "Verify fontSize px set." );
 
 	child.css("height", "100%");
-	equals( child[0].style.height, "100%", "Make sure the height is being set correctly." );
+	equal( child[0].style.height, "100%", "Make sure the height is being set correctly." );
 
 	child.attr("class", "em");
-	equals( parseInt(child.css("fontSize")), 32, "Verify fontSize em set." );
+	equal( parseInt(child.css("fontSize")), 32, "Verify fontSize em set." );
 
 	// Have to verify this as the result depends upon the browser's CSS
 	// support for font-size percentages
@@ -86,29 +86,29 @@ test("css(String|Hash)", function() {
 		checkval = prctval;
 	}
 
-	equals( prctval, checkval, "Verify fontSize % set." );
+	equal( prctval, checkval, "Verify fontSize % set." );
 
-	equals( typeof child.css("width"), "string", "Make sure that a string width is returned from css('width')." );
+	equal( typeof child.css("width"), "string", "Make sure that a string width is returned from css('width')." );
 
 	var old = child[0].style.height;
 
 	// Test NaN
 	child.css("height", parseFloat("zoo"));
-	equals( child[0].style.height, old, "Make sure height isn't changed on NaN." );
+	equal( child[0].style.height, old, "Make sure height isn't changed on NaN." );
 
 	// Test null
 	child.css("height", null);
-	equals( child[0].style.height, old, "Make sure height isn't changed on null." );
+	equal( child[0].style.height, old, "Make sure height isn't changed on null." );
 
 	old = child[0].style.fontSize;
 
 	// Test NaN
 	child.css("font-size", parseFloat("zoo"));
-	equals( child[0].style.fontSize, old, "Make sure font-size isn't changed on NaN." );
+	equal( child[0].style.fontSize, old, "Make sure font-size isn't changed on NaN." );
 
 	// Test null
 	child.css("font-size", null);
-	equals( child[0].style.fontSize, old, "Make sure font-size isn't changed on null." );
+	equal( child[0].style.fontSize, old, "Make sure font-size isn't changed on null." );
 });
 
 test("css() explicit and relative values", function() {
@@ -116,87 +116,87 @@ test("css() explicit and relative values", function() {
 	var $elem = jQuery("#nothiddendiv");
 
 	$elem.css({ width: 1, height: 1, paddingLeft: "1px", opacity: 1 });
-	equals( $elem.width(), 1, "Initial css set or width/height works (hash)" );
-	equals( $elem.css("paddingLeft"), "1px", "Initial css set of paddingLeft works (hash)" );
-	equals( $elem.css("opacity"), "1", "Initial css set of opacity works (hash)" );
+	equal( $elem.width(), 1, "Initial css set or width/height works (hash)" );
+	equal( $elem.css("paddingLeft"), "1px", "Initial css set of paddingLeft works (hash)" );
+	equal( $elem.css("opacity"), "1", "Initial css set of opacity works (hash)" );
 
 	$elem.css({ width: "+=9" });
-	equals( $elem.width(), 10, "'+=9' on width (hash)" );
+	equal( $elem.width(), 10, "'+=9' on width (hash)" );
 
 	$elem.css({ width: "-=9" });
-	equals( $elem.width(), 1, "'-=9' on width (hash)" );
+	equal( $elem.width(), 1, "'-=9' on width (hash)" );
 
 	$elem.css({ width: "+=9px" });
-	equals( $elem.width(), 10, "'+=9px' on width (hash)" );
+	equal( $elem.width(), 10, "'+=9px' on width (hash)" );
 
 	$elem.css({ width: "-=9px" });
-	equals( $elem.width(), 1, "'-=9px' on width (hash)" );
+	equal( $elem.width(), 1, "'-=9px' on width (hash)" );
 
 	$elem.css( "width", "+=9" );
-	equals( $elem.width(), 10, "'+=9' on width (params)" );
+	equal( $elem.width(), 10, "'+=9' on width (params)" );
 
 	$elem.css( "width", "-=9" ) ;
-	equals( $elem.width(), 1, "'-=9' on width (params)" );
+	equal( $elem.width(), 1, "'-=9' on width (params)" );
 
 	$elem.css( "width", "+=9px" );
-	equals( $elem.width(), 10, "'+=9px' on width (params)" );
+	equal( $elem.width(), 10, "'+=9px' on width (params)" );
 
 	$elem.css( "width", "-=9px" );
-	equals( $elem.width(), 1, "'-=9px' on width (params)" );
+	equal( $elem.width(), 1, "'-=9px' on width (params)" );
 
 	$elem.css( "width", "-=-9px" );
-	equals( $elem.width(), 10, "'-=-9px' on width (params)" );
+	equal( $elem.width(), 10, "'-=-9px' on width (params)" );
 
 	$elem.css( "width", "+=-9px" );
-	equals( $elem.width(), 1, "'+=-9px' on width (params)" );
+	equal( $elem.width(), 1, "'+=-9px' on width (params)" );
 
 	$elem.css({ paddingLeft: "+=4" });
-	equals( $elem.css("paddingLeft"), "5px", "'+=4' on paddingLeft (hash)" );
+	equal( $elem.css("paddingLeft"), "5px", "'+=4' on paddingLeft (hash)" );
 
 	$elem.css({ paddingLeft: "-=4" });
-	equals( $elem.css("paddingLeft"), "1px", "'-=4' on paddingLeft (hash)" );
+	equal( $elem.css("paddingLeft"), "1px", "'-=4' on paddingLeft (hash)" );
 
 	$elem.css({ paddingLeft: "+=4px" });
-	equals( $elem.css("paddingLeft"), "5px", "'+=4px' on paddingLeft (hash)" );
+	equal( $elem.css("paddingLeft"), "5px", "'+=4px' on paddingLeft (hash)" );
 
 	$elem.css({ paddingLeft: "-=4px" });
-	equals( $elem.css("paddingLeft"), "1px", "'-=4px' on paddingLeft (hash)" );
+	equal( $elem.css("paddingLeft"), "1px", "'-=4px' on paddingLeft (hash)" );
 
 	$elem.css({ "padding-left": "+=4" });
-	equals( $elem.css("paddingLeft"), "5px", "'+=4' on padding-left (hash)" );
+	equal( $elem.css("paddingLeft"), "5px", "'+=4' on padding-left (hash)" );
 
 	$elem.css({ "padding-left": "-=4" });
-	equals( $elem.css("paddingLeft"), "1px", "'-=4' on padding-left (hash)" );
+	equal( $elem.css("paddingLeft"), "1px", "'-=4' on padding-left (hash)" );
 
 	$elem.css({ "padding-left": "+=4px" });
-	equals( $elem.css("paddingLeft"), "5px", "'+=4px' on padding-left (hash)" );
+	equal( $elem.css("paddingLeft"), "5px", "'+=4px' on padding-left (hash)" );
 
 	$elem.css({ "padding-left": "-=4px" });
-	equals( $elem.css("paddingLeft"), "1px", "'-=4px' on padding-left (hash)" );
+	equal( $elem.css("paddingLeft"), "1px", "'-=4px' on padding-left (hash)" );
 
 	$elem.css( "paddingLeft", "+=4" );
-	equals( $elem.css("paddingLeft"), "5px", "'+=4' on paddingLeft (params)" );
+	equal( $elem.css("paddingLeft"), "5px", "'+=4' on paddingLeft (params)" );
 
 	$elem.css( "paddingLeft", "-=4" );
-	equals( $elem.css("paddingLeft"), "1px", "'-=4' on paddingLeft (params)" );
+	equal( $elem.css("paddingLeft"), "1px", "'-=4' on paddingLeft (params)" );
 
 	$elem.css( "padding-left", "+=4px" );
-	equals( $elem.css("paddingLeft"), "5px", "'+=4px' on padding-left (params)" );
+	equal( $elem.css("paddingLeft"), "5px", "'+=4px' on padding-left (params)" );
 
 	$elem.css( "padding-left", "-=4px" );
-	equals( $elem.css("paddingLeft"), "1px", "'-=4px' on padding-left (params)" );
+	equal( $elem.css("paddingLeft"), "1px", "'-=4px' on padding-left (params)" );
 
 	$elem.css({ opacity: "-=0.5" });
-	equals( $elem.css("opacity"), "0.5", "'-=0.5' on opacity (hash)" );
+	equal( $elem.css("opacity"), "0.5", "'-=0.5' on opacity (hash)" );
 
 	$elem.css({ opacity: "+=0.5" });
-	equals( $elem.css("opacity"), "1", "'+=0.5' on opacity (hash)" );
+	equal( $elem.css("opacity"), "1", "'+=0.5' on opacity (hash)" );
 
 	$elem.css( "opacity", "-=0.5" );
-	equals( $elem.css("opacity"), "0.5", "'-=0.5' on opacity (params)" );
+	equal( $elem.css("opacity"), "0.5", "'-=0.5' on opacity (params)" );
 
 	$elem.css( "opacity", "+=0.5" );
-	equals( $elem.css("opacity"), "1", "'+=0.5' on opacity (params)" );
+	equal( $elem.css("opacity"), "1", "'+=0.5' on opacity (params)" );
 });
 
 test("css(String, Object)", function() {
@@ -212,33 +212,33 @@ test("css(String, Object)", function() {
 	ok( jQuery("#nothiddendiv").css("top"), -16, "Check negative number in EMs." );
 
 	jQuery("#floatTest").css("float", "left");
-	equals( jQuery("#floatTest").css("float"), "left", "Modified CSS float using \"float\": Assert float is left");
+	equal( jQuery("#floatTest").css("float"), "left", "Modified CSS float using \"float\": Assert float is left");
 	jQuery("#floatTest").css("font-size", "20px");
-	equals( jQuery("#floatTest").css("font-size"), "20px", "Modified CSS font-size: Assert font-size is 20px");
+	equal( jQuery("#floatTest").css("font-size"), "20px", "Modified CSS font-size: Assert font-size is 20px");
 
 	jQuery.each("0,0.25,0.5,0.75,1".split(","), function(i, n) {
 		jQuery("#foo").css("opacity", n);
-		equals( jQuery("#foo").css("opacity"), parseFloat(n), "Assert opacity is " + parseFloat(n) + " as a String" );
+		equal( jQuery("#foo").css("opacity"), parseFloat(n), "Assert opacity is " + parseFloat(n) + " as a String" );
 		jQuery("#foo").css("opacity", parseFloat(n));
-		equals( jQuery("#foo").css("opacity"), parseFloat(n), "Assert opacity is " + parseFloat(n) + " as a Number" );
+		equal( jQuery("#foo").css("opacity"), parseFloat(n), "Assert opacity is " + parseFloat(n) + " as a Number" );
 	});
 	jQuery("#foo").css("opacity", "");
-	equals( jQuery("#foo").css("opacity"), "1", "Assert opacity is 1 when set to an empty String" );
+	equal( jQuery("#foo").css("opacity"), "1", "Assert opacity is 1 when set to an empty String" );
 
 	// using contents will get comments regular, text, and comment nodes
 	var j = jQuery("#nonnodes").contents();
 	j.css("overflow", "visible");
-	equals( j.css("overflow"), "visible", "Check node,textnode,comment css works" );
+	equal( j.css("overflow"), "visible", "Check node,textnode,comment css works" );
 	// opera sometimes doesn't update 'display' correctly, see #2037
 	jQuery("#t2037")[0].innerHTML = jQuery("#t2037")[0].innerHTML;
-	equals( jQuery("#t2037 .hidden").css("display"), "none", "Make sure browser thinks it is hidden" );
+	equal( jQuery("#t2037 .hidden").css("display"), "none", "Make sure browser thinks it is hidden" );
 
 	var div = jQuery("#nothiddendiv"),
 		display = div.css("display"),
 		ret = div.css("display", undefined);
 
-	equals( ret, div, "Make sure setting undefined returns the original set." );
-	equals( div.css("display"), display, "Make sure that the display wasn't changed." );
+	equal( ret, div, "Make sure setting undefined returns the original set." );
+	equal( div.css("display"), display, "Make sure that the display wasn't changed." );
 
 	// Test for Bug #5509
 	var success = true;
@@ -255,16 +255,16 @@ if ( !jQuery.support.opacity ) {
 	test("css(String, Object) for MSIE", function() {
 		// for #1438, IE throws JS error when filter exists but doesn't have opacity in it
 		jQuery("#foo").css("filter", "progid:DXImageTransform.Microsoft.Chroma(color='red');");
-		equals( jQuery("#foo").css("opacity"), "1", "Assert opacity is 1 when a different filter is set in IE, #1438" );
+		equal( jQuery("#foo").css("opacity"), "1", "Assert opacity is 1 when a different filter is set in IE, #1438" );
 
 		var filterVal = "progid:DXImageTransform.Microsoft.Alpha(opacity=30) progid:DXImageTransform.Microsoft.Blur(pixelradius=5)";
 		var filterVal2 = "progid:DXImageTransform.Microsoft.alpha(opacity=100) progid:DXImageTransform.Microsoft.Blur(pixelradius=5)";
 		var filterVal3 = "progid:DXImageTransform.Microsoft.Blur(pixelradius=5)";
 		jQuery("#foo").css("filter", filterVal);
-		equals( jQuery("#foo").css("filter"), filterVal, "css('filter', val) works" );
+		equal( jQuery("#foo").css("filter"), filterVal, "css('filter', val) works" );
 		jQuery("#foo").css("opacity", 1);
-		equals( jQuery("#foo").css("filter"), filterVal2, "Setting opacity in IE doesn't duplicate opacity filter" );
-		equals( jQuery("#foo").css("opacity"), 1, "Setting opacity in IE with other filters works" );
+		equal( jQuery("#foo").css("filter"), filterVal2, "Setting opacity in IE doesn't duplicate opacity filter" );
+		equal( jQuery("#foo").css("opacity"), 1, "Setting opacity in IE with other filters works" );
 		jQuery("#foo").css("filter", filterVal3).css("opacity", 1);
 		ok( jQuery("#foo").css("filter").indexOf(filterVal3) !== -1, "Setting opacity in IE doesn't clobber other filters" );
 	});
@@ -310,7 +310,7 @@ test("css(String, Function)", function() {
 	jQuery("#cssFunctionTest div").each(function() {
 		var computedSize = jQuery(this).css("font-size")
 		var expectedSize = sizes[index]
-		equals( computedSize, expectedSize, "Div #" + index + " should be " + expectedSize );
+		equal( computedSize, expectedSize, "Div #" + index + " should be " + expectedSize );
 		index++;
 	});
 
@@ -339,7 +339,7 @@ test("css(String, Function) with incoming value", function() {
 
 	jQuery("#cssFunctionTest div").css("font-size", function(i, computedSize) {
 		var expectedSize = sizes[index]
-		equals( computedSize, expectedSize, "Div #" + index + " should be " + expectedSize );
+		equal( computedSize, expectedSize, "Div #" + index + " should be " + expectedSize );
 		index++;
 		return computedSize;
 	});
@@ -370,7 +370,7 @@ test("css(Object) where values are Functions", function() {
 	jQuery("#cssFunctionTest div").each(function() {
 		var computedSize = jQuery(this).css("font-size")
 		var expectedSize = sizes[index]
-		equals( computedSize, expectedSize, "Div #" + index + " should be " + expectedSize );
+		equal( computedSize, expectedSize, "Div #" + index + " should be " + expectedSize );
 		index++;
 	});
 
@@ -399,7 +399,7 @@ test("css(Object) where values are Functions with incoming values", function() {
 
 	jQuery("#cssFunctionTest div").css({"font-size": function(i, computedSize) {
 		var expectedSize = sizes[index]
-		equals( computedSize, expectedSize, "Div #" + index + " should be " + expectedSize );
+		equal( computedSize, expectedSize, "Div #" + index + " should be " + expectedSize );
 		index++;
 		return computedSize;
 	}});
@@ -423,13 +423,13 @@ test(":visible selector works properly on table elements (bug #4512)", function 
 	expect(1);
 
 	jQuery("#table").html("<tr><td style='display:none'>cell</td><td>cell</td></tr>");
-	equals(jQuery("#table td:visible").length, 1, "hidden cell is not perceived as visible");
+	equal(jQuery("#table td:visible").length, 1, "hidden cell is not perceived as visible");
 });
 
 test(":visible selector works properly on children with a hidden parent (bug #4512)", function () {
 	expect(1);
 	jQuery("#table").css("display", "none").html("<tr><td>cell</td><td>cell</td></tr>");
-	equals(jQuery("#table td:visible").length, 0, "hidden cell children not perceived as visible");
+	equal(jQuery("#table td:visible").length, 0, "hidden cell children not perceived as visible");
 });
 
 test("internal ref to elem.runtimeStyle (bug #7608)", function () {
@@ -454,7 +454,7 @@ test("marginRight computed style (bug #3333)", function() {
 		marginRight: 0
 	});
 
-	equals($div.css("marginRight"), "0px", "marginRight correctly calculated with a width and display block");
+	equal($div.css("marginRight"), "0px", "marginRight correctly calculated with a width and display block");
 });
 
 test("jQuery.cssProps behavior, (bug #8402)", function() {

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -3,7 +3,7 @@ module("data", { teardown: moduleTeardown });
 test("expando", function(){
 	expect(1);
 
-	equals("expando" in jQuery, true, "jQuery is exposing the expando");
+	equal("expando" in jQuery, true, "jQuery is exposing the expando");
 });
 
 function dataTests (elem) {
@@ -18,26 +18,26 @@ function dataTests (elem) {
 		return cacheLength;
 	}
 
-	equals( jQuery.data(elem, "foo"), undefined, "No data exists initially" );
+	equal( jQuery.data(elem, "foo"), undefined, "No data exists initially" );
 	strictEqual( jQuery.hasData(elem), false, "jQuery.hasData agrees no data exists initially" );
 
 	var dataObj = jQuery.data(elem);
-	equals( typeof dataObj, "object", "Calling data with no args gives us a data object reference" );
+	equal( typeof dataObj, "object", "Calling data with no args gives us a data object reference" );
 	strictEqual( jQuery.data(elem), dataObj, "Calling jQuery.data returns the same data object when called multiple times" );
 
 	strictEqual( jQuery.hasData(elem), false, "jQuery.hasData agrees no data exists even when an empty data obj exists" );
 
 	dataObj.foo = "bar";
-	equals( jQuery.data(elem, "foo"), "bar", "Data is readable by jQuery.data when set directly on a returned data object" );
+	equal( jQuery.data(elem, "foo"), "bar", "Data is readable by jQuery.data when set directly on a returned data object" );
 
 	strictEqual( jQuery.hasData(elem), true, "jQuery.hasData agrees data exists when data exists" );
 
 	jQuery.data(elem, "foo", "baz");
-	equals( jQuery.data(elem, "foo"), "baz", "Data can be changed by jQuery.data" );
-	equals( dataObj.foo, "baz", "Changes made through jQuery.data propagate to referenced data object" );
+	equal( jQuery.data(elem, "foo"), "baz", "Data can be changed by jQuery.data" );
+	equal( dataObj.foo, "baz", "Changes made through jQuery.data propagate to referenced data object" );
 
 	jQuery.data(elem, "foo", undefined);
-	equals( jQuery.data(elem, "foo"), "baz", "Data is not unset by passing undefined to jQuery.data" );
+	equal( jQuery.data(elem, "foo"), "baz", "Data is not unset by passing undefined to jQuery.data" );
 
 	jQuery.data(elem, "foo", null);
 	strictEqual( jQuery.data(elem, "foo"), null, "Setting null using jQuery.data works OK" );
@@ -46,11 +46,11 @@ function dataTests (elem) {
 
 	jQuery.data(elem, { "bar" : "baz", "boom" : "bloz" });
 	strictEqual( jQuery.data(elem, "foo"), "foo1", "Passing an object extends the data object instead of replacing it" );
-	equals( jQuery.data(elem, "boom"), "bloz", "Extending the data object works" );
+	equal( jQuery.data(elem, "boom"), "bloz", "Extending the data object works" );
 
 	jQuery._data(elem, "foo", "foo2");
-	equals( jQuery._data(elem, "foo"), "foo2", "Setting internal data works" );
-	equals( jQuery.data(elem, "foo"), "foo1", "Setting internal data does not override user data" );
+	equal( jQuery._data(elem, "foo"), "foo2", "Setting internal data works" );
+	equal( jQuery.data(elem, "foo"), "foo1", "Setting internal data does not override user data" );
 
 	var internalDataObj = jQuery._data( elem );
 	ok( internalDataObj, "Internal data object exists" );
@@ -73,7 +73,7 @@ function dataTests (elem) {
 	strictEqual( jQuery.hasData(elem), true, "jQuery.hasData shows data exists even if it is only internal data" );
 
 	jQuery.data(elem, "foo", "foo1");
-	equals( jQuery._data(elem, "foo"), "foo2", "Setting user data does not override internal data" );
+	equal( jQuery._data(elem, "foo"), "foo2", "Setting user data does not override internal data" );
 
 	// delete the last private data key so we can test removing public data
 	// will destroy the cache
@@ -83,7 +83,7 @@ function dataTests (elem) {
 		var oldCacheLength = getCacheLength();
 		jQuery.removeData(elem, "foo");
 
-		equals( getCacheLength(), oldCacheLength - 1, "Removing the last item in the data object destroys it" );
+		equal( getCacheLength(), oldCacheLength - 1, "Removing the last item in the data object destroys it" );
 	}
 	else {
 		jQuery.removeData(elem, "foo");
@@ -98,29 +98,29 @@ function dataTests (elem) {
 			actual = elem[ jQuery.expando ];
 		}
 
-		equals( actual, expected, "Removing the last item in the data object destroys it" );
+		equal( actual, expected, "Removing the last item in the data object destroys it" );
 	}
 
 	jQuery.data(elem, "foo", "foo1");
 	jQuery._data(elem, "foo", "foo2");
 
-	equals( jQuery.data(elem, "foo"), "foo1", "(sanity check) Ensure data is set in user data object" );
-	equals( jQuery._data(elem, "foo"), "foo2", "(sanity check) Ensure data is set in internal data object" );
+	equal( jQuery.data(elem, "foo"), "foo1", "(sanity check) Ensure data is set in user data object" );
+	equal( jQuery._data(elem, "foo"), "foo2", "(sanity check) Ensure data is set in internal data object" );
 
 	jQuery.removeData(elem, "foo", true);
 
 	strictEqual( jQuery.data(elem, jQuery.expando), undefined, "Removing the last item in internal data destroys the internal data object" );
 
 	jQuery._data(elem, "foo", "foo2");
-	equals( jQuery._data(elem, "foo"), "foo2", "(sanity check) Ensure data is set in internal data object" );
+	equal( jQuery._data(elem, "foo"), "foo2", "(sanity check) Ensure data is set in internal data object" );
 
 	jQuery.removeData(elem, "foo");
-	equals( jQuery._data(elem, "foo"), "foo2", "(sanity check) jQuery.removeData for user data does not remove internal data" );
+	equal( jQuery._data(elem, "foo"), "foo2", "(sanity check) jQuery.removeData for user data does not remove internal data" );
 
 	if (elem.nodeType) {
 		oldCacheLength = getCacheLength();
 		jQuery.removeData(elem, "foo", true);
-		equals( getCacheLength(), oldCacheLength - 1, "Removing the last item in the internal data object also destroys the user data object when it is empty" );
+		equal( getCacheLength(), oldCacheLength - 1, "Removing the last item in the internal data object also destroys the user data object when it is empty" );
 	}
 	else {
 		jQuery.removeData(elem, "foo", true);
@@ -134,7 +134,7 @@ function dataTests (elem) {
 			actual = elem[ jQuery.expando ];
 		}
 
-		equals( actual, expected, "Removing the last item in the internal data object also destroys the user data object when it is empty" );
+		equal( actual, expected, "Removing the last item in the internal data object also destroys the user data object when it is empty" );
 	}
 }
 
@@ -187,11 +187,11 @@ test(".data()", function() {
 	// TODO: Remove this hack which was introduced in 1.5.1
 	delete dataObj.toJSON;
 
-	same( dataObj, {test: "success"}, "data() get the entire data object" );
+	deepEqual( dataObj, {test: "success"}, "data() get the entire data object" );
 	strictEqual( div.data("foo"), undefined, "Make sure that missing result is still undefined" );
 
 	var nodiv = jQuery("#unfound");
-	equals( nodiv.data(), null, "data() on empty set returns null" );
+	equal( nodiv.data(), null, "data() on empty set returns null" );
 
 	var obj = { foo: "bar" };
 	jQuery(obj).data("foo", "baz");
@@ -217,13 +217,13 @@ test(".data(String) and .data(String, Object)", function() {
 	ok( div.data("test") === undefined, "Check for no data exists" );
 
 	div.data("test", "success");
-	equals( div.data("test"), "success", "Check for added data" );
+	equal( div.data("test"), "success", "Check for added data" );
 
 	div.data("test", "overwritten");
-	equals( div.data("test"), "overwritten", "Check for overwritten data" );
+	equal( div.data("test"), "overwritten", "Check for overwritten data" );
 
 	div.data("test", undefined);
-	equals( div.data("test"), "overwritten", "Check that data wasn't removed");
+	equal( div.data("test"), "overwritten", "Check that data wasn't removed");
 
 	div.data("test", null);
 	ok( div.data("test") === null, "Check for null data");
@@ -252,13 +252,13 @@ test(".data(String) and .data(String, Object)", function() {
 		.bind("getData.foo",function(e,key){ gets[key] += 3; });
 
 	div.data("test.foo", 2);
-	equals( div.data("test"), "overwritten", "Check for original data" );
-	equals( div.data("test.foo"), 2, "Check for namespaced data" );
-	equals( div.data("test.bar"), "overwritten", "Check for unmatched namespace" );
-	equals( hits.test, 2, "Check triggered setter functions" );
-	equals( gets.test, 5, "Check triggered getter functions" );
-	equals( changes.test, 2, "Check sets raise changeData");
-	equals( changes.value, 2, "Check changeData after data has been set" );
+	equal( div.data("test"), "overwritten", "Check for original data" );
+	equal( div.data("test.foo"), 2, "Check for namespaced data" );
+	equal( div.data("test.bar"), "overwritten", "Check for unmatched namespace" );
+	equal( hits.test, 2, "Check triggered setter functions" );
+	equal( gets.test, 5, "Check triggered getter functions" );
+	equal( changes.test, 2, "Check sets raise changeData");
+	equal( changes.value, 2, "Check changeData after data has been set" );
 
 	hits.test = 0;
 	gets.test = 0;
@@ -266,29 +266,29 @@ test(".data(String) and .data(String, Object)", function() {
 	changes.value = null;
 
 	div.data("test", 1);
-	equals( div.data("test"), 1, "Check for original data" );
-	equals( div.data("test.foo"), 2, "Check for namespaced data" );
-	equals( div.data("test.bar"), 1, "Check for unmatched namespace" );
-	equals( hits.test, 1, "Check triggered setter functions" );
-	equals( gets.test, 5, "Check triggered getter functions" );
-	equals( changes.test, 1, "Check sets raise changeData" );
-	equals( changes.value, 1, "Check changeData after data has been set" );
+	equal( div.data("test"), 1, "Check for original data" );
+	equal( div.data("test.foo"), 2, "Check for namespaced data" );
+	equal( div.data("test.bar"), 1, "Check for unmatched namespace" );
+	equal( hits.test, 1, "Check triggered setter functions" );
+	equal( gets.test, 5, "Check triggered getter functions" );
+	equal( changes.test, 1, "Check sets raise changeData" );
+	equal( changes.value, 1, "Check changeData after data has been set" );
 
 	div
 		.bind("getData",function(e,key){ return key + "root"; })
 		.bind("getData.foo",function(e,key){ return key + "foo"; });
 
-	equals( div.data("test"), "testroot", "Check for original data" );
-	equals( div.data("test.foo"), "testfoo", "Check for namespaced data" );
-	equals( div.data("test.bar"), "testroot", "Check for unmatched namespace" );
+	equal( div.data("test"), "testroot", "Check for original data" );
+	equal( div.data("test.foo"), "testfoo", "Check for namespaced data" );
+	equal( div.data("test.bar"), "testroot", "Check for unmatched namespace" );
 
 	// #3748
 	var $elem = jQuery({exists:true});
-	equals( $elem.data("nothing"), undefined, "Non-existent data returns undefined");
-	equals( $elem.data("null", null).data("null"), null, "null's are preserved");
-	equals( $elem.data("emptyString", "").data("emptyString"), "", "Empty strings are preserved");
-	equals( $elem.data("false", false).data("false"), false, "false's are preserved");
-	equals( $elem.data("exists"), undefined, "Existing data is not returned" );
+	equal( $elem.data("nothing"), undefined, "Non-existent data returns undefined");
+	equal( $elem.data("null", null).data("null"), null, "null's are preserved");
+	equal( $elem.data("emptyString", "").data("emptyString"), "", "Empty strings are preserved");
+	equal( $elem.data("false", false).data("false"), false, "false's are preserved");
+	equal( $elem.data("exists"), undefined, "Existing data is not returned" );
 
 	// Clean up
 	$elem.removeData();
@@ -304,27 +304,27 @@ test("data-* attributes", function() {
 		child = jQuery("<div data-myobj='old data' data-ignored=\"DOM\" data-other='test'></div>"),
 		dummy = jQuery("<div data-myobj='old data' data-ignored=\"DOM\" data-other='test'></div>");
 
-	equals( div.data("attr"), undefined, "Check for non-existing data-attr attribute" );
+	equal( div.data("attr"), undefined, "Check for non-existing data-attr attribute" );
 
 	div.attr("data-attr", "exists");
-	equals( div.data("attr"), "exists", "Check for existing data-attr attribute" );
+	equal( div.data("attr"), "exists", "Check for existing data-attr attribute" );
 
 	div.attr("data-attr", "exists2");
-	equals( div.data("attr"), "exists", "Check that updates to data- don't update .data()" );
+	equal( div.data("attr"), "exists", "Check that updates to data- don't update .data()" );
 
 	div.data("attr", "internal").attr("data-attr", "external");
-	equals( div.data("attr"), "internal", "Check for .data('attr') precedence (internal > external data-* attribute)" );
+	equal( div.data("attr"), "internal", "Check for .data('attr') precedence (internal > external data-* attribute)" );
 
 	div.remove();
 
 	child.appendTo("#qunit-fixture");
-	equals( child.data("myobj"), "old data", "Value accessed from data-* attribute");
+	equal( child.data("myobj"), "old data", "Value accessed from data-* attribute");
 
 	child.data("myobj", "replaced");
-	equals( child.data("myobj"), "replaced", "Original data overwritten");
+	equal( child.data("myobj"), "replaced", "Original data overwritten");
 
 	child.data("ignored", "cache");
-	equals( child.data("ignored"), "cache", "Cached data used before DOM data-* fallback");
+	equal( child.data("ignored"), "cache", "Cached data used before DOM data-* fallback");
 
 	var obj = child.data(), obj2 = dummy.data(), check = [ "myobj", "ignored", "other" ], num = 0, num2 = 0;
 
@@ -339,17 +339,17 @@ test("data-* attributes", function() {
 		num++;
 	}
 
-	equals( num, check.length, "Make sure that the right number of properties came through." );
+	equal( num, check.length, "Make sure that the right number of properties came through." );
 
 	for ( var prop in obj2 ) {
 		num2++;
 	}
 
-	equals( num2, check.length, "Make sure that the right number of properties came through." );
+	equal( num2, check.length, "Make sure that the right number of properties came through." );
 
 	child.attr("data-other", "newvalue");
 
-	equals( child.data("other"), "test", "Make sure value was pulled in properly from a .data()." );
+	equal( child.data("other"), "test", "Make sure value was pulled in properly from a .data()." );
 
 	child
 		.attr("data-true", "true")
@@ -386,20 +386,20 @@ test("data-* attributes", function() {
 	function testData(index, elem) {
 		switch (index) {
 		case 0:
-			equals(jQuery(elem).data("foo"), "bar", "Check foo property");
-			equals(jQuery(elem).data("bar"), "baz", "Check baz property");
+			equal(jQuery(elem).data("foo"), "bar", "Check foo property");
+			equal(jQuery(elem).data("bar"), "baz", "Check baz property");
 			break;
 		case 1:
-			equals(jQuery(elem).data("test"), "bar", "Check test property");
-			equals(jQuery(elem).data("bar"), "baz", "Check bar property");
+			equal(jQuery(elem).data("test"), "bar", "Check test property");
+			equal(jQuery(elem).data("bar"), "baz", "Check bar property");
 			break;
 		case 2:
-			equals(jQuery(elem).data("zoooo"), "bar", "Check zoooo property");
-			same(jQuery(elem).data("bar"), {"test":"baz"}, "Check bar property");
+			equal(jQuery(elem).data("zoooo"), "bar", "Check zoooo property");
+			deepEqual(jQuery(elem).data("bar"), {"test":"baz"}, "Check bar property");
 			break;
 		case 3:
-			equals(jQuery(elem).data("number"), true, "Check number property");
-			same(jQuery(elem).data("stuff"), [2,8], "Check stuff property");
+			equal(jQuery(elem).data("number"), true, "Check number property");
+			deepEqual(jQuery(elem).data("stuff"), [2,8], "Check stuff property");
 			break;
 		default:
 			ok(false, ["Assertion failed on index ", index, ", with data ", data].join(""));
@@ -419,15 +419,15 @@ test(".data(Object)", function() {
 	var div = jQuery("<div/>");
 
 	div.data({ "test": "in", "test2": "in2" });
-	equals( div.data("test"), "in", "Verify setting an object in data" );
-	equals( div.data("test2"), "in2", "Verify setting an object in data" );
+	equal( div.data("test"), "in", "Verify setting an object in data" );
+	equal( div.data("test2"), "in2", "Verify setting an object in data" );
 
 	var obj = {test:"unset"},
 		jqobj = jQuery(obj);
 	jqobj.data("test", "unset");
 	jqobj.data({ "test": "in", "test2": "in2" });
-	equals( jQuery.data(obj).test, "in", "Verify setting an object on an object extends the data object" );
-	equals( obj.test2, undefined, "Verify setting an object on an object does not extend the object" );
+	equal( jQuery.data(obj).test, "in", "Verify setting an object on an object extends the data object" );
+	equal( obj.test2, undefined, "Verify setting an object on an object does not extend the object" );
 
 	// manually clean up detached elements
 	div.remove();
@@ -438,7 +438,7 @@ test("jQuery.removeData", function() {
 	var div = jQuery("#foo")[0];
 	jQuery.data(div, "test", "testing");
 	jQuery.removeData(div, "test");
-	equals( jQuery.data(div, "test"), undefined, "Check removal of data" );
+	equal( jQuery.data(div, "test"), undefined, "Check removal of data" );
 
 	jQuery.data(div, "test2", "testing");
 	jQuery.removeData( div );
@@ -469,9 +469,9 @@ test("jQuery.removeData", function() {
 
 	var obj = {};
 	jQuery.data(obj, "test", "testing");
-	equals( jQuery(obj).data("test"), "testing", "verify data on plain object");
+	equal( jQuery(obj).data("test"), "testing", "verify data on plain object");
 	jQuery.removeData(obj, "test");
-	equals( jQuery.data(obj, "test"), undefined, "Check removal of data on plain object" );
+	equal( jQuery.data(obj, "test"), undefined, "Check removal of data on plain object" );
 
 	jQuery.data( window, "BAD", true );
 	jQuery.removeData( window, "BAD" );
@@ -483,20 +483,20 @@ test(".removeData()", function() {
 	var div = jQuery("#foo");
 	div.data("test", "testing");
 	div.removeData("test");
-	equals( div.data("test"), undefined, "Check removal of data" );
+	equal( div.data("test"), undefined, "Check removal of data" );
 
 	div.data("test", "testing");
 	div.data("test.foo", "testing2");
 	div.removeData("test.bar");
-	equals( div.data("test.foo"), "testing2", "Make sure data is intact" );
-	equals( div.data("test"), "testing", "Make sure data is intact" );
+	equal( div.data("test.foo"), "testing2", "Make sure data is intact" );
+	equal( div.data("test"), "testing", "Make sure data is intact" );
 
 	div.removeData("test");
-	equals( div.data("test.foo"), "testing2", "Make sure data is intact" );
-	equals( div.data("test"), undefined, "Make sure data is intact" );
+	equal( div.data("test.foo"), "testing2", "Make sure data is intact" );
+	equal( div.data("test"), undefined, "Make sure data is intact" );
 
 	div.removeData("test.foo");
-	equals( div.data("test.foo"), undefined, "Make sure data is intact" );
+	equal( div.data("test.foo"), undefined, "Make sure data is intact" );
 });
 
 if (window.JSON && window.JSON.stringify) {
@@ -506,7 +506,7 @@ if (window.JSON && window.JSON.stringify) {
 		var obj = { foo: "bar" };
 		jQuery.data(obj, "hidden", true);
 
-		equals( JSON.stringify(obj), "{\"foo\":\"bar\"}", "Expando is hidden from JSON.stringify" );
+		equal( JSON.stringify(obj), "{\"foo\":\"bar\"}", "Expando is hidden from JSON.stringify" );
 	});
 }
 

--- a/test/unit/deferred.js
+++ b/test/unit/deferred.js
@@ -351,18 +351,18 @@ test("jQuery.when - joined", function() {
 
 			var promise = jQuery.when( defer1, defer2 ).done(function( a, b ) {
 				if ( shouldResolve ) {
-					same( [ a, b ], expected, code + " => resolve" );
+					deepEqual( [ a, b ], expected, code + " => resolve" );
 				} else {
 					ok( false ,  code + " => resolve" );
 				}
 			}).fail(function( a, b ) {
 				if ( shouldError ) {
-					same( [ a, b ], expected, code + " => reject" );
+					deepEqual( [ a, b ], expected, code + " => reject" );
 				} else {
 					ok( false ,  code + " => reject" );
 				}
 			}).progress(function progress( a, b ) {
-				same( [ a, b ], expectedNotify, code + " => progress" );
+				deepEqual( [ a, b ], expectedNotify, code + " => progress" );
 			});
 		} );
 	} );

--- a/test/unit/dimensions.js
+++ b/test/unit/dimensions.js
@@ -13,26 +13,26 @@ function testWidth( val ) {
 
 	var $div = jQuery("#nothiddendiv");
 	$div.width( val(30) );
-	equals($div.width(), 30, "Test set to 30 correctly");
+	equal($div.width(), 30, "Test set to 30 correctly");
 	$div.hide();
-	equals($div.width(), 30, "Test hidden div");
+	equal($div.width(), 30, "Test hidden div");
 	$div.show();
 	$div.width( val(-1) ); // handle negative numbers by ignoring #1599
-	equals($div.width(), 30, "Test negative width ignored");
+	equal($div.width(), 30, "Test negative width ignored");
 	$div.css("padding", "20px");
-	equals($div.width(), 30, "Test padding specified with pixels");
+	equal($div.width(), 30, "Test padding specified with pixels");
 	$div.css("border", "2px solid #fff");
-	equals($div.width(), 30, "Test border specified with pixels");
+	equal($div.width(), 30, "Test border specified with pixels");
 
 	$div.css({ display: "", border: "", padding: "" });
 
 	jQuery("#nothiddendivchild").css({ width: 20, padding: "3px", border: "2px solid #fff" });
-	equals(jQuery("#nothiddendivchild").width(), 20, "Test child width with border and padding");
+	equal(jQuery("#nothiddendivchild").width(), 20, "Test child width with border and padding");
 	jQuery("#nothiddendiv, #nothiddendivchild").css({ border: "", padding: "", width: "" });
 
 	var blah = jQuery("blah");
-	equals( blah.width( val(10) ), blah, "Make sure that setting a width on an empty set returns the set." );
-	equals( blah.width(), null, "Make sure 'null' is returned on an empty set");
+	equal( blah.width( val(10) ), blah, "Make sure that setting a width on an empty set returns the set." );
+	equal( blah.width(), null, "Make sure 'null' is returned on an empty set");
 
 	jQuery.removeData($div[0], "olddisplay", true);
 }
@@ -50,11 +50,11 @@ test("width() with function args", function() {
 
 	var $div = jQuery("#nothiddendiv");
 	$div.width( 30 ).width(function(i, width) {
-		equals( width, 30, "Make sure previous value is corrrect." );
+		equal( width, 30, "Make sure previous value is corrrect." );
 		return width + 1;
 	});
 
-	equals( $div.width(), 31, "Make sure value was modified correctly." );
+	equal( $div.width(), 31, "Make sure value was modified correctly." );
 });
 
 function testHeight( val ) {
@@ -62,26 +62,26 @@ function testHeight( val ) {
 
 	var $div = jQuery("#nothiddendiv");
 	$div.height( val(30) );
-	equals($div.height(), 30, "Test set to 30 correctly");
+	equal($div.height(), 30, "Test set to 30 correctly");
 	$div.hide();
-	equals($div.height(), 30, "Test hidden div");
+	equal($div.height(), 30, "Test hidden div");
 	$div.show();
 	$div.height( val(-1) ); // handle negative numbers by ignoring #1599
-	equals($div.height(), 30, "Test negative height ignored");
+	equal($div.height(), 30, "Test negative height ignored");
 	$div.css("padding", "20px");
-	equals($div.height(), 30, "Test padding specified with pixels");
+	equal($div.height(), 30, "Test padding specified with pixels");
 	$div.css("border", "2px solid #fff");
-	equals($div.height(), 30, "Test border specified with pixels");
+	equal($div.height(), 30, "Test border specified with pixels");
 
 	$div.css({ display: "", border: "", padding: "", height: "1px" });
 
 	jQuery("#nothiddendivchild").css({ height: 20, padding: "3px", border: "2px solid #fff" });
-	equals(jQuery("#nothiddendivchild").height(), 20, "Test child height with border and padding");
+	equal(jQuery("#nothiddendivchild").height(), 20, "Test child height with border and padding");
 	jQuery("#nothiddendiv, #nothiddendivchild").css({ border: "", padding: "", height: "" });
 
 	var blah = jQuery("blah");
-	equals( blah.height( val(10) ), blah, "Make sure that setting a height on an empty set returns the set." );
-	equals( blah.height(), null, "Make sure 'null' is returned on an empty set");
+	equal( blah.height( val(10) ), blah, "Make sure that setting a height on an empty set returns the set." );
+	equal( blah.height(), null, "Make sure 'null' is returned on an empty set");
 
 	jQuery.removeData($div[0], "olddisplay", true);
 }
@@ -99,11 +99,11 @@ test("height() with function args", function() {
 
 	var $div = jQuery("#nothiddendiv");
 	$div.height( 30 ).height(function(i, height) {
-		equals( height, 30, "Make sure previous value is corrrect." );
+		equal( height, 30, "Make sure previous value is corrrect." );
 		return height + 1;
 	});
 
-	equals( $div.height(), 31, "Make sure value was modified correctly." );
+	equal( $div.height(), 31, "Make sure value was modified correctly." );
 });
 
 test("innerWidth()", function() {
@@ -112,11 +112,11 @@ test("innerWidth()", function() {
 	var winWidth = jQuery( window ).width(),
 		docWidth = jQuery( document ).width();
 
-	equals(jQuery(window).innerWidth(), winWidth, "Test on window without margin option");
-	equals(jQuery(window).innerWidth(true), winWidth, "Test on window with margin option");
+	equal(jQuery(window).innerWidth(), winWidth, "Test on window without margin option");
+	equal(jQuery(window).innerWidth(true), winWidth, "Test on window with margin option");
 
-	equals(jQuery(document).innerWidth(), docWidth, "Test on document without margin option");
-	equals(jQuery(document).innerWidth(true), docWidth, "Test on document with margin option");
+	equal(jQuery(document).innerWidth(), docWidth, "Test on document without margin option");
+	equal(jQuery(document).innerWidth(true), docWidth, "Test on document with margin option");
 
 	var $div = jQuery("#nothiddendiv");
 	// set styles
@@ -126,11 +126,11 @@ test("innerWidth()", function() {
 		width: 30
 	});
 
-	equals($div.innerWidth(), 30, "Test with margin and border");
+	equal($div.innerWidth(), 30, "Test with margin and border");
 	$div.css("padding", "20px");
-	equals($div.innerWidth(), 70, "Test with margin, border and padding");
+	equal($div.innerWidth(), 70, "Test with margin, border and padding");
 	$div.hide();
-	equals($div.innerWidth(), 70, "Test hidden div");
+	equal($div.innerWidth(), 70, "Test hidden div");
 
 	// reset styles
 	$div.css({ display: "", border: "", padding: "", width: "", height: "" });
@@ -138,7 +138,7 @@ test("innerWidth()", function() {
 	var div = jQuery( "<div>" );
 
 	// Temporarily require 0 for backwards compat - should be auto
-	equals( div.innerWidth(), 0, "Make sure that disconnected nodes are handled." );
+	equal( div.innerWidth(), 0, "Make sure that disconnected nodes are handled." );
 
 	div.remove();
 	jQuery.removeData($div[0], "olddisplay", true);
@@ -150,11 +150,11 @@ test("innerHeight()", function() {
 	var winHeight = jQuery( window ).height(),
 		docHeight = jQuery( document ).height();
 
-	equals(jQuery(window).innerHeight(), winHeight, "Test on window without margin option");
-	equals(jQuery(window).innerHeight(true), winHeight, "Test on window with margin option");
+	equal(jQuery(window).innerHeight(), winHeight, "Test on window without margin option");
+	equal(jQuery(window).innerHeight(true), winHeight, "Test on window with margin option");
 
-	equals(jQuery(document).innerHeight(), docHeight, "Test on document without margin option");
-	equals(jQuery(document).innerHeight(true), docHeight, "Test on document with margin option");
+	equal(jQuery(document).innerHeight(), docHeight, "Test on document without margin option");
+	equal(jQuery(document).innerHeight(true), docHeight, "Test on document with margin option");
 
 	var $div = jQuery("#nothiddendiv");
 	// set styles
@@ -164,11 +164,11 @@ test("innerHeight()", function() {
 		height: 30
 	});
 
-	equals($div.innerHeight(), 30, "Test with margin and border");
+	equal($div.innerHeight(), 30, "Test with margin and border");
 	$div.css("padding", "20px");
-	equals($div.innerHeight(), 70, "Test with margin, border and padding");
+	equal($div.innerHeight(), 70, "Test with margin, border and padding");
 	$div.hide();
-	equals($div.innerHeight(), 70, "Test hidden div");
+	equal($div.innerHeight(), 70, "Test hidden div");
 
 	// reset styles
 	$div.css({ display: "", border: "", padding: "", width: "", height: "" });
@@ -176,7 +176,7 @@ test("innerHeight()", function() {
 	var div = jQuery( "<div>" );
 
 	// Temporarily require 0 for backwards compat - should be auto
-	equals( div.innerHeight(), 0, "Make sure that disconnected nodes are handled." );
+	equal( div.innerHeight(), 0, "Make sure that disconnected nodes are handled." );
 
 	div.remove();
 	jQuery.removeData($div[0], "olddisplay", true);
@@ -196,17 +196,17 @@ test("outerWidth()", function() {
 	var $div = jQuery("#nothiddendiv");
 	$div.css("width", 30);
 
-	equals($div.outerWidth(), 30, "Test with only width set");
+	equal($div.outerWidth(), 30, "Test with only width set");
 	$div.css("padding", "20px");
-	equals($div.outerWidth(), 70, "Test with padding");
+	equal($div.outerWidth(), 70, "Test with padding");
 	$div.css("border", "2px solid #fff");
-	equals($div.outerWidth(), 74, "Test with padding and border");
+	equal($div.outerWidth(), 74, "Test with padding and border");
 	$div.css("margin", "10px");
-	equals($div.outerWidth(), 74, "Test with padding, border and margin without margin option");
+	equal($div.outerWidth(), 74, "Test with padding, border and margin without margin option");
 	$div.css("position", "absolute");
-	equals($div.outerWidth(true), 94, "Test with padding, border and margin with margin option");
+	equal($div.outerWidth(true), 94, "Test with padding, border and margin with margin option");
 	$div.hide();
-	equals($div.outerWidth(true), 94, "Test hidden div with padding, border and margin with margin option");
+	equal($div.outerWidth(true), 94, "Test hidden div with padding, border and margin with margin option");
 
 	// reset styles
 	$div.css({ position: "", display: "", border: "", padding: "", width: "", height: "" });
@@ -214,7 +214,7 @@ test("outerWidth()", function() {
 	var div = jQuery( "<div>" );
 
 	// Temporarily require 0 for backwards compat - should be auto
-	equals( div.outerWidth(), 0, "Make sure that disconnected nodes are handled." );
+	equal( div.outerWidth(), 0, "Make sure that disconnected nodes are handled." );
 
 	div.remove();
 	jQuery.removeData($div[0], "olddisplay", true);
@@ -230,15 +230,15 @@ test("child of a hidden elem has accurate inner/outer/Width()/Height()  see #944
 	$divNormal.appendTo("body");
 
 	// tests that child div of a hidden div works the same as a normal div
-	equals( $divChild.width(), $divNormal.width(), "child of a hidden element width() is wrong see #9441" );
-	equals( $divChild.innerWidth(), $divNormal.innerWidth(), "child of a hidden element innerWidth() is wrong see #9441" );
-	equals( $divChild.outerWidth(), $divNormal.outerWidth(), "child of a hidden element outerWidth() is wrong see #9441" );
-	equals( $divChild.outerWidth(true), $divNormal.outerWidth( true ), "child of a hidden element outerWidth( true ) is wrong see #9300" );
+	equal( $divChild.width(), $divNormal.width(), "child of a hidden element width() is wrong see #9441" );
+	equal( $divChild.innerWidth(), $divNormal.innerWidth(), "child of a hidden element innerWidth() is wrong see #9441" );
+	equal( $divChild.outerWidth(), $divNormal.outerWidth(), "child of a hidden element outerWidth() is wrong see #9441" );
+	equal( $divChild.outerWidth(true), $divNormal.outerWidth( true ), "child of a hidden element outerWidth( true ) is wrong see #9300" );
 
-	equals( $divChild.height(), $divNormal.height(), "child of a hidden element height() is wrong see #9441" );
-	equals( $divChild.innerHeight(), $divNormal.innerHeight(), "child of a hidden element innerHeight() is wrong see #9441" );
-	equals( $divChild.outerHeight(), $divNormal.outerHeight(), "child of a hidden element outerHeight() is wrong see #9441" );
-	equals( $divChild.outerHeight(true), $divNormal.outerHeight( true ), "child of a hidden element outerHeight( true ) is wrong see #9300" );
+	equal( $divChild.height(), $divNormal.height(), "child of a hidden element height() is wrong see #9441" );
+	equal( $divChild.innerHeight(), $divNormal.innerHeight(), "child of a hidden element innerHeight() is wrong see #9441" );
+	equal( $divChild.outerHeight(), $divNormal.outerHeight(), "child of a hidden element outerHeight() is wrong see #9441" );
+	equal( $divChild.outerHeight(true), $divNormal.outerHeight( true ), "child of a hidden element outerHeight( true ) is wrong see #9300" );
 
 	// teardown html
 	$divHiddenParent.remove();
@@ -283,16 +283,16 @@ test("outerHeight()", function() {
 	var $div = jQuery("#nothiddendiv");
 	$div.css("height", 30);
 
-	equals($div.outerHeight(), 30, "Test with only width set");
+	equal($div.outerHeight(), 30, "Test with only width set");
 	$div.css("padding", "20px");
-	equals($div.outerHeight(), 70, "Test with padding");
+	equal($div.outerHeight(), 70, "Test with padding");
 	$div.css("border", "2px solid #fff");
-	equals($div.outerHeight(), 74, "Test with padding and border");
+	equal($div.outerHeight(), 74, "Test with padding and border");
 	$div.css("margin", "10px");
-	equals($div.outerHeight(), 74, "Test with padding, border and margin without margin option");
-	equals($div.outerHeight(true), 94, "Test with padding, border and margin with margin option");
+	equal($div.outerHeight(), 74, "Test with padding, border and margin without margin option");
+	equal($div.outerHeight(true), 94, "Test with padding, border and margin with margin option");
 	$div.hide();
-	equals($div.outerHeight(true), 94, "Test hidden div with padding, border and margin with margin option");
+	equal($div.outerHeight(true), 94, "Test hidden div with padding, border and margin with margin option");
 
 	// reset styles
 	$div.css({ display: "", border: "", padding: "", width: "", height: "" });
@@ -300,7 +300,7 @@ test("outerHeight()", function() {
 	var div = jQuery( "<div>" );
 
 	// Temporarily require 0 for backwards compat - should be auto
-	equals( div.outerHeight(), 0, "Make sure that disconnected nodes are handled." );
+	equal( div.outerHeight(), 0, "Make sure that disconnected nodes are handled." );
 
 	div.remove();
 	jQuery.removeData($div[0], "olddisplay", true);

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -12,7 +12,7 @@ test("show()", function() {
 
 	hiddendiv.hide().show();
 
-	equals( hiddendiv.css("display"), "block", "Make sure a pre-hidden div is visible." );
+	equal( hiddendiv.css("display"), "block", "Make sure a pre-hidden div is visible." );
 
 	var div = jQuery("<div>").hide().appendTo("#qunit-fixture").show();
 
@@ -87,7 +87,7 @@ test("show()", function() {
 
 	jQuery.each(test, function(selector, expected) {
 		var elem = jQuery(selector, "#show-tests").show();
-		equals( elem.css("display"), expected, "Show using correct display type for " + selector );
+		equal( elem.css("display"), expected, "Show using correct display type for " + selector );
 	});
 
 	// Make sure that showing or hiding a text node doesn't cause an error
@@ -126,7 +126,7 @@ test("show(Number) - other displays", function() {
 
 	jQuery.each(test, function(selector, expected) {
 		var elem = jQuery(selector, "#show-tests").show(1, function() {
-			equals( elem.css("display"), expected, "Show using correct display type for " + selector );
+			equal( elem.css("display"), expected, "Show using correct display type for " + selector );
 			if ( ++num === 15 ) {
 				start();
 			}
@@ -156,11 +156,11 @@ test("Persist correct display value", function() {
 	$span.hide();
 
 	$span.fadeIn(100, function() {
-		equals($span.css("display"), display, "Expecting display: " + display);
+		equal($span.css("display"), display, "Expecting display: " + display);
 		$span.fadeOut(100, function () {
-			equals($span.css("display"), displayNone, "Expecting display: " + displayNone);
+			equal($span.css("display"), displayNone, "Expecting display: " + displayNone);
 			$span.fadeIn(100, function() {
-				equals($span.css("display"), display, "Expecting display: " + display);
+				equal($span.css("display"), display, "Expecting display: " + display);
 				start();
 			});
 		});
@@ -172,16 +172,16 @@ test("show() resolves correct default display #8099", function() {
 	var tt8099 = jQuery("<tt/>").appendTo("body"),
 			dfn8099 = jQuery("<dfn/>", { html: "foo"}).appendTo("body");
 
-	equals( tt8099.css("display"), "none", "default display override for all tt" );
-	equals( tt8099.show().css("display"), "inline", "Correctly resolves display:inline" );
+	equal( tt8099.css("display"), "none", "default display override for all tt" );
+	equal( tt8099.show().css("display"), "inline", "Correctly resolves display:inline" );
 
-	equals( jQuery("#foo").hide().show().css("display"), "block", "Correctly resolves display:block after hide/show" );
+	equal( jQuery("#foo").hide().show().css("display"), "block", "Correctly resolves display:block after hide/show" );
 
-	equals( tt8099.hide().css("display"), "none", "default display override for all tt" );
-	equals( tt8099.show().css("display"), "inline", "Correctly resolves display:inline" );
+	equal( tt8099.hide().css("display"), "none", "default display override for all tt" );
+	equal( tt8099.show().css("display"), "inline", "Correctly resolves display:inline" );
 
-	equals( dfn8099.css("display"), "none", "default display override for all dfn" );
-	equals( dfn8099.show().css("display"), "inline", "Correctly resolves display:inline" );
+	equal( dfn8099.css("display"), "none", "default display override for all dfn" );
+	equal( dfn8099.show().css("display"), "inline", "Correctly resolves display:inline" );
 
 	tt8099.remove();
 	dfn8099.remove();
@@ -195,7 +195,7 @@ test("animate(Hash, Object, Function)", function() {
 	var hash = {opacity: "show"};
 	var hashCopy = jQuery.extend({}, hash);
 	jQuery("#foo").animate(hash, 0, function() {
-		equals( hash.opacity, hashCopy.opacity, "Check if animate changed the hash parameter" );
+		equal( hash.opacity, hashCopy.opacity, "Check if animate changed the hash parameter" );
 		start();
 	});
 });
@@ -204,7 +204,7 @@ test("animate negative height", function() {
 	expect(1);
 	stop();
 	jQuery("#foo").animate({ height: -100 }, 100, function() {
-		equals( this.offsetHeight, 0, "Verify height." );
+		equal( this.offsetHeight, 0, "Verify height." );
 		start();
 	});
 });
@@ -221,9 +221,9 @@ test("animate block as inline width/height", function() {
 		stop();
 
 		jQuery("#foo").css({ display: "inline", width: "", height: "" }).animate({ width: 42, height: 42 }, 100, function() {
-			equals( jQuery(this).css("display"), jQuery.support.inlineBlockNeedsLayout ? "inline" : "inline-block", "inline-block was set on non-floated inline element when animating width/height" );
-			equals( this.offsetWidth, 42, "width was animated" );
-			equals( this.offsetHeight, 42, "height was animated" );
+			equal( jQuery(this).css("display"), jQuery.support.inlineBlockNeedsLayout ? "inline" : "inline-block", "inline-block was set on non-floated inline element when animating width/height" );
+			equal( this.offsetWidth, 42, "width was animated" );
+			equal( this.offsetHeight, 42, "height was animated" );
 			start();
 		});
 
@@ -249,9 +249,9 @@ test("animate native inline width/height", function() {
 			.append("<span>text</span>")
 			.children("span")
 				.animate({ width: 42, height: 42 }, 100, function() {
-					equals( jQuery(this).css("display"), "inline-block", "inline-block was set on non-floated inline element when animating width/height" );
-					equals( this.offsetWidth, 42, "width was animated" );
-					equals( this.offsetHeight, 42, "height was animated" );
+					equal( jQuery(this).css("display"), "inline-block", "inline-block was set on non-floated inline element when animating width/height" );
+					equal( this.offsetWidth, 42, "width was animated" );
+					equal( this.offsetHeight, 42, "height was animated" );
 					start();
 				});
 
@@ -267,9 +267,9 @@ test("animate block width/height", function() {
 	expect(3);
 	stop();
 	jQuery("#foo").css({ display: "block", width: 20, height: 20 }).animate({ width: 42, height: 42 }, 100, function() {
-		equals( jQuery(this).css("display"), "block", "inline-block was not set on block element when animating width/height" );
-		equals( this.offsetWidth, 42, "width was animated" );
-		equals( this.offsetHeight, 42, "height was animated" );
+		equal( jQuery(this).css("display"), "block", "inline-block was not set on block element when animating width/height" );
+		equal( this.offsetWidth, 42, "width was animated" );
+		equal( this.offsetHeight, 42, "height was animated" );
 		start();
 	});
 });
@@ -281,7 +281,7 @@ test("animate table width/height", function() {
 	var displayMode = jQuery("#table").css("display") !== "table" ? "block" : "table";
 
 	jQuery("#table").animate({ width: 42, height: 42 }, 100, function() {
-		equals( jQuery(this).css("display"), displayMode, "display mode is correct" );
+		equal( jQuery(this).css("display"), displayMode, "display mode is correct" );
 		start();
 	});
 });
@@ -294,13 +294,13 @@ test("animate table-row width/height", function() {
 		.html("<tr style='height:42px;'><td style='padding:0;'><div style='width:20px;height:20px;'></div></td></tr>")
 		.find("tr");
 
-	// IE<8 uses “block” instead of the correct display type
+	// IE<8 uses "block" instead of the correct display type
 	var displayMode = tr.css("display") !== "table-row" ? "block" : "table-row";
 
 	tr.animate({ width: 10, height: 10 }, 100, function() {
-		equals( jQuery(this).css("display"), displayMode, "display mode is correct" );
-		equals( this.offsetWidth, 20, "width animated to shrink wrap point" );
-		equals( this.offsetHeight, 20, "height animated to shrink wrap point" );
+		equal( jQuery(this).css("display"), displayMode, "display mode is correct" );
+		equal( this.offsetWidth, 20, "width animated to shrink wrap point" );
+		equal( this.offsetHeight, 20, "height animated to shrink wrap point" );
 		start();
 	});
 });
@@ -313,13 +313,13 @@ test("animate table-cell width/height", function() {
 		.html("<tr><td style='width:42px;height:42px;padding:0;'><div style='width:20px;height:20px;'></div></td></tr>")
 		.find("td");
 
-	// IE<8 uses “block” instead of the correct display type
+	// IE<8 uses "block" instead of the correct display type
 	var displayMode = td.css("display") !== "table-cell" ? "block" : "table-cell";
 
 	td.animate({ width: 10, height: 10 }, 100, function() {
-		equals( jQuery(this).css("display"), displayMode, "display mode is correct" );
-		equals( this.offsetWidth, 20, "width animated to shrink wrap point" );
-		equals( this.offsetHeight, 20, "height animated to shrink wrap point" );
+		equal( jQuery(this).css("display"), displayMode, "display mode is correct" );
+		equal( this.offsetWidth, 20, "width animated to shrink wrap point" );
+		equal( this.offsetHeight, 20, "height animated to shrink wrap point" );
 		start();
 	});
 });
@@ -330,8 +330,8 @@ test("animate resets overflow-x and overflow-y when finished", function() {
 	jQuery("#foo")
 		.css({ display: "block", width: 20, height: 20, overflowX: "visible", overflowY: "auto" })
 		.animate({ width: 42, height: 42 }, 100, function() {
-			equals( this.style.overflowX, "visible", "overflow-x is visible" );
-			equals( this.style.overflowY, "auto", "overflow-y is auto" );
+			equal( this.style.overflowX, "visible", "overflow-x is visible" );
+			equal( this.style.overflowY, "auto", "overflow-y is auto" );
 			start();
 		});
 });
@@ -347,7 +347,7 @@ test("animate option (queue === false)", function () {
 	$foo.animate({width:"100px"}, 3000, function () {
 		// should finish after unqueued animation so second
 		order.push(2);
-		same( order, [ 1, 2 ], "Animations finished in the correct order" );
+		deepEqual( order, [ 1, 2 ], "Animations finished in the correct order" );
 		start();
 	});
 	$foo.animate({fontSize:"2em"}, {queue:false, duration:10, complete:function () {
@@ -372,7 +372,7 @@ asyncTest( "animate option { queue: false }", function() {
 		}
 	});
 
-	equals( foo.queue().length, 0, "Queue is empty" );
+	equal( foo.queue().length, 0, "Queue is empty" );
 });
 
 asyncTest( "animate option { queue: true }", function() {
@@ -407,8 +407,8 @@ asyncTest( "animate option { queue: 'name' }", function() {
 
 			// second callback function
 			order.push( 2 );
-			equals( foo.width(), origWidth + 100, "Animation ended" );
-			equals( foo.queue("name").length, 1, "Queue length of 'name' queue" );
+			equal( foo.width(), origWidth + 100, "Animation ended" );
+			equal( foo.queue("name").length, 1, "Queue length of 'name' queue" );
 		}
 	}).queue( "name", function( next ) {
 
@@ -421,8 +421,8 @@ asyncTest( "animate option { queue: 'name' }", function() {
 
 		// this is the first callback function that should be called
 		order.push( 1 );
-		equals( foo.width(), origWidth, "Animation does not start on its own." );
-		equals( foo.queue("name").length, 2, "Queue length of 'name' queue" );
+		equal( foo.width(), origWidth, "Animation does not start on its own." );
+		equal( foo.queue("name").length, 2, "Queue length of 'name' queue" );
 		foo.dequeue( "name" );
 	}, 100 );
 
@@ -437,7 +437,7 @@ test("animate with no properties", function() {
 		count++;
 	});
 
-	equals( divs.length, count, "Make sure that callback is called for each element in the set." );
+	equal( divs.length, count, "Make sure that callback is called for each element in the set." );
 
 	stop();
 
@@ -457,7 +457,7 @@ test("animate duration 0", function() {
 
 	var $elems = jQuery([{ a:0 },{ a:0 }]), counter = 0;
 
-	equals( jQuery.timers.length, 0, "Make sure no animation was running from another test" );
+	equal( jQuery.timers.length, 0, "Make sure no animation was running from another test" );
 
 	$elems.eq(0).animate( {a:1}, 0, function(){
 		ok( true, "Animate a simple property." );
@@ -465,16 +465,16 @@ test("animate duration 0", function() {
 	});
 
 	// Failed until [6115]
-	equals( jQuery.timers.length, 0, "Make sure synchronic animations are not left on jQuery.timers" );
+	equal( jQuery.timers.length, 0, "Make sure synchronic animations are not left on jQuery.timers" );
 
-	equals( counter, 1, "One synchronic animations" );
+	equal( counter, 1, "One synchronic animations" );
 
 	$elems.animate( { a:2 }, 0, function(){
 		ok( true, "Animate a second simple property." );
 		counter++;
 	});
 
-	equals( counter, 3, "Multiple synchronic animations" );
+	equal( counter, 3, "Multiple synchronic animations" );
 
 	$elems.eq(0).animate( {a:3}, 0, function(){
 		ok( true, "Animate a third simple property." );
@@ -483,7 +483,7 @@ test("animate duration 0", function() {
 	$elems.eq(1).animate( {a:3}, 200, function(){
 		counter++;
 		// Failed until [6115]
-		equals( counter, 5, "One synchronic and one asynchronic" );
+		equal( counter, 5, "One synchronic and one asynchronic" );
 		start();
 	});
 
@@ -506,7 +506,7 @@ test("animate hyphenated properties", function() {
 	jQuery("#foo")
 		.css("font-size", 10)
 		.animate({"font-size": 20}, 200, function() {
-			equals( this.style.fontSize, "20px", "The font-size property was animated." );
+			equal( this.style.fontSize, "20px", "The font-size property was animated." );
 			start();
 		});
 });
@@ -518,7 +518,7 @@ test("animate non-element", function() {
 	var obj = { test: 0 };
 
 	jQuery(obj).animate({test: 200}, 200, function(){
-		equals( obj.test, 200, "The custom property should be modified." );
+		equal( obj.test, 200, "The custom property should be modified." );
 		start();
 	});
 });
@@ -543,7 +543,7 @@ test("stop()", function() {
 		setTimeout(function() {
 			$foo.removeData();
 			$foo.removeData(undefined, true);
-			equals( nw, $foo.width(), "The animation didn't continue" );
+			equal( nw, $foo.width(), "The animation didn't continue" );
 			start();
 		}, 100);
 	}, 100);
@@ -574,7 +574,7 @@ test("stop() - several in queue", function() {
 	$foo.animate({ width: "hide" }, 1000);
 	$foo.animate({ width: "show" }, 1000);
 	setTimeout(function(){
-		equals( $foo.queue().length, 3, "All 3 still in the queue" );
+		equal( $foo.queue().length, 3, "All 3 still in the queue" );
 		var nw = $foo.width();
 		notEqual( nw, w, "An animation occurred " + nw + "px " + w + "px");
 		$foo.stop();
@@ -606,9 +606,9 @@ test("stop(clearQueue)", function() {
 		nw = $foo.width();
 		ok( nw != w, "Stop didn't reset the animation " + nw + "px " + w + "px");
 
-		equals( $foo.queue().length, 0, "The animation queue was cleared" );
+		equal( $foo.queue().length, 0, "The animation queue was cleared" );
 		setTimeout(function(){
-			equals( nw, $foo.width(), "The animation didn't continue" );
+			equal( nw, $foo.width(), "The animation didn't continue" );
 			start();
 		}, 100);
 	}, 100);
@@ -633,11 +633,11 @@ test("stop(clearQueue, gotoEnd)", function() {
 
 		nw = $foo.width();
 		// Disabled, being flaky
-		//equals( nw, 1, "Stop() reset the animation" );
+		//equal( nw, 1, "Stop() reset the animation" );
 
 		setTimeout(function(){
 			// Disabled, being flaky
-			//equals( $foo.queue().length, 2, "The next animation continued" );
+			//equal( $foo.queue().length, 2, "The next animation continued" );
 			$foo.stop(true);
 			start();
 		}, 100);
@@ -655,8 +655,8 @@ asyncTest( "stop( queue, ..., ... ) - Stop single queues", function() {
 	},{
 		duration: 1000,
 		complete: function() {
-			equals( foo.width(), 400, "Animation completed for standard queue" );
-			equals( foo.height(), saved, "Height was not changed after the second stop");
+			equal( foo.width(), 400, "Animation completed for standard queue" );
+			equal( foo.height(), saved, "Height was not changed after the second stop");
 			start();
 		}
 	});
@@ -668,7 +668,7 @@ asyncTest( "stop( queue, ..., ... ) - Stop single queues", function() {
 		queue: "height"
 	}).dequeue( "height" ).stop( "height", false, true );
 
-	equals( foo.height(), 400, "Height was stopped with gotoEnd" );
+	equal( foo.height(), 400, "Height was stopped with gotoEnd" );
 
 	foo.animate({
 		height: 200
@@ -699,8 +699,8 @@ test("toggle()", function() {
 jQuery.checkOverflowDisplay = function(){
 	var o = jQuery.css( this, "overflow" );
 
-	equals(o, "visible", "Overflow should be visible: " + o);
-	equals(jQuery.css( this, "display" ), "inline", "Display shouldn't be tampered with.");
+	equal(o, "visible", "Overflow should be visible: " + o);
+	equal(jQuery.css( this, "display" ), "inline", "Display shouldn't be tampered with.");
 
 	start();
 };
@@ -713,7 +713,7 @@ test( "jQuery.fx.prototype.cur()", 6, function() {
 			marginBottom: "-11000px"
 		})[0];
 
-	equals(
+	equal(
 		( new jQuery.fx( div, {}, "color" ) ).cur(),
 		jQuery.css( div, "color" ),
 		"Return the same value as jQuery.css for complex properties (bug #7912)"
@@ -748,7 +748,7 @@ test( "jQuery.fx.prototype.cur()", 6, function() {
 		"Return 0 when jQuery.css returns 'auto'"
 	);
 
-	equals(
+	equal(
 		( new jQuery.fx( div, {}, "marginBottom" ) ).cur(),
 		-11000,
 		"support negative values < -10000 (bug #7193)"
@@ -875,7 +875,7 @@ jQuery.each({
 				elem = elem[ 0 ];
 
 				if ( t_w == "show" ) {
-					equals( elem.style.display, "block", "Showing, display should block: " + elem.style.display );
+					equal( elem.style.display, "block", "Showing, display should block: " + elem.style.display );
 				}
 
 				if ( t_w == "hide" || t_w == "show" ) {
@@ -903,21 +903,21 @@ jQuery.each({
 				}
 
 				if ( t_o == "hide" || t_o == "show" ) {
-					equals( cur_o, f_o, "Opacity must be reset to " + f_o + ": " + cur_o );
+					equal( cur_o, f_o, "Opacity must be reset to " + f_o + ": " + cur_o );
 				}
 
 				if ( t_w == "hide" ) {
-					equals( elem.style.display, "none", "Hiding, display should be none: " + elem.style.display );
+					equal( elem.style.display, "none", "Hiding, display should be none: " + elem.style.display );
 				}
 
 				if ( t_o.constructor == Number ) {
-					equals( cur_o, t_o, "Final opacity should be " + t_o + ": " + cur_o );
+					equal( cur_o, t_o, "Final opacity should be " + t_o + ": " + cur_o );
 
 					ok( jQuery.css(elem, "opacity") != "" || cur_o == t_o, "Opacity should be explicitly set to " + t_o + ", is instead: " + cur_o );
 				}
 
 				if ( t_w.constructor == Number ) {
-					equals( elem.style.width, t_w + "px", "Final width should be " + t_w + ": " + elem.style.width );
+					equal( elem.style.width, t_w + "px", "Final width should be " + t_w + ": " + elem.style.width );
 
 					var cur_w = jQuery.css( elem,"width" );
 
@@ -925,7 +925,7 @@ jQuery.each({
 				}
 
 				if ( t_h.constructor == Number ) {
-					equals( elem.style.height, t_h + "px", "Final height should be " + t_h + ": " + elem.style.height );
+					equal( elem.style.height, t_h + "px", "Final height should be " + t_h + ": " + elem.style.height );
 
 					var cur_h = jQuery.css( elem,"height" );
 
@@ -939,7 +939,7 @@ jQuery.each({
 					if ( /Auto/.test( fn ) ) {
 						notEqual( jQuery.css( elem, "height" ), old_h, "Make sure height is auto." );
 					} else {
-						equals( jQuery.css( elem, "height" ), old_h, "Make sure height is not auto." );
+						equal( jQuery.css( elem, "height" ), old_h, "Make sure height is not auto." );
 					}
 				}
 
@@ -970,7 +970,7 @@ jQuery.checkState = function() {
 	var self = this;
 	jQuery.each(this.save, function( c, v ) {
 		var cur = self.style[ c ] || jQuery.css( self, c );
-		equals( cur, v, "Make sure that " + c + " is reset (Old: " + v + " Cur: " + cur + ")");
+		equal( cur, v, "Make sure that " + c + " is reset (Old: " + v + " Cur: " + cur + ")");
 	});
 
 	// manually clean data on modified element
@@ -1147,11 +1147,11 @@ test("hide hidden elements (bug #7141)", function() {
 	QUnit.reset();
 
 	var div = jQuery("<div style='display:none'></div>").appendTo("#qunit-fixture");
-	equals( div.css("display"), "none", "Element is hidden by default" );
+	equal( div.css("display"), "none", "Element is hidden by default" );
 	div.hide();
 	ok( !jQuery._data(div, "olddisplay"), "olddisplay is undefined after hiding an already-hidden element" );
 	div.show();
-	equals( div.css("display"), "block", "Show a double-hidden element" );
+	equal( div.css("display"), "block", "Show a double-hidden element" );
 
 	div.remove();
 });
@@ -1162,11 +1162,11 @@ test("hide hidden elements, with animation (bug #7141)", function() {
 	stop();
 
 	var div = jQuery("<div style='display:none'></div>").appendTo("#qunit-fixture");
-	equals( div.css("display"), "none", "Element is hidden by default" );
+	equal( div.css("display"), "none", "Element is hidden by default" );
 	div.hide(1, function () {
 		ok( !jQuery._data(div, "olddisplay"), "olddisplay is undefined after hiding an already-hidden element" );
 		div.show(1, function () {
-			equals( div.css("display"), "block", "Show a double-hidden element" );
+			equal( div.css("display"), "block", "Show a double-hidden element" );
 			start();
 		});
 	});

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -55,7 +55,7 @@ test("Handler changes and .trigger() order", function() {
 
 	markup.find( "b" ).trigger( "click" );
 
-	equals( path, "b p div div ", "Delivered all events" );
+	equal( path, "b p div div ", "Delivered all events" );
 
 	markup.remove();
 });
@@ -64,7 +64,7 @@ test("bind(), with data", function() {
 	expect(4);
 	var handler = function(event) {
 		ok( event.data, "bind() with data, check passed data exists" );
-		equals( event.data.foo, "bar", "bind() with data, Check value of passed data" );
+		equal( event.data.foo, "bar", "bind() with data, Check value of passed data" );
 	};
 	jQuery("#firstp").bind("click", {foo: "bar"}, handler).click().unbind("click", handler);
 
@@ -72,7 +72,7 @@ test("bind(), with data", function() {
 
 	var test = function(){};
 	var handler2 = function(event) {
-		equals( event.data, test, "bind() with function data, Check value of passed data" );
+		equal( event.data, test, "bind() with function data, Check value of passed data" );
 	};
 	jQuery("#firstp").bind("click", test, handler2).click().unbind("click", handler2);
 });
@@ -81,7 +81,7 @@ test("click(), with data", function() {
 	expect(3);
 	var handler = function(event) {
 		ok( event.data, "bind() with data, check passed data exists" );
-		equals( event.data.foo, "bar", "bind() with data, Check value of passed data" );
+		equal( event.data.foo, "bar", "bind() with data, Check value of passed data" );
 	};
 	jQuery("#firstp").click({foo: "bar"}, handler).click().unbind("click", handler);
 
@@ -92,9 +92,9 @@ test("bind(), with data, trigger with data", function() {
 	expect(4);
 	var handler = function(event, data) {
 		ok( event.data, "check passed data exists" );
-		equals( event.data.foo, "bar", "Check value of passed data" );
+		equal( event.data.foo, "bar", "Check value of passed data" );
 		ok( data, "Check trigger data" );
-		equals( data.bar, "foo", "Check value of trigger data" );
+		equal( data.bar, "foo", "Check value of trigger data" );
 	};
 	jQuery("#firstp").bind("click", {foo: "bar"}, handler).trigger("click", [{bar: "foo"}]).unbind("click", handler);
 });
@@ -110,8 +110,8 @@ test("bind(), multiple events at once", function() {
 			mouseoverCounter += 1;
 	};
 	jQuery("#firstp").bind("click mouseover", handler).trigger("click").trigger("mouseover");
-	equals( clickCounter, 1, "bind() with multiple events at once" );
-	equals( mouseoverCounter, 1, "bind() with multiple events at once" );
+	equal( clickCounter, 1, "bind() with multiple events at once" );
+	equal( mouseoverCounter, 1, "bind() with multiple events at once" );
 });
 
 test("bind(), five events at once", function() {
@@ -127,7 +127,7 @@ test("bind(), five events at once", function() {
 		.trigger("foo").trigger("bar")
 		.trigger("baz");
 
-	equals( count, 5, "bind() five events at once" );
+	equal( count, 5, "bind() five events at once" );
 });
 
 test("bind(), multiple events at once and namespaces", function() {
@@ -136,7 +136,7 @@ test("bind(), multiple events at once and namespaces", function() {
 	var cur, obj = {};
 
 	var div = jQuery("<div/>").bind("focusin.a", function(e) {
-		equals( e.type, cur, "Verify right single event was fired." );
+		equal( e.type, cur, "Verify right single event was fired." );
 	});
 
 	cur = "focusin";
@@ -146,8 +146,8 @@ test("bind(), multiple events at once and namespaces", function() {
 	div.remove();
 
 	div = jQuery("<div/>").bind("click mouseover", obj, function(e) {
-		equals( e.type, cur, "Verify right multi event was fired." );
-		equals( e.data, obj, "Make sure the data came in correctly." );
+		equal( e.type, cur, "Verify right multi event was fired." );
+		equal( e.data, obj, "Make sure the data came in correctly." );
 	});
 
 	cur = "click";
@@ -160,7 +160,7 @@ test("bind(), multiple events at once and namespaces", function() {
 	div.remove();
 
 	div = jQuery("<div/>").bind("focusin.a focusout.b", function(e) {
-		equals( e.type, cur, "Verify right multi event was fired." );
+		equal( e.type, cur, "Verify right multi event was fired." );
 	});
 
 	cur = "focusin";
@@ -184,9 +184,9 @@ test("bind(), namespace with special add", function() {
 
 	jQuery.event.special.test = {
 		_default: function(e, data) {
-			equals( this, document, "Make sure we're at the top of the chain." );
-			equals( e.type, "test", "And that we're still dealing with a test event." );
-			equals( e.target, div[0], "And that the target is correct." );
+			equal( this, document, "Make sure we're at the top of the chain." );
+			equal( e.type, "test", "And that we're still dealing with a test event." );
+			equal( e.target, div[0], "And that the target is correct." );
 			ok( data !== undefined , "And that trigger data was passed." );
 		},
 		setup: function(){},
@@ -207,12 +207,12 @@ test("bind(), namespace with special add", function() {
 
 	div.bind("test.a", {x: 1}, function(e) {
 		ok( !!e.xyz, "Make sure that the data is getting passed through." );
-		equals( e.data.x, 1, "Make sure data is attached properly." );
+		equal( e.data.x, 1, "Make sure data is attached properly." );
 	});
 
 	div.bind("test.b", {x: 2}, function(e) {
 		ok( !!e.xyz, "Make sure that the data is getting passed through." );
-		equals( e.data.x, 2, "Make sure data is attached properly." );
+		equal( e.data.x, 2, "Make sure data is attached properly." );
 	});
 
 	// Should trigger 5
@@ -281,12 +281,12 @@ test("bind/one/unbind(Object)", function(){
 
 	trigger();
 
-	equals( clickCounter, 3, "bind(Object)" );
-	equals( mouseoverCounter, 3, "bind(Object)" );
+	equal( clickCounter, 3, "bind(Object)" );
+	equal( mouseoverCounter, 3, "bind(Object)" );
 
 	trigger();
-	equals( clickCounter, 4, "bind(Object)" );
-	equals( mouseoverCounter, 4, "bind(Object)" );
+	equal( clickCounter, 4, "bind(Object)" );
+	equal( mouseoverCounter, 4, "bind(Object)" );
 
 	jQuery("#firstp").unbind({
 		click:handler,
@@ -294,8 +294,8 @@ test("bind/one/unbind(Object)", function(){
 	});
 
 	trigger();
-	equals( clickCounter, 4, "bind(Object)" );
-	equals( mouseoverCounter, 4, "bind(Object)" );
+	equal( clickCounter, 4, "bind(Object)" );
+	equal( mouseoverCounter, 4, "bind(Object)" );
 });
 
 test("live/die(Object), delegate/undelegate(String, Object)", function() {
@@ -321,20 +321,20 @@ test("live/die(Object), delegate/undelegate(String, Object)", function() {
 	$p.delegate( "a", events, 2 );
 
 	trigger();
-	equals( clickCounter, 3, "live/delegate" );
-	equals( mouseoverCounter, 3, "live/delegate" );
+	equal( clickCounter, 3, "live/delegate" );
+	equal( mouseoverCounter, 3, "live/delegate" );
 
 	$p.undelegate( "a", events );
 
 	trigger();
-	equals( clickCounter, 4, "undelegate" );
-	equals( mouseoverCounter, 4, "undelegate" );
+	equal( clickCounter, 4, "undelegate" );
+	equal( mouseoverCounter, 4, "undelegate" );
 
 	$a.die( events );
 
 	trigger();
-	equals( clickCounter, 4, "die" );
-	equals( mouseoverCounter, 4, "die" );
+	equal( clickCounter, 4, "die" );
+	equal( mouseoverCounter, 4, "die" );
 });
 
 test("live/delegate immediate propagation", function() {
@@ -351,7 +351,7 @@ test("live/delegate immediate propagation", function() {
 		lastClick = "click2";
 	});
 	$a.trigger( "click" );
-	equals( lastClick, "click1", "live stopImmediatePropagation" );
+	equal( lastClick, "click1", "live stopImmediatePropagation" );
 	$a.die( "click" );
 
 	lastClick = "";
@@ -363,7 +363,7 @@ test("live/delegate immediate propagation", function() {
 		lastClick = "click2";
 	});
 	$a.trigger( "click" );
-	equals( lastClick, "click1", "delegate stopImmediatePropagation" );
+	equal( lastClick, "click1", "delegate stopImmediatePropagation" );
 	$p.undelegate( "click" );
 });
 
@@ -389,7 +389,7 @@ test("bind/delegate bubbling, isDefaultPrevented", function() {
 		var orig = e.originalEvent;
 
 		if ( typeof(orig.defaultPrevented) === "boolean" || typeof(orig.returnValue) === "boolean" || orig.getPreventDefault ) {
-			equals( e.isDefaultPrevented(), true, "isDefaultPrevented true passed to bubbled event" );
+			equal( e.isDefaultPrevented(), true, "isDefaultPrevented true passed to bubbled event" );
 
 		} else {
 			// Opera < 11 doesn't implement any interface we can use, so give it a pass
@@ -403,7 +403,7 @@ test("bind/delegate bubbling, isDefaultPrevented", function() {
 		// Let the default action occur
 	});
 	$main.delegate("#foo", "click", function(e) {
-		equals( e.isDefaultPrevented(), false, "isDefaultPrevented false passed to bubbled event" );
+		equal( e.isDefaultPrevented(), false, "isDefaultPrevented false passed to bubbled event" );
 	});
 	fakeClick( $anchor2 );
 	$anchor2.unbind( "click" );
@@ -423,7 +423,7 @@ test("bind(), trigger change on select", function() {
 	expect(5);
 	var counter = 0;
 	function selectOnChange(event) {
-		equals( event.data, counter++, "Event.data is not a global event object" );
+		equal( event.data, counter++, "Event.data is not a global event object" );
 	};
 	jQuery("#form select").each(function(i){
 		jQuery(this).bind("change", i, selectOnChange);
@@ -474,7 +474,7 @@ test("bind(), namespaced events, cloned events", 18, function() {
 
 	// using contents will get comments regular, text, and comment nodes
 	jQuery("#nonnodes").contents().bind("tester", function () {
-		equals(this.nodeType, 1, "Check node,textnode,comment bind just does real nodes" );
+		equal(this.nodeType, 1, "Check node,textnode,comment bind just does real nodes" );
 	}).trigger("tester");
 
 	// Make sure events stick with appendTo'd elements (which are cloned) #2027
@@ -495,7 +495,7 @@ test("bind(), multi-namespaced events", function() {
 	];
 
 	function check(name, msg){
-		same(name, order.shift(), msg);
+		deepEqual(name, order.shift(), msg);
 	}
 
 	jQuery("#firstp").bind("custom.test",function(e){
@@ -550,12 +550,12 @@ test("bind(), with same function", function() {
 	jQuery("#liveHandlerOrder").bind("foo.bar", func).bind("foo.zar", func);
 	jQuery("#liveHandlerOrder").trigger("foo.bar");
 
-	equals(count, 1, "Verify binding function with multiple namespaces." );
+	equal(count, 1, "Verify binding function with multiple namespaces." );
 
 	jQuery("#liveHandlerOrder").unbind("foo.bar", func).unbind("foo.zar", func);
 	jQuery("#liveHandlerOrder").trigger("foo.bar");
 
-	equals(count, 1, "Verify that removing events still work." );
+	equal(count, 1, "Verify that removing events still work." );
 });
 
 test("bind(), make sure order is maintained", function() {
@@ -573,7 +573,7 @@ test("bind(), make sure order is maintained", function() {
 
 	elem.trigger("click");
 
-	equals( log.join(","), check.join(","), "Make sure order was maintained." );
+	equal( log.join(","), check.join(","), "Make sure order was maintained." );
 
 	elem.unbind("click");
 });
@@ -583,11 +583,11 @@ test("bind(), with different this object", function() {
 	var thisObject = { myThis: true },
 		data = { myData: true },
 		handler1 = function( event ) {
-			equals( this, thisObject, "bind() with different this object" );
+			equal( this, thisObject, "bind() with different this object" );
 		},
 		handler2 = function( event ) {
-			equals( this, thisObject, "bind() with different this object and data" );
-			equals( event.data, data, "bind() with different this object and data" );
+			equal( this, thisObject, "bind() with different this object and data" );
+			equal( event.data, data, "bind() with different this object and data" );
 		};
 
 	jQuery("#firstp")
@@ -603,17 +603,17 @@ test("bind(name, false), unbind(name, false)", function() {
 	var main = 0;
 	jQuery("#qunit-fixture").bind("click", function(e){ main++; });
 	jQuery("#ap").trigger("click");
-	equals( main, 1, "Verify that the trigger happened correctly." );
+	equal( main, 1, "Verify that the trigger happened correctly." );
 
 	main = 0;
 	jQuery("#ap").bind("click", false);
 	jQuery("#ap").trigger("click");
-	equals( main, 0, "Verify that no bubble happened." );
+	equal( main, 0, "Verify that no bubble happened." );
 
 	main = 0;
 	jQuery("#ap").unbind("click", false);
 	jQuery("#ap").trigger("click");
-	equals( main, 1, "Verify that the trigger happened correctly." );
+	equal( main, 1, "Verify that the trigger happened correctly." );
 
 	// manually clean up events from elements outside the fixture
 	jQuery("#qunit-fixture").unbind("click");
@@ -625,17 +625,17 @@ test("live(name, false), die(name, false)", function() {
 	var main = 0;
 	jQuery("#qunit-fixture").live("click", function(e){ main++; });
 	jQuery("#ap").trigger("click");
-	equals( main, 1, "Verify that the trigger happened correctly." );
+	equal( main, 1, "Verify that the trigger happened correctly." );
 
 	main = 0;
 	jQuery("#ap").live("click", false);
 	jQuery("#ap").trigger("click");
-	equals( main, 0, "Verify that no bubble happened." );
+	equal( main, 0, "Verify that no bubble happened." );
 
 	main = 0;
 	jQuery("#ap").die("click", false);
 	jQuery("#ap").trigger("click");
-	equals( main, 1, "Verify that the trigger happened correctly." );
+	equal( main, 1, "Verify that the trigger happened correctly." );
 	jQuery("#qunit-fixture").die("click");
 });
 
@@ -646,17 +646,17 @@ test("delegate(selector, name, false), undelegate(selector, name, false)", funct
 
 	jQuery("#qunit-fixture").delegate("#ap", "click", function(e){ main++; });
 	jQuery("#ap").trigger("click");
-	equals( main, 1, "Verify that the trigger happened correctly." );
+	equal( main, 1, "Verify that the trigger happened correctly." );
 
 	main = 0;
 	jQuery("#ap").delegate("#groups", "click", false);
 	jQuery("#groups").trigger("click");
-	equals( main, 0, "Verify that no bubble happened." );
+	equal( main, 0, "Verify that no bubble happened." );
 
 	main = 0;
 	jQuery("#ap").undelegate("#groups", "click", false);
 	jQuery("#groups").trigger("click");
-	equals( main, 1, "Verify that the trigger happened correctly." );
+	equal( main, 1, "Verify that the trigger happened correctly." );
 	jQuery("#qunit-fixture").undelegate("#ap", "click");
 });
 
@@ -682,9 +682,9 @@ test("bind()/trigger()/unbind() on plain object", function() {
 
 	var events = jQuery._data(obj, "events");
 	ok( events, "Object has events bound." );
-	equals( obj.events, undefined, "Events object on plain objects is not events" );
-	equals( obj.test, undefined, "Make sure that test event is not on the plain object." );
-	equals( obj.handle, undefined, "Make sure that the event handler is not on the plain object." );
+	equal( obj.events, undefined, "Events object on plain objects is not events" );
+	equal( obj.test, undefined, "Make sure that test event is not on the plain object." );
+	equal( obj.handle, undefined, "Make sure that the event handler is not on the plain object." );
 
 	// Should trigger 1
 	jQuery(obj).trigger("test");
@@ -699,7 +699,7 @@ test("bind()/trigger()/unbind() on plain object", function() {
 	// Make sure it doesn't complain when no events are found
 	jQuery(obj).unbind("test");
 
-	equals( obj && obj[ jQuery.expando ] &&
+	equal( obj && obj[ jQuery.expando ] &&
 			obj[ jQuery.expando ][ jQuery.expando ] &&
 			obj[ jQuery.expando ][ jQuery.expando ].events, undefined, "Make sure events object is removed" );
 });
@@ -759,7 +759,7 @@ test("unbind(eventObject)", function() {
 	function assert( expected ){
 		num = 0;
 		$elem.trigger("foo").triggerHandler("bar");
-		equals( num, expected, "Check the right handlers are triggered" );
+		equal( num, expected, "Check the right handlers are triggered" );
 	}
 
 	$elem
@@ -803,7 +803,7 @@ test("hover() and hover pseudo-event", function() {
 		.unbind("mouseenter mouseleave", handler1)
 		.mouseenter().mouseleave();
 
-	equals( times, 4, "hover handlers fired" );
+	equal( times, 4, "hover handlers fired" );
 
 	var balance = 0;
 	jQuery( "#firstp" )
@@ -821,7 +821,7 @@ test("hover() and hover pseudo-event", function() {
 		.unbind("hover")
 		.trigger("mouseenter");
 
-	equals( balance, 0, "hover pseudo-event" );
+	equal( balance, 0, "hover pseudo-event" );
 });
 
 test("mouseover triggers mouseenter", function() {
@@ -833,7 +833,7 @@ test("mouseover triggers mouseenter", function() {
 	  count++;
 	});
 	elem.trigger("mouseover");
-	equals(count, 1, "make sure mouseover triggers a mouseenter" );
+	equal(count, 1, "make sure mouseover triggers a mouseenter" );
 
 	elem.remove();
 });
@@ -865,13 +865,13 @@ test("mouseenter, mouseleave don't catch exceptions", function() {
 	try {
 		elem.mouseenter();
 	} catch (e) {
-		equals( e, "an Exception", "mouseenter doesn't catch exceptions" );
+		equal( e, "an Exception", "mouseenter doesn't catch exceptions" );
 	}
 
 	try {
 		elem.mouseleave();
 	} catch (e) {
-		equals( e, "an Exception", "mouseleave doesn't catch exceptions" );
+		equal( e, "an Exception", "mouseleave doesn't catch exceptions" );
 	}
 });
 
@@ -881,7 +881,7 @@ test("trigger() shortcuts", function() {
 	var elem = jQuery("<li><a href='#'>Change location</a></li>").prependTo("#firstUL");
 	elem.find("a").bind("click", function() {
 		var close = jQuery("spanx", this); // same with jQuery(this).find("span");
-		equals( close.length, 0, "Context element does not exist, length must be zero" );
+		equal( close.length, 0, "Context element does not exist, length must be zero" );
 		ok( !close[0], "Context element does not exist, direct access to element must return undefined" );
 		return false;
 	}).click();
@@ -898,14 +898,14 @@ test("trigger() shortcuts", function() {
 		counter++;
 	};
 	jQuery("#firstp").click();
-	equals( counter, 1, "Check that click, triggers onclick event handler also" );
+	equal( counter, 1, "Check that click, triggers onclick event handler also" );
 
 	var clickCounter = 0;
 	jQuery("#simon1")[0].onclick = function(event) {
 		clickCounter++;
 	};
 	jQuery("#simon1").click();
-	equals( clickCounter, 1, "Check that click, triggers onclick event handler on an a tag also" );
+	equal( clickCounter, 1, "Check that click, triggers onclick event handler on an a tag also" );
 
 	elem = jQuery("<img />").load(function(){
 		ok( true, "Trigger the load event, using the shortcut .load() (#2819)");
@@ -933,29 +933,29 @@ test("trigger() bubbling", function() {
 	jQuery("#ap").bind("click", function(){ ap++; return false; });
 
 	jQuery("html").trigger("click");
-	equals( win, 1, "HTML bubble" );
-	equals( doc, 1, "HTML bubble" );
-	equals( html, 1, "HTML bubble" );
+	equal( win, 1, "HTML bubble" );
+	equal( doc, 1, "HTML bubble" );
+	equal( html, 1, "HTML bubble" );
 
 	jQuery("body").trigger("click");
-	equals( win, 2, "Body bubble" );
-	equals( doc, 2, "Body bubble" );
-	equals( html, 2, "Body bubble" );
-	equals( body, 1, "Body bubble" );
+	equal( win, 2, "Body bubble" );
+	equal( doc, 2, "Body bubble" );
+	equal( html, 2, "Body bubble" );
+	equal( body, 1, "Body bubble" );
 
 	jQuery("#qunit-fixture").trigger("click");
-	equals( win, 3, "Main bubble" );
-	equals( doc, 3, "Main bubble" );
-	equals( html, 3, "Main bubble" );
-	equals( body, 2, "Main bubble" );
-	equals( main, 1, "Main bubble" );
+	equal( win, 3, "Main bubble" );
+	equal( doc, 3, "Main bubble" );
+	equal( html, 3, "Main bubble" );
+	equal( body, 2, "Main bubble" );
+	equal( main, 1, "Main bubble" );
 
 	jQuery("#ap").trigger("click");
-	equals( doc, 3, "ap bubble" );
-	equals( html, 3, "ap bubble" );
-	equals( body, 2, "ap bubble" );
-	equals( main, 1, "ap bubble" );
-	equals( ap, 1, "ap bubble" );
+	equal( doc, 3, "ap bubble" );
+	equal( html, 3, "ap bubble" );
+	equal( body, 2, "ap bubble" );
+	equal( main, 1, "ap bubble" );
+	equal( ap, 1, "ap bubble" );
 
 	// manually clean up events from elements outside the fixture
 	jQuery(document).unbind("click");
@@ -966,10 +966,10 @@ test("trigger(type, [data], [fn])", function() {
 	expect(16);
 
 	var handler = function(event, a, b, c) {
-		equals( event.type, "click", "check passed data" );
-		equals( a, 1, "check passed data" );
-		equals( b, "2", "check passed data" );
-		equals( c, "abc", "check passed data" );
+		equal( event.type, "click", "check passed data" );
+		equal( a, 1, "check passed data" );
+		equal( b, "2", "check passed data" );
+		equal( c, "abc", "check passed data" );
 		return "test";
 	};
 
@@ -1008,7 +1008,7 @@ test("trigger(type, [data], [fn])", function() {
 
 	// Trigger only the handlers (no native)
 	// Triggers 5
-	equals( $elem.triggerHandler("click", [1, "2", "abc"]), "test", "Verify handler response" );
+	equal( $elem.triggerHandler("click", [1, "2", "abc"]), "test", "Verify handler response" );
 
 	var pass = true;
 	try {
@@ -1060,28 +1060,28 @@ test("trigger(eventObject, [data], [fn])", function() {
 
 	var event = jQuery.Event("noNew");
 	ok( event != window, "Instantiate jQuery.Event without the 'new' keyword" );
-	equals( event.type, "noNew", "Verify its type" );
+	equal( event.type, "noNew", "Verify its type" );
 
-	equals( event.isDefaultPrevented(), false, "Verify isDefaultPrevented" );
-	equals( event.isPropagationStopped(), false, "Verify isPropagationStopped" );
-	equals( event.isImmediatePropagationStopped(), false, "Verify isImmediatePropagationStopped" );
+	equal( event.isDefaultPrevented(), false, "Verify isDefaultPrevented" );
+	equal( event.isPropagationStopped(), false, "Verify isPropagationStopped" );
+	equal( event.isImmediatePropagationStopped(), false, "Verify isImmediatePropagationStopped" );
 
 	event.preventDefault();
-	equals( event.isDefaultPrevented(), true, "Verify isDefaultPrevented" );
+	equal( event.isDefaultPrevented(), true, "Verify isDefaultPrevented" );
 	event.stopPropagation();
-	equals( event.isPropagationStopped(), true, "Verify isPropagationStopped" );
+	equal( event.isPropagationStopped(), true, "Verify isPropagationStopped" );
 
 	event.isPropagationStopped = function(){ return false };
 	event.stopImmediatePropagation();
-	equals( event.isPropagationStopped(), true, "Verify isPropagationStopped" );
-	equals( event.isImmediatePropagationStopped(), true, "Verify isPropagationStopped" );
+	equal( event.isPropagationStopped(), true, "Verify isPropagationStopped" );
+	equal( event.isImmediatePropagationStopped(), true, "Verify isPropagationStopped" );
 
 	$parent.bind("foo",function(e){
 		// Tries bubbling
-		equals( e.type, "foo", "Verify event type when passed passing an event object" );
-		equals( e.target.id, "child", "Verify event.target when passed passing an event object" );
-		equals( e.currentTarget.id, "par", "Verify event.currentTarget when passed passing an event object" );
-		equals( e.secret, "boo!", "Verify event object's custom attribute when passed passing an event object" );
+		equal( e.type, "foo", "Verify event type when passed passing an event object" );
+		equal( e.target.id, "child", "Verify event.target when passed passing an event object" );
+		equal( e.currentTarget.id, "par", "Verify event.currentTarget when passed passing an event object" );
+		equal( e.secret, "boo!", "Verify event object's custom attribute when passed passing an event object" );
 	});
 
 	// test with an event object
@@ -1101,14 +1101,14 @@ test("trigger(eventObject, [data], [fn])", function() {
 	$parent.bind("foo", error );
 
 	$child.bind("foo",function(e, a, b, c ){
-		equals( arguments.length, 4, "Check arguments length");
-		equals( a, 1, "Check first custom argument");
-		equals( b, 2, "Check second custom argument");
-		equals( c, 3, "Check third custom argument");
+		equal( arguments.length, 4, "Check arguments length");
+		equal( a, 1, "Check first custom argument");
+		equal( b, 2, "Check second custom argument");
+		equal( c, 3, "Check third custom argument");
 
-		equals( e.isDefaultPrevented(), false, "Verify isDefaultPrevented" );
-		equals( e.isPropagationStopped(), false, "Verify isPropagationStopped" );
-		equals( e.isImmediatePropagationStopped(), false, "Verify isImmediatePropagationStopped" );
+		equal( e.isDefaultPrevented(), false, "Verify isDefaultPrevented" );
+		equal( e.isPropagationStopped(), false, "Verify isPropagationStopped" );
+		equal( e.isImmediatePropagationStopped(), false, "Verify isImmediatePropagationStopped" );
 
 		// Skips both errors
 		e.stopImmediatePropagation();
@@ -1122,7 +1122,7 @@ test("trigger(eventObject, [data], [fn])", function() {
 
 	event = new jQuery.Event("foo");
 	$child.trigger( event, [1,2,3] ).unbind();
-	equals( event.result, "result", "Check event.result attribute");
+	equal( event.result, "result", "Check event.result attribute");
 
 	// Will error if it bubbles
 	$child.triggerHandler("foo");
@@ -1184,11 +1184,11 @@ test("jQuery.Event.currentTarget", function(){
 	
 	jQuery('<div><p><button>shiny</button></p></div>')
 		.on( "click", "p", function( e ){
-				equals( e.currentTarget, this, "Check delegated currentTarget on event" );
+				equal( e.currentTarget, this, "Check delegated currentTarget on event" );
 		})
 		.find( "button" )
 			.on( "click", function( e ){
-				equals( e.currentTarget, this, "Check currentTarget on event" );
+				equal( e.currentTarget, this, "Check currentTarget on event" );
 			})
 			.click()
 			.off( "click" )
@@ -1205,19 +1205,19 @@ test("toggle(Function, Function, ...)", function() {
 		preventDefault = function(e) { e.preventDefault() },
 		link = jQuery("#mark");
 	link.click(preventDefault).click().toggle(fn1, fn2).click().click().click().click().click();
-	equals( count, 1, "Check for toggle(fn, fn)" );
+	equal( count, 1, "Check for toggle(fn, fn)" );
 
 	jQuery("#firstp").toggle(function () {
-		equals(arguments.length, 4, "toggle correctly passes through additional triggered arguments, see #1701" )
+		equal(arguments.length, 4, "toggle correctly passes through additional triggered arguments, see #1701" )
 	}, function() {}).trigger("click", [ 1, 2, 3 ]);
 
 	var first = 0;
 	jQuery("#simon1").one("click", function() {
 		ok( true, "Execute event only once" );
 		jQuery(this).toggle(function() {
-			equals( first++, 0, "toggle(Function,Function) assigned from within one('xxx'), see #1054" );
+			equal( first++, 0, "toggle(Function,Function) assigned from within one('xxx'), see #1054" );
 		}, function() {
-			equals( first, 1, "toggle(Function,Function) assigned from within one('xxx'), see #1054" );
+			equal( first, 1, "toggle(Function,Function) assigned from within one('xxx'), see #1054" );
 		});
 		return false;
 	}).click().click().click();
@@ -1237,15 +1237,15 @@ test("toggle(Function, Function, ...)", function() {
 
 	var $div = jQuery("<div>&nbsp;</div>").toggle( fns[0], fns[1], fns[2] );
 	$div.click();
-	equals( turn, 1, "Trying toggle with 3 functions, attempt 1 yields 1");
+	equal( turn, 1, "Trying toggle with 3 functions, attempt 1 yields 1");
 	$div.click();
-	equals( turn, 2, "Trying toggle with 3 functions, attempt 2 yields 2");
+	equal( turn, 2, "Trying toggle with 3 functions, attempt 2 yields 2");
 	$div.click();
-	equals( turn, 3, "Trying toggle with 3 functions, attempt 3 yields 3");
+	equal( turn, 3, "Trying toggle with 3 functions, attempt 3 yields 3");
 	$div.click();
-	equals( turn, 1, "Trying toggle with 3 functions, attempt 4 yields 1");
+	equal( turn, 1, "Trying toggle with 3 functions, attempt 4 yields 1");
 	$div.click();
-	equals( turn, 2, "Trying toggle with 3 functions, attempt 5 yields 2");
+	equal( turn, 2, "Trying toggle with 3 functions, attempt 5 yields 2");
 
 	$div.unbind("click",fns[0]);
 	var data = jQuery._data( $div[0], "events" );
@@ -1259,16 +1259,16 @@ test("toggle(Function, Function, ...)", function() {
 	$div = jQuery("<div/>");
 	$div.toggle(function(){ a.push(1); }, function(){ a.push(2); });
 	$div.click();
-	same( a, [1], "Check that a click worked." );
+	deepEqual( a, [1], "Check that a click worked." );
 
 	$div.toggle(function(){ b.push(1); }, function(){ b.push(2); });
 	$div.click();
-	same( a, [1,2], "Check that a click worked with a second toggle." );
-	same( b, [1], "Check that a click worked with a second toggle." );
+	deepEqual( a, [1,2], "Check that a click worked with a second toggle." );
+	deepEqual( b, [1], "Check that a click worked with a second toggle." );
 
 	$div.click();
-	same( a, [1,2,1], "Check that a click worked with a second toggle, second click." );
-	same( b, [1,2], "Check that a click worked with a second toggle, second click." );
+	deepEqual( a, [1,2,1], "Check that a click worked with a second toggle, second click." );
+	deepEqual( b, [1,2], "Check that a click worked with a second toggle, second click." );
 
 	// manually clean up detached elements
 	$div.remove();
@@ -1286,68 +1286,68 @@ test(".live()/.die()", function() {
 
 	// Nothing should trigger on the body
 	jQuery("body").trigger("click");
-	equals( submit, 0, "Click on body" );
-	equals( div, 0, "Click on body" );
-	equals( livea, 0, "Click on body" );
-	equals( liveb, 0, "Click on body" );
+	equal( submit, 0, "Click on body" );
+	equal( div, 0, "Click on body" );
+	equal( livea, 0, "Click on body" );
+	equal( liveb, 0, "Click on body" );
 
 	// This should trigger two events
 	submit = 0, div = 0, livea = 0, liveb = 0;
 	jQuery("div#nothiddendiv").trigger("click");
-	equals( submit, 0, "Click on div" );
-	equals( div, 1, "Click on div" );
-	equals( livea, 1, "Click on div" );
-	equals( liveb, 0, "Click on div" );
+	equal( submit, 0, "Click on div" );
+	equal( div, 1, "Click on div" );
+	equal( livea, 1, "Click on div" );
+	equal( liveb, 0, "Click on div" );
 
 	// This should trigger three events (w/ bubbling)
 	submit = 0, div = 0, livea = 0, liveb = 0;
 	jQuery("div#nothiddendivchild").trigger("click");
-	equals( submit, 0, "Click on inner div" );
-	equals( div, 2, "Click on inner div" );
-	equals( livea, 1, "Click on inner div" );
-	equals( liveb, 1, "Click on inner div" );
+	equal( submit, 0, "Click on inner div" );
+	equal( div, 2, "Click on inner div" );
+	equal( livea, 1, "Click on inner div" );
+	equal( liveb, 1, "Click on inner div" );
 
 	// This should trigger one submit
 	submit = 0, div = 0, livea = 0, liveb = 0;
 	jQuery("div#nothiddendivchild").trigger("submit");
-	equals( submit, 1, "Submit on div" );
-	equals( div, 0, "Submit on div" );
-	equals( livea, 0, "Submit on div" );
-	equals( liveb, 0, "Submit on div" );
+	equal( submit, 1, "Submit on div" );
+	equal( div, 0, "Submit on div" );
+	equal( livea, 0, "Submit on div" );
+	equal( liveb, 0, "Submit on div" );
 
 	// Make sure no other events were removed in the process
 	submit = 0, div = 0, livea = 0, liveb = 0;
 	jQuery("div#nothiddendivchild").trigger("click");
-	equals( submit, 0, "die Click on inner div" );
-	equals( div, 2, "die Click on inner div" );
-	equals( livea, 1, "die Click on inner div" );
-	equals( liveb, 1, "die Click on inner div" );
+	equal( submit, 0, "die Click on inner div" );
+	equal( div, 2, "die Click on inner div" );
+	equal( livea, 1, "die Click on inner div" );
+	equal( liveb, 1, "die Click on inner div" );
 
 	// Now make sure that the removal works
 	submit = 0, div = 0, livea = 0, liveb = 0;
 	jQuery("div#nothiddendivchild").die("click");
 	jQuery("div#nothiddendivchild").trigger("click");
-	equals( submit, 0, "die Click on inner div" );
-	equals( div, 2, "die Click on inner div" );
-	equals( livea, 1, "die Click on inner div" );
-	equals( liveb, 0, "die Click on inner div" );
+	equal( submit, 0, "die Click on inner div" );
+	equal( div, 2, "die Click on inner div" );
+	equal( livea, 1, "die Click on inner div" );
+	equal( liveb, 0, "die Click on inner div" );
 
 	// Make sure that the click wasn't removed too early
 	submit = 0, div = 0, livea = 0, liveb = 0;
 	jQuery("div#nothiddendiv").trigger("click");
-	equals( submit, 0, "die Click on inner div" );
-	equals( div, 1, "die Click on inner div" );
-	equals( livea, 1, "die Click on inner div" );
-	equals( liveb, 0, "die Click on inner div" );
+	equal( submit, 0, "die Click on inner div" );
+	equal( div, 1, "die Click on inner div" );
+	equal( livea, 1, "die Click on inner div" );
+	equal( liveb, 0, "die Click on inner div" );
 
 	// Make sure that stopPropgation doesn't stop live events
 	submit = 0, div = 0, livea = 0, liveb = 0;
 	jQuery("div#nothiddendivchild").live("click", function(e){ liveb++; e.stopPropagation(); });
 	jQuery("div#nothiddendivchild").trigger("click");
-	equals( submit, 0, "stopPropagation Click on inner div" );
-	equals( div, 1, "stopPropagation Click on inner div" );
-	equals( livea, 0, "stopPropagation Click on inner div" );
-	equals( liveb, 1, "stopPropagation Click on inner div" );
+	equal( submit, 0, "stopPropagation Click on inner div" );
+	equal( div, 1, "stopPropagation Click on inner div" );
+	equal( livea, 0, "stopPropagation Click on inner div" );
+	equal( liveb, 1, "stopPropagation Click on inner div" );
 
 	// Make sure click events only fire with primary click
 	submit = 0, div = 0, livea = 0, liveb = 0;
@@ -1355,7 +1355,7 @@ test(".live()/.die()", function() {
 	event.button = 1;
 	jQuery("div#nothiddendiv").trigger(event);
 
-	equals( livea, 0, "live secondary click" );
+	equal( livea, 0, "live secondary click" );
 
 	jQuery("div#nothiddendivchild").die("click");
 	jQuery("div#nothiddendiv").die("click");
@@ -1369,30 +1369,30 @@ test(".live()/.die()", function() {
 	jQuery("#foo").trigger("click");
 	jQuery("#qunit-fixture").trigger("click");
 	jQuery("body").trigger("click");
-	equals( clicked, 2, "live with a context" );
+	equal( clicked, 2, "live with a context" );
 
 	// Test unbinding with a different context
 	jQuery("#foo", container).die("click");
 	jQuery("#foo").trigger("click");
-	equals( clicked, 2, "die with a context");
+	equal( clicked, 2, "die with a context");
 
 	// Test binding with event data
-	jQuery("#foo").live("click", true, function(e){ equals( e.data, true, "live with event data" ); });
+	jQuery("#foo").live("click", true, function(e){ equal( e.data, true, "live with event data" ); });
 	jQuery("#foo").trigger("click").die("click");
 
 	// Test binding with trigger data
-	jQuery("#foo").live("click", function(e, data){ equals( data, true, "live with trigger data" ); });
+	jQuery("#foo").live("click", function(e, data){ equal( data, true, "live with trigger data" ); });
 	jQuery("#foo").trigger("click", true).die("click");
 
 	// Test binding with different this object
-	jQuery("#foo").live("click", jQuery.proxy(function(e){ equals( this.foo, "bar", "live with event scope" ); }, { foo: "bar" }));
+	jQuery("#foo").live("click", jQuery.proxy(function(e){ equal( this.foo, "bar", "live with event scope" ); }, { foo: "bar" }));
 	jQuery("#foo").trigger("click").die("click");
 
 	// Test binding with different this object, event data, and trigger data
 	jQuery("#foo").live("click", true, jQuery.proxy(function(e, data){
-		equals( e.data, true, "live with with different this object, event data, and trigger data" );
-		equals( this.foo, "bar", "live with with different this object, event data, and trigger data" );
-		equals( data, true, "live with with different this object, event data, and trigger data")
+		equal( e.data, true, "live with with different this object, event data, and trigger data" );
+		equal( this.foo, "bar", "live with with different this object, event data, and trigger data" );
+		equal( data, true, "live with with different this object, event data, and trigger data")
 	}, { foo: "bar" }));
 	jQuery("#foo").trigger("click", true).die("click");
 
@@ -1400,14 +1400,14 @@ test(".live()/.die()", function() {
 	jQuery("#anchor2").live("click", function(){ return false; });
 	var hash = window.location.hash;
 	jQuery("#anchor2").trigger("click");
-	equals( window.location.hash, hash, "return false worked" );
+	equal( window.location.hash, hash, "return false worked" );
 	jQuery("#anchor2").die("click");
 
 	// Verify that .preventDefault() prevents default action
 	jQuery("#anchor2").live("click", function(e){ e.preventDefault(); });
 	var hash = window.location.hash;
 	jQuery("#anchor2").trigger("click");
-	equals( window.location.hash, hash, "e.preventDefault() worked" );
+	equal( window.location.hash, hash, "e.preventDefault() worked" );
 	jQuery("#anchor2").die("click");
 
 	// Test binding the same handler to multiple points
@@ -1418,22 +1418,22 @@ test(".live()/.die()", function() {
 	jQuery("#anchor2").live("click", callback);
 
 	jQuery("#nothiddendiv").trigger("click");
-	equals( called, 1, "Verify that only one click occurred." );
+	equal( called, 1, "Verify that only one click occurred." );
 
 	called = 0;
 	jQuery("#anchor2").trigger("click");
-	equals( called, 1, "Verify that only one click occurred." );
+	equal( called, 1, "Verify that only one click occurred." );
 
 	// Make sure that only one callback is removed
 	jQuery("#anchor2").die("click", callback);
 
 	called = 0;
 	jQuery("#nothiddendiv").trigger("click");
-	equals( called, 1, "Verify that only one click occurred." );
+	equal( called, 1, "Verify that only one click occurred." );
 
 	called = 0;
 	jQuery("#anchor2").trigger("click");
-	equals( called, 0, "Verify that no click occurred." );
+	equal( called, 0, "Verify that no click occurred." );
 
 	// Make sure that it still works if the selector is the same,
 	// but the event type is different
@@ -1444,11 +1444,11 @@ test(".live()/.die()", function() {
 
 	called = 0;
 	jQuery("#nothiddendiv").trigger("click");
-	equals( called, 0, "Verify that no click occurred." );
+	equal( called, 0, "Verify that no click occurred." );
 
 	called = 0;
 	jQuery("#nothiddendiv").trigger("foo");
-	equals( called, 1, "Verify that one foo occurred." );
+	equal( called, 1, "Verify that one foo occurred." );
 
 	// Cleanup
 	jQuery("#nothiddendiv").die("foo", callback);
@@ -1461,8 +1461,8 @@ test(".live()/.die()", function() {
 	jQuery("#nothiddendivchild").live("click", function(e){ if(e.target) {livec++;} });
 
 	jQuery("#nothiddendiv span").click();
-	equals( jQuery("#nothiddendiv span").length, 0, "Verify that first handler occurred and modified the DOM." );
-	equals( livec, 1, "Verify that second handler occurred even with nuked target." );
+	equal( jQuery("#nothiddendiv span").length, 0, "Verify that first handler occurred and modified the DOM." );
+	equal( livec, 1, "Verify that second handler occurred even with nuked target." );
 
 	// Cleanup
 	jQuery("#nothiddendivchild").die("click");
@@ -1476,8 +1476,8 @@ test(".live()/.die()", function() {
 	jQuery("span#liveSpan1").live("click", function(){ livee++; });
 
 	jQuery("span#liveSpan1 a").click();
-	equals( lived, 1, "Verify that only one first handler occurred." );
-	equals( livee, 0, "Verify that second handler doesn't." );
+	equal( lived, 1, "Verify that only one first handler occurred." );
+	equal( livee, 0, "Verify that second handler doesn't." );
 
 	// and one pair in inverse
 	jQuery("span#liveSpan2").live("click", function(){ livee++; });
@@ -1486,8 +1486,8 @@ test(".live()/.die()", function() {
 	lived = 0;
 	livee = 0;
 	jQuery("span#liveSpan2 a").click();
-	equals( lived, 1, "Verify that only one first handler occurred." );
-	equals( livee, 0, "Verify that second handler doesn't." );
+	equal( lived, 1, "Verify that only one first handler occurred." );
+	equal( livee, 0, "Verify that second handler doesn't." );
 
 	// Cleanup
 	jQuery("span#liveSpan1 a").die("click")
@@ -1497,10 +1497,10 @@ test(".live()/.die()", function() {
 
 	// Test this, target and currentTarget are correct
 	jQuery("span#liveSpan1").live("click", function(e){
-		equals( this.id, "liveSpan1", "Check the this within a live handler" );
-		equals( e.currentTarget.id, "liveSpan1", "Check the event.currentTarget within a live handler" );
-		equals( e.delegateTarget, document, "Check the event.delegateTarget within a live handler" );
-		equals( e.target.nodeName.toUpperCase(), "A", "Check the event.target within a live handler" );
+		equal( this.id, "liveSpan1", "Check the this within a live handler" );
+		equal( e.currentTarget.id, "liveSpan1", "Check the event.currentTarget within a live handler" );
+		equal( e.delegateTarget, document, "Check the event.delegateTarget within a live handler" );
+		equal( e.target.nodeName.toUpperCase(), "A", "Check the event.target within a live handler" );
 	});
 
 	jQuery("span#liveSpan1 a").click();
@@ -1516,31 +1516,31 @@ test(".live()/.die()", function() {
 	jQuery("#nothiddendiv div").live("click", clickB);
 	jQuery("#nothiddendiv div").live("mouseover", function(){ livee++; });
 
-	equals( livee, 0, "No clicks, deep selector." );
+	equal( livee, 0, "No clicks, deep selector." );
 
 	livee = 0;
 	jQuery("#nothiddendivchild").trigger("click");
-	equals( livee, 2, "Click, deep selector." );
+	equal( livee, 2, "Click, deep selector." );
 
 	livee = 0;
 	jQuery("#nothiddendivchild").trigger("mouseover");
-	equals( livee, 1, "Mouseover, deep selector." );
+	equal( livee, 1, "Mouseover, deep selector." );
 
 	jQuery("#nothiddendiv div").die("mouseover");
 
 	livee = 0;
 	jQuery("#nothiddendivchild").trigger("click");
-	equals( livee, 2, "Click, deep selector." );
+	equal( livee, 2, "Click, deep selector." );
 
 	livee = 0;
 	jQuery("#nothiddendivchild").trigger("mouseover");
-	equals( livee, 0, "Mouseover, deep selector." );
+	equal( livee, 0, "Mouseover, deep selector." );
 
 	jQuery("#nothiddendiv div").die("click", clickB);
 
 	livee = 0;
 	jQuery("#nothiddendivchild").trigger("click");
-	equals( livee, 1, "Click, deep selector." );
+	equal( livee, 1, "Click, deep selector." );
 
 	jQuery("#nothiddendiv div").die("click");
 
@@ -1567,7 +1567,7 @@ test("die all bound events", function(){
 	div.trigger("click");
 	div.trigger("submit");
 
-	equals( count, 0, "Make sure no events were triggered." );
+	equal( count, 0, "Make sure no events were triggered." );
 });
 
 test("live with multiple events", function(){
@@ -1581,7 +1581,7 @@ test("live with multiple events", function(){
 	div.trigger("click");
 	div.trigger("submit");
 
-	equals( count, 2, "Make sure both the click and submit were triggered." );
+	equal( count, 2, "Make sure both the click and submit were triggered." );
 
 	// manually clean up events from elements outside the fixture
 	div.die();
@@ -1593,24 +1593,24 @@ test("live with namespaces", function(){
 	var count1 = 0, count2 = 0;
 
 	jQuery("#liveSpan1").live("foo.bar", function(e){
-		equals( e.namespace, "bar", "namespace is bar" );
+		equal( e.namespace, "bar", "namespace is bar" );
 		count1++;
 	});
 
 	jQuery("#liveSpan1").live("foo.zed", function(e){
-		equals( e.namespace, "zed", "namespace is zed" );
+		equal( e.namespace, "zed", "namespace is zed" );
 		count2++;
 	});
 
 	jQuery("#liveSpan1").trigger("foo.bar");
-	equals( count1, 1, "Got live foo.bar" );
-	equals( count2, 0, "Got live foo.bar" );
+	equal( count1, 1, "Got live foo.bar" );
+	equal( count2, 0, "Got live foo.bar" );
 
 	count1 = 0, count2 = 0;
 
 	jQuery("#liveSpan1").trigger("foo.zed");
-	equals( count1, 0, "Got live foo.zed" );
-	equals( count2, 1, "Got live foo.zed" );
+	equal( count1, 0, "Got live foo.zed" );
+	equal( count2, 1, "Got live foo.zed" );
 
 	//remove one
 	count1 = 0, count2 = 0;
@@ -1618,14 +1618,14 @@ test("live with namespaces", function(){
 	jQuery("#liveSpan1").die("foo.zed");
 	jQuery("#liveSpan1").trigger("foo.bar");
 
-	equals( count1, 1, "Got live foo.bar after dieing foo.zed" );
-	equals( count2, 0, "Got live foo.bar after dieing foo.zed" );
+	equal( count1, 1, "Got live foo.bar after dieing foo.zed" );
+	equal( count2, 0, "Got live foo.bar after dieing foo.zed" );
 
 	count1 = 0, count2 = 0;
 
 	jQuery("#liveSpan1").trigger("foo.zed");
-	equals( count1, 0, "Got live foo.zed" );
-	equals( count2, 0, "Got live foo.zed" );
+	equal( count1, 0, "Got live foo.zed" );
+	equal( count2, 0, "Got live foo.zed" );
 
 	//remove the other
 	jQuery("#liveSpan1").die("foo.bar");
@@ -1633,12 +1633,12 @@ test("live with namespaces", function(){
 	count1 = 0, count2 = 0;
 
 	jQuery("#liveSpan1").trigger("foo.bar");
-	equals( count1, 0, "Did not respond to foo.bar after dieing it" );
-	equals( count2, 0, "Did not respond to foo.bar after dieing it" );
+	equal( count1, 0, "Did not respond to foo.bar after dieing it" );
+	equal( count2, 0, "Did not respond to foo.bar after dieing it" );
 
 	jQuery("#liveSpan1").trigger("foo.zed");
-	equals( count1, 0, "Did not trigger foo.zed again" );
-	equals( count2, 0, "Did not trigger foo.zed again" );
+	equal( count1, 0, "Did not trigger foo.zed again" );
+	equal( count2, 0, "Did not trigger foo.zed again" );
 });
 
 test("live with change", function(){
@@ -1663,17 +1663,17 @@ test("live with change", function(){
 	selectChange = 0;
 	select[0].selectedIndex = select[0].selectedIndex ? 0 : 1;
 	select.trigger("change");
-	equals( selectChange, 1, "Change on click." );
+	equal( selectChange, 1, "Change on click." );
 
 	// test keys on select
 	selectChange = 0;
 	select[0].selectedIndex = select[0].selectedIndex ? 0 : 1;
 	select.trigger("change");
-	equals( selectChange, 1, "Change on keyup." );
+	equal( selectChange, 1, "Change on keyup." );
 
 	// test click on checkbox
 	checkbox.trigger("change");
-	equals( checkboxChange, 1, "Change on checkbox." );
+	equal( checkboxChange, 1, "Change on checkbox." );
 
 	// test blur/focus on text
 	var text = jQuery("#name"), textChange = 0, oldTextVal = text.val();
@@ -1683,7 +1683,7 @@ test("live with change", function(){
 
 	text.val(oldTextVal+"foo");
 	text.trigger("change");
-	equals( textChange, 1, "Change on text input." );
+	equal( textChange, 1, "Change on text input." );
 
 	text.val(oldTextVal);
 	text.die("change");
@@ -1696,7 +1696,7 @@ test("live with change", function(){
 
 	password.val(oldPasswordVal + "foo");
 	password.trigger("change");
-	equals( passwordChange, 1, "Change on password input." );
+	equal( passwordChange, 1, "Change on password input." );
 
 	password.val(oldPasswordVal);
 	password.die("change");
@@ -1708,17 +1708,17 @@ test("live with change", function(){
 	select.die("change");
 	select[0].selectedIndex = select[0].selectedIndex ? 0 : 1;
 	select.trigger("change");
-	equals( selectChange, 0, "Die on click works." );
+	equal( selectChange, 0, "Die on click works." );
 
 	selectChange = 0;
 	select[0].selectedIndex = select[0].selectedIndex ? 0 : 1;
 	select.trigger("change");
-	equals( selectChange, 0, "Die on keyup works." );
+	equal( selectChange, 0, "Die on keyup works." );
 
 	// die specific checkbox
 	checkbox.die("change", checkboxFunction);
 	checkbox.trigger("change");
-	equals( checkboxChange, 1, "Die on checkbox." );
+	equal( checkboxChange, 1, "Die on checkbox." );
 });
 
 test("live with submit", function() {
@@ -1737,20 +1737,20 @@ test("live with submit", function() {
 	});
 
 	jQuery("#testForm input[name=sub1]").submit();
-	equals( count1, 1, "Verify form submit." );
-	equals( count2, 1, "Verify body submit." );
+	equal( count1, 1, "Verify form submit." );
+	equal( count2, 1, "Verify body submit." );
 
 	jQuery("#testForm input[name=sub1]").live("click", function(ev) {
 		ok( true, "cancelling submit still calls click handler" );
 	});
 
 	jQuery("#testForm input[name=sub1]")[0].click();
-	equals( count1, 2, "Verify form submit." );
-	equals( count2, 2, "Verify body submit." );
+	equal( count1, 2, "Verify form submit." );
+	equal( count2, 2, "Verify body submit." );
 
 	jQuery("#testForm button[name=sub4]")[0].click();
-	equals( count1, 3, "Verify form submit." );
-	equals( count2, 3, "Verify body submit." );
+	equal( count1, 3, "Verify form submit." );
+	equal( count2, 3, "Verify body submit." );
 
 	jQuery("#testForm").die("submit");
 	jQuery("#testForm input[name=sub1]").die("click");
@@ -1818,68 +1818,68 @@ test(".delegate()/.undelegate()", function() {
 
 	// Nothing should trigger on the body
 	jQuery("body").trigger("click");
-	equals( submit, 0, "Click on body" );
-	equals( div, 0, "Click on body" );
-	equals( livea, 0, "Click on body" );
-	equals( liveb, 0, "Click on body" );
+	equal( submit, 0, "Click on body" );
+	equal( div, 0, "Click on body" );
+	equal( livea, 0, "Click on body" );
+	equal( liveb, 0, "Click on body" );
 
 	// This should trigger two events
 	submit = 0, div = 0, livea = 0, liveb = 0;
 	jQuery("div#nothiddendiv").trigger("click");
-	equals( submit, 0, "Click on div" );
-	equals( div, 1, "Click on div" );
-	equals( livea, 1, "Click on div" );
-	equals( liveb, 0, "Click on div" );
+	equal( submit, 0, "Click on div" );
+	equal( div, 1, "Click on div" );
+	equal( livea, 1, "Click on div" );
+	equal( liveb, 0, "Click on div" );
 
 	// This should trigger three events (w/ bubbling)
 	submit = 0, div = 0, livea = 0, liveb = 0;
 	jQuery("div#nothiddendivchild").trigger("click");
-	equals( submit, 0, "Click on inner div" );
-	equals( div, 2, "Click on inner div" );
-	equals( livea, 1, "Click on inner div" );
-	equals( liveb, 1, "Click on inner div" );
+	equal( submit, 0, "Click on inner div" );
+	equal( div, 2, "Click on inner div" );
+	equal( livea, 1, "Click on inner div" );
+	equal( liveb, 1, "Click on inner div" );
 
 	// This should trigger one submit
 	submit = 0, div = 0, livea = 0, liveb = 0;
 	jQuery("div#nothiddendivchild").trigger("submit");
-	equals( submit, 1, "Submit on div" );
-	equals( div, 0, "Submit on div" );
-	equals( livea, 0, "Submit on div" );
-	equals( liveb, 0, "Submit on div" );
+	equal( submit, 1, "Submit on div" );
+	equal( div, 0, "Submit on div" );
+	equal( livea, 0, "Submit on div" );
+	equal( liveb, 0, "Submit on div" );
 
 	// Make sure no other events were removed in the process
 	submit = 0, div = 0, livea = 0, liveb = 0;
 	jQuery("div#nothiddendivchild").trigger("click");
-	equals( submit, 0, "undelegate Click on inner div" );
-	equals( div, 2, "undelegate Click on inner div" );
-	equals( livea, 1, "undelegate Click on inner div" );
-	equals( liveb, 1, "undelegate Click on inner div" );
+	equal( submit, 0, "undelegate Click on inner div" );
+	equal( div, 2, "undelegate Click on inner div" );
+	equal( livea, 1, "undelegate Click on inner div" );
+	equal( liveb, 1, "undelegate Click on inner div" );
 
 	// Now make sure that the removal works
 	submit = 0, div = 0, livea = 0, liveb = 0;
 	jQuery("#body").undelegate("div#nothiddendivchild", "click");
 	jQuery("div#nothiddendivchild").trigger("click");
-	equals( submit, 0, "undelegate Click on inner div" );
-	equals( div, 2, "undelegate Click on inner div" );
-	equals( livea, 1, "undelegate Click on inner div" );
-	equals( liveb, 0, "undelegate Click on inner div" );
+	equal( submit, 0, "undelegate Click on inner div" );
+	equal( div, 2, "undelegate Click on inner div" );
+	equal( livea, 1, "undelegate Click on inner div" );
+	equal( liveb, 0, "undelegate Click on inner div" );
 
 	// Make sure that the click wasn't removed too early
 	submit = 0, div = 0, livea = 0, liveb = 0;
 	jQuery("div#nothiddendiv").trigger("click");
-	equals( submit, 0, "undelegate Click on inner div" );
-	equals( div, 1, "undelegate Click on inner div" );
-	equals( livea, 1, "undelegate Click on inner div" );
-	equals( liveb, 0, "undelegate Click on inner div" );
+	equal( submit, 0, "undelegate Click on inner div" );
+	equal( div, 1, "undelegate Click on inner div" );
+	equal( livea, 1, "undelegate Click on inner div" );
+	equal( liveb, 0, "undelegate Click on inner div" );
 
 	// Make sure that stopPropgation doesn't stop live events
 	submit = 0, div = 0, livea = 0, liveb = 0;
 	jQuery("#body").delegate("div#nothiddendivchild", "click", function(e){ liveb++; e.stopPropagation(); });
 	jQuery("div#nothiddendivchild").trigger("click");
-	equals( submit, 0, "stopPropagation Click on inner div" );
-	equals( div, 1, "stopPropagation Click on inner div" );
-	equals( livea, 0, "stopPropagation Click on inner div" );
-	equals( liveb, 1, "stopPropagation Click on inner div" );
+	equal( submit, 0, "stopPropagation Click on inner div" );
+	equal( div, 1, "stopPropagation Click on inner div" );
+	equal( livea, 0, "stopPropagation Click on inner div" );
+	equal( liveb, 1, "stopPropagation Click on inner div" );
 
 	// Make sure click events only fire with primary click
 	submit = 0, div = 0, livea = 0, liveb = 0;
@@ -1887,7 +1887,7 @@ test(".delegate()/.undelegate()", function() {
 	event.button = 1;
 	jQuery("div#nothiddendiv").trigger(event);
 
-	equals( livea, 0, "delegate secondary click" );
+	equal( livea, 0, "delegate secondary click" );
 
 	jQuery("#body").undelegate("div#nothiddendivchild", "click");
 	jQuery("#body").undelegate("div#nothiddendiv", "click");
@@ -1901,33 +1901,33 @@ test(".delegate()/.undelegate()", function() {
 	jQuery("#foo").trigger("click");
 	jQuery("#qunit-fixture").trigger("click");
 	jQuery("body").trigger("click");
-	equals( clicked, 2, "delegate with a context" );
+	equal( clicked, 2, "delegate with a context" );
 
 	// Test unbinding with a different context
 	jQuery("#qunit-fixture").undelegate("#foo", "click");
 	jQuery("#foo").trigger("click");
-	equals( clicked, 2, "undelegate with a context");
+	equal( clicked, 2, "undelegate with a context");
 
 	// Test binding with event data
-	jQuery("#body").delegate("#foo", "click", true, function(e){ equals( e.data, true, "delegate with event data" ); });
+	jQuery("#body").delegate("#foo", "click", true, function(e){ equal( e.data, true, "delegate with event data" ); });
 	jQuery("#foo").trigger("click");
 	jQuery("#body").undelegate("#foo", "click");
 
 	// Test binding with trigger data
-	jQuery("#body").delegate("#foo", "click", function(e, data){ equals( data, true, "delegate with trigger data" ); });
+	jQuery("#body").delegate("#foo", "click", function(e, data){ equal( data, true, "delegate with trigger data" ); });
 	jQuery("#foo").trigger("click", true);
 	jQuery("#body").undelegate("#foo", "click");
 
 	// Test binding with different this object
-	jQuery("#body").delegate("#foo", "click", jQuery.proxy(function(e){ equals( this.foo, "bar", "delegate with event scope" ); }, { foo: "bar" }));
+	jQuery("#body").delegate("#foo", "click", jQuery.proxy(function(e){ equal( this.foo, "bar", "delegate with event scope" ); }, { foo: "bar" }));
 	jQuery("#foo").trigger("click");
 	jQuery("#body").undelegate("#foo", "click");
 
 	// Test binding with different this object, event data, and trigger data
 	jQuery("#body").delegate("#foo", "click", true, jQuery.proxy(function(e, data){
-		equals( e.data, true, "delegate with with different this object, event data, and trigger data" );
-		equals( this.foo, "bar", "delegate with with different this object, event data, and trigger data" );
-		equals( data, true, "delegate with with different this object, event data, and trigger data")
+		equal( e.data, true, "delegate with with different this object, event data, and trigger data" );
+		equal( this.foo, "bar", "delegate with with different this object, event data, and trigger data" );
+		equal( data, true, "delegate with with different this object, event data, and trigger data")
 	}, { foo: "bar" }));
 	jQuery("#foo").trigger("click", true);
 	jQuery("#body").undelegate("#foo", "click");
@@ -1936,14 +1936,14 @@ test(".delegate()/.undelegate()", function() {
 	jQuery("#body").delegate("#anchor2", "click", function(){ return false; });
 	var hash = window.location.hash;
 	jQuery("#anchor2").trigger("click");
-	equals( window.location.hash, hash, "return false worked" );
+	equal( window.location.hash, hash, "return false worked" );
 	jQuery("#body").undelegate("#anchor2", "click");
 
 	// Verify that .preventDefault() prevents default action
 	jQuery("#body").delegate("#anchor2", "click", function(e){ e.preventDefault(); });
 	var hash = window.location.hash;
 	jQuery("#anchor2").trigger("click");
-	equals( window.location.hash, hash, "e.preventDefault() worked" );
+	equal( window.location.hash, hash, "e.preventDefault() worked" );
 	jQuery("#body").undelegate("#anchor2", "click");
 
 	// Test binding the same handler to multiple points
@@ -1954,22 +1954,22 @@ test(".delegate()/.undelegate()", function() {
 	jQuery("#body").delegate("#anchor2", "click", callback);
 
 	jQuery("#nothiddendiv").trigger("click");
-	equals( called, 1, "Verify that only one click occurred." );
+	equal( called, 1, "Verify that only one click occurred." );
 
 	called = 0;
 	jQuery("#anchor2").trigger("click");
-	equals( called, 1, "Verify that only one click occurred." );
+	equal( called, 1, "Verify that only one click occurred." );
 
 	// Make sure that only one callback is removed
 	jQuery("#body").undelegate("#anchor2", "click", callback);
 
 	called = 0;
 	jQuery("#nothiddendiv").trigger("click");
-	equals( called, 1, "Verify that only one click occurred." );
+	equal( called, 1, "Verify that only one click occurred." );
 
 	called = 0;
 	jQuery("#anchor2").trigger("click");
-	equals( called, 0, "Verify that no click occurred." );
+	equal( called, 0, "Verify that no click occurred." );
 
 	// Make sure that it still works if the selector is the same,
 	// but the event type is different
@@ -1980,11 +1980,11 @@ test(".delegate()/.undelegate()", function() {
 
 	called = 0;
 	jQuery("#nothiddendiv").trigger("click");
-	equals( called, 0, "Verify that no click occurred." );
+	equal( called, 0, "Verify that no click occurred." );
 
 	called = 0;
 	jQuery("#nothiddendiv").trigger("foo");
-	equals( called, 1, "Verify that one foo occurred." );
+	equal( called, 1, "Verify that one foo occurred." );
 
 	// Cleanup
 	jQuery("#body").undelegate("#nothiddendiv", "foo", callback);
@@ -1997,8 +1997,8 @@ test(".delegate()/.undelegate()", function() {
 	jQuery("#body").delegate("#nothiddendivchild", "click", function(e){ if(e.target) {livec++;} });
 
 	jQuery("#nothiddendiv span").click();
-	equals( jQuery("#nothiddendiv span").length, 0, "Verify that first handler occurred and modified the DOM." );
-	equals( livec, 1, "Verify that second handler occurred even with nuked target." );
+	equal( jQuery("#nothiddendiv span").length, 0, "Verify that first handler occurred and modified the DOM." );
+	equal( livec, 1, "Verify that second handler occurred even with nuked target." );
 
 	// Cleanup
 	jQuery("#body").undelegate("#nothiddendivchild", "click");
@@ -2012,8 +2012,8 @@ test(".delegate()/.undelegate()", function() {
 	jQuery("#body").delegate("span#liveSpan1", "click", function(){ livee++; });
 
 	jQuery("span#liveSpan1 a").click();
-	equals( lived, 1, "Verify that only one first handler occurred." );
-	equals( livee, 0, "Verify that second handler doesn't." );
+	equal( lived, 1, "Verify that only one first handler occurred." );
+	equal( livee, 0, "Verify that second handler doesn't." );
 
 	// and one pair in inverse
 	jQuery("#body").delegate("span#liveSpan2", "click", function(){ livee++; });
@@ -2022,18 +2022,18 @@ test(".delegate()/.undelegate()", function() {
 	lived = 0;
 	livee = 0;
 	jQuery("span#liveSpan2 a").click();
-	equals( lived, 1, "Verify that only one first handler occurred." );
-	equals( livee, 0, "Verify that second handler doesn't." );
+	equal( lived, 1, "Verify that only one first handler occurred." );
+	equal( livee, 0, "Verify that second handler doesn't." );
 
 	// Cleanup
 	jQuery("#body").undelegate("click");
 
 	// Test this, target and currentTarget are correct
 	jQuery("#body").delegate("span#liveSpan1", "click", function(e){
-		equals( this.id, "liveSpan1", "Check the this within a delegate handler" );
-		equals( e.currentTarget.id, "liveSpan1", "Check the event.currentTarget within a delegate handler" );
-		equals( e.delegateTarget, document.body, "Check the event.delegateTarget within a delegate handler" );
-		equals( e.target.nodeName.toUpperCase(), "A", "Check the event.target within a delegate handler" );
+		equal( this.id, "liveSpan1", "Check the this within a delegate handler" );
+		equal( e.currentTarget.id, "liveSpan1", "Check the event.currentTarget within a delegate handler" );
+		equal( e.delegateTarget, document.body, "Check the event.delegateTarget within a delegate handler" );
+		equal( e.target.nodeName.toUpperCase(), "A", "Check the event.target within a delegate handler" );
 	});
 
 	jQuery("span#liveSpan1 a").click();
@@ -2049,31 +2049,31 @@ test(".delegate()/.undelegate()", function() {
 	jQuery("#body").delegate("#nothiddendiv div", "click", clickB);
 	jQuery("#body").delegate("#nothiddendiv div", "mouseover", function(){ livee++; });
 
-	equals( livee, 0, "No clicks, deep selector." );
+	equal( livee, 0, "No clicks, deep selector." );
 
 	livee = 0;
 	jQuery("#nothiddendivchild").trigger("click");
-	equals( livee, 2, "Click, deep selector." );
+	equal( livee, 2, "Click, deep selector." );
 
 	livee = 0;
 	jQuery("#nothiddendivchild").trigger("mouseover");
-	equals( livee, 1, "Mouseover, deep selector." );
+	equal( livee, 1, "Mouseover, deep selector." );
 
 	jQuery("#body").undelegate("#nothiddendiv div", "mouseover");
 
 	livee = 0;
 	jQuery("#nothiddendivchild").trigger("click");
-	equals( livee, 2, "Click, deep selector." );
+	equal( livee, 2, "Click, deep selector." );
 
 	livee = 0;
 	jQuery("#nothiddendivchild").trigger("mouseover");
-	equals( livee, 0, "Mouseover, deep selector." );
+	equal( livee, 0, "Mouseover, deep selector." );
 
 	jQuery("#body").undelegate("#nothiddendiv div", "click", clickB);
 
 	livee = 0;
 	jQuery("#nothiddendivchild").trigger("click");
-	equals( livee, 1, "Click, deep selector." );
+	equal( livee, 1, "Click, deep selector." );
 
 	jQuery("#body").undelegate("#nothiddendiv div", "click");
 });
@@ -2085,7 +2085,7 @@ test("jQuery.off using dispatched jQuery.Event", function() {
 		count = 0;
 	markup
 		.on( "click.name", "a", function( event ) {
-			equals( ++count, 1, "event called once before removal" );
+			equal( ++count, 1, "event called once before removal" );
 			jQuery().off( event );
 		})
 		.find( "a" ).click().click().end()
@@ -2120,7 +2120,7 @@ test("undelegate all bound events", function(){
 	jQuery("div#nothiddendivchild").trigger("click");
 	jQuery("div#nothiddendivchild").trigger("submit");
 
-	equals( count, 0, "Make sure no events were triggered." );
+	equal( count, 0, "Make sure no events were triggered." );
 });
 
 test("delegate with multiple events", function(){
@@ -2134,7 +2134,7 @@ test("delegate with multiple events", function(){
 	jQuery("div#nothiddendivchild").trigger("click");
 	jQuery("div#nothiddendivchild").trigger("submit");
 
-	equals( count, 2, "Make sure both the click and submit were triggered." );
+	equal( count, 2, "Make sure both the click and submit were triggered." );
 
 	jQuery("#body").undelegate();
 });
@@ -2161,17 +2161,17 @@ test("delegate with change", function(){
 	selectChange = 0;
 	select[0].selectedIndex = select[0].selectedIndex ? 0 : 1;
 	select.trigger("change");
-	equals( selectChange, 1, "Change on click." );
+	equal( selectChange, 1, "Change on click." );
 
 	// test keys on select
 	selectChange = 0;
 	select[0].selectedIndex = select[0].selectedIndex ? 0 : 1;
 	select.trigger("change");
-	equals( selectChange, 1, "Change on keyup." );
+	equal( selectChange, 1, "Change on keyup." );
 
 	// test click on checkbox
 	checkbox.trigger("change");
-	equals( checkboxChange, 1, "Change on checkbox." );
+	equal( checkboxChange, 1, "Change on checkbox." );
 
 	// test blur/focus on text
 	var text = jQuery("#name"), textChange = 0, oldTextVal = text.val();
@@ -2181,7 +2181,7 @@ test("delegate with change", function(){
 
 	text.val(oldTextVal+"foo");
 	text.trigger("change");
-	equals( textChange, 1, "Change on text input." );
+	equal( textChange, 1, "Change on text input." );
 
 	text.val(oldTextVal);
 	jQuery("#body").die("change");
@@ -2194,7 +2194,7 @@ test("delegate with change", function(){
 
 	password.val(oldPasswordVal + "foo");
 	password.trigger("change");
-	equals( passwordChange, 1, "Change on password input." );
+	equal( passwordChange, 1, "Change on password input." );
 
 	password.val(oldPasswordVal);
 	jQuery("#body").undelegate("#name", "change");
@@ -2206,17 +2206,17 @@ test("delegate with change", function(){
 	jQuery("#body").undelegate("select[name='S1']", "change");
 	select[0].selectedIndex = select[0].selectedIndex ? 0 : 1;
 	select.trigger("change");
-	equals( selectChange, 0, "Die on click works." );
+	equal( selectChange, 0, "Die on click works." );
 
 	selectChange = 0;
 	select[0].selectedIndex = select[0].selectedIndex ? 0 : 1;
 	select.trigger("change");
-	equals( selectChange, 0, "Die on keyup works." );
+	equal( selectChange, 0, "Die on keyup works." );
 
 	// die specific checkbox
 	jQuery("#body").undelegate("#check2", "change", checkboxFunction);
 	checkbox.trigger("change");
-	equals( checkboxChange, 1, "Die on checkbox." );
+	equal( checkboxChange, 1, "Die on checkbox." );
 });
 
 test("delegate with submit", function() {
@@ -2233,8 +2233,8 @@ test("delegate with submit", function() {
 	});
 
 	jQuery("#testForm input[name=sub1]").submit();
-	equals( count1, 1, "Verify form submit." );
-	equals( count2, 1, "Verify body submit." );
+	equal( count1, 1, "Verify form submit." );
+	equal( count2, 1, "Verify body submit." );
 
 	jQuery("#body").undelegate();
 	jQuery(document).undelegate();
@@ -2252,13 +2252,13 @@ test("undelegate() with only namespaces", function() {
 
 	jQuery("a", $delegate).eq(0).trigger("click.ns");
 
-	equals( count, 1, "delegated click.ns");
+	equal( count, 1, "delegated click.ns");
 
 	$delegate.undelegate(".ns");
 
 	jQuery("a", $delegate).eq(1).trigger("click.ns");
 
-	equals( count, 1, "no more .ns after undelegate");
+	equal( count, 1, "no more .ns after undelegate");
 });
 
 test("Non DOM element events", function() {
@@ -2292,11 +2292,11 @@ test("focusin bubbles", function() {
 		order = 0;
 
 	jQuery( "body" ).bind( "focusin.focusinBubblesTest", function(){
-		equals( 1, order++, "focusin on the body second" );
+		equal( 1, order++, "focusin on the body second" );
 	});
 
 	input.bind( "focusin.focusinBubblesTest", function(){
-		equals( 0, order++, "focusin on the element first" );
+		equal( 0, order++, "focusin on the element first" );
 	});
 
 	// DOM focus method
@@ -2355,7 +2355,7 @@ test(".on and .off", function() {
 		.click()
 		.trigger( "click", 17 )
 		.off( "click" );
-	equals( counter, 54, "direct event bindings with data" );
+	equal( counter, 54, "direct event bindings with data" );
 
 	// Delegated events only
 	counter = 0;
@@ -2371,7 +2371,7 @@ test(".on and .off", function() {
 			.trigger( "click", 17 )
 		.end()
 		.off( "click", "em" );
-	equals( counter, 54, "delegated event bindings with data" );
+	equal( counter, 54, "delegated event bindings with data" );
 
 
 	// Mixed event bindings and types
@@ -2385,7 +2385,7 @@ test(".on and .off", function() {
 		.on( "cluck", mixfn )
 		.trigger( "what!" )
 		.each( function() {
-			equals( counter, 0, "nothing triggered yet" );
+			equal( counter, 0, "nothing triggered yet" );
 		})
 		.find( "em" )
 			.one( "cluck", 3, mixfn )
@@ -2394,12 +2394,12 @@ test(".on and .off", function() {
 			.trigger( "cluck", 9 )			// 2+9 + 0+9 = 20
 		.end()
 		.each( function() {
-			equals( counter, 49, "after triggering em element" );
+			equal( counter, 49, "after triggering em element" );
 		})
 		.off( "cluck", function(){} )		// shouldn't remove anything
 		.trigger( "cluck", 2 )				// 0+2 = 2
 		.each( function() {
-			equals( counter, 51, "after triggering #onandoff cluck" );
+			equal( counter, 51, "after triggering #onandoff cluck" );
 		})
 		.find( "b" )
 			.on( "click", 95, mixfn )
@@ -2409,7 +2409,7 @@ test(".on and .off", function() {
 			.off( "click clack cluck" )
 		.end()
 		.each( function() {
-			equals( counter, 51, "after triggering b" );
+			equal( counter, 51, "after triggering b" );
 		})
 		.trigger( "cluck", 3 )				// 0+3 = 3
 		.off( "clack", "em", mixfn )
@@ -2417,13 +2417,13 @@ test(".on and .off", function() {
 			.trigger( "clack" )				// 0
 		.end()
 		.each( function() {
-			equals( counter, 54, "final triggers" );
+			equal( counter, 54, "final triggers" );
 		})
 		.off( "click cluck" );
 
 	// We should have removed all the event handlers ... kinda hacky way to check this
 	var data = jQuery.data[ jQuery( "#onandoff" )[0].expando ] || {};
-	equals( data.events, undefined, "no events left" );
+	equal( data.events, undefined, "no events left" );
 
 	jQuery("#onandoff").remove();
 });
@@ -2444,7 +2444,7 @@ test("delegated events quickIs", function() {
 		check = function(el, expect){
 			str = "";
 			markup.find( el ).trigger( "blink" );
-			equals( str, expect, "On " + el );
+			equal( str, expect, "On " + el );
 		},
 		func = function(e){
 			var tag = this.nodeName.toLowerCase();
@@ -2495,7 +2495,7 @@ test("fixHooks extensions", function() {
 
 	// Trigger a native click and ensure the property is set
 	$fixture.bind( "click", function( event ) {
-		equals( event.blurrinessLevel, 42, "event.blurrinessLevel was set" );
+		equal( event.blurrinessLevel, 42, "event.blurrinessLevel was set" );
 	});
 	fireNative( $fixture[0], 'click' );
 
@@ -2515,8 +2515,8 @@ test("fixHooks extensions", function() {
 	test("jQuery.isReady", function() {
 		expect(2);
 
-		equals(notYetReady, true, "jQuery.isReady should not be true before DOM ready");
-		equals(jQuery.isReady, true, "jQuery.isReady should be true once DOM is ready");
+		equal(notYetReady, true, "jQuery.isReady should not be true before DOM ready");
+		equal(jQuery.isReady, true, "jQuery.isReady should be true once DOM is ready");
 	});
 
 	// Create an event handler.
@@ -2549,11 +2549,11 @@ test("fixHooks extensions", function() {
 		ok(noEarlyExecution, "Handlers bound to DOM ready should not execute before DOM ready");
 
 		// Ensure execution order.
-		same(order, ["a", "b", "d", "e", "c", "f"], "Bound DOM ready handlers should execute in bind-order, but those bound with jQuery(document).bind( 'ready', fn ) will always execute last");
+		deepEqual(order, ["a", "b", "d", "e", "c", "f"], "Bound DOM ready handlers should execute in bind-order, but those bound with jQuery(document).bind( 'ready', fn ) will always execute last");
 
 		// Ensure handler argument is correct.
-		equals(args.a, jQuery, "Argument passed to fn in jQuery( fn ) should be jQuery");
-		equals(args.b, jQuery, "Argument passed to fn in jQuery(document).ready( fn ) should be jQuery");
+		equal(args.a, jQuery, "Argument passed to fn in jQuery( fn ) should be jQuery");
+		equal(args.b, jQuery, "Argument passed to fn in jQuery(document).ready( fn ) should be jQuery");
 		ok(args.c instanceof jQuery.Event, "Argument passed to fn in jQuery(document).bind( 'ready', fn ) should be an event object");
 
 		order = [];
@@ -2561,15 +2561,15 @@ test("fixHooks extensions", function() {
 		// Now that the ready event has fired, again bind to the ready event
 		// in every possible way. These event handlers should execute immediately.
 		jQuery(makeHandler("g"));
-		equals(order.pop(), "g", "Event handler should execute immediately");
-		equals(args.g, jQuery, "Argument passed to fn in jQuery( fn ) should be jQuery");
+		equal(order.pop(), "g", "Event handler should execute immediately");
+		equal(args.g, jQuery, "Argument passed to fn in jQuery( fn ) should be jQuery");
 
 		jQuery(document).ready(makeHandler("h"));
-		equals(order.pop(), "h", "Event handler should execute immediately");
-		equals(args.h, jQuery, "Argument passed to fn in jQuery(document).ready( fn ) should be jQuery");
+		equal(order.pop(), "h", "Event handler should execute immediately");
+		equal(args.h, jQuery, "Argument passed to fn in jQuery(document).ready( fn ) should be jQuery");
 
 		jQuery(document).bind("ready.readytest", makeHandler("never"));
-		equals(order.length, 0, "Event handler should never execute since DOM ready has already passed");
+		equal(order.length, 0, "Event handler should never execute since DOM ready has already passed");
 
 		// Cleanup.
 		jQuery(document).unbind("ready.readytest");

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -9,25 +9,25 @@ var functionReturningObj = function(value) { return (function() { return value; 
 test("text()", function() {
 	expect(2);
 	var expected = "This link has class=\"blog\": Simon Willison's Weblog";
-	equals( jQuery("#sap").text(), expected, "Check for merged text of more then one element." );
+	equal( jQuery("#sap").text(), expected, "Check for merged text of more then one element." );
 
 	// Check serialization of text values
-	equals( jQuery(document.createTextNode("foo")).text(), "foo", "Text node was retreived from .text()." );
+	equal( jQuery(document.createTextNode("foo")).text(), "foo", "Text node was retreived from .text()." );
 });
 
 var testText = function(valueObj) {
 	expect(4);
 	var val = valueObj("<div><b>Hello</b> cruel world!</div>");
-	equals( jQuery("#foo").text(val)[0].innerHTML.replace(/>/g, "&gt;"), "&lt;div&gt;&lt;b&gt;Hello&lt;/b&gt; cruel world!&lt;/div&gt;", "Check escaped text" );
+	equal( jQuery("#foo").text(val)[0].innerHTML.replace(/>/g, "&gt;"), "&lt;div&gt;&lt;b&gt;Hello&lt;/b&gt; cruel world!&lt;/div&gt;", "Check escaped text" );
 
 	// using contents will get comments regular, text, and comment nodes
 	var j = jQuery("#nonnodes").contents();
 	j.text(valueObj("hi!"));
-	equals( jQuery(j[0]).text(), "hi!", "Check node,textnode,comment with text()" );
-	equals( j[1].nodeValue, " there ", "Check node,textnode,comment with text()" );
+	equal( jQuery(j[0]).text(), "hi!", "Check node,textnode,comment with text()" );
+	equal( j[1].nodeValue, " there ", "Check node,textnode,comment with text()" );
 
 	// Blackberry 4.6 doesn't maintain comments in the DOM
-	equals( jQuery("#nonnodes")[0].childNodes.length < 3 ? 8 : j[2].nodeType, 8, "Check node,textnode,comment with text()" );
+	equal( jQuery("#nonnodes")[0].childNodes.length < 3 ? 8 : j[2].nodeType, 8, "Check node,textnode,comment with text()" );
 }
 
 test("text(String)", function() {
@@ -44,11 +44,11 @@ test("text(Function) with incoming value", function() {
 	var old = "This link has class=\"blog\": Simon Willison's Weblog";
 
 	jQuery("#sap").text(function(i, val) {
-		equals( val, old, "Make sure the incoming value is correct." );
+		equal( val, old, "Make sure the incoming value is correct." );
 		return "foobar";
 	});
 
-	equals( jQuery("#sap").text(), "foobar", "Check for merged text of more then one element." );
+	equal( jQuery("#sap").text(), "foobar", "Check for merged text of more then one element." );
 
 	QUnit.reset();
 });
@@ -57,13 +57,13 @@ var testWrap = function(val) {
 	expect(19);
 	var defaultText = "Try them out:";
 	var result = jQuery("#first").wrap(val( "<div class='red'><span></span></div>" )).text();
-	equals( defaultText, result, "Check for wrapping of on-the-fly html" );
+	equal( defaultText, result, "Check for wrapping of on-the-fly html" );
 	ok( jQuery("#first").parent().parent().is(".red"), "Check if wrapper has class 'red'" );
 
 	QUnit.reset();
 	result = jQuery("#first").wrap(val( document.getElementById("empty") )).parent();
 	ok( result.is("ol"), "Check for element wrapping" );
-	equals( result.text(), defaultText, "Check for element wrapping" );
+	equal( result.text(), defaultText, "Check for element wrapping" );
 
 	QUnit.reset();
 	jQuery("#check1").click(function() {
@@ -78,8 +78,8 @@ var testWrap = function(val) {
 	j.wrap(val( "<i></i>" ));
 
 	// Blackberry 4.6 doesn't maintain comments in the DOM
-	equals( jQuery("#nonnodes > i").length, jQuery("#nonnodes")[0].childNodes.length, "Check node,textnode,comment wraps ok" );
-	equals( jQuery("#nonnodes > i").text(), j.text(), "Check node,textnode,comment wraps doesn't hurt text" );
+	equal( jQuery("#nonnodes > i").length, jQuery("#nonnodes")[0].childNodes.length, "Check node,textnode,comment wraps ok" );
+	equal( jQuery("#nonnodes > i").text(), j.text(), "Check node,textnode,comment wraps doesn't hurt text" );
 
 	// Try wrapping a disconnected node
 	var cacheLength = 0;
@@ -88,28 +88,28 @@ var testWrap = function(val) {
 	}
 
 	j = jQuery("<label/>").wrap(val( "<li/>" ));
-	equals( j[0].nodeName.toUpperCase(), "LABEL", "Element is a label" );
-	equals( j[0].parentNode.nodeName.toUpperCase(), "LI", "Element has been wrapped" );
+	equal( j[0].nodeName.toUpperCase(), "LABEL", "Element is a label" );
+	equal( j[0].parentNode.nodeName.toUpperCase(), "LI", "Element has been wrapped" );
 
 	for (i in jQuery.cache) {
 		cacheLength--;
 	}
-	equals(cacheLength, 0, "No memory leak in jQuery.cache (bug #7165)");
+	equal(cacheLength, 0, "No memory leak in jQuery.cache (bug #7165)");
 
 	// Wrap an element containing a text node
 	j = jQuery("<span/>").wrap("<div>test</div>");
-	equals( j[0].previousSibling.nodeType, 3, "Make sure the previous node is a text element" );
-	equals( j[0].parentNode.nodeName.toUpperCase(), "DIV", "And that we're in the div element." );
+	equal( j[0].previousSibling.nodeType, 3, "Make sure the previous node is a text element" );
+	equal( j[0].parentNode.nodeName.toUpperCase(), "DIV", "And that we're in the div element." );
 
 	// Try to wrap an element with multiple elements (should fail)
 	j = jQuery("<div><span></span></div>").children().wrap("<p></p><div></div>");
-	equals( j[0].parentNode.parentNode.childNodes.length, 1, "There should only be one element wrapping." );
-	equals( j.length, 1, "There should only be one element (no cloning)." );
-	equals( j[0].parentNode.nodeName.toUpperCase(), "P", "The span should be in the paragraph." );
+	equal( j[0].parentNode.parentNode.childNodes.length, 1, "There should only be one element wrapping." );
+	equal( j.length, 1, "There should only be one element (no cloning)." );
+	equal( j[0].parentNode.nodeName.toUpperCase(), "P", "The span should be in the paragraph." );
 
 	// Wrap an element with a jQuery set
 	j = jQuery("<span/>").wrap(jQuery("<div></div>"));
-	equals( j[0].parentNode.nodeName.toLowerCase(), "div", "Wrapping works." );
+	equal( j[0].parentNode.nodeName.toLowerCase(), "div", "Wrapping works." );
 
 	// Wrap an element with a jQuery set and event
 	result = jQuery("<div></div>").click(function(){
@@ -121,7 +121,7 @@ var testWrap = function(val) {
 	});
 
 	j = jQuery("<span/>").wrap(result);
-	equals( j[0].parentNode.nodeName.toLowerCase(), "div", "Wrapping works." );
+	equal( j[0].parentNode.nodeName.toLowerCase(), "div", "Wrapping works." );
 
 	j.parent().trigger("click");
 
@@ -143,19 +143,19 @@ var testWrapAll = function(val) {
 	var p = jQuery("#firstp,#first")[0].parentNode;
 
 	var result = jQuery("#firstp,#first").wrapAll(val( "<div class='red'><div class='tmp'></div></div>" ));
-	equals( result.parent().length, 1, "Check for wrapping of on-the-fly html" );
+	equal( result.parent().length, 1, "Check for wrapping of on-the-fly html" );
 	ok( jQuery("#first").parent().parent().is(".red"), "Check if wrapper has class 'red'" );
 	ok( jQuery("#firstp").parent().parent().is(".red"), "Check if wrapper has class 'red'" );
-	equals( jQuery("#first").parent().parent()[0].previousSibling, prev, "Correct Previous Sibling" );
-	equals( jQuery("#first").parent().parent()[0].parentNode, p, "Correct Parent" );
+	equal( jQuery("#first").parent().parent()[0].previousSibling, prev, "Correct Previous Sibling" );
+	equal( jQuery("#first").parent().parent()[0].parentNode, p, "Correct Parent" );
 
 	QUnit.reset();
 	var prev = jQuery("#firstp")[0].previousSibling;
 	var p = jQuery("#first")[0].parentNode;
 	var result = jQuery("#firstp,#first").wrapAll(val( document.getElementById("empty") ));
-	equals( jQuery("#first").parent()[0], jQuery("#firstp").parent()[0], "Same Parent" );
-	equals( jQuery("#first").parent()[0].previousSibling, prev, "Correct Previous Sibling" );
-	equals( jQuery("#first").parent()[0].parentNode, p, "Correct Parent" );
+	equal( jQuery("#first").parent()[0], jQuery("#firstp").parent()[0], "Same Parent" );
+	equal( jQuery("#first").parent()[0].previousSibling, prev, "Correct Previous Sibling" );
+	equal( jQuery("#first").parent()[0].parentNode, p, "Correct Parent" );
 }
 
 test("wrapAll(String|Element)", function() {
@@ -166,28 +166,28 @@ var testWrapInner = function(val) {
 	expect(11);
 	var num = jQuery("#first").children().length;
 	var result = jQuery("#first").wrapInner(val("<div class='red'><div id='tmp'></div></div>"));
-	equals( jQuery("#first").children().length, 1, "Only one child" );
+	equal( jQuery("#first").children().length, 1, "Only one child" );
 	ok( jQuery("#first").children().is(".red"), "Verify Right Element" );
-	equals( jQuery("#first").children().children().children().length, num, "Verify Elements Intact" );
+	equal( jQuery("#first").children().children().children().length, num, "Verify Elements Intact" );
 
 	QUnit.reset();
 	var num = jQuery("#first").html("foo<div>test</div><div>test2</div>").children().length;
 	var result = jQuery("#first").wrapInner(val("<div class='red'><div id='tmp'></div></div>"));
-	equals( jQuery("#first").children().length, 1, "Only one child" );
+	equal( jQuery("#first").children().length, 1, "Only one child" );
 	ok( jQuery("#first").children().is(".red"), "Verify Right Element" );
-	equals( jQuery("#first").children().children().children().length, num, "Verify Elements Intact" );
+	equal( jQuery("#first").children().children().children().length, num, "Verify Elements Intact" );
 
 	QUnit.reset();
 	var num = jQuery("#first").children().length;
 	var result = jQuery("#first").wrapInner(val(document.getElementById("empty")));
-	equals( jQuery("#first").children().length, 1, "Only one child" );
+	equal( jQuery("#first").children().length, 1, "Only one child" );
 	ok( jQuery("#first").children().is("#empty"), "Verify Right Element" );
-	equals( jQuery("#first").children().children().length, num, "Verify Elements Intact" );
+	equal( jQuery("#first").children().children().length, num, "Verify Elements Intact" );
 
 	var div = jQuery("<div/>");
 	div.wrapInner(val("<span></span>"));
-	equals(div.children().length, 1, "The contents were wrapped.");
-	equals(div.children()[0].nodeName.toLowerCase(), "span", "A span was inserted.");
+	equal(div.children().length, 1, "The contents were wrapped.");
+	equal(div.children()[0].nodeName.toLowerCase(), "span", "A span was inserted.");
 }
 
 test("wrapInner(String|Element)", function() {
@@ -206,21 +206,21 @@ test("unwrap()", function() {
 	var abcd = jQuery("#unwrap1 > span, #unwrap2 > span").get(),
 		abcdef = jQuery("#unwrap span").get();
 
-	equals( jQuery("#unwrap1 span").add("#unwrap2 span:first").unwrap().length, 3, "make #unwrap1 and #unwrap2 go away" );
-	same( jQuery("#unwrap > span").get(), abcd, "all four spans should still exist" );
+	equal( jQuery("#unwrap1 span").add("#unwrap2 span:first").unwrap().length, 3, "make #unwrap1 and #unwrap2 go away" );
+	deepEqual( jQuery("#unwrap > span").get(), abcd, "all four spans should still exist" );
 
-	same( jQuery("#unwrap3 span").unwrap().get(), jQuery("#unwrap3 > span").get(), "make all b in #unwrap3 go away" );
+	deepEqual( jQuery("#unwrap3 span").unwrap().get(), jQuery("#unwrap3 > span").get(), "make all b in #unwrap3 go away" );
 
-	same( jQuery("#unwrap3 span").unwrap().get(), jQuery("#unwrap > span.unwrap3").get(), "make #unwrap3 go away" );
+	deepEqual( jQuery("#unwrap3 span").unwrap().get(), jQuery("#unwrap > span.unwrap3").get(), "make #unwrap3 go away" );
 
-	same( jQuery("#unwrap").children().get(), abcdef, "#unwrap only contains 6 child spans" );
+	deepEqual( jQuery("#unwrap").children().get(), abcdef, "#unwrap only contains 6 child spans" );
 
-	same( jQuery("#unwrap > span").unwrap().get(), jQuery("body > span.unwrap").get(), "make the 6 spans become children of body" );
+	deepEqual( jQuery("#unwrap > span").unwrap().get(), jQuery("body > span.unwrap").get(), "make the 6 spans become children of body" );
 
-	same( jQuery("body > span.unwrap").unwrap().get(), jQuery("body > span.unwrap").get(), "can't unwrap children of body" );
-	same( jQuery("body > span.unwrap").unwrap().get(), abcdef, "can't unwrap children of body" );
+	deepEqual( jQuery("body > span.unwrap").unwrap().get(), jQuery("body > span.unwrap").get(), "can't unwrap children of body" );
+	deepEqual( jQuery("body > span.unwrap").unwrap().get(), abcdef, "can't unwrap children of body" );
 
-	same( jQuery("body > span.unwrap").get(), abcdef, "body contains 6 .unwrap child spans" );
+	deepEqual( jQuery("body > span.unwrap").get(), abcdef, "body contains 6 .unwrap child spans" );
 
 	jQuery("body > span.unwrap").remove();
 });
@@ -229,23 +229,23 @@ var testAppend = function(valueObj) {
 	expect(41);
 	var defaultText = "Try them out:"
 	var result = jQuery("#first").append(valueObj("<b>buga</b>"));
-	equals( result.text(), defaultText + "buga", "Check if text appending works" );
-	equals( jQuery("#select3").append(valueObj("<option value='appendTest'>Append Test</option>")).find("option:last-child").attr("value"), "appendTest", "Appending html options to select element");
+	equal( result.text(), defaultText + "buga", "Check if text appending works" );
+	equal( jQuery("#select3").append(valueObj("<option value='appendTest'>Append Test</option>")).find("option:last-child").attr("value"), "appendTest", "Appending html options to select element");
 
 	QUnit.reset();
 	var expected = "This link has class=\"blog\": Simon Willison's WeblogTry them out:";
 	jQuery("#sap").append(valueObj(document.getElementById("first")));
-	equals( jQuery("#sap").text(), expected, "Check for appending of element" );
+	equal( jQuery("#sap").text(), expected, "Check for appending of element" );
 
 	QUnit.reset();
 	expected = "This link has class=\"blog\": Simon Willison's WeblogTry them out:Yahoo";
 	jQuery("#sap").append(valueObj([document.getElementById("first"), document.getElementById("yahoo")]));
-	equals( jQuery("#sap").text(), expected, "Check for appending of array of elements" );
+	equal( jQuery("#sap").text(), expected, "Check for appending of array of elements" );
 
 	QUnit.reset();
 	expected = "This link has class=\"blog\": Simon Willison's WeblogYahooTry them out:";
 	jQuery("#sap").append(valueObj(jQuery("#yahoo, #first")));
-	equals( jQuery("#sap").text(), expected, "Check for appending of jQuery object" );
+	equal( jQuery("#sap").text(), expected, "Check for appending of jQuery object" );
 
 	QUnit.reset();
 	jQuery("#sap").append(valueObj( 5 ));
@@ -280,7 +280,7 @@ var testAppend = function(valueObj) {
 
 	QUnit.reset();
 	jQuery("#sap").append(valueObj( document.getElementById("form") ));
-	equals( jQuery("#sap>form").size(), 1, "Check for appending a form" ); // Bug #910
+	equal( jQuery("#sap>form").size(), 1, "Check for appending a form" ); // Bug #910
 
 	QUnit.reset();
 	var pass = true;
@@ -300,7 +300,7 @@ var testAppend = function(valueObj) {
 
 	QUnit.reset();
 	jQuery("#select1").append(valueObj( "<OPTION>Test</OPTION>" ));
-	equals( jQuery("#select1 option:last").text(), "Test", "Appending &lt;OPTION&gt; (all caps)" );
+	equal( jQuery("#select1 option:last").text(), "Test", "Appending &lt;OPTION&gt; (all caps)" );
 
 	jQuery("#table").append(valueObj( "<colgroup></colgroup>" ));
 	ok( jQuery("#table colgroup").length, "Append colgroup" );
@@ -319,12 +319,12 @@ var testAppend = function(valueObj) {
 
 	t( "Append Select", "#appendSelect1, #appendSelect2", ["appendSelect1", "appendSelect2"] );
 
-	equals( "Two nodes", jQuery("<div />").append("Two", " nodes").text(), "Appending two text nodes (#4011)" );
+	equal( "Two nodes", jQuery("<div />").append("Two", " nodes").text(), "Appending two text nodes (#4011)" );
 
 	// using contents will get comments regular, text, and comment nodes
 	var j = jQuery("#nonnodes").contents();
 	var d = jQuery("<div/>").appendTo("#nonnodes").append(j);
-	equals( jQuery("#nonnodes").length, 1, "Check node,textnode,comment append moved leaving just the div" );
+	equal( jQuery("#nonnodes").length, 1, "Check node,textnode,comment append moved leaving just the div" );
 	ok( d.contents().length >= 2, "Check node,textnode,comment append works" );
 	d.contents().appendTo("#nonnodes");
 	d.remove();
@@ -332,7 +332,7 @@ var testAppend = function(valueObj) {
 
 	QUnit.reset();
 	var $input = jQuery("<input />").attr({ "type": "checkbox", "checked": true }).appendTo('#testForm');
-	equals( $input[0].checked, true, "A checked checkbox that is appended stays checked" );
+	equal( $input[0].checked, true, "A checked checkbox that is appended stays checked" );
 
 	QUnit.reset();
 	var $radios = jQuery("input:radio[name='R1']"),
@@ -340,8 +340,8 @@ var testAppend = function(valueObj) {
 		$radio = $radios.eq(1).click();
 	$radioNot[0].checked = false;
 	$radios.parent().wrap("<div></div>");
-	equals( $radio[0].checked, true, "Reappending radios uphold which radio is checked" );
-	equals( $radioNot[0].checked, false, "Reappending radios uphold not being checked" );
+	equal( $radio[0].checked, true, "Reappending radios uphold which radio is checked" );
+	equal( $radioNot[0].checked, false, "Reappending radios uphold not being checked" );
 	QUnit.reset();
 
 	var prev = jQuery("#sap").children().length;
@@ -352,7 +352,7 @@ var testAppend = function(valueObj) {
 		"<span></span>"
 	);
 
-	equals( jQuery("#sap").children().length, prev + 3, "Make sure that multiple arguments works." );
+	equal( jQuery("#sap").children().length, prev + 3, "Make sure that multiple arguments works." );
 	QUnit.reset();
 }
 
@@ -370,16 +370,16 @@ test("append(Function) with incoming value", function() {
 	var defaultText = "Try them out:", old = jQuery("#first").html();
 
 	var result = jQuery("#first").append(function(i, val){
-		equals( val, old, "Make sure the incoming value is correct." );
+		equal( val, old, "Make sure the incoming value is correct." );
 		return "<b>buga</b>";
 	});
-	equals( result.text(), defaultText + "buga", "Check if text appending works" );
+	equal( result.text(), defaultText + "buga", "Check if text appending works" );
 
 	var select = jQuery("#select3");
 	old = select.html();
 
-	equals( select.append(function(i, val){
-		equals( val, old, "Make sure the incoming value is correct." );
+	equal( select.append(function(i, val){
+		equal( val, old, "Make sure the incoming value is correct." );
 		return "<option value='appendTest'>Append Test</option>";
 	}).find("option:last-child").attr("value"), "appendTest", "Appending html options to select element");
 
@@ -388,36 +388,36 @@ test("append(Function) with incoming value", function() {
 	old = jQuery("#sap").html();
 
 	jQuery("#sap").append(function(i, val){
-		equals( val, old, "Make sure the incoming value is correct." );
+		equal( val, old, "Make sure the incoming value is correct." );
 		return document.getElementById("first");
 	});
-	equals( jQuery("#sap").text(), expected, "Check for appending of element" );
+	equal( jQuery("#sap").text(), expected, "Check for appending of element" );
 
 	QUnit.reset();
 	expected = "This link has class=\"blog\": Simon Willison's WeblogTry them out:Yahoo";
 	old = jQuery("#sap").html();
 
 	jQuery("#sap").append(function(i, val){
-		equals( val, old, "Make sure the incoming value is correct." );
+		equal( val, old, "Make sure the incoming value is correct." );
 		return [document.getElementById("first"), document.getElementById("yahoo")];
 	});
-	equals( jQuery("#sap").text(), expected, "Check for appending of array of elements" );
+	equal( jQuery("#sap").text(), expected, "Check for appending of array of elements" );
 
 	QUnit.reset();
 	expected = "This link has class=\"blog\": Simon Willison's WeblogYahooTry them out:";
 	old = jQuery("#sap").html();
 
 	jQuery("#sap").append(function(i, val){
-		equals( val, old, "Make sure the incoming value is correct." );
+		equal( val, old, "Make sure the incoming value is correct." );
 		return jQuery("#yahoo, #first");
 	});
-	equals( jQuery("#sap").text(), expected, "Check for appending of jQuery object" );
+	equal( jQuery("#sap").text(), expected, "Check for appending of jQuery object" );
 
 	QUnit.reset();
 	old = jQuery("#sap").html();
 
 	jQuery("#sap").append(function(i, val){
-		equals( val, old, "Make sure the incoming value is correct." );
+		equal( val, old, "Make sure the incoming value is correct." );
 		return 5;
 	});
 	ok( jQuery("#sap")[0].innerHTML.match( /5$/ ), "Check for appending a number" );
@@ -545,8 +545,8 @@ test("appendTo(String|Element|Array&lt;Element&gt;|jQuery)", function() {
 
 	var defaultText = "Try them out:"
 	jQuery("<b>buga</b>").appendTo("#first");
-	equals( jQuery("#first").text(), defaultText + "buga", "Check if text appending works" );
-	equals( jQuery("<option value='appendTest'>Append Test</option>").appendTo("#select3").parent().find("option:last-child").attr("value"), "appendTest", "Appending html options to select element");
+	equal( jQuery("#first").text(), defaultText + "buga", "Check if text appending works" );
+	equal( jQuery("<option value='appendTest'>Append Test</option>").appendTo("#select3").parent().find("option:last-child").attr("value"), "appendTest", "Appending html options to select element");
 
 	QUnit.reset();
 	var l = jQuery("#first").children().length + 2;
@@ -554,18 +554,18 @@ test("appendTo(String|Element|Array&lt;Element&gt;|jQuery)", function() {
 	jQuery("<strong>test</strong>");
 	jQuery([ jQuery("<strong>test</strong>")[0], jQuery("<strong>test</strong>")[0] ])
 		.appendTo("#first");
-	equals( jQuery("#first").children().length, l, "Make sure the elements were inserted." );
-	equals( jQuery("#first").children().last()[0].nodeName.toLowerCase(), "strong", "Verify the last element." );
+	equal( jQuery("#first").children().length, l, "Make sure the elements were inserted." );
+	equal( jQuery("#first").children().last()[0].nodeName.toLowerCase(), "strong", "Verify the last element." );
 
 	QUnit.reset();
 	var expected = "This link has class=\"blog\": Simon Willison's WeblogTry them out:";
 	jQuery(document.getElementById("first")).appendTo("#sap");
-	equals( jQuery("#sap").text(), expected, "Check for appending of element" );
+	equal( jQuery("#sap").text(), expected, "Check for appending of element" );
 
 	QUnit.reset();
 	expected = "This link has class=\"blog\": Simon Willison's WeblogTry them out:Yahoo";
 	jQuery([document.getElementById("first"), document.getElementById("yahoo")]).appendTo("#sap");
-	equals( jQuery("#sap").text(), expected, "Check for appending of array of elements" );
+	equal( jQuery("#sap").text(), expected, "Check for appending of array of elements" );
 
 	QUnit.reset();
 	ok( jQuery(document.createElement("script")).appendTo("body").length, "Make sure a disconnected script can be appended." );
@@ -573,7 +573,7 @@ test("appendTo(String|Element|Array&lt;Element&gt;|jQuery)", function() {
 	QUnit.reset();
 	expected = "This link has class=\"blog\": Simon Willison's WeblogYahooTry them out:";
 	jQuery("#yahoo, #first").appendTo("#sap");
-	equals( jQuery("#sap").text(), expected, "Check for appending of jQuery object" );
+	equal( jQuery("#sap").text(), expected, "Check for appending of jQuery object" );
 
 	QUnit.reset();
 	jQuery("#select1").appendTo("#foo");
@@ -591,7 +591,7 @@ test("appendTo(String|Element|Array&lt;Element&gt;|jQuery)", function() {
 	QUnit.reset();
 	div = jQuery("<div/>").appendTo("#qunit-fixture, #moretests");
 
-	equals( div.length, 2, "appendTo returns the inserted elements" );
+	equal( div.length, 2, "appendTo returns the inserted elements" );
 
 	div.addClass("test");
 
@@ -603,14 +603,14 @@ test("appendTo(String|Element|Array&lt;Element&gt;|jQuery)", function() {
 	div = jQuery("<div/>");
 	jQuery("<span>a</span><b>b</b>").filter("span").appendTo( div );
 
-	equals( div.children().length, 1, "Make sure the right number of children were inserted." );
+	equal( div.children().length, 1, "Make sure the right number of children were inserted." );
 
 	div = jQuery("#moretests div");
 
 	var num = jQuery("#qunit-fixture div").length;
 	div.remove().appendTo("#qunit-fixture");
 
-	equals( jQuery("#qunit-fixture div").length, num, "Make sure all the removed divs were inserted." );
+	equal( jQuery("#qunit-fixture div").length, num, "Make sure all the removed divs were inserted." );
 
 	QUnit.reset();
 
@@ -625,23 +625,23 @@ var testPrepend = function(val) {
 	expect(5);
 	var defaultText = "Try them out:"
 	var result = jQuery("#first").prepend(val( "<b>buga</b>" ));
-	equals( result.text(), "buga" + defaultText, "Check if text prepending works" );
-	equals( jQuery("#select3").prepend(val( "<option value='prependTest'>Prepend Test</option>" )).find("option:first-child").attr("value"), "prependTest", "Prepending html options to select element");
+	equal( result.text(), "buga" + defaultText, "Check if text prepending works" );
+	equal( jQuery("#select3").prepend(val( "<option value='prependTest'>Prepend Test</option>" )).find("option:first-child").attr("value"), "prependTest", "Prepending html options to select element");
 
 	QUnit.reset();
 	var expected = "Try them out:This link has class=\"blog\": Simon Willison's Weblog";
 	jQuery("#sap").prepend(val( document.getElementById("first") ));
-	equals( jQuery("#sap").text(), expected, "Check for prepending of element" );
+	equal( jQuery("#sap").text(), expected, "Check for prepending of element" );
 
 	QUnit.reset();
 	expected = "Try them out:YahooThis link has class=\"blog\": Simon Willison's Weblog";
 	jQuery("#sap").prepend(val( [document.getElementById("first"), document.getElementById("yahoo")] ));
-	equals( jQuery("#sap").text(), expected, "Check for prepending of array of elements" );
+	equal( jQuery("#sap").text(), expected, "Check for prepending of array of elements" );
 
 	QUnit.reset();
 	expected = "YahooTry them out:This link has class=\"blog\": Simon Willison's Weblog";
 	jQuery("#sap").prepend(val( jQuery("#yahoo, #first") ));
-	equals( jQuery("#sap").text(), expected, "Check for prepending of jQuery object" );
+	equal( jQuery("#sap").text(), expected, "Check for prepending of jQuery object" );
 };
 
 test("prepend(String|Element|Array&lt;Element&gt;|jQuery)", function() {
@@ -657,15 +657,15 @@ test("prepend(Function) with incoming value", function() {
 
 	var defaultText = "Try them out:", old = jQuery("#first").html();
 	var result = jQuery("#first").prepend(function(i, val) {
-		equals( val, old, "Make sure the incoming value is correct." );
+		equal( val, old, "Make sure the incoming value is correct." );
 		return "<b>buga</b>";
 	});
-	equals( result.text(), "buga" + defaultText, "Check if text prepending works" );
+	equal( result.text(), "buga" + defaultText, "Check if text prepending works" );
 
 	old = jQuery("#select3").html();
 
-	equals( jQuery("#select3").prepend(function(i, val) {
-		equals( val, old, "Make sure the incoming value is correct." );
+	equal( jQuery("#select3").prepend(function(i, val) {
+		equal( val, old, "Make sure the incoming value is correct." );
 		return "<option value='prependTest'>Prepend Test</option>";
 	}).find("option:first-child").attr("value"), "prependTest", "Prepending html options to select element");
 
@@ -674,56 +674,56 @@ test("prepend(Function) with incoming value", function() {
 	old = jQuery("#sap").html();
 
 	jQuery("#sap").prepend(function(i, val) {
-		equals( val, old, "Make sure the incoming value is correct." );
+		equal( val, old, "Make sure the incoming value is correct." );
 		return document.getElementById("first");
 	});
 
-	equals( jQuery("#sap").text(), expected, "Check for prepending of element" );
+	equal( jQuery("#sap").text(), expected, "Check for prepending of element" );
 
 	QUnit.reset();
 	expected = "Try them out:YahooThis link has class=\"blog\": Simon Willison's Weblog";
 	old = jQuery("#sap").html();
 
 	jQuery("#sap").prepend(function(i, val) {
-		equals( val, old, "Make sure the incoming value is correct." );
+		equal( val, old, "Make sure the incoming value is correct." );
 		return [document.getElementById("first"), document.getElementById("yahoo")];
 	});
 
-	equals( jQuery("#sap").text(), expected, "Check for prepending of array of elements" );
+	equal( jQuery("#sap").text(), expected, "Check for prepending of array of elements" );
 
 	QUnit.reset();
 	expected = "YahooTry them out:This link has class=\"blog\": Simon Willison's Weblog";
 	old = jQuery("#sap").html();
 
 	jQuery("#sap").prepend(function(i, val) {
-		equals( val, old, "Make sure the incoming value is correct." );
+		equal( val, old, "Make sure the incoming value is correct." );
 		return jQuery("#yahoo, #first");
 	});
 
-	equals( jQuery("#sap").text(), expected, "Check for prepending of jQuery object" );
+	equal( jQuery("#sap").text(), expected, "Check for prepending of jQuery object" );
 });
 
 test("prependTo(String|Element|Array&lt;Element&gt;|jQuery)", function() {
 	expect(6);
 	var defaultText = "Try them out:"
 	jQuery("<b>buga</b>").prependTo("#first");
-	equals( jQuery("#first").text(), "buga" + defaultText, "Check if text prepending works" );
-	equals( jQuery("<option value='prependTest'>Prepend Test</option>").prependTo("#select3").parent().find("option:first-child").attr("value"), "prependTest", "Prepending html options to select element");
+	equal( jQuery("#first").text(), "buga" + defaultText, "Check if text prepending works" );
+	equal( jQuery("<option value='prependTest'>Prepend Test</option>").prependTo("#select3").parent().find("option:first-child").attr("value"), "prependTest", "Prepending html options to select element");
 
 	QUnit.reset();
 	var expected = "Try them out:This link has class=\"blog\": Simon Willison's Weblog";
 	jQuery(document.getElementById("first")).prependTo("#sap");
-	equals( jQuery("#sap").text(), expected, "Check for prepending of element" );
+	equal( jQuery("#sap").text(), expected, "Check for prepending of element" );
 
 	QUnit.reset();
 	expected = "Try them out:YahooThis link has class=\"blog\": Simon Willison's Weblog";
 	jQuery([document.getElementById("first"), document.getElementById("yahoo")]).prependTo("#sap");
-	equals( jQuery("#sap").text(), expected, "Check for prepending of array of elements" );
+	equal( jQuery("#sap").text(), expected, "Check for prepending of array of elements" );
 
 	QUnit.reset();
 	expected = "YahooTry them out:This link has class=\"blog\": Simon Willison's Weblog";
 	jQuery("#yahoo, #first").prependTo("#sap");
-	equals( jQuery("#sap").text(), expected, "Check for prepending of jQuery object" );
+	equal( jQuery("#sap").text(), expected, "Check for prepending of jQuery object" );
 
 	QUnit.reset();
 	jQuery("<select id='prependSelect1'></select>").prependTo("form:last");
@@ -736,26 +736,26 @@ var testBefore = function(val) {
 	expect(6);
 	var expected = "This is a normal link: bugaYahoo";
 	jQuery("#yahoo").before(val( "<b>buga</b>" ));
-	equals( jQuery("#en").text(), expected, "Insert String before" );
+	equal( jQuery("#en").text(), expected, "Insert String before" );
 
 	QUnit.reset();
 	expected = "This is a normal link: Try them out:Yahoo";
 	jQuery("#yahoo").before(val( document.getElementById("first") ));
-	equals( jQuery("#en").text(), expected, "Insert element before" );
+	equal( jQuery("#en").text(), expected, "Insert element before" );
 
 	QUnit.reset();
 	expected = "This is a normal link: Try them out:diveintomarkYahoo";
 	jQuery("#yahoo").before(val( [document.getElementById("first"), document.getElementById("mark")] ));
-	equals( jQuery("#en").text(), expected, "Insert array of elements before" );
+	equal( jQuery("#en").text(), expected, "Insert array of elements before" );
 
 	QUnit.reset();
 	expected = "This is a normal link: diveintomarkTry them out:Yahoo";
 	jQuery("#yahoo").before(val( jQuery("#mark, #first") ));
-	equals( jQuery("#en").text(), expected, "Insert jQuery before" );
+	equal( jQuery("#en").text(), expected, "Insert jQuery before" );
 
 	var set = jQuery("<div/>").before("<span>test</span>");
-	equals( set[0].nodeName.toLowerCase(), "span", "Insert the element before the disconnected node." );
-	equals( set.length, 2, "Insert the element before the disconnected node." );
+	equal( set[0].nodeName.toLowerCase(), "span", "Insert the element before the disconnected node." );
+	equal( set.length, 2, "Insert the element before the disconnected node." );
 }
 
 test("before(String|Element|Array&lt;Element&gt;|jQuery)", function() {
@@ -770,48 +770,48 @@ test("insertBefore(String|Element|Array&lt;Element&gt;|jQuery)", function() {
 	expect(4);
 	var expected = "This is a normal link: bugaYahoo";
 	jQuery("<b>buga</b>").insertBefore("#yahoo");
-	equals( jQuery("#en").text(), expected, "Insert String before" );
+	equal( jQuery("#en").text(), expected, "Insert String before" );
 
 	QUnit.reset();
 	expected = "This is a normal link: Try them out:Yahoo";
 	jQuery(document.getElementById("first")).insertBefore("#yahoo");
-	equals( jQuery("#en").text(), expected, "Insert element before" );
+	equal( jQuery("#en").text(), expected, "Insert element before" );
 
 	QUnit.reset();
 	expected = "This is a normal link: Try them out:diveintomarkYahoo";
 	jQuery([document.getElementById("first"), document.getElementById("mark")]).insertBefore("#yahoo");
-	equals( jQuery("#en").text(), expected, "Insert array of elements before" );
+	equal( jQuery("#en").text(), expected, "Insert array of elements before" );
 
 	QUnit.reset();
 	expected = "This is a normal link: diveintomarkTry them out:Yahoo";
 	jQuery("#mark, #first").insertBefore("#yahoo");
-	equals( jQuery("#en").text(), expected, "Insert jQuery before" );
+	equal( jQuery("#en").text(), expected, "Insert jQuery before" );
 });
 
 var testAfter = function(val) {
 	expect(6);
 	var expected = "This is a normal link: Yahoobuga";
 	jQuery("#yahoo").after(val( "<b>buga</b>" ));
-	equals( jQuery("#en").text(), expected, "Insert String after" );
+	equal( jQuery("#en").text(), expected, "Insert String after" );
 
 	QUnit.reset();
 	expected = "This is a normal link: YahooTry them out:";
 	jQuery("#yahoo").after(val( document.getElementById("first") ));
-	equals( jQuery("#en").text(), expected, "Insert element after" );
+	equal( jQuery("#en").text(), expected, "Insert element after" );
 
 	QUnit.reset();
 	expected = "This is a normal link: YahooTry them out:diveintomark";
 	jQuery("#yahoo").after(val( [document.getElementById("first"), document.getElementById("mark")] ));
-	equals( jQuery("#en").text(), expected, "Insert array of elements after" );
+	equal( jQuery("#en").text(), expected, "Insert array of elements after" );
 
 	QUnit.reset();
 	expected = "This is a normal link: YahoodiveintomarkTry them out:";
 	jQuery("#yahoo").after(val( jQuery("#mark, #first") ));
-	equals( jQuery("#en").text(), expected, "Insert jQuery after" );
+	equal( jQuery("#en").text(), expected, "Insert jQuery after" );
 
 	var set = jQuery("<div/>").after("<span>test</span>");
-	equals( set[1].nodeName.toLowerCase(), "span", "Insert the element after the disconnected node." );
-	equals( set.length, 2, "Insert the element after the disconnected node." );
+	equal( set[1].nodeName.toLowerCase(), "span", "Insert the element after the disconnected node." );
+	equal( set.length, 2, "Insert the element after the disconnected node." );
 };
 
 test("after(String|Element|Array&lt;Element&gt;|jQuery)", function() {
@@ -826,22 +826,22 @@ test("insertAfter(String|Element|Array&lt;Element&gt;|jQuery)", function() {
 	expect(4);
 	var expected = "This is a normal link: Yahoobuga";
 	jQuery("<b>buga</b>").insertAfter("#yahoo");
-	equals( jQuery("#en").text(), expected, "Insert String after" );
+	equal( jQuery("#en").text(), expected, "Insert String after" );
 
 	QUnit.reset();
 	expected = "This is a normal link: YahooTry them out:";
 	jQuery(document.getElementById("first")).insertAfter("#yahoo");
-	equals( jQuery("#en").text(), expected, "Insert element after" );
+	equal( jQuery("#en").text(), expected, "Insert element after" );
 
 	QUnit.reset();
 	expected = "This is a normal link: YahooTry them out:diveintomark";
 	jQuery([document.getElementById("first"), document.getElementById("mark")]).insertAfter("#yahoo");
-	equals( jQuery("#en").text(), expected, "Insert array of elements after" );
+	equal( jQuery("#en").text(), expected, "Insert array of elements after" );
 
 	QUnit.reset();
 	expected = "This is a normal link: YahoodiveintomarkTry them out:";
 	jQuery("#mark, #first").insertAfter("#yahoo");
-	equals( jQuery("#en").text(), expected, "Insert jQuery after" );
+	equal( jQuery("#en").text(), expected, "Insert jQuery after" );
 });
 
 var testReplaceWith = function(val) {
@@ -858,7 +858,7 @@ var testReplaceWith = function(val) {
 	QUnit.reset();
 	jQuery("#qunit-fixture").append("<div id='bar'><div id='baz'</div></div>");
 	jQuery("#baz").replaceWith("Baz");
-	equals( jQuery("#bar").text(),"Baz", "Replace element with text" );
+	equal( jQuery("#bar").text(),"Baz", "Replace element with text" );
 	ok( !jQuery("#baz")[0], "Verify that original element is gone, after element" );
 
 	QUnit.reset();
@@ -903,30 +903,30 @@ var testReplaceWith = function(val) {
 	QUnit.reset();
 
 	var set = jQuery("<div/>").replaceWith(val("<span>test</span>"));
-	equals( set[0].nodeName.toLowerCase(), "span", "Replace the disconnected node." );
-	equals( set.length, 1, "Replace the disconnected node." );
+	equal( set[0].nodeName.toLowerCase(), "span", "Replace the disconnected node." );
+	equal( set.length, 1, "Replace the disconnected node." );
 
 	var non_existant = jQuery("#does-not-exist").replaceWith( val("<b>should not throw an error</b>") );
-	equals( non_existant.length, 0, "Length of non existant element." );
+	equal( non_existant.length, 0, "Length of non existant element." );
 
 	var $div = jQuery("<div class='replacewith'></div>").appendTo("body");
 	// TODO: Work on jQuery(...) inline script execution
 	//$div.replaceWith("<div class='replacewith'></div><script>" +
-		//"equals(jQuery('.replacewith').length, 1, 'Check number of elements in page.');" +
+		//"equal(jQuery('.replacewith').length, 1, 'Check number of elements in page.');" +
 		//"</script>");
-	equals(jQuery(".replacewith").length, 1, "Check number of elements in page.");
+	equal(jQuery(".replacewith").length, 1, "Check number of elements in page.");
 	jQuery(".replacewith").remove();
 
 	QUnit.reset();
 
 	jQuery("#qunit-fixture").append("<div id='replaceWith'></div>");
-	equals( jQuery("#qunit-fixture").find("div[id=replaceWith]").length, 1, "Make sure only one div exists." );
+	equal( jQuery("#qunit-fixture").find("div[id=replaceWith]").length, 1, "Make sure only one div exists." );
 
 	jQuery("#replaceWith").replaceWith( val("<div id='replaceWith'></div>") );
-	equals( jQuery("#qunit-fixture").find("div[id=replaceWith]").length, 1, "Make sure only one div exists." );
+	equal( jQuery("#qunit-fixture").find("div[id=replaceWith]").length, 1, "Make sure only one div exists." );
 
 	jQuery("#replaceWith").replaceWith( val("<div id='replaceWith'></div>") );
-	equals( jQuery("#qunit-fixture").find("div[id=replaceWith]").length, 1, "Make sure only one div exists." );
+	equal( jQuery("#qunit-fixture").find("div[id=replaceWith]").length, 1, "Make sure only one div exists." );
 }
 
 test("replaceWith(String|Element|Array&lt;Element&gt;|jQuery)", function() {
@@ -941,7 +941,7 @@ test("replaceWith(Function)", function() {
 	var y = jQuery("#yahoo")[0];
 
 	jQuery(y).replaceWith(function(){
-		equals( this, y, "Make sure the context is coming in correctly." );
+		equal( this, y, "Make sure the context is coming in correctly." );
 	});
 
 	QUnit.reset();
@@ -950,11 +950,11 @@ test("replaceWith(Function)", function() {
 test("replaceWith(string) for more than one element", function(){
 	expect(3);
 
-	equals(jQuery("#foo p").length, 3, "ensuring that test data has not changed");
+	equal(jQuery("#foo p").length, 3, "ensuring that test data has not changed");
 
 	jQuery("#foo p").replaceWith("<span>bar</span>");
-	equals(jQuery("#foo span").length, 3, "verify that all the three original element have been replaced");
-	equals(jQuery("#foo p").length, 0, "verify that all the three original element have been replaced");
+	equal(jQuery("#foo span").length, 3, "verify that all the three original element have been replaced");
+	equal(jQuery("#foo p").length, 0, "verify that all the three original element have been replaced");
 });
 
 test("replaceAll(String|Element|Array&lt;Element&gt;|jQuery)", function() {
@@ -990,7 +990,7 @@ test("jQuery.clone() (#8017)", function() {
 	var main = jQuery("#qunit-fixture")[0],
 			clone = jQuery.clone( main );
 
-	equals( main.childNodes.length, clone.childNodes.length, "Simple child length to ensure a large dom tree copies correctly" );
+	equal( main.childNodes.length, clone.childNodes.length, "Simple child length to ensure a large dom tree copies correctly" );
 });
 
 test("clone() (#8070)", function () {
@@ -1000,18 +1000,18 @@ test("clone() (#8070)", function () {
 	var selects = jQuery(".test8070");
 	selects.append("<OPTION>1</OPTION><OPTION>2</OPTION>");
 
-	equals( selects[0].childNodes.length, 2, "First select got two nodes" );
-	equals( selects[1].childNodes.length, 2, "Second select got two nodes" );
+	equal( selects[0].childNodes.length, 2, "First select got two nodes" );
+	equal( selects[1].childNodes.length, 2, "Second select got two nodes" );
 
 	selects.remove();
 });
 
 test("clone()", function() {
 	expect(40);
-	equals( "This is a normal link: Yahoo", jQuery("#en").text(), "Assert text for #en" );
+	equal( "This is a normal link: Yahoo", jQuery("#en").text(), "Assert text for #en" );
 	var clone = jQuery("#yahoo").clone();
-	equals( "Try them out:Yahoo", jQuery("#first").append(clone).text(), "Check for clone" );
-	equals( "This is a normal link: Yahoo", jQuery("#en").text(), "Reassert text for #en" );
+	equal( "Try them out:Yahoo", jQuery("#first").append(clone).text(), "Check for clone" );
+	equal( "This is a normal link: Yahoo", jQuery("#en").text(), "Reassert text for #en" );
 
 	var cloneTags = [
 		"<table/>", "<tr/>", "<td/>", "<div/>",
@@ -1021,7 +1021,7 @@ test("clone()", function() {
 	];
 	for (var i = 0; i < cloneTags.length; i++) {
 		var j = jQuery(cloneTags[i]);
-		equals( j[0].tagName, j.clone()[0].tagName, "Clone a " + cloneTags[i]);
+		equal( j[0].tagName, j.clone()[0].tagName, "Clone a " + cloneTags[i]);
 	}
 
 	// using contents will get comments regular, text, and comment nodes
@@ -1042,8 +1042,8 @@ test("clone()", function() {
 	// manually clean up detached elements
 	clone.remove();
 
-	equals( div.length, 1, "One element cloned" );
-	equals( div[0].nodeName.toUpperCase(), "DIV", "DIV element cloned" );
+	equal( div.length, 1, "One element cloned" );
+	equal( div[0].nodeName.toUpperCase(), "DIV", "DIV element cloned" );
 	div.trigger("click");
 
 	// manually clean up detached elements
@@ -1055,8 +1055,8 @@ test("clone()", function() {
 	});
 
 	clone = div.clone(true);
-	equals( clone.length, 1, "One element cloned" );
-	equals( clone[0].nodeName.toUpperCase(), "DIV", "DIV element cloned" );
+	equal( clone.length, 1, "One element cloned" );
+	equal( clone[0].nodeName.toUpperCase(), "DIV", "DIV element cloned" );
 	clone.find("table:last").trigger("click");
 
 	// manually clean up detached elements
@@ -1078,9 +1078,9 @@ test("clone()", function() {
 	div = jQuery("<div/>").html('<embed height="355" width="425" src="http://www.youtube.com/v/3KANI2dpXLw&amp;hl=en"></embed>');
 
 	clone = div.clone(true);
-	equals( clone.length, 1, "One element cloned" );
-	equals( clone.html(), div.html(), "Element contents cloned" );
-	equals( clone[0].nodeName.toUpperCase(), "DIV", "DIV element cloned" );
+	equal( clone.length, 1, "One element cloned" );
+	equal( clone.html(), div.html(), "Element contents cloned" );
+	equal( clone[0].nodeName.toUpperCase(), "DIV", "DIV element cloned" );
 
 	// this is technically an invalid object, but because of the special
 	// classid instantiation it is the only kind that IE has trouble with,
@@ -1088,24 +1088,24 @@ test("clone()", function() {
 	div = jQuery("<div/>").html("<object height='355' width='425' classid='clsid:D27CDB6E-AE6D-11cf-96B8-444553540000'>  <param name='movie' value='http://www.youtube.com/v/3KANI2dpXLw&amp;hl=en'>  <param name='wmode' value='transparent'> </object>");
 
 	clone = div.clone(true);
-	equals( clone.length, 1, "One element cloned" );
-	equals( clone.html(), div.html(), "Element contents cloned" );
-	equals( clone[0].nodeName.toUpperCase(), "DIV", "DIV element cloned" );
+	equal( clone.length, 1, "One element cloned" );
+	equal( clone.html(), div.html(), "Element contents cloned" );
+	equal( clone[0].nodeName.toUpperCase(), "DIV", "DIV element cloned" );
 
 	// and here's a valid one.
 	div = jQuery("<div/>").html("<object height='355' width='425' type='application/x-shockwave-flash' data='http://www.youtube.com/v/3KANI2dpXLw&amp;hl=en'>  <param name='movie' value='http://www.youtube.com/v/3KANI2dpXLw&amp;hl=en'>  <param name='wmode' value='transparent'> </object>");
 
 	clone = div.clone(true);
-	equals( clone.length, 1, "One element cloned" );
-	equals( clone.html(), div.html(), "Element contents cloned" );
-	equals( clone[0].nodeName.toUpperCase(), "DIV", "DIV element cloned" );
+	equal( clone.length, 1, "One element cloned" );
+	equal( clone.html(), div.html(), "Element contents cloned" );
+	equal( clone[0].nodeName.toUpperCase(), "DIV", "DIV element cloned" );
 
 	div = jQuery("<div/>").data({ a: true });
 	clone = div.clone(true);
-	equals( clone.data("a"), true, "Data cloned." );
+	equal( clone.data("a"), true, "Data cloned." );
 	clone.data("a", false);
-	equals( clone.data("a"), false, "Ensure cloned element data object was correctly modified" );
-	equals( div.data("a"), true, "Ensure cloned element data object is copied, not referenced" );
+	equal( clone.data("a"), false, "Ensure cloned element data object was correctly modified" );
+	equal( div.data("a"), true, "Ensure cloned element data object is copied, not referenced" );
 
 	// manually clean up detached elements
 	div.remove();
@@ -1117,7 +1117,7 @@ test("clone()", function() {
 	div.appendChild( document.createTextNode("test") );
 	form.appendChild( div );
 
-	equals( jQuery(form).clone().children().length, 1, "Make sure we just get the form back." );
+	equal( jQuery(form).clone().children().length, 1, "Make sure we just get the form back." );
 
 	equal( jQuery("body").clone().children()[0].id, "qunit-header", "Make sure cloning body works" );
 });
@@ -1126,31 +1126,31 @@ test("clone(form element) (Bug #3879, #6655)", function() {
 	expect(5);
 	var element = jQuery("<select><option>Foo</option><option selected>Bar</option></select>");
 
-	equals( element.clone().find("option:selected").val(), element.find("option:selected").val(), "Selected option cloned correctly" );
+	equal( element.clone().find("option:selected").val(), element.find("option:selected").val(), "Selected option cloned correctly" );
 
 	element = jQuery("<input type='checkbox' value='foo'>").attr("checked", "checked");
 	clone = element.clone();
 
-	equals( clone.is(":checked"), element.is(":checked"), "Checked input cloned correctly" );
-	equals( clone[0].defaultValue, "foo", "Checked input defaultValue cloned correctly" );
+	equal( clone.is(":checked"), element.is(":checked"), "Checked input cloned correctly" );
+	equal( clone[0].defaultValue, "foo", "Checked input defaultValue cloned correctly" );
 
 	// defaultChecked also gets set now due to setAttribute in attr, is this check still valid?
-	// equals( clone[0].defaultChecked, !jQuery.support.noCloneChecked, "Checked input defaultChecked cloned correctly" );
+	// equal( clone[0].defaultChecked, !jQuery.support.noCloneChecked, "Checked input defaultChecked cloned correctly" );
 
 	element = jQuery("<input type='text' value='foo'>");
 	clone = element.clone();
-	equals( clone[0].defaultValue, "foo", "Text input defaultValue cloned correctly" );
+	equal( clone[0].defaultValue, "foo", "Text input defaultValue cloned correctly" );
 
 	element = jQuery("<textarea>foo</textarea>");
 	clone = element.clone();
-	equals( clone[0].defaultValue, "foo", "Textarea defaultValue cloned correctly" );
+	equal( clone[0].defaultValue, "foo", "Textarea defaultValue cloned correctly" );
 });
 
 test("clone(multiple selected options) (Bug #8129)", function() {
 	expect(1);
 	var element = jQuery("<select><option>Foo</option><option selected>Bar</option><option selected>Baz</option></select>");
 
-	equals( element.clone().find("option:selected").length, element.find("option:selected").length, "Multiple selected options cloned correctly" );
+	equal( element.clone().find("option:selected").length, element.find("option:selected").length, "Multiple selected options cloned correctly" );
 
 });
 
@@ -1164,8 +1164,8 @@ test("clone() on XML nodes", function() {
 		var cloneTab = jQuery("tab", root).eq(0);
 		origTab.text("origval");
 		cloneTab.text("cloneval");
-		equals(origTab.text(), "origval", "Check original XML node was correctly set");
-		equals(cloneTab.text(), "cloneval", "Check cloned XML node was correctly set");
+		equal(origTab.text(), "origval", "Check original XML node was correctly set");
+		equal(cloneTab.text(), "cloneval", "Check cloned XML node was correctly set");
 		start();
 	});
 });
@@ -1186,17 +1186,17 @@ var testHtml = function(valueObj) {
 
 	div = jQuery("<div/>").html( valueObj("<div id='parent_1'><div id='child_1'/></div><div id='parent_2'/>") );
 
-	equals( div.children().length, 2, "Make sure two child nodes exist." );
-	equals( div.children().children().length, 1, "Make sure that a grandchild exists." );
+	equal( div.children().length, 2, "Make sure two child nodes exist." );
+	equal( div.children().children().length, 1, "Make sure that a grandchild exists." );
 
 	var space = jQuery("<div/>").html(valueObj("&#160;"))[0].innerHTML;
 	ok( /^\xA0$|^&nbsp;$/.test( space ), "Make sure entities are passed through correctly." );
-	equals( jQuery("<div/>").html(valueObj("&amp;"))[0].innerHTML, "&amp;", "Make sure entities are passed through correctly." );
+	equal( jQuery("<div/>").html(valueObj("&amp;"))[0].innerHTML, "&amp;", "Make sure entities are passed through correctly." );
 
 	jQuery("#qunit-fixture").html(valueObj("<style>.foobar{color:green;}</style>"));
 
-	equals( jQuery("#qunit-fixture").children().length, 1, "Make sure there is a child element." );
-	equals( jQuery("#qunit-fixture").children()[0].nodeName.toUpperCase(), "STYLE", "And that a style element was inserted." );
+	equal( jQuery("#qunit-fixture").children().length, 1, "Make sure there is a child element." );
+	equal( jQuery("#qunit-fixture").children()[0].nodeName.toUpperCase(), "STYLE", "And that a style element was inserted." );
 
 	QUnit.reset();
 	// using contents will get comments regular, text, and comment nodes
@@ -1205,25 +1205,25 @@ var testHtml = function(valueObj) {
 
 	// this is needed, or the expando added by jQuery unique will yield a different html
 	j.find("b").removeData();
-	equals( j.html().replace(/ xmlns="[^"]+"/g, "").toLowerCase(), "<b>bold</b>", "Check node,textnode,comment with html()" );
+	equal( j.html().replace(/ xmlns="[^"]+"/g, "").toLowerCase(), "<b>bold</b>", "Check node,textnode,comment with html()" );
 
 	jQuery("#qunit-fixture").html(valueObj("<select/>"));
 	jQuery("#qunit-fixture select").html(valueObj("<option>O1</option><option selected='selected'>O2</option><option>O3</option>"));
-	equals( jQuery("#qunit-fixture select").val(), "O2", "Selected option correct" );
+	equal( jQuery("#qunit-fixture select").val(), "O2", "Selected option correct" );
 
 	var $div = jQuery("<div />");
-	equals( $div.html(valueObj( 5 )).html(), "5", "Setting a number as html" );
-	equals( $div.html(valueObj( 0 )).html(), "0", "Setting a zero as html" );
+	equal( $div.html(valueObj( 5 )).html(), "5", "Setting a number as html" );
+	equal( $div.html(valueObj( 0 )).html(), "0", "Setting a zero as html" );
 
 	var $div2 = jQuery("<div/>"), insert = "&lt;div&gt;hello1&lt;/div&gt;";
-	equals( $div2.html(insert).html().replace(/>/g, "&gt;"), insert, "Verify escaped insertion." );
-	equals( $div2.html("x" + insert).html().replace(/>/g, "&gt;"), "x" + insert, "Verify escaped insertion." );
-	equals( $div2.html(" " + insert).html().replace(/>/g, "&gt;"), " " + insert, "Verify escaped insertion." );
+	equal( $div2.html(insert).html().replace(/>/g, "&gt;"), insert, "Verify escaped insertion." );
+	equal( $div2.html("x" + insert).html().replace(/>/g, "&gt;"), "x" + insert, "Verify escaped insertion." );
+	equal( $div2.html(" " + insert).html().replace(/>/g, "&gt;"), " " + insert, "Verify escaped insertion." );
 
 	var map = jQuery("<map/>").html(valueObj("<area id='map01' shape='rect' coords='50,50,150,150' href='http://www.jquery.com/' alt='jQuery'>"));
 
-	equals( map[0].childNodes.length, 1, "The area was inserted." );
-	equals( map[0].firstChild.nodeName.toLowerCase(), "area", "The area was inserted." );
+	equal( map[0].childNodes.length, 1, "The area was inserted." );
+	equal( map[0].firstChild.nodeName.toLowerCase(), "area", "The area was inserted." );
 
 	QUnit.reset();
 
@@ -1231,9 +1231,9 @@ var testHtml = function(valueObj) {
 
 	var child = jQuery("#qunit-fixture").find("script");
 
-	equals( child.length, 2, "Make sure that two non-JavaScript script tags are left." );
-	equals( child[0].type, "something/else", "Verify type of script tag." );
-	equals( child[1].type, "something/else", "Verify type of script tag." );
+	equal( child.length, 2, "Make sure that two non-JavaScript script tags are left." );
+	equal( child[0].type, "something/else", "Verify type of script tag." );
+	equal( child[1].type, "something/else", "Verify type of script tag." );
 
 	jQuery("#qunit-fixture").html(valueObj("<script>ok( true, 'Test repeated injection of script.' );</script>"));
 	jQuery("#qunit-fixture").html(valueObj("<script>ok( true, 'Test repeated injection of script.' );</script>"));
@@ -1243,7 +1243,7 @@ var testHtml = function(valueObj) {
 
 	jQuery("#qunit-fixture").html(valueObj("foo <form><script type='text/javascript'>ok( true, 'jQuery().html().evalScripts() Evals Scripts Twice in Firefox, see #975 (2)' );</script></form>"));
 
-	jQuery("#qunit-fixture").html(valueObj("<script>equals(jQuery.scriptorder++, 0, 'Script is executed in order');equals(jQuery('#scriptorder').length, 1,'Execute after html (even though appears before)')<\/script><span id='scriptorder'><script>equals(jQuery.scriptorder++, 1, 'Script (nested) is executed in order');equals(jQuery('#scriptorder').length, 1,'Execute after html')<\/script></span><script>equals(jQuery.scriptorder++, 2, 'Script (unnested) is executed in order');equals(jQuery('#scriptorder').length, 1,'Execute after html')<\/script>"));
+	jQuery("#qunit-fixture").html(valueObj("<script>equal(jQuery.scriptorder++, 0, 'Script is executed in order');equal(jQuery('#scriptorder').length, 1,'Execute after html (even though appears before)')<\/script><span id='scriptorder'><script>equal(jQuery.scriptorder++, 1, 'Script (nested) is executed in order');equal(jQuery('#scriptorder').length, 1,'Execute after html')<\/script></span><script>equal(jQuery.scriptorder++, 2, 'Script (unnested) is executed in order');equal(jQuery('#scriptorder').length, 1,'Execute after html')<\/script>"));
 }
 
 test("html(String)", function() {
@@ -1271,7 +1271,7 @@ test("html(Function) with incoming value", function() {
 	var div = jQuery("#qunit-fixture > div"), old = div.map(function(){ return jQuery(this).html() });
 
 	div.html(function(i, val) {
-		equals( val, old[i], "Make sure the incoming value is correct." );
+		equal( val, old[i], "Make sure the incoming value is correct." );
 		return "<b>test</b>";
 	});
 
@@ -1289,43 +1289,43 @@ test("html(Function) with incoming value", function() {
 	old = j.map(function(){ return jQuery(this).html(); });
 
 	j.html(function(i, val) {
-		equals( val, old[i], "Make sure the incoming value is correct." );
+		equal( val, old[i], "Make sure the incoming value is correct." );
 		return "<b>bold</b>";
 	});
 
 	// Handle the case where no comment is in the document
 	if ( j.length === 2 ) {
-		equals( null, null, "Make sure the incoming value is correct." );
+		equal( null, null, "Make sure the incoming value is correct." );
 	}
 
 	j.find("b").removeData();
-	equals( j.html().replace(/ xmlns="[^"]+"/g, "").toLowerCase(), "<b>bold</b>", "Check node,textnode,comment with html()" );
+	equal( j.html().replace(/ xmlns="[^"]+"/g, "").toLowerCase(), "<b>bold</b>", "Check node,textnode,comment with html()" );
 
 	var $div = jQuery("<div />");
 
-	equals( $div.html(function(i, val) {
-		equals( val, "", "Make sure the incoming value is correct." );
+	equal( $div.html(function(i, val) {
+		equal( val, "", "Make sure the incoming value is correct." );
 		return 5;
 	}).html(), "5", "Setting a number as html" );
 
-	equals( $div.html(function(i, val) {
-		equals( val, "5", "Make sure the incoming value is correct." );
+	equal( $div.html(function(i, val) {
+		equal( val, "5", "Make sure the incoming value is correct." );
 		return 0;
 	}).html(), "0", "Setting a zero as html" );
 
 	var $div2 = jQuery("<div/>"), insert = "&lt;div&gt;hello1&lt;/div&gt;";
-	equals( $div2.html(function(i, val) {
-		equals( val, "", "Make sure the incoming value is correct." );
+	equal( $div2.html(function(i, val) {
+		equal( val, "", "Make sure the incoming value is correct." );
 		return insert;
 	}).html().replace(/>/g, "&gt;"), insert, "Verify escaped insertion." );
 
-	equals( $div2.html(function(i, val) {
-		equals( val.replace(/>/g, "&gt;"), insert, "Make sure the incoming value is correct." );
+	equal( $div2.html(function(i, val) {
+		equal( val.replace(/>/g, "&gt;"), insert, "Make sure the incoming value is correct." );
 		return "x" + insert;
 	}).html().replace(/>/g, "&gt;"), "x" + insert, "Verify escaped insertion." );
 
-	equals( $div2.html(function(i, val) {
-		equals( val.replace(/>/g, "&gt;"), "x" + insert, "Make sure the incoming value is correct." );
+	equal( $div2.html(function(i, val) {
+		equal( val.replace(/>/g, "&gt;"), "x" + insert, "Make sure the incoming value is correct." );
 		return " " + insert;
 	}).html().replace(/>/g, "&gt;"), " " + insert, "Verify escaped insertion." );
 });
@@ -1338,23 +1338,23 @@ var testRemove = function(method) {
 
 	jQuery("#ap").children()[method]();
 	ok( jQuery("#ap").text().length > 10, "Check text is not removed" );
-	equals( jQuery("#ap").children().length, 0, "Check remove" );
+	equal( jQuery("#ap").children().length, 0, "Check remove" );
 
-	equals( first.data("foo"), method == "remove" ? null : "bar" );
+	equal( first.data("foo"), method == "remove" ? null : "bar" );
 
 	QUnit.reset();
 	jQuery("#ap").children()[method]("a");
 	ok( jQuery("#ap").text().length > 10, "Check text is not removed" );
-	equals( jQuery("#ap").children().length, 1, "Check filtered remove" );
+	equal( jQuery("#ap").children().length, 1, "Check filtered remove" );
 
 	jQuery("#ap").children()[method]("a, code");
-	equals( jQuery("#ap").children().length, 0, "Check multi-filtered remove" );
+	equal( jQuery("#ap").children().length, 0, "Check multi-filtered remove" );
 
 	// using contents will get comments regular, text, and comment nodes
 	// Handle the case where no comment is in the document
 	ok( jQuery("#nonnodes").contents().length >= 2, "Check node,textnode,comment remove works" );
 	jQuery("#nonnodes").contents()[method]();
-	equals( jQuery("#nonnodes").contents().length, 0, "Check node,textnode,comment remove works" );
+	equal( jQuery("#nonnodes").contents().length, 0, "Check node,textnode,comment remove works" );
 
 	// manually clean up detached elements
 	if (method === "detach") {
@@ -1367,7 +1367,7 @@ var testRemove = function(method) {
 	var first = jQuery("#ap").children(":first");
 	var cleanUp = first.click(function() { count++ })[method]().appendTo("#qunit-fixture").click();
 
-	equals( method == "remove" ? 0 : 1, count );
+	equal( method == "remove" ? 0 : 1, count );
 
 	// manually clean up detached elements
 	cleanUp.remove();
@@ -1383,13 +1383,13 @@ test("detach()", function() {
 
 test("empty()", function() {
 	expect(3);
-	equals( jQuery("#ap").children().empty().text().length, 0, "Check text is removed" );
-	equals( jQuery("#ap").children().length, 4, "Check elements are not removed" );
+	equal( jQuery("#ap").children().empty().text().length, 0, "Check text is removed" );
+	equal( jQuery("#ap").children().length, 4, "Check elements are not removed" );
 
 	// using contents will get comments regular, text, and comment nodes
 	var j = jQuery("#nonnodes").contents();
 	j.empty();
-	equals( j.html(), "", "Check node,textnode,comment empty works" );
+	equal( j.html(), "", "Check node,textnode,comment empty works" );
 });
 
 test("jQuery.cleanData", function() {
@@ -1482,7 +1482,7 @@ test("jQuery.buildFragment - no plain-text caching (Bug #6779)", function() {
 		}
 		catch(e) {}
 	}
-	equals($f.text(), bad.join(""), "Cached strings that match Object properties");
+	equal($f.text(), bad.join(""), "Cached strings that match Object properties");
 	$f.remove();
 });
 

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -5,8 +5,8 @@ test("disconnected node", function() {
 
 	var result = jQuery( document.createElement("div") ).offset();
 
-	equals( result.top, 0, "Check top" );
-	equals( result.left, 0, "Check left" );
+	equal( result.top, 0, "Check top" );
+	equal( result.left, 0, "Check left" );
 });
 
 var supportsScroll = false;
@@ -34,8 +34,8 @@ testoffset("absolute", function($, iframe) {
 		{ id: "#absolute-1", top: 1, left: 1 }
 	];
 	jQuery.each( tests, function() {
-		equals( jQuery( this.id, doc ).offset().top,  this.top,  "jQuery('" + this.id + "').offset().top" );
-		equals( jQuery( this.id, doc ).offset().left, this.left, "jQuery('" + this.id + "').offset().left" );
+		equal( jQuery( this.id, doc ).offset().top,  this.top,  "jQuery('" + this.id + "').offset().top" );
+		equal( jQuery( this.id, doc ).offset().left, this.left, "jQuery('" + this.id + "').offset().left" );
 	});
 
 
@@ -44,8 +44,8 @@ testoffset("absolute", function($, iframe) {
 		{ id: "#absolute-1", top: 0, left: 0 }
 	];
 	jQuery.each( tests, function() {
-		equals( jQuery( this.id, doc ).position().top,  this.top,  "jQuery('" + this.id + "').position().top" );
-		equals( jQuery( this.id, doc ).position().left, this.left, "jQuery('" + this.id + "').position().left" );
+		equal( jQuery( this.id, doc ).position().top,  this.top,  "jQuery('" + this.id + "').position().top" );
+		equal( jQuery( this.id, doc ).position().left, this.left, "jQuery('" + this.id + "').position().left" );
 	});
 
 	forceScroll.remove();
@@ -62,8 +62,8 @@ testoffset("absolute", function( jQuery ) {
 		{ id: "#absolute-2",     top: 20, left: 20 }
 	];
 	jQuery.each( tests, function() {
-		equals( jQuery( this.id ).offset().top,  this.top,  "jQuery('" + this.id + "').offset().top" );
-		equals( jQuery( this.id ).offset().left, this.left, "jQuery('" + this.id + "').offset().left" );
+		equal( jQuery( this.id ).offset().top,  this.top,  "jQuery('" + this.id + "').offset().top" );
+		equal( jQuery( this.id ).offset().left, this.left, "jQuery('" + this.id + "').offset().left" );
 	});
 
 
@@ -75,14 +75,14 @@ testoffset("absolute", function( jQuery ) {
 		{ id: "#absolute-2",     top: 19, left: 19 }
 	];
 	jQuery.each( tests, function() {
-		equals( jQuery( this.id ).position().top,  this.top,  "jQuery('" + this.id + "').position().top" );
-		equals( jQuery( this.id ).position().left, this.left, "jQuery('" + this.id + "').position().left" );
+		equal( jQuery( this.id ).position().top,  this.top,  "jQuery('" + this.id + "').position().top" );
+		equal( jQuery( this.id ).position().left, this.left, "jQuery('" + this.id + "').position().left" );
 	});
 
 	// test #5781
 	var offset = jQuery( "#positionTest" ).offset({ top: 10, left: 10 }).offset();
-	equals( offset.top,  10, "Setting offset on element with position absolute but 'auto' values." )
-	equals( offset.left, 10, "Setting offset on element with position absolute but 'auto' values." )
+	equal( offset.top,  10, "Setting offset on element with position absolute but 'auto' values." )
+	equal( offset.left, 10, "Setting offset on element with position absolute but 'auto' values." )
 
 
 	// set offset
@@ -106,24 +106,24 @@ testoffset("absolute", function( jQuery ) {
 	];
 	jQuery.each( tests, function() {
 		jQuery( this.id ).offset({ top: this.top, left: this.left });
-		equals( jQuery( this.id ).offset().top,  this.top,  "jQuery('" + this.id + "').offset({ top: "  + this.top  + " })" );
-		equals( jQuery( this.id ).offset().left, this.left, "jQuery('" + this.id + "').offset({ left: " + this.left + " })" );
+		equal( jQuery( this.id ).offset().top,  this.top,  "jQuery('" + this.id + "').offset({ top: "  + this.top  + " })" );
+		equal( jQuery( this.id ).offset().left, this.left, "jQuery('" + this.id + "').offset({ left: " + this.left + " })" );
 
 		var top = this.top, left = this.left;
 
 		jQuery( this.id ).offset(function(i, val){
-			equals( val.top, top, "Verify incoming top position." );
-			equals( val.left, left, "Verify incoming top position." );
+			equal( val.top, top, "Verify incoming top position." );
+			equal( val.left, left, "Verify incoming top position." );
 			return { top: top + 1, left: left + 1 };
 		});
-		equals( jQuery( this.id ).offset().top,  this.top  + 1, "jQuery('" + this.id + "').offset({ top: "  + (this.top  + 1) + " })" );
-		equals( jQuery( this.id ).offset().left, this.left + 1, "jQuery('" + this.id + "').offset({ left: " + (this.left + 1) + " })" );
+		equal( jQuery( this.id ).offset().top,  this.top  + 1, "jQuery('" + this.id + "').offset({ top: "  + (this.top  + 1) + " })" );
+		equal( jQuery( this.id ).offset().left, this.left + 1, "jQuery('" + this.id + "').offset({ left: " + (this.left + 1) + " })" );
 
 		jQuery( this.id )
 			.offset({ left: this.left + 2 })
 			.offset({ top:  this.top  + 2 });
-		equals( jQuery( this.id ).offset().top,  this.top  + 2, "Setting one property at a time." );
-		equals( jQuery( this.id ).offset().left, this.left + 2, "Setting one property at a time." );
+		equal( jQuery( this.id ).offset().top,  this.top  + 2, "Setting one property at a time." );
+		equal( jQuery( this.id ).offset().left, this.left + 2, "Setting one property at a time." );
 
 		jQuery( this.id ).offset({ top: this.top, left: this.left, using: function( props ) {
 			jQuery( this ).css({
@@ -131,8 +131,8 @@ testoffset("absolute", function( jQuery ) {
 				left: props.left + 1
 			});
 		}});
-		equals( jQuery( this.id ).offset().top,  this.top  + 1, "jQuery('" + this.id + "').offset({ top: "  + (this.top  + 1) + ", using: fn })" );
-		equals( jQuery( this.id ).offset().left, this.left + 1, "jQuery('" + this.id + "').offset({ left: " + (this.left + 1) + ", using: fn })" );
+		equal( jQuery( this.id ).offset().top,  this.top  + 1, "jQuery('" + this.id + "').offset({ top: "  + (this.top  + 1) + ", using: fn })" );
+		equal( jQuery( this.id ).offset().left, this.left + 1, "jQuery('" + this.id + "').offset({ left: " + (this.left + 1) + ", using: fn })" );
 	});
 });
 
@@ -149,8 +149,8 @@ testoffset("relative", function( jQuery ) {
 		{ id: "#relative-2",   top: ie ? 141 : 142, left: 27 }
 	];
 	jQuery.each( tests, function() {
-		equals( jQuery( this.id ).offset().top,  this.top,  "jQuery('" + this.id + "').offset().top" );
-		equals( jQuery( this.id ).offset().left, this.left, "jQuery('" + this.id + "').offset().left" );
+		equal( jQuery( this.id ).offset().top,  this.top,  "jQuery('" + this.id + "').offset().top" );
+		equal( jQuery( this.id ).offset().left, this.left, "jQuery('" + this.id + "').offset().left" );
 	});
 
 
@@ -161,8 +161,8 @@ testoffset("relative", function( jQuery ) {
 		{ id: "#relative-2",   top: ie ? 140 : 141, left: 26 }
 	];
 	jQuery.each( tests, function() {
-		equals( jQuery( this.id ).position().top,  this.top,  "jQuery('" + this.id + "').position().top" );
-		equals( jQuery( this.id ).position().left, this.left, "jQuery('" + this.id + "').position().left" );
+		equal( jQuery( this.id ).position().top,  this.top,  "jQuery('" + this.id + "').position().top" );
+		equal( jQuery( this.id ).position().left, this.left, "jQuery('" + this.id + "').position().left" );
 	});
 
 
@@ -183,8 +183,8 @@ testoffset("relative", function( jQuery ) {
 	];
 	jQuery.each( tests, function() {
 		jQuery( this.id ).offset({ top: this.top, left: this.left });
-		equals( jQuery( this.id ).offset().top,  this.top,  "jQuery('" + this.id + "').offset({ top: "  + this.top  + " })" );
-		equals( jQuery( this.id ).offset().left, this.left, "jQuery('" + this.id + "').offset({ left: " + this.left + " })" );
+		equal( jQuery( this.id ).offset().top,  this.top,  "jQuery('" + this.id + "').offset({ top: "  + this.top  + " })" );
+		equal( jQuery( this.id ).offset().left, this.left, "jQuery('" + this.id + "').offset({ left: " + this.left + " })" );
 
 		jQuery( this.id ).offset({ top: this.top, left: this.left, using: function( props ) {
 			jQuery( this ).css({
@@ -192,8 +192,8 @@ testoffset("relative", function( jQuery ) {
 				left: props.left + 1
 			});
 		}});
-		equals( jQuery( this.id ).offset().top,  this.top  + 1, "jQuery('" + this.id + "').offset({ top: "  + (this.top  + 1) + ", using: fn })" );
-		equals( jQuery( this.id ).offset().left, this.left + 1, "jQuery('" + this.id + "').offset({ left: " + (this.left + 1) + ", using: fn })" );
+		equal( jQuery( this.id ).offset().top,  this.top  + 1, "jQuery('" + this.id + "').offset({ top: "  + (this.top  + 1) + ", using: fn })" );
+		equal( jQuery( this.id ).offset().left, this.left + 1, "jQuery('" + this.id + "').offset({ left: " + (this.left + 1) + ", using: fn })" );
 	});
 });
 
@@ -211,8 +211,8 @@ testoffset("static", function( jQuery ) {
 		{ id: "#static-2",     top: ie ? 121 : 122, left:  7 }
 	];
 	jQuery.each( tests, function() {
-		equals( jQuery( this.id ).offset().top,  this.top,  "jQuery('" + this.id + "').offset().top" );
-		equals( jQuery( this.id ).offset().left, this.left, "jQuery('" + this.id + "').offset().left" );
+		equal( jQuery( this.id ).offset().top,  this.top,  "jQuery('" + this.id + "').offset().top" );
+		equal( jQuery( this.id ).offset().left, this.left, "jQuery('" + this.id + "').offset().left" );
 	});
 
 
@@ -224,8 +224,8 @@ testoffset("static", function( jQuery ) {
 		{ id: "#static-2",     top: ie ? 120 : 121, left:  6 }
 	];
 	jQuery.each( tests, function() {
-		equals( jQuery( this.id ).position().top,  this.top,  "jQuery('" + this.top  + "').position().top" );
-		equals( jQuery( this.id ).position().left, this.left, "jQuery('" + this.left +"').position().left" );
+		equal( jQuery( this.id ).position().top,  this.top,  "jQuery('" + this.top  + "').position().top" );
+		equal( jQuery( this.id ).position().left, this.left, "jQuery('" + this.left +"').position().left" );
 	});
 
 
@@ -250,8 +250,8 @@ testoffset("static", function( jQuery ) {
 	];
 	jQuery.each( tests, function() {
 		jQuery( this.id ).offset({ top: this.top, left: this.left });
-		equals( jQuery( this.id ).offset().top,  this.top,  "jQuery('" + this.id + "').offset({ top: "  + this.top  + " })" );
-		equals( jQuery( this.id ).offset().left, this.left, "jQuery('" + this.id + "').offset({ left: " + this.left + " })" );
+		equal( jQuery( this.id ).offset().top,  this.top,  "jQuery('" + this.id + "').offset({ top: "  + this.top  + " })" );
+		equal( jQuery( this.id ).offset().left, this.left, "jQuery('" + this.id + "').offset({ left: " + this.left + " })" );
 
 		jQuery( this.id ).offset({ top: this.top, left: this.left, using: function( props ) {
 			jQuery( this ).css({
@@ -259,8 +259,8 @@ testoffset("static", function( jQuery ) {
 				left: props.left + 1
 			});
 		}});
-		equals( jQuery( this.id ).offset().top,  this.top  + 1, "jQuery('" + this.id + "').offset({ top: "  + (this.top  + 1) + ", using: fn })" );
-		equals( jQuery( this.id ).offset().left, this.left + 1, "jQuery('" + this.id + "').offset({ left: " + (this.left + 1) + ", using: fn })" );
+		equal( jQuery( this.id ).offset().top,  this.top  + 1, "jQuery('" + this.id + "').offset({ top: "  + (this.top  + 1) + ", using: fn })" );
+		equal( jQuery( this.id ).offset().left, this.left + 1, "jQuery('" + this.id + "').offset({ left: " + (this.left + 1) + ", using: fn })" );
 	});
 });
 
@@ -278,8 +278,8 @@ testoffset("fixed", function( jQuery ) {
 			ok( true, "Browser doesn't support scroll position." );
 
 		} else if ( jQuery.offset.supportsFixedPosition ) {
-			equals( jQuery( this.id ).offset().top,  this.top,  "jQuery('" + this.id + "').offset().top" );
-			equals( jQuery( this.id ).offset().left, this.left, "jQuery('" + this.id + "').offset().left" );
+			equal( jQuery( this.id ).offset().top,  this.top,  "jQuery('" + this.id + "').offset().top" );
+			equal( jQuery( this.id ).offset().left, this.left, "jQuery('" + this.id + "').offset().left" );
 		} else {
 			// need to have same number of assertions
 			ok( true, "Fixed position is not supported" );
@@ -299,8 +299,8 @@ testoffset("fixed", function( jQuery ) {
 	jQuery.each( tests, function() {
 		if ( jQuery.offset.supportsFixedPosition ) {
 			jQuery( this.id ).offset({ top: this.top, left: this.left });
-			equals( jQuery( this.id ).offset().top,  this.top,  "jQuery('" + this.id + "').offset({ top: "  + this.top  + " })" );
-			equals( jQuery( this.id ).offset().left, this.left, "jQuery('" + this.id + "').offset({ left: " + this.left + " })" );
+			equal( jQuery( this.id ).offset().top,  this.top,  "jQuery('" + this.id + "').offset({ top: "  + this.top  + " })" );
+			equal( jQuery( this.id ).offset().left, this.left, "jQuery('" + this.id + "').offset({ left: " + this.left + " })" );
 
 			jQuery( this.id ).offset({ top: this.top, left: this.left, using: function( props ) {
 				jQuery( this ).css({
@@ -308,8 +308,8 @@ testoffset("fixed", function( jQuery ) {
 					left: props.left + 1
 				});
 			}});
-			equals( jQuery( this.id ).offset().top,  this.top  + 1, "jQuery('" + this.id + "').offset({ top: "  + (this.top  + 1) + ", using: fn })" );
-			equals( jQuery( this.id ).offset().left, this.left + 1, "jQuery('" + this.id + "').offset({ left: " + (this.left + 1) + ", using: fn })" );
+			equal( jQuery( this.id ).offset().top,  this.top  + 1, "jQuery('" + this.id + "').offset({ top: "  + (this.top  + 1) + ", using: fn })" );
+			equal( jQuery( this.id ).offset().left, this.left + 1, "jQuery('" + this.id + "').offset({ left: " + (this.left + 1) + ", using: fn })" );
 		} else {
 			// need to have same number of assertions
 			ok( true, "Fixed position is not supported" );
@@ -322,8 +322,8 @@ testoffset("fixed", function( jQuery ) {
 	// Bug 8316
 	var $noTopLeft = jQuery("#fixed-no-top-left");
 	if ( jQuery.offset.supportsFixedPosition ) {
-		equals( $noTopLeft.offset().top,  1007,  "Check offset top for fixed element with no top set" );
-		equals( $noTopLeft.offset().left, 1007, "Check offset left for fixed element with no left set" );
+		equal( $noTopLeft.offset().top,  1007,  "Check offset top for fixed element with no top set" );
+		equal( $noTopLeft.offset().left, 1007, "Check offset left for fixed element with no left set" );
 	} else {
 		// need to have same number of assertions
 		ok( true, "Fixed position is not supported" );
@@ -334,11 +334,11 @@ testoffset("fixed", function( jQuery ) {
 testoffset("table", function( jQuery ) {
 	expect(4);
 
-	equals( jQuery("#table-1").offset().top, 6, "jQuery('#table-1').offset().top" );
-	equals( jQuery("#table-1").offset().left, 6, "jQuery('#table-1').offset().left" );
+	equal( jQuery("#table-1").offset().top, 6, "jQuery('#table-1').offset().top" );
+	equal( jQuery("#table-1").offset().left, 6, "jQuery('#table-1').offset().left" );
 
-	equals( jQuery("#th-1").offset().top, 10, "jQuery('#th-1').offset().top" );
-	equals( jQuery("#th-1").offset().left, 10, "jQuery('#th-1').offset().left" );
+	equal( jQuery("#th-1").offset().top, 10, "jQuery('#th-1').offset().top" );
+	equal( jQuery("#th-1").offset().left, 10, "jQuery('#th-1').offset().left" );
 });
 
 testoffset("scroll", function( jQuery, win ) {
@@ -347,23 +347,23 @@ testoffset("scroll", function( jQuery, win ) {
 	var ie = jQuery.browser.msie && parseInt( jQuery.browser.version, 10 ) < 8;
 
 	// IE is collapsing the top margin of 1px
-	equals( jQuery("#scroll-1").offset().top, ie ? 6 : 7, "jQuery('#scroll-1').offset().top" );
-	equals( jQuery("#scroll-1").offset().left, 7, "jQuery('#scroll-1').offset().left" );
+	equal( jQuery("#scroll-1").offset().top, ie ? 6 : 7, "jQuery('#scroll-1').offset().top" );
+	equal( jQuery("#scroll-1").offset().left, 7, "jQuery('#scroll-1').offset().left" );
 
 	// IE is collapsing the top margin of 1px
-	equals( jQuery("#scroll-1-1").offset().top, ie ? 9 : 11, "jQuery('#scroll-1-1').offset().top" );
-	equals( jQuery("#scroll-1-1").offset().left, 11, "jQuery('#scroll-1-1').offset().left" );
+	equal( jQuery("#scroll-1-1").offset().top, ie ? 9 : 11, "jQuery('#scroll-1-1').offset().top" );
+	equal( jQuery("#scroll-1-1").offset().left, 11, "jQuery('#scroll-1-1').offset().left" );
 
 
 	// scroll offset tests .scrollTop/Left
-	equals( jQuery("#scroll-1").scrollTop(), 5, "jQuery('#scroll-1').scrollTop()" );
-	equals( jQuery("#scroll-1").scrollLeft(), 5, "jQuery('#scroll-1').scrollLeft()" );
+	equal( jQuery("#scroll-1").scrollTop(), 5, "jQuery('#scroll-1').scrollTop()" );
+	equal( jQuery("#scroll-1").scrollLeft(), 5, "jQuery('#scroll-1').scrollLeft()" );
 
-	equals( jQuery("#scroll-1-1").scrollTop(), 0, "jQuery('#scroll-1-1').scrollTop()" );
-	equals( jQuery("#scroll-1-1").scrollLeft(), 0, "jQuery('#scroll-1-1').scrollLeft()" );
+	equal( jQuery("#scroll-1-1").scrollTop(), 0, "jQuery('#scroll-1-1').scrollTop()" );
+	equal( jQuery("#scroll-1-1").scrollLeft(), 0, "jQuery('#scroll-1-1').scrollLeft()" );
 
-	// equals( jQuery("body").scrollTop(), 0, "jQuery("body").scrollTop()" );
-	// equals( jQuery("body").scrollLeft(), 0, "jQuery("body").scrollTop()" );
+	// equal( jQuery("body").scrollTop(), 0, "jQuery("body").scrollTop()" );
+	// equal( jQuery("body").scrollLeft(), 0, "jQuery("body").scrollTop()" );
 
 	win.name = "test";
 
@@ -374,20 +374,20 @@ testoffset("scroll", function( jQuery, win ) {
 		ok( true, "Browser doesn't support scroll position." );
 		ok( true, "Browser doesn't support scroll position." );
 	} else {
-		equals( jQuery(win).scrollTop(), 1000, "jQuery(window).scrollTop()" );
-		equals( jQuery(win).scrollLeft(), 1000, "jQuery(window).scrollLeft()" );
+		equal( jQuery(win).scrollTop(), 1000, "jQuery(window).scrollTop()" );
+		equal( jQuery(win).scrollLeft(), 1000, "jQuery(window).scrollLeft()" );
 
-		equals( jQuery(win.document).scrollTop(), 1000, "jQuery(document).scrollTop()" );
-		equals( jQuery(win.document).scrollLeft(), 1000, "jQuery(document).scrollLeft()" );
+		equal( jQuery(win.document).scrollTop(), 1000, "jQuery(document).scrollTop()" );
+		equal( jQuery(win.document).scrollLeft(), 1000, "jQuery(document).scrollLeft()" );
 	}
 
 	// test jQuery using parent window/document
 	// jQuery reference here is in the iframe
 	window.scrollTo(0,0);
-	equals( jQuery(window).scrollTop(), 0, "jQuery(window).scrollTop() other window" );
-	equals( jQuery(window).scrollLeft(), 0, "jQuery(window).scrollLeft() other window" );
-	equals( jQuery(document).scrollTop(), 0, "jQuery(window).scrollTop() other document" );
-	equals( jQuery(document).scrollLeft(), 0, "jQuery(window).scrollLeft() other document" );
+	equal( jQuery(window).scrollTop(), 0, "jQuery(window).scrollTop() other window" );
+	equal( jQuery(window).scrollLeft(), 0, "jQuery(window).scrollLeft() other window" );
+	equal( jQuery(document).scrollTop(), 0, "jQuery(window).scrollTop() other document" );
+	equal( jQuery(document).scrollLeft(), 0, "jQuery(window).scrollLeft() other document" );
 
 	// Tests scrollTop/Left with empty jquery objects
 	notEqual( jQuery().scrollTop(100), null, "jQuery().scrollTop(100) testing setter on empty jquery object" );
@@ -401,42 +401,42 @@ testoffset("scroll", function( jQuery, win ) {
 testoffset("body", function( jQuery ) {
 	expect(2);
 
-	equals( jQuery("body").offset().top, 1, "jQuery('#body').offset().top" );
-	equals( jQuery("body").offset().left, 1, "jQuery('#body').offset().left" );
+	equal( jQuery("body").offset().top, 1, "jQuery('#body').offset().top" );
+	equal( jQuery("body").offset().left, 1, "jQuery('#body').offset().left" );
 });
 
 test("Chaining offset(coords) returns jQuery object", function() {
 	expect(2);
 	var coords = { top:  1, left:  1 };
-	equals( jQuery("#absolute-1").offset(coords).selector, "#absolute-1", "offset(coords) returns jQuery object" );
-	equals( jQuery("#non-existent").offset(coords).selector, "#non-existent", "offset(coords) with empty jQuery set returns jQuery object" );
+	equal( jQuery("#absolute-1").offset(coords).selector, "#absolute-1", "offset(coords) returns jQuery object" );
+	equal( jQuery("#non-existent").offset(coords).selector, "#non-existent", "offset(coords) with empty jQuery set returns jQuery object" );
 });
 
 test("offsetParent", function(){
 	expect(11);
 
 	var body = jQuery("body").offsetParent();
-	equals( body.length, 1, "Only one offsetParent found." );
-	equals( body[0], document.body, "The body is its own offsetParent." );
+	equal( body.length, 1, "Only one offsetParent found." );
+	equal( body[0], document.body, "The body is its own offsetParent." );
 
 	var header = jQuery("#qunit-header").offsetParent();
-	equals( header.length, 1, "Only one offsetParent found." );
-	equals( header[0], document.body, "The body is the offsetParent." );
+	equal( header.length, 1, "Only one offsetParent found." );
+	equal( header[0], document.body, "The body is the offsetParent." );
 
 	var div = jQuery("#nothiddendivchild").offsetParent();
-	equals( div.length, 1, "Only one offsetParent found." );
-	equals( div[0], document.body, "The body is the offsetParent." );
+	equal( div.length, 1, "Only one offsetParent found." );
+	equal( div[0], document.body, "The body is the offsetParent." );
 
 	jQuery("#nothiddendiv").css("position", "relative");
 
 	div = jQuery("#nothiddendivchild").offsetParent();
-	equals( div.length, 1, "Only one offsetParent found." );
-	equals( div[0], jQuery("#nothiddendiv")[0], "The div is the offsetParent." );
+	equal( div.length, 1, "Only one offsetParent found." );
+	equal( div[0], jQuery("#nothiddendiv")[0], "The div is the offsetParent." );
 
 	div = jQuery("body, #nothiddendivchild").offsetParent();
-	equals( div.length, 2, "Two offsetParent found." );
-	equals( div[0], document.body, "The body is the offsetParent." );
-	equals( div[1], jQuery("#nothiddendiv")[0], "The div is the offsetParent." );
+	equal( div.length, 2, "Two offsetParent found." );
+	equal( div[0], document.body, "The body is the offsetParent." );
+	equal( div[1], jQuery("#nothiddendiv")[0], "The div is the offsetParent." );
 });
 
 test("fractions (see #7730 and #7885)", function() {
@@ -459,8 +459,8 @@ test("fractions (see #7730 and #7885)", function() {
 
 	var result = div.offset();
 
-	equals( result.top, expected.top, "Check top" );
-	equals( result.left, expected.left, "Check left" );
+	equal( result.top, expected.top, "Check top" );
+	equal( result.left, expected.left, "Check left" );
 
 	div.remove();
 });

--- a/test/unit/queue.js
+++ b/test/unit/queue.js
@@ -10,41 +10,41 @@ test("queue() with other types",function() {
 		defer;
 
 	$div.promise("foo").done(function() {
-		equals( counter, 0, "Deferred for collection with no queue is automatically resolved" );
+		equal( counter, 0, "Deferred for collection with no queue is automatically resolved" );
 	});
 
 	$div
 		.queue("foo",function(){
-			equals( ++counter, 1, "Dequeuing" );
+			equal( ++counter, 1, "Dequeuing" );
 			jQuery.dequeue(this,"foo");
 		})
 		.queue("foo",function(){
-			equals( ++counter, 2, "Dequeuing" );
+			equal( ++counter, 2, "Dequeuing" );
 			jQuery(this).dequeue("foo");
 		})
 		.queue("foo",function(){
-			equals( ++counter, 3, "Dequeuing" );
+			equal( ++counter, 3, "Dequeuing" );
 		})
 		.queue("foo",function(){
-			equals( ++counter, 4, "Dequeuing" );
+			equal( ++counter, 4, "Dequeuing" );
 		});
 
 	defer = $div.promise("foo").done(function() {
-		equals(  counter, 4, "Testing previous call to dequeue in deferred"  );
+		equal(  counter, 4, "Testing previous call to dequeue in deferred"  );
 		start();
 	});
 
-	equals( $div.queue("foo").length, 4, "Testing queue length" );
+	equal( $div.queue("foo").length, 4, "Testing queue length" );
 
 	$div.dequeue("foo");
 
-	equals( counter, 3, "Testing previous call to dequeue" );
-	equals( $div.queue("foo").length, 1, "Testing queue length" );
+	equal( counter, 3, "Testing previous call to dequeue" );
+	equal( $div.queue("foo").length, 1, "Testing queue length" );
 
 	$div.dequeue("foo");
 
-	equals( counter, 4, "Testing previous call to dequeue" );
-	equals( $div.queue("foo").length, 0, "Testing queue length" );
+	equal( counter, 4, "Testing previous call to dequeue" );
+	equal( $div.queue("foo").length, 0, "Testing queue length" );
 });
 
 test("queue(name) passes in the next item in the queue as a parameter", function() {
@@ -54,13 +54,13 @@ test("queue(name) passes in the next item in the queue as a parameter", function
 	var counter = 0;
 
 	div.queue("foo", function(next) {
-		equals(++counter, 1, "Dequeueing");
+		equal(++counter, 1, "Dequeueing");
 		next();
 	}).queue("foo", function(next) {
-		equals(++counter, 2, "Next was called");
+		equal(++counter, 2, "Next was called");
 		next();
 	}).queue("bar", function() {
-		equals(++counter, 3, "Other queues are not triggered by next()")
+		equal(++counter, 3, "Other queues are not triggered by next()")
 	});
 
 	div.dequeue("foo");
@@ -74,18 +74,18 @@ test("queue() passes in the next item in the queue as a parameter to fx queues",
 	var counter = 0;
 
 	div.queue(function(next) {
-		equals(++counter, 1, "Dequeueing");
+		equal(++counter, 1, "Dequeueing");
 		var self = this;
 		setTimeout(function() { next() }, 500);
 	}).queue(function(next) {
-		equals(++counter, 2, "Next was called");
+		equal(++counter, 2, "Next was called");
 		next();
 	}).queue("bar", function() {
-		equals(++counter, 3, "Other queues are not triggered by next()")
+		equal(++counter, 3, "Other queues are not triggered by next()")
 	});
 
 	jQuery.when( div.promise("fx"), div ).done(function() {
-		equals(counter, 2, "Deferreds resolved");
+		equal(counter, 2, "Deferreds resolved");
 		start();
 	});
 });
@@ -110,7 +110,7 @@ test("callbacks keep their place in the queue", function() {
 	});
 
 	div.promise("fx").done(function() {
-		equals(counter, 4, "Deferreds resolved");
+		equal(counter, 4, "Deferreds resolved");
 		start();
 	});
 });
@@ -127,7 +127,7 @@ test("delay()", function() {
 		start();
 	});
 
-	equals( run, 0, "The delay delayed the next function from running." );
+	equal( run, 0, "The delay delayed the next function from running." );
 });
 
 test("delay() can be stopped", function() {
@@ -191,7 +191,7 @@ test("clearQueue(name) clears the queue", function() {
 
 	div.dequeue("foo");
 
-	equals(counter, 1, "the queue was cleared");
+	equal(counter, 1, "the queue was cleared");
 });
 
 test("clearQueue() clears the fx queue", function() {
@@ -208,7 +208,7 @@ test("clearQueue() clears the fx queue", function() {
 		counter++;
 	});
 
-	equals(counter, 1, "the queue was cleared");
+	equal(counter, 1, "the queue was cleared");
 
 	div.removeData();
 });

--- a/test/unit/traversing.js
+++ b/test/unit/traversing.js
@@ -2,15 +2,15 @@ module("traversing", { teardown: moduleTeardown });
 
 test("find(String)", function() {
 	expect(5);
-	equals( "Yahoo", jQuery("#foo").find(".blogTest").text(), "Check for find" );
+	equal( "Yahoo", jQuery("#foo").find(".blogTest").text(), "Check for find" );
 
 	// using contents will get comments regular, text, and comment nodes
 	var j = jQuery("#nonnodes").contents();
-	equals( j.find("div").length, 0, "Check node,textnode,comment to find zero divs" );
+	equal( j.find("div").length, 0, "Check node,textnode,comment to find zero divs" );
 
-	same( jQuery("#qunit-fixture").find("> div").get(), q("foo", "moretests", "tabindex-tests", "liveHandlerOrder", "siblingTest"), "find child elements" );
-	same( jQuery("#qunit-fixture").find("> #foo, > #moretests").get(), q("foo", "moretests"), "find child elements" );
-	same( jQuery("#qunit-fixture").find("> #foo > p").get(), q("sndp", "en", "sap"), "find child elements" );
+	deepEqual( jQuery("#qunit-fixture").find("> div").get(), q("foo", "moretests", "tabindex-tests", "liveHandlerOrder", "siblingTest"), "find child elements" );
+	deepEqual( jQuery("#qunit-fixture").find("> #foo, > #moretests").get(), q("foo", "moretests"), "find child elements" );
+	deepEqual( jQuery("#qunit-fixture").find("> #foo > p").get(), q("sndp", "en", "sap"), "find child elements" );
 });
 
 test("find(node|jQuery object)", function() {
@@ -22,18 +22,18 @@ test("find(node|jQuery object)", function() {
 		$two = $blog.add( $first ),
 		$fooTwo = $foo.add( $blog );
 
-	equals( $foo.find( $blog ).text(), "Yahoo", "Find with blog jQuery object" );
-	equals( $foo.find( $blog[0] ).text(), "Yahoo", "Find with blog node" );
-	equals( $foo.find( $first ).length, 0, "#first is not in #foo" );
-	equals( $foo.find( $first[0]).length, 0, "#first not in #foo (node)" );
+	equal( $foo.find( $blog ).text(), "Yahoo", "Find with blog jQuery object" );
+	equal( $foo.find( $blog[0] ).text(), "Yahoo", "Find with blog node" );
+	equal( $foo.find( $first ).length, 0, "#first is not in #foo" );
+	equal( $foo.find( $first[0]).length, 0, "#first not in #foo (node)" );
 	ok( $foo.find( $two ).is(".blogTest"), "Find returns only nodes within #foo" );
 	ok( $fooTwo.find( $blog ).is(".blogTest"), "Blog is part of the collection, but also within foo" );
 	ok( $fooTwo.find( $blog[0] ).is(".blogTest"), "Blog is part of the collection, but also within foo(node)" );
 
-	equals( $two.find( $foo ).length, 0, "Foo is not in two elements" );
-	equals( $two.find( $foo[0] ).length, 0, "Foo is not in two elements(node)" );
-	equals( $two.find( $first ).length, 0, "first is in the collection and not within two" );
-	equals( $two.find( $first ).length, 0, "first is in the collection and not within two(node)" );
+	equal( $two.find( $foo ).length, 0, "Foo is not in two elements" );
+	equal( $two.find( $foo[0] ).length, 0, "Foo is not in two elements(node)" );
+	equal( $two.find( $first ).length, 0, "first is in the collection and not within two" );
+	equal( $two.find( $first ).length, 0, "first is in the collection and not within two(node)" );
 
 });
 
@@ -156,74 +156,74 @@ test("index(Object|String|undefined)", function() {
 		inputElements = jQuery("#radio1,#radio2,#check1,#check2");
 
 	// Passing a node
-	equals( elements.index(window), 0, "Check for index of elements" );
-	equals( elements.index(document), 1, "Check for index of elements" );
-	equals( inputElements.index(document.getElementById("radio1")), 0, "Check for index of elements" );
-	equals( inputElements.index(document.getElementById("radio2")), 1, "Check for index of elements" );
-	equals( inputElements.index(document.getElementById("check1")), 2, "Check for index of elements" );
-	equals( inputElements.index(document.getElementById("check2")), 3, "Check for index of elements" );
-	equals( inputElements.index(window), -1, "Check for not found index" );
-	equals( inputElements.index(document), -1, "Check for not found index" );
+	equal( elements.index(window), 0, "Check for index of elements" );
+	equal( elements.index(document), 1, "Check for index of elements" );
+	equal( inputElements.index(document.getElementById("radio1")), 0, "Check for index of elements" );
+	equal( inputElements.index(document.getElementById("radio2")), 1, "Check for index of elements" );
+	equal( inputElements.index(document.getElementById("check1")), 2, "Check for index of elements" );
+	equal( inputElements.index(document.getElementById("check2")), 3, "Check for index of elements" );
+	equal( inputElements.index(window), -1, "Check for not found index" );
+	equal( inputElements.index(document), -1, "Check for not found index" );
 
 	// Passing a jQuery object
 	// enabled since [5500]
-	equals( elements.index( elements ), 0, "Pass in a jQuery object" );
-	equals( elements.index( elements.eq(1) ), 1, "Pass in a jQuery object" );
-	equals( jQuery("#form :radio").index( jQuery("#radio2") ), 1, "Pass in a jQuery object" );
+	equal( elements.index( elements ), 0, "Pass in a jQuery object" );
+	equal( elements.index( elements.eq(1) ), 1, "Pass in a jQuery object" );
+	equal( jQuery("#form :radio").index( jQuery("#radio2") ), 1, "Pass in a jQuery object" );
 
 	// Passing a selector or nothing
 	// enabled since [6330]
-	equals( jQuery("#text2").index(), 2, "Check for index amongst siblings" );
-	equals( jQuery("#form").children().eq(4).index(), 4, "Check for index amongst siblings" );
-	equals( jQuery("#radio2").index("#form :radio") , 1, "Check for index within a selector" );
-	equals( jQuery("#form :radio").index( jQuery("#radio2") ), 1, "Check for index within a selector" );
-	equals( jQuery("#radio2").index("#form :text") , -1, "Check for index not found within a selector" );
+	equal( jQuery("#text2").index(), 2, "Check for index amongst siblings" );
+	equal( jQuery("#form").children().eq(4).index(), 4, "Check for index amongst siblings" );
+	equal( jQuery("#radio2").index("#form :radio") , 1, "Check for index within a selector" );
+	equal( jQuery("#form :radio").index( jQuery("#radio2") ), 1, "Check for index within a selector" );
+	equal( jQuery("#radio2").index("#form :text") , -1, "Check for index not found within a selector" );
 });
 
 test("filter(Selector|undefined)", function() {
 	expect(9);
-	same( jQuery("#form input").filter(":checked").get(), q("radio2", "check1"), "filter(String)" );
-	same( jQuery("p").filter("#ap, #sndp").get(), q("ap", "sndp"), "filter('String, String')" );
-	same( jQuery("p").filter("#ap,#sndp").get(), q("ap", "sndp"), "filter('String,String')" );
+	deepEqual( jQuery("#form input").filter(":checked").get(), q("radio2", "check1"), "filter(String)" );
+	deepEqual( jQuery("p").filter("#ap, #sndp").get(), q("ap", "sndp"), "filter('String, String')" );
+	deepEqual( jQuery("p").filter("#ap,#sndp").get(), q("ap", "sndp"), "filter('String,String')" );
 
-	same( jQuery("p").filter(null).get(),      [], "filter(null) should return an empty jQuery object");
-	same( jQuery("p").filter(undefined).get(), [], "filter(undefined) should return an empty jQuery object");
-	same( jQuery("p").filter(0).get(),         [], "filter(0) should return an empty jQuery object");
-	same( jQuery("p").filter("").get(),        [], "filter('') should return an empty jQuery object");
+	deepEqual( jQuery("p").filter(null).get(),      [], "filter(null) should return an empty jQuery object");
+	deepEqual( jQuery("p").filter(undefined).get(), [], "filter(undefined) should return an empty jQuery object");
+	deepEqual( jQuery("p").filter(0).get(),         [], "filter(0) should return an empty jQuery object");
+	deepEqual( jQuery("p").filter("").get(),        [], "filter('') should return an empty jQuery object");
 
 	// using contents will get comments regular, text, and comment nodes
 	var j = jQuery("#nonnodes").contents();
-	equals( j.filter("span").length, 1, "Check node,textnode,comment to filter the one span" );
-	equals( j.filter("[name]").length, 0, "Check node,textnode,comment to filter the one span" );
+	equal( j.filter("span").length, 1, "Check node,textnode,comment to filter the one span" );
+	equal( j.filter("[name]").length, 0, "Check node,textnode,comment to filter the one span" );
 });
 
 test("filter(Function)", function() {
 	expect(2);
 
-	same( jQuery("#qunit-fixture p").filter(function() { return !jQuery("a", this).length }).get(), q("sndp", "first"), "filter(Function)" );
+	deepEqual( jQuery("#qunit-fixture p").filter(function() { return !jQuery("a", this).length }).get(), q("sndp", "first"), "filter(Function)" );
 
-	same( jQuery("#qunit-fixture p").filter(function(i, elem) { return !jQuery("a", elem).length }).get(), q("sndp", "first"), "filter(Function) using arg" );
+	deepEqual( jQuery("#qunit-fixture p").filter(function(i, elem) { return !jQuery("a", elem).length }).get(), q("sndp", "first"), "filter(Function) using arg" );
 });
 
 test("filter(Element)", function() {
 	expect(1);
 
 	var element = document.getElementById("text1");
-	same( jQuery("#form input").filter(element).get(), q("text1"), "filter(Element)" );
+	deepEqual( jQuery("#form input").filter(element).get(), q("text1"), "filter(Element)" );
 });
 
 test("filter(Array)", function() {
 	expect(1);
 
 	var elements = [ document.getElementById("text1") ];
-	same( jQuery("#form input").filter(elements).get(), q("text1"), "filter(Element)" );
+	deepEqual( jQuery("#form input").filter(elements).get(), q("text1"), "filter(Element)" );
 });
 
 test("filter(jQuery)", function() {
 	expect(1);
 
 	var elements = jQuery("#text1");
-	same( jQuery("#form input").filter(elements).get(), q("text1"), "filter(Element)" );
+	deepEqual( jQuery("#form input").filter(elements).get(), q("text1"), "filter(Element)" );
 });
 
 
@@ -272,41 +272,41 @@ test("filter() with positional selectors", function() {
 
 test("closest()", function() {
 	expect(13);
-	same( jQuery("body").closest("body").get(), q("body"), "closest(body)" );
-	same( jQuery("body").closest("html").get(), q("html"), "closest(html)" );
-	same( jQuery("body").closest("div").get(), [], "closest(div)" );
-	same( jQuery("#qunit-fixture").closest("span,#html").get(), q("html"), "closest(span,#html)" );
+	deepEqual( jQuery("body").closest("body").get(), q("body"), "closest(body)" );
+	deepEqual( jQuery("body").closest("html").get(), q("html"), "closest(html)" );
+	deepEqual( jQuery("body").closest("div").get(), [], "closest(div)" );
+	deepEqual( jQuery("#qunit-fixture").closest("span,#html").get(), q("html"), "closest(span,#html)" );
 
-	same( jQuery("div:eq(1)").closest("div:first").get(), [], "closest(div:first)" );
-	same( jQuery("div").closest("body:first div:last").get(), q("fx-tests"), "closest(body:first div:last)" );
+	deepEqual( jQuery("div:eq(1)").closest("div:first").get(), [], "closest(div:first)" );
+	deepEqual( jQuery("div").closest("body:first div:last").get(), q("fx-tests"), "closest(body:first div:last)" );
 
 	// Test .closest() limited by the context
 	var jq = jQuery("#nothiddendivchild");
-	same( jq.closest("html", document.body).get(), [], "Context limited." );
-	same( jq.closest("body", document.body).get(), [], "Context limited." );
-	same( jq.closest("#nothiddendiv", document.body).get(), q("nothiddendiv"), "Context not reached." );
+	deepEqual( jq.closest("html", document.body).get(), [], "Context limited." );
+	deepEqual( jq.closest("body", document.body).get(), [], "Context limited." );
+	deepEqual( jq.closest("#nothiddendiv", document.body).get(), q("nothiddendiv"), "Context not reached." );
 
 	//Test that .closest() returns unique'd set
-	equals( jQuery("#qunit-fixture p").closest("#qunit-fixture").length, 1, "Closest should return a unique set" );
+	equal( jQuery("#qunit-fixture p").closest("#qunit-fixture").length, 1, "Closest should return a unique set" );
 
 	// Test on disconnected node
-	equals( jQuery("<div><p></p></div>").find("p").closest("table").length, 0, "Make sure disconnected closest work." );
+	equal( jQuery("<div><p></p></div>").find("p").closest("table").length, 0, "Make sure disconnected closest work." );
 
 	// Bug #7369
-	equals( jQuery("<div foo='bar'></div>").closest("[foo]").length, 1, "Disconnected nodes with attribute selector" );
-	equals( jQuery("<div>text</div>").closest("[lang]").length, 0, "Disconnected nodes with text and non-existent attribute selector" );
+	equal( jQuery("<div foo='bar'></div>").closest("[foo]").length, 1, "Disconnected nodes with attribute selector" );
+	equal( jQuery("<div>text</div>").closest("[lang]").length, 0, "Disconnected nodes with text and non-existent attribute selector" );
 });
 
 test("closest(Array)", function() {
 	expect(7);
-	same( jQuery("body").closest(["body"]), [{selector:"body", elem:document.body, level:1}], "closest([body])" );
-	same( jQuery("body").closest(["html"]), [{selector:"html", elem:document.documentElement, level:2}], "closest([html])" );
-	same( jQuery("body").closest(["div"]), [], "closest([div])" );
-	same( jQuery("#yahoo").closest(["div"]), [{"selector":"div", "elem": document.getElementById("foo"), "level": 3}, { "selector": "div", "elem": document.getElementById("qunit-fixture"), "level": 4 }], "closest([div])" );
-	same( jQuery("#qunit-fixture").closest(["span,#html"]), [{selector:"span,#html", elem:document.documentElement, level:4}], "closest([span,#html])" );
+	deepEqual( jQuery("body").closest(["body"]), [{selector:"body", elem:document.body, level:1}], "closest([body])" );
+	deepEqual( jQuery("body").closest(["html"]), [{selector:"html", elem:document.documentElement, level:2}], "closest([html])" );
+	deepEqual( jQuery("body").closest(["div"]), [], "closest([div])" );
+	deepEqual( jQuery("#yahoo").closest(["div"]), [{"selector":"div", "elem": document.getElementById("foo"), "level": 3}, { "selector": "div", "elem": document.getElementById("qunit-fixture"), "level": 4 }], "closest([div])" );
+	deepEqual( jQuery("#qunit-fixture").closest(["span,#html"]), [{selector:"span,#html", elem:document.documentElement, level:4}], "closest([span,#html])" );
 
-	same( jQuery("body").closest(["body","html"]), [{selector:"body", elem:document.body, level:1}, {selector:"html", elem:document.documentElement, level:2}], "closest([body, html])" );
-	same( jQuery("body").closest(["span","html"]), [{selector:"html", elem:document.documentElement, level:2}], "closest([body, html])" );
+	deepEqual( jQuery("body").closest(["body","html"]), [{selector:"body", elem:document.body, level:1}, {selector:"html", elem:document.documentElement, level:2}], "closest([body, html])" );
+	deepEqual( jQuery("body").closest(["span","html"]), [{selector:"html", elem:document.documentElement, level:2}], "closest([body, html])" );
 });
 
 test("closest(jQuery)", function() {
@@ -319,132 +319,132 @@ test("closest(jQuery)", function() {
 	ok( $child.closest( $parent[0] ).is("#nothiddendiv"), "closest( jQuery('#nothiddendiv') ) :: node" );
 	ok( $child.closest( $child ).is("#nothiddendivchild"), "child is included" );
 	ok( $child.closest( $child[0] ).is("#nothiddendivchild"), "child is included  :: node" );
-	equals( $child.closest( document.createElement("div") ).length, 0, "created element is not related" );
-	equals( $child.closest( $main ).length, 0, "Main not a parent of child" );
-	equals( $child.closest( $main[0] ).length, 0, "Main not a parent of child :: node" );
+	equal( $child.closest( document.createElement("div") ).length, 0, "created element is not related" );
+	equal( $child.closest( $main ).length, 0, "Main not a parent of child" );
+	equal( $child.closest( $main[0] ).length, 0, "Main not a parent of child :: node" );
 	ok( $child.closest( $body.add($parent) ).is("#nothiddendiv"), "Closest ancestor retrieved." );
 });
 
 test("not(Selector|undefined)", function() {
 	expect(11);
-	equals( jQuery("#qunit-fixture > p#ap > a").not("#google").length, 2, "not('selector')" );
-	same( jQuery("p").not(".result").get(), q("firstp", "ap", "sndp", "en", "sap", "first"), "not('.class')" );
-	same( jQuery("p").not("#ap, #sndp, .result").get(), q("firstp", "en", "sap", "first"), "not('selector, selector')" );
-	same( jQuery("#form option").not("option.emptyopt:contains('Nothing'),[selected],[value='1']").get(), q("option1c", "option1d", "option2c", "option3d", "option3e", "option4e","option5b"), "not('complex selector')");
+	equal( jQuery("#qunit-fixture > p#ap > a").not("#google").length, 2, "not('selector')" );
+	deepEqual( jQuery("p").not(".result").get(), q("firstp", "ap", "sndp", "en", "sap", "first"), "not('.class')" );
+	deepEqual( jQuery("p").not("#ap, #sndp, .result").get(), q("firstp", "en", "sap", "first"), "not('selector, selector')" );
+	deepEqual( jQuery("#form option").not("option.emptyopt:contains('Nothing'),[selected],[value='1']").get(), q("option1c", "option1d", "option2c", "option3d", "option3e", "option4e","option5b"), "not('complex selector')");
 
-	same( jQuery("#ap *").not("code").get(), q("google", "groups", "anchor1", "mark"), "not('tag selector')" );
-	same( jQuery("#ap *").not("code, #mark").get(), q("google", "groups", "anchor1"), "not('tag, ID selector')" );
-	same( jQuery("#ap *").not("#mark, code").get(), q("google", "groups", "anchor1"), "not('ID, tag selector')");
+	deepEqual( jQuery("#ap *").not("code").get(), q("google", "groups", "anchor1", "mark"), "not('tag selector')" );
+	deepEqual( jQuery("#ap *").not("code, #mark").get(), q("google", "groups", "anchor1"), "not('tag, ID selector')" );
+	deepEqual( jQuery("#ap *").not("#mark, code").get(), q("google", "groups", "anchor1"), "not('ID, tag selector')");
 
 	var all = jQuery("p").get();
-	same( jQuery("p").not(null).get(),      all, "not(null) should have no effect");
-	same( jQuery("p").not(undefined).get(), all, "not(undefined) should have no effect");
-	same( jQuery("p").not(0).get(),         all, "not(0) should have no effect");
-	same( jQuery("p").not("").get(),        all, "not('') should have no effect");
+	deepEqual( jQuery("p").not(null).get(),      all, "not(null) should have no effect");
+	deepEqual( jQuery("p").not(undefined).get(), all, "not(undefined) should have no effect");
+	deepEqual( jQuery("p").not(0).get(),         all, "not(0) should have no effect");
+	deepEqual( jQuery("p").not("").get(),        all, "not('') should have no effect");
 });
 
 test("not(Element)", function() {
 	expect(1);
 
 	var selects = jQuery("#form select");
-	same( selects.not( selects[1] ).get(), q("select1", "select3", "select4", "select5"), "filter out DOM element");
+	deepEqual( selects.not( selects[1] ).get(), q("select1", "select3", "select4", "select5"), "filter out DOM element");
 });
 
 test("not(Function)", function() {
-	same( jQuery("#qunit-fixture p").not(function() { return jQuery("a", this).length }).get(), q("sndp", "first"), "not(Function)" );
+	deepEqual( jQuery("#qunit-fixture p").not(function() { return jQuery("a", this).length }).get(), q("sndp", "first"), "not(Function)" );
 });
 
 test("not(Array)", function() {
 	expect(2);
 
-	equals( jQuery("#qunit-fixture > p#ap > a").not(document.getElementById("google")).length, 2, "not(DOMElement)" );
-	equals( jQuery("p").not(document.getElementsByTagName("p")).length, 0, "not(Array-like DOM collection)" );
+	equal( jQuery("#qunit-fixture > p#ap > a").not(document.getElementById("google")).length, 2, "not(DOMElement)" );
+	equal( jQuery("p").not(document.getElementsByTagName("p")).length, 0, "not(Array-like DOM collection)" );
 });
 
 test("not(jQuery)", function() {
 	expect(1);
 
-	same( jQuery("p").not(jQuery("#ap, #sndp, .result")).get(), q("firstp", "en", "sap", "first"), "not(jQuery)" );
+	deepEqual( jQuery("p").not(jQuery("#ap, #sndp, .result")).get(), q("firstp", "en", "sap", "first"), "not(jQuery)" );
 });
 
 test("has(Element)", function() {
 	expect(2);
 
 	var obj = jQuery("#qunit-fixture").has(jQuery("#sndp")[0]);
-	same( obj.get(), q("qunit-fixture"), "Keeps elements that have the element as a descendant" );
+	deepEqual( obj.get(), q("qunit-fixture"), "Keeps elements that have the element as a descendant" );
 
 	var multipleParent = jQuery("#qunit-fixture, #header").has(jQuery("#sndp")[0]);
-	same( obj.get(), q("qunit-fixture"), "Does not include elements that do not have the element as a descendant" );
+	deepEqual( obj.get(), q("qunit-fixture"), "Does not include elements that do not have the element as a descendant" );
 });
 
 test("has(Selector)", function() {
 	expect(3);
 
 	var obj = jQuery("#qunit-fixture").has("#sndp");
-	same( obj.get(), q("qunit-fixture"), "Keeps elements that have any element matching the selector as a descendant" );
+	deepEqual( obj.get(), q("qunit-fixture"), "Keeps elements that have any element matching the selector as a descendant" );
 
 	var multipleParent = jQuery("#qunit-fixture, #header").has("#sndp");
-	same( obj.get(), q("qunit-fixture"), "Does not include elements that do not have the element as a descendant" );
+	deepEqual( obj.get(), q("qunit-fixture"), "Does not include elements that do not have the element as a descendant" );
 
 	var multipleHas = jQuery("#qunit-fixture").has("#sndp, #first");
-	same( multipleHas.get(), q("qunit-fixture"), "Only adds elements once" );
+	deepEqual( multipleHas.get(), q("qunit-fixture"), "Only adds elements once" );
 });
 
 test("has(Arrayish)", function() {
 	expect(3);
 
 	var simple = jQuery("#qunit-fixture").has(jQuery("#sndp"));
-	same( simple.get(), q("qunit-fixture"), "Keeps elements that have any element in the jQuery list as a descendant" );
+	deepEqual( simple.get(), q("qunit-fixture"), "Keeps elements that have any element in the jQuery list as a descendant" );
 
 	var multipleParent = jQuery("#qunit-fixture, #header").has(jQuery("#sndp"));
-	same( multipleParent.get(), q("qunit-fixture"), "Does not include elements that do not have an element in the jQuery list as a descendant" );
+	deepEqual( multipleParent.get(), q("qunit-fixture"), "Does not include elements that do not have an element in the jQuery list as a descendant" );
 
 	var multipleHas = jQuery("#qunit-fixture").has(jQuery("#sndp, #first"));
-	same( simple.get(), q("qunit-fixture"), "Only adds elements once" );
+	deepEqual( simple.get(), q("qunit-fixture"), "Only adds elements once" );
 });
 
 test("andSelf()", function() {
 	expect(4);
-	same( jQuery("#en").siblings().andSelf().get(), q("sndp", "en", "sap"), "Check for siblings and self" );
-	same( jQuery("#foo").children().andSelf().get(), q("foo", "sndp", "en", "sap"), "Check for children and self" );
-	same( jQuery("#sndp, #en").parent().andSelf().get(), q("foo","sndp","en"), "Check for parent and self" );
-	same( jQuery("#groups").parents("p, div").andSelf().get(), q("qunit-fixture", "ap", "groups"), "Check for parents and self" );
+	deepEqual( jQuery("#en").siblings().andSelf().get(), q("sndp", "en", "sap"), "Check for siblings and self" );
+	deepEqual( jQuery("#foo").children().andSelf().get(), q("foo", "sndp", "en", "sap"), "Check for children and self" );
+	deepEqual( jQuery("#sndp, #en").parent().andSelf().get(), q("foo","sndp","en"), "Check for parent and self" );
+	deepEqual( jQuery("#groups").parents("p, div").andSelf().get(), q("qunit-fixture", "ap", "groups"), "Check for parents and self" );
 });
 
 test("siblings([String])", function() {
 	expect(6);
-	same( jQuery("#en").siblings().get(), q("sndp", "sap"), "Check for siblings" );
-	same( jQuery("#sndp").siblings(":has(code)").get(), q("sap"), "Check for filtered siblings (has code child element)" );
-	same( jQuery("#sndp").siblings(":has(a)").get(), q("en", "sap"), "Check for filtered siblings (has anchor child element)" );
-	same( jQuery("#foo").siblings("form, b").get(), q("form", "floatTest", "lengthtest", "name-tests", "testForm"), "Check for multiple filters" );
+	deepEqual( jQuery("#en").siblings().get(), q("sndp", "sap"), "Check for siblings" );
+	deepEqual( jQuery("#sndp").siblings(":has(code)").get(), q("sap"), "Check for filtered siblings (has code child element)" );
+	deepEqual( jQuery("#sndp").siblings(":has(a)").get(), q("en", "sap"), "Check for filtered siblings (has anchor child element)" );
+	deepEqual( jQuery("#foo").siblings("form, b").get(), q("form", "floatTest", "lengthtest", "name-tests", "testForm"), "Check for multiple filters" );
 	var set = q("sndp", "en", "sap");
-	same( jQuery("#en, #sndp").siblings().get(), set, "Check for unique results from siblings" );
+	deepEqual( jQuery("#en, #sndp").siblings().get(), set, "Check for unique results from siblings" );
 	deepEqual( jQuery("#option5a").siblings("option[data-attr]").get(), q("option5c"), "Has attribute selector in siblings (#9261)" );
 });
 
 test("children([String])", function() {
 	expect(3);
-	same( jQuery("#foo").children().get(), q("sndp", "en", "sap"), "Check for children" );
-	same( jQuery("#foo").children(":has(code)").get(), q("sndp", "sap"), "Check for filtered children" );
-	same( jQuery("#foo").children("#en, #sap").get(), q("en", "sap"), "Check for multiple filters" );
+	deepEqual( jQuery("#foo").children().get(), q("sndp", "en", "sap"), "Check for children" );
+	deepEqual( jQuery("#foo").children(":has(code)").get(), q("sndp", "sap"), "Check for filtered children" );
+	deepEqual( jQuery("#foo").children("#en, #sap").get(), q("en", "sap"), "Check for multiple filters" );
 });
 
 test("parent([String])", function() {
 	expect(5);
-	equals( jQuery("#groups").parent()[0].id, "ap", "Simple parent check" );
-	equals( jQuery("#groups").parent("p")[0].id, "ap", "Filtered parent check" );
-	equals( jQuery("#groups").parent("div").length, 0, "Filtered parent check, no match" );
-	equals( jQuery("#groups").parent("div, p")[0].id, "ap", "Check for multiple filters" );
-	same( jQuery("#en, #sndp").parent().get(), q("foo"), "Check for unique results from parent" );
+	equal( jQuery("#groups").parent()[0].id, "ap", "Simple parent check" );
+	equal( jQuery("#groups").parent("p")[0].id, "ap", "Filtered parent check" );
+	equal( jQuery("#groups").parent("div").length, 0, "Filtered parent check, no match" );
+	equal( jQuery("#groups").parent("div, p")[0].id, "ap", "Check for multiple filters" );
+	deepEqual( jQuery("#en, #sndp").parent().get(), q("foo"), "Check for unique results from parent" );
 });
 
 test("parents([String])", function() {
 	expect(5);
-	equals( jQuery("#groups").parents()[0].id, "ap", "Simple parents check" );
-	equals( jQuery("#groups").parents("p")[0].id, "ap", "Filtered parents check" );
-	equals( jQuery("#groups").parents("div")[0].id, "qunit-fixture", "Filtered parents check2" );
-	same( jQuery("#groups").parents("p, div").get(), q("ap", "qunit-fixture"), "Check for multiple filters" );
-	same( jQuery("#en, #sndp").parents().get(), q("foo", "qunit-fixture", "dl", "body", "html"), "Check for unique results from parents" );
+	equal( jQuery("#groups").parents()[0].id, "ap", "Simple parents check" );
+	equal( jQuery("#groups").parents("p")[0].id, "ap", "Filtered parents check" );
+	equal( jQuery("#groups").parents("div")[0].id, "qunit-fixture", "Filtered parents check2" );
+	deepEqual( jQuery("#groups").parents("p, div").get(), q("ap", "qunit-fixture"), "Check for multiple filters" );
+	deepEqual( jQuery("#en, #sndp").parents().get(), q("foo", "qunit-fixture", "dl", "body", "html"), "Check for unique results from parents" );
 });
 
 test("parentsUntil([String])", function() {
@@ -452,31 +452,31 @@ test("parentsUntil([String])", function() {
 
 	var parents = jQuery("#groups").parents();
 
-	same( jQuery("#groups").parentsUntil().get(), parents.get(), "parentsUntil with no selector (nextAll)" );
-	same( jQuery("#groups").parentsUntil(".foo").get(), parents.get(), "parentsUntil with invalid selector (nextAll)" );
-	same( jQuery("#groups").parentsUntil("#html").get(), parents.not(":last").get(), "Simple parentsUntil check" );
-	equals( jQuery("#groups").parentsUntil("#ap").length, 0, "Simple parentsUntil check" );
-	same( jQuery("#groups").parentsUntil("#html, #body").get(), parents.slice( 0, 3 ).get(), "Less simple parentsUntil check" );
-	same( jQuery("#groups").parentsUntil("#html", "div").get(), jQuery("#qunit-fixture").get(), "Filtered parentsUntil check" );
-	same( jQuery("#groups").parentsUntil("#html", "p,div,dl").get(), parents.slice( 0, 3 ).get(), "Multiple-filtered parentsUntil check" );
-	equals( jQuery("#groups").parentsUntil("#html", "span").length, 0, "Filtered parentsUntil check, no match" );
-	same( jQuery("#groups, #ap").parentsUntil("#html", "p,div,dl").get(), parents.slice( 0, 3 ).get(), "Multi-source, multiple-filtered parentsUntil check" );
+	deepEqual( jQuery("#groups").parentsUntil().get(), parents.get(), "parentsUntil with no selector (nextAll)" );
+	deepEqual( jQuery("#groups").parentsUntil(".foo").get(), parents.get(), "parentsUntil with invalid selector (nextAll)" );
+	deepEqual( jQuery("#groups").parentsUntil("#html").get(), parents.not(":last").get(), "Simple parentsUntil check" );
+	equal( jQuery("#groups").parentsUntil("#ap").length, 0, "Simple parentsUntil check" );
+	deepEqual( jQuery("#groups").parentsUntil("#html, #body").get(), parents.slice( 0, 3 ).get(), "Less simple parentsUntil check" );
+	deepEqual( jQuery("#groups").parentsUntil("#html", "div").get(), jQuery("#qunit-fixture").get(), "Filtered parentsUntil check" );
+	deepEqual( jQuery("#groups").parentsUntil("#html", "p,div,dl").get(), parents.slice( 0, 3 ).get(), "Multiple-filtered parentsUntil check" );
+	equal( jQuery("#groups").parentsUntil("#html", "span").length, 0, "Filtered parentsUntil check, no match" );
+	deepEqual( jQuery("#groups, #ap").parentsUntil("#html", "p,div,dl").get(), parents.slice( 0, 3 ).get(), "Multi-source, multiple-filtered parentsUntil check" );
 });
 
 test("next([String])", function() {
 	expect(4);
-	equals( jQuery("#ap").next()[0].id, "foo", "Simple next check" );
-	equals( jQuery("#ap").next("div")[0].id, "foo", "Filtered next check" );
-	equals( jQuery("#ap").next("p").length, 0, "Filtered next check, no match" );
-	equals( jQuery("#ap").next("div, p")[0].id, "foo", "Multiple filters" );
+	equal( jQuery("#ap").next()[0].id, "foo", "Simple next check" );
+	equal( jQuery("#ap").next("div")[0].id, "foo", "Filtered next check" );
+	equal( jQuery("#ap").next("p").length, 0, "Filtered next check, no match" );
+	equal( jQuery("#ap").next("div, p")[0].id, "foo", "Multiple filters" );
 });
 
 test("prev([String])", function() {
 	expect(4);
-	equals( jQuery("#foo").prev()[0].id, "ap", "Simple prev check" );
-	equals( jQuery("#foo").prev("p")[0].id, "ap", "Filtered prev check" );
-	equals( jQuery("#foo").prev("div").length, 0, "Filtered prev check, no match" );
-	equals( jQuery("#foo").prev("p, div")[0].id, "ap", "Multiple filters" );
+	equal( jQuery("#foo").prev()[0].id, "ap", "Simple prev check" );
+	equal( jQuery("#foo").prev("p")[0].id, "ap", "Filtered prev check" );
+	equal( jQuery("#foo").prev("div").length, 0, "Filtered prev check, no match" );
+	equal( jQuery("#foo").prev("p, div")[0].id, "ap", "Multiple filters" );
 });
 
 test("nextAll([String])", function() {
@@ -484,10 +484,10 @@ test("nextAll([String])", function() {
 
 	var elems = jQuery("#form").children();
 
-	same( jQuery("#label-for").nextAll().get(), elems.not(":first").get(), "Simple nextAll check" );
-	same( jQuery("#label-for").nextAll("input").get(), elems.not(":first").filter("input").get(), "Filtered nextAll check" );
-	same( jQuery("#label-for").nextAll("input,select").get(), elems.not(":first").filter("input,select").get(), "Multiple-filtered nextAll check" );
-	same( jQuery("#label-for, #hidden1").nextAll("input,select").get(), elems.not(":first").filter("input,select").get(), "Multi-source, multiple-filtered nextAll check" );
+	deepEqual( jQuery("#label-for").nextAll().get(), elems.not(":first").get(), "Simple nextAll check" );
+	deepEqual( jQuery("#label-for").nextAll("input").get(), elems.not(":first").filter("input").get(), "Filtered nextAll check" );
+	deepEqual( jQuery("#label-for").nextAll("input,select").get(), elems.not(":first").filter("input,select").get(), "Multiple-filtered nextAll check" );
+	deepEqual( jQuery("#label-for, #hidden1").nextAll("input,select").get(), elems.not(":first").filter("input,select").get(), "Multi-source, multiple-filtered nextAll check" );
 });
 
 test("prevAll([String])", function() {
@@ -495,10 +495,10 @@ test("prevAll([String])", function() {
 
 	var elems = jQuery( jQuery("#form").children().slice(0, 12).get().reverse() );
 
-	same( jQuery("#area1").prevAll().get(), elems.get(), "Simple prevAll check" );
-	same( jQuery("#area1").prevAll("input").get(), elems.filter("input").get(), "Filtered prevAll check" );
-	same( jQuery("#area1").prevAll("input,select").get(), elems.filter("input,select").get(), "Multiple-filtered prevAll check" );
-	same( jQuery("#area1, #hidden1").prevAll("input,select").get(), elems.filter("input,select").get(), "Multi-source, multiple-filtered prevAll check" );
+	deepEqual( jQuery("#area1").prevAll().get(), elems.get(), "Simple prevAll check" );
+	deepEqual( jQuery("#area1").prevAll("input").get(), elems.filter("input").get(), "Filtered prevAll check" );
+	deepEqual( jQuery("#area1").prevAll("input,select").get(), elems.filter("input,select").get(), "Multiple-filtered prevAll check" );
+	deepEqual( jQuery("#area1, #hidden1").prevAll("input,select").get(), elems.filter("input,select").get(), "Multi-source, multiple-filtered prevAll check" );
 });
 
 test("nextUntil([String])", function() {
@@ -506,18 +506,18 @@ test("nextUntil([String])", function() {
 
 	var elems = jQuery("#form").children().slice( 2, 12 );
 
-	same( jQuery("#text1").nextUntil().get(), jQuery("#text1").nextAll().get(), "nextUntil with no selector (nextAll)" );
-	same( jQuery("#text1").nextUntil(".foo").get(), jQuery("#text1").nextAll().get(), "nextUntil with invalid selector (nextAll)" );
-	same( jQuery("#text1").nextUntil("#area1").get(), elems.get(), "Simple nextUntil check" );
-	equals( jQuery("#text1").nextUntil("#text2").length, 0, "Simple nextUntil check" );
-	same( jQuery("#text1").nextUntil("#area1, #radio1").get(), jQuery("#text1").next().get(), "Less simple nextUntil check" );
-	same( jQuery("#text1").nextUntil("#area1", "input").get(), elems.not("button").get(), "Filtered nextUntil check" );
-	same( jQuery("#text1").nextUntil("#area1", "button").get(), elems.not("input").get(), "Filtered nextUntil check" );
-	same( jQuery("#text1").nextUntil("#area1", "button,input").get(), elems.get(), "Multiple-filtered nextUntil check" );
-	equals( jQuery("#text1").nextUntil("#area1", "div").length, 0, "Filtered nextUntil check, no match" );
-	same( jQuery("#text1, #hidden1").nextUntil("#area1", "button,input").get(), elems.get(), "Multi-source, multiple-filtered nextUntil check" );
+	deepEqual( jQuery("#text1").nextUntil().get(), jQuery("#text1").nextAll().get(), "nextUntil with no selector (nextAll)" );
+	deepEqual( jQuery("#text1").nextUntil(".foo").get(), jQuery("#text1").nextAll().get(), "nextUntil with invalid selector (nextAll)" );
+	deepEqual( jQuery("#text1").nextUntil("#area1").get(), elems.get(), "Simple nextUntil check" );
+	equal( jQuery("#text1").nextUntil("#text2").length, 0, "Simple nextUntil check" );
+	deepEqual( jQuery("#text1").nextUntil("#area1, #radio1").get(), jQuery("#text1").next().get(), "Less simple nextUntil check" );
+	deepEqual( jQuery("#text1").nextUntil("#area1", "input").get(), elems.not("button").get(), "Filtered nextUntil check" );
+	deepEqual( jQuery("#text1").nextUntil("#area1", "button").get(), elems.not("input").get(), "Filtered nextUntil check" );
+	deepEqual( jQuery("#text1").nextUntil("#area1", "button,input").get(), elems.get(), "Multiple-filtered nextUntil check" );
+	equal( jQuery("#text1").nextUntil("#area1", "div").length, 0, "Filtered nextUntil check, no match" );
+	deepEqual( jQuery("#text1, #hidden1").nextUntil("#area1", "button,input").get(), elems.get(), "Multi-source, multiple-filtered nextUntil check" );
 
-	same( jQuery("#text1").nextUntil("[class=foo]").get(), jQuery("#text1").nextAll().get(), "Non-element nodes must be skipped, since they have no attributes" );
+	deepEqual( jQuery("#text1").nextUntil("[class=foo]").get(), jQuery("#text1").nextAll().get(), "Non-element nodes must be skipped, since they have no attributes" );
 });
 
 test("prevUntil([String])", function() {
@@ -525,54 +525,54 @@ test("prevUntil([String])", function() {
 
 	var elems = jQuery("#area1").prevAll();
 
-	same( jQuery("#area1").prevUntil().get(), elems.get(), "prevUntil with no selector (prevAll)" );
-	same( jQuery("#area1").prevUntil(".foo").get(), elems.get(), "prevUntil with invalid selector (prevAll)" );
-	same( jQuery("#area1").prevUntil("label").get(), elems.not(":last").get(), "Simple prevUntil check" );
-	equals( jQuery("#area1").prevUntil("#button").length, 0, "Simple prevUntil check" );
-	same( jQuery("#area1").prevUntil("label, #search").get(), jQuery("#area1").prev().get(), "Less simple prevUntil check" );
-	same( jQuery("#area1").prevUntil("label", "input").get(), elems.not(":last").not("button").get(), "Filtered prevUntil check" );
-	same( jQuery("#area1").prevUntil("label", "button").get(), elems.not(":last").not("input").get(), "Filtered prevUntil check" );
-	same( jQuery("#area1").prevUntil("label", "button,input").get(), elems.not(":last").get(), "Multiple-filtered prevUntil check" );
-	equals( jQuery("#area1").prevUntil("label", "div").length, 0, "Filtered prevUntil check, no match" );
-	same( jQuery("#area1, #hidden1").prevUntil("label", "button,input").get(), elems.not(":last").get(), "Multi-source, multiple-filtered prevUntil check" );
+	deepEqual( jQuery("#area1").prevUntil().get(), elems.get(), "prevUntil with no selector (prevAll)" );
+	deepEqual( jQuery("#area1").prevUntil(".foo").get(), elems.get(), "prevUntil with invalid selector (prevAll)" );
+	deepEqual( jQuery("#area1").prevUntil("label").get(), elems.not(":last").get(), "Simple prevUntil check" );
+	equal( jQuery("#area1").prevUntil("#button").length, 0, "Simple prevUntil check" );
+	deepEqual( jQuery("#area1").prevUntil("label, #search").get(), jQuery("#area1").prev().get(), "Less simple prevUntil check" );
+	deepEqual( jQuery("#area1").prevUntil("label", "input").get(), elems.not(":last").not("button").get(), "Filtered prevUntil check" );
+	deepEqual( jQuery("#area1").prevUntil("label", "button").get(), elems.not(":last").not("input").get(), "Filtered prevUntil check" );
+	deepEqual( jQuery("#area1").prevUntil("label", "button,input").get(), elems.not(":last").get(), "Multiple-filtered prevUntil check" );
+	equal( jQuery("#area1").prevUntil("label", "div").length, 0, "Filtered prevUntil check, no match" );
+	deepEqual( jQuery("#area1, #hidden1").prevUntil("label", "button,input").get(), elems.not(":last").get(), "Multi-source, multiple-filtered prevUntil check" );
 });
 
 test("contents()", function() {
 	expect(12);
-	equals( jQuery("#ap").contents().length, 9, "Check element contents" );
+	equal( jQuery("#ap").contents().length, 9, "Check element contents" );
 	ok( jQuery("#iframe").contents()[0], "Check existance of IFrame document" );
 	var ibody = jQuery("#loadediframe").contents()[0].body;
 	ok( ibody, "Check existance of IFrame body" );
 
-	equals( jQuery("span", ibody).text(), "span text", "Find span in IFrame and check its text" );
+	equal( jQuery("span", ibody).text(), "span text", "Find span in IFrame and check its text" );
 
 	jQuery(ibody).append("<div>init text</div>");
-	equals( jQuery("div", ibody).length, 2, "Check the original div and the new div are in IFrame" );
+	equal( jQuery("div", ibody).length, 2, "Check the original div and the new div are in IFrame" );
 
-	equals( jQuery("div:last", ibody).text(), "init text", "Add text to div in IFrame" );
+	equal( jQuery("div:last", ibody).text(), "init text", "Add text to div in IFrame" );
 
 	jQuery("div:last", ibody).text("div text");
-	equals( jQuery("div:last", ibody).text(), "div text", "Add text to div in IFrame" );
+	equal( jQuery("div:last", ibody).text(), "div text", "Add text to div in IFrame" );
 
 	jQuery("div:last", ibody).remove();
-	equals( jQuery("div", ibody).length, 1, "Delete the div and check only one div left in IFrame" );
+	equal( jQuery("div", ibody).length, 1, "Delete the div and check only one div left in IFrame" );
 
-	equals( jQuery("div", ibody).text(), "span text", "Make sure the correct div is still left after deletion in IFrame" );
+	equal( jQuery("div", ibody).text(), "span text", "Make sure the correct div is still left after deletion in IFrame" );
 
 	jQuery("<table/>", ibody).append("<tr><td>cell</td></tr>").appendTo(ibody);
 	jQuery("table", ibody).remove();
-	equals( jQuery("div", ibody).length, 1, "Check for JS error on add and delete of a table in IFrame" );
+	equal( jQuery("div", ibody).length, 1, "Check for JS error on add and delete of a table in IFrame" );
 
 	// using contents will get comments regular, text, and comment nodes
 	var c = jQuery("#nonnodes").contents().contents();
-	equals( c.length, 1, "Check node,textnode,comment contents is just one" );
-	equals( c[0].nodeValue, "hi", "Check node,textnode,comment contents is just the one from span" );
+	equal( c.length, 1, "Check node,textnode,comment contents is just one" );
+	equal( c[0].nodeValue, "hi", "Check node,textnode,comment contents is just the one from span" );
 });
 
 test("add(String|Element|Array|undefined)", function() {
 	expect(16);
-	same( jQuery("#sndp").add("#en").add("#sap").get(), q("sndp", "en", "sap"), "Check elements from document" );
-	same( jQuery("#sndp").add( jQuery("#en")[0] ).add( jQuery("#sap") ).get(), q("sndp", "en", "sap"), "Check elements from document" );
+	deepEqual( jQuery("#sndp").add("#en").add("#sap").get(), q("sndp", "en", "sap"), "Check elements from document" );
+	deepEqual( jQuery("#sndp").add( jQuery("#en")[0] ).add( jQuery("#sap") ).get(), q("sndp", "en", "sap"), "Check elements from document" );
 
 	// We no longer support .add(form.elements), unfortunately.
 	// There is no way, in browsers, to reliably determine the difference
@@ -582,13 +582,13 @@ test("add(String|Element|Array|undefined)", function() {
 
 	// For the time being, we're discontinuing support for jQuery(form.elements) since it's ambiguous in IE
 	// use jQuery([]).add(form.elements) instead.
-	//equals( jQuery([]).add(jQuery("#form")[0].elements).length, jQuery(jQuery("#form")[0].elements).length, "Array in constructor must equals array in add()" );
+	//equal( jQuery([]).add(jQuery("#form")[0].elements).length, jQuery(jQuery("#form")[0].elements).length, "Array in constructor must equals array in add()" );
 
 	var divs = jQuery("<div/>").add("#sndp");
 	ok( !divs[0].parentNode, "Make sure the first element is still the disconnected node." );
 
 	divs = jQuery("<div>test</div>").add("#sndp");
-	equals( divs[0].parentNode.nodeType, 11, "Make sure the first element is still the disconnected node." );
+	equal( divs[0].parentNode.nodeType, 11, "Make sure the first element is still the disconnected node." );
 
 	divs = jQuery("#sndp").add("<div/>");
 	ok( !divs[1].parentNode, "Make sure the first element is still the disconnected node." );
@@ -596,26 +596,26 @@ test("add(String|Element|Array|undefined)", function() {
 	var tmp = jQuery("<div/>");
 
 	var x = jQuery([]).add(jQuery("<p id='x1'>xxx</p>").appendTo(tmp)).add(jQuery("<p id='x2'>xxx</p>").appendTo(tmp));
-	equals( x[0].id, "x1", "Check on-the-fly element1" );
-	equals( x[1].id, "x2", "Check on-the-fly element2" );
+	equal( x[0].id, "x1", "Check on-the-fly element1" );
+	equal( x[1].id, "x2", "Check on-the-fly element2" );
 
 	var x = jQuery([]).add(jQuery("<p id='x1'>xxx</p>").appendTo(tmp)[0]).add(jQuery("<p id='x2'>xxx</p>").appendTo(tmp)[0]);
-	equals( x[0].id, "x1", "Check on-the-fly element1" );
-	equals( x[1].id, "x2", "Check on-the-fly element2" );
+	equal( x[0].id, "x1", "Check on-the-fly element1" );
+	equal( x[1].id, "x2", "Check on-the-fly element2" );
 
 	var x = jQuery([]).add(jQuery("<p id='x1'>xxx</p>")).add(jQuery("<p id='x2'>xxx</p>"));
-	equals( x[0].id, "x1", "Check on-the-fly element1" );
-	equals( x[1].id, "x2", "Check on-the-fly element2" );
+	equal( x[0].id, "x1", "Check on-the-fly element1" );
+	equal( x[1].id, "x2", "Check on-the-fly element2" );
 
 	var x = jQuery([]).add("<p id='x1'>xxx</p>").add("<p id='x2'>xxx</p>");
-	equals( x[0].id, "x1", "Check on-the-fly element1" );
-	equals( x[1].id, "x2", "Check on-the-fly element2" );
+	equal( x[0].id, "x1", "Check on-the-fly element1" );
+	equal( x[1].id, "x2", "Check on-the-fly element2" );
 
 	var notDefined;
-	equals( jQuery([]).add(notDefined).length, 0, "Check that undefined adds nothing" );
+	equal( jQuery([]).add(notDefined).length, 0, "Check that undefined adds nothing" );
 
-	equals( jQuery([]).add( document.getElementById("form") ).length, 1, "Add a form" );
-	equals( jQuery([]).add( document.getElementById("select1") ).length, 1, "Add a select" );
+	equal( jQuery([]).add( document.getElementById("form") ).length, 1, "Add a form" );
+	equal( jQuery([]).add( document.getElementById("select1") ).length, 1, "Add a select" );
 });
 
 test("add(String, Context)", function() {


### PR DESCRIPTION
fixes #10691, remove all instances of equals() and same(), as these are deprecated in QUnit.

A big PR, I know, but I've tested this a few times, and it is relatively harmless, and I'll do another sweep in a few weeks to catch any other PR's that get in that use these functions.

Also, if any PR's get in that DO use equals() or same(), QUnit already has a backup of these functions, so the backwars compat stuff in testrunner.js was unnecessary anyway and won't cause tests to break.
