### PR TITLE
Drag and drop events have dataTransfer and filtered as mouse events. Fixes #10729

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -1043,5 +1043,14 @@ jQuery.each( ("blur focus focusin focusout load resize scroll unload click dblcl
 	}
 });
 
+jQuery.event.dndHooks = {
+    props: jQuery.event.mouseHooks.props.concat( "dataTransfer" ),
+    filter: jQuery.event.mouseHooks.filter
+};
+
+jQuery.each( ("dragstart dragenter dragover dragleave drag drop dragend").split(" "), function ( i, name ) {
+    jQuery.event.fixHooks[ name ] = jQuery.event.dndHooks;
+});
+
 })( jQuery );
 


### PR DESCRIPTION
Adds a `dndHooks` property to `jQuery.event`, containing `jQuery.event.mouseHooks` filter and props, with a `dataTransfer` property added to props. After this, adds the drag and drop events to `jQuery.event.fixHooks`, with `jQuery.event.dndHooks` as value.
