### PR TITLE
ability to retrieve uncomputed styles in IE<9, fixes #10796

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -5,7 +5,7 @@ var ralpha = /alpha\([^)]*\)/i,
 	// fixed for IE9, see #8346
 	rupper = /([A-Z]|^ms)/g,
 	rnumpx = /^-?\d+(?:px)?$/i,
-	rnumnopx = /^-?\d+(?!px)[^\d]+$/i,
+	rnumnopx = /^-?\d+(?!px)[^\d\s]+$/i,
 	rrelNum = /^([\-+])=([\-+.\de]+)/,
 
 	cssShow = { position: "absolute", visibility: "hidden", display: "block" },
@@ -297,7 +297,7 @@ if ( document.documentElement.currentStyle ) {
 
 		// If we're not dealing with a regular pixel number
 		// but a number that has a weird ending, we need to convert it to pixels
-		if ( !rnumpx.test( ret ) && rnumnopx.test( ret ) ) {
+		if ( rnumnopx.test( ret ) ) {
 
 			// Remember the original values
 			left = style.left;

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -512,19 +512,26 @@ test("can't get css for disconnected in IE<9, see #10254 and #8388", function() 
 });
 
 test("can't get background-position in IE<9, see #10796", function() {
-	expect( 4 );
+	var div = jQuery( "<div/>" ).appendTo( "#qunit-fixture" ),
+		units = [
+			"0 0",
+			"12px 12px",
+			"13px 12em",
+			"12em 13px",
+			"12em center",
+			"+12em center",
+			"12.2em center",
+			"center center",
+		],
+		l = units.length,
+		i = 0;
 
-	var div = jQuery( "<div/>" ).css( "background-position", "0 0" ).appendTo( "#qunit-fixture" );
-	notEqual( div.css( "background-position" ), null, "can't get background-position in IE<9, see #10796" );
+	expect( l );
 
-	div.css( "background-position", "12px 12px" );
-	notEqual( div.css( "background-position" ), null, "can't get background-position in IE<9, see #10796" );
-
-	div.css( "background-position", "13px 12em" );
-	notEqual( div.css( "background-position" ), null, "can't get background-position in IE<9, see #10796" );
-
-	div.css( "background-position", "12em 13px" );
-	notEqual( div.css( "background-position" ), null, "can't get background-position in IE<9, see #10796" );
+	for( ; i < l; i++ ) {
+		div.css( "background-position", units [ i ] );
+		ok( div.css( "background-position" ), "can't get background-position in IE<9, see #10796" );
+	}
 });
 
 test("Do not append px to 'fill-opacity' #9548", 1, function() {


### PR DESCRIPTION
> Some people, when confronted with a problem, think "I know, I'll use regular expressions." Now they have two problems.

But seriously, I suck at them. Please let me know if there is a less complex regex that fixes this bug.
