### PR TITLE
`self` instead of `$this`

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -294,12 +294,12 @@ jQuery.fn.extend({
 
 		} else {
 			return this.each(function() {
-				var $this = jQuery( this ),
+				var self = jQuery( this ),
 					args = [ parts[0], value ];
 
-				$this.triggerHandler( "setData" + parts[1] + "!", args );
+				self.triggerHandler( "setData" + parts[1] + "!", args );
 				jQuery.data( this, key, value );
-				$this.triggerHandler( "changeData" + parts[1] + "!", args );
+				self.triggerHandler( "changeData" + parts[1] + "!", args );
 			});
 		}
 	},


### PR DESCRIPTION
It seems the convention is to use `self` for caching `jQuery ( this )` instead of using `$this`.
