### PR TITLE
Replace .bind with .on when building event aliases

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -1033,7 +1033,7 @@ jQuery.each( ("blur focus focusin focusout load resize scroll unload click dblcl
 		}
 
 		return arguments.length > 0 ?
-			this.bind( name, data, fn ) :
+			this.on( name, null, data, fn ) :
 			this.trigger( name );
 	};
 


### PR DESCRIPTION
Noticed this earlier when I was answering a question.  If .bind is deprecated and .on is the preferred method, I figure it should be swapped out here.
