### PR TITLE
Reorder build file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ BASE_FILES = ${SRC_DIR}/core.js\
 	${SRC_DIR}/event.js\
 	${SRC_DIR}/selector.js\
 	${SRC_DIR}/ajax.js\
-	${SRC_DIR}/manipulation.js
+	${SRC_DIR}/manipulation.js\
 	${SRC_DIR}/traversing.js\
 	${SRC_DIR}/effects.js\
 	${SRC_DIR}/callbacks.js\


### PR DESCRIPTION
By re-ordering the build file to make GZIP a bit more effective, I was able to shave off 140 gzipped bytes with no code change.

The tests seem to be working, meaning that no new tests fail ( there are a couple in master that fail for me, don't know if that's expected ), but obviously someone with more experience should try this out and confirm.
