### PR TITLE
fix: The "sys" module is now called "util". It should have a similar

### DIFF
--- a/build/jshint-check.js
+++ b/build/jshint-check.js
@@ -1,5 +1,5 @@
 ﻿var JSHINT = require("./lib/jshint").JSHINT,
-	print = require("sys").print,
+	print = require(/^v0\.[012]/.test(process.version) ? "sys" : "util").print,
 	src = require("fs").readFileSync("dist/jquery.js", "utf8");
 
 JSHINT(src, {

--- a/build/post-compile.js
+++ b/build/post-compile.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-var print = require( "sys" ).print,
+var print = require( /^v0\.[012]/.test(process.version) ? "sys" : "util" ).print,
 	fs = require( "fs" ),
 	src = fs.readFileSync( process.argv[2], "utf8" ),
 	version = fs.readFileSync( "version.txt", "utf8" ),


### PR DESCRIPTION
Hello,

This patch is the correction of my preview pull request:
https://github.com/jquery/jquery/pull/635

This patch only resolve the node warning message when build the library.
Tested with version 0.6.4.

BR,
Ion Lupascu.
