### PR TITLE
Removing .unbind in favor of .off in jQuery.ready

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -418,7 +418,7 @@ jQuery.extend({
 
 			// Trigger any bound ready events
 			if ( jQuery.fn.trigger ) {
-				jQuery( document ).trigger( "ready" ).unbind( "ready" );
+				jQuery( document ).trigger( "ready" ).off( "ready" );
 			}
 		}
 	},


### PR DESCRIPTION
Another place that's using a deprecated event function
