### PR TITLE
Fixes #10699. Trigger directly-bound event handlers if passed event was initially prevented.

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -442,9 +442,7 @@ jQuery.event = {
 			handlerQueue.push({ elem: this, matches: handlers.slice( delegateCount ) });
 		}
 
-		// Run delegates first; they may want to stop propagation beneath us
-		for ( i = 0; i < handlerQueue.length && !event.isPropagationStopped(); i++ ) {
-			matched = handlerQueue[ i ];
+		function runEvent(matched) {
 			event.currentTarget = matched.elem;
 
 			for ( j = 0; j < matched.matches.length && !event.isImmediatePropagationStopped(); j++ ) {
@@ -469,6 +467,16 @@ jQuery.event = {
 					}
 				}
 			}
+		}
+
+		// Run delegates first; they may want to stop propagation beneath us
+		if (!event.isPropagationStopped()) {
+			for ( i = 0; i < handlerQueue.length && !event.isPropagationStopped(); i++ ) {
+				runEvent ( handlerQueue[ i ] );
+			}
+		} else {
+			// Run only directly-bound handlers
+			runEvent ( handlerQueue[ handlerQueue.length - 1 ] );
 		}
 
 		return event.result;

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -1158,6 +1158,27 @@ test(".trigger() bubbling on disconnected elements (#10489)", function() {
 	jQuery( window ).off( "click" );
 });
 
+test(".trigger() of event object with stopped propagation (#10699)", function() {
+	expect(1);
+
+	var e = new jQuery.Event("foo");
+	e.stopPropagation();
+
+	jQuery("<div><p>hello</p></div>")
+		.on("foo", function() {
+			ok(false, "event should not bubble");
+		})
+		.find("p")
+			.on("foo", function() {
+				ok(true, "element events should be triggered");
+			})
+			.trigger(e)
+			.off("foo")
+		.end()
+		.off("foo")
+		.remove();
+});
+
 test(".trigger() doesn't bubble load event (#10717)", function() {
 	expect(1);
 


### PR DESCRIPTION
Simple check for events that are being triggered after stopPropagation() has been called. Quoting my original [bug report](http://bugs.jquery.com/ticket/10699#comment:3), this is useful when having nested elements that are bound to the same event and one needs to trigger only the handlers for the nested element.
