### PR TITLE
Correctly detect width and height of box-sizing:border-box elements

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -244,17 +244,18 @@ function getWidthOrHeight( elem, name, extra ) {
 	// Start with offset property
 	var val = name === "width" ? elem.offsetWidth : elem.offsetHeight,
 		i = name === "width" ? 1 : 0,
-		len = 4;
+		len = 4,
+		boxSizing = jQuery.css( elem,"box-sizing" ) === "border-box";
 
 	if ( val > 0 ) {
 		if ( extra !== "border" ) {
 			for ( ; i < len; i += 2 ) {
-				if ( !extra ) {
+				if ( !extra && !boxSizing ) {
 					val -= parseFloat( jQuery.css( elem, "padding" + cssExpand[ i ] ) ) || 0;
 				}
 				if ( extra === "margin" ) {
 					val += parseFloat( jQuery.css( elem, extra + cssExpand[ i ] ) ) || 0;
-				} else {
+				} else if ( !boxSizing ) {
 					val -= parseFloat( jQuery.css( elem, "border" + cssExpand[ i ] + "Width" ) ) || 0;
 				}
 			}


### PR DESCRIPTION
fixes #11004 'GetWH incorrectly removes padding and border width when box-sizing is border-box'
