### PR TITLE
add nextAt and prevAt method

### DIFF
--- a/src/traversing.js
+++ b/src/traversing.js
@@ -197,6 +197,12 @@ jQuery.each({
 	prevAll: function( elem ) {
 		return jQuery.dir( elem, "previousSibling" );
 	},
+	nextAll: function( elem ) {
+		return jQuery.dir( elem, "nextSibling" );
+	},
+	prevAll: function( elem ) {
+		return jQuery.dir( elem, "previousSibling" );
+	},
 	nextUntil: function( elem, i, until ) {
 		return jQuery.dir( elem, "nextSibling", until );
 	},
@@ -273,6 +279,16 @@ jQuery.extend({
 		return cur;
 	},
 
+
+	n_at: function( cur, dir, at ) {
+		for ( ; cur; cur = cur[dir] ) {
+			if ( cur.nodeType === 1 && jQuery( cur ).is( at ) ) {
+				break;
+			}
+		}
+
+		return cur;
+	},
 	sibling: function( n, elem ) {
 		var r = [];
 


### PR DESCRIPTION
Hello,

I propose to add nextAt and prevAt methods for find next/preview match element by selector (e.g.: for <h3 id="elem1"></h3><other><other><div><div> will be: $("#elem1").nextAt("div") will return element <div>). in More complicated situation this method is required.

Maybe the same method already exists, but i didn't found time to find this. Let me know if exists the same method.

BR.
Ion Lupascu
