### PR TITLE
Move AMD registration to end of file.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -934,20 +934,6 @@ function doScrollCheck() {
 	jQuery.ready();
 }
 
-// Expose jQuery as an AMD module, but only for AMD loaders that
-// understand the issues with loading multiple versions of jQuery
-// in a page that all might call define(). The loader will indicate
-// they have special allowances for multiple jQuery versions by
-// specifying define.amd.jQuery = true. Register as a named module,
-// since jQuery can be concatenated with other files that may use define,
-// but not use a proper concatenation script that understands anonymous
-// AMD modules. A named AMD is safest and most robust way to register.
-// Lowercase jquery is used because AMD module names are derived from
-// file names, and jQuery is normally delivered in a lowercase file name.
-if ( typeof define === "function" && define.amd && define.amd.jQuery ) {
-	define( "jquery", [], function () { return jQuery; } );
-}
-
 return jQuery;
 
 })();

--- a/src/outro.js
+++ b/src/outro.js
@@ -1,3 +1,20 @@
 // Expose jQuery to the global object
 window.jQuery = window.$ = jQuery;
+
+// Expose jQuery as an AMD module, but only for AMD loaders that
+// understand the issues with loading multiple versions of jQuery
+// in a page that all might call define(). The loader will indicate
+// they have special allowances for multiple jQuery versions by
+// specifying define.amd.jQuery = true. Register as a named module,
+// since jQuery can be concatenated with other files that may use define,
+// but not use a proper concatenation script that understands anonymous
+// AMD modules. A named AMD is safest and most robust way to register.
+// Lowercase jquery is used because AMD module names are derived from
+// file names, and jQuery is normally delivered in a lowercase file name.
+// Do this after creating the global so that if an AMD module wants to call
+// noConflict to hide this version of jQuery, it will work.
+if ( typeof define === "function" && define.amd && define.amd.jQuery ) {
+	define( "jquery", [], function () { return jQuery; } );
+}
+
 })( window );

--- a/test/data/testinit.js
+++ b/test/data/testinit.js
@@ -1,19 +1,7 @@
 var jQuery = this.jQuery || "jQuery", // For testing .noConflict()
 	$ = this.$ || "$",
 	originaljQuery = jQuery,
-	original$ = $,
-	amdDefined;
-
-/**
- * Set up a mock AMD define function for testing AMD registration.
- */
-function define(name, dependencies, callback) {
-	amdDefined = callback();
-}
-
-define.amd = {
-	jQuery: true
-};
+	original$ = $;
 
 /**
  * Returns an array of elements with the given IDs, eg.

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -225,12 +225,6 @@ test("browser", function() {
 });
 }
 
-test("amdModule", function() {
-	expect(1);
-
-	equal( jQuery, amdDefined, "Make sure defined module matches jQuery" );
-});
-
 test("noConflict", function() {
 	expect(7);
 
@@ -522,7 +516,7 @@ test("isXMLDoc - HTML", function() {
 
 test("XSS via location.hash", function() {
 	expect(1);
-	
+
 	stop();
 	jQuery._check9521 = function(x){
 		ok( x, "script called from #id-like selector with inline handler" );


### PR DESCRIPTION
This is in reference to [ticket 10687](http://bugs.jquery.com/ticket/10687):

This better represents when jQuery is completely defined and is compatible with more AMD loaders.

It meant the unit test had to be removed since the AMD registration moved to outro.js, and as far as I know there are no tests just for outro. However I have tested this file and it does work in requirejs. @unscriptable should probably also give it a whirl in curl to confirm the fix.

If it makes sense, I can do a test that can be placed in the test/ directory and load the dist/jquery.js file for the test, but I am not sure if there is precedent for that, or if it is good enough that some AMD folks have confirmed the fix.
