### PR TITLE
fixes #11048: make sure support tests don't modify the layout of the body

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -283,6 +283,10 @@ jQuery.support = (function() {
 			support.pixelMargin = ( window.getComputedStyle( div, null ) || { marginTop: 0 } ).marginTop !== "1%";
 		}
 
+		if ( typeof container.style.zoom !== "undefined" ) {
+			container.style.zoom = 1;
+		}
+
 		body.removeChild( container );
 		div  = container = null;
 


### PR DESCRIPTION
screenshot of the issue in IE6:http://imageshack.us/photo/my-images/836/26724504.jpg/
fiddle that caused that screenshot: http://jsfiddle.net/timmywil/wryLs/59/
http://bugs.jquery.com/ticket/11048

Moving the support tests to after docready caused some weird layout issues. This hack resolves them.

I hope that this hack becomes obsolete in jQuery 1.8 with the removal of the support tests that cause the issue, but I saw this was a blocker on 1.7.2 so I figured I'd get it out of the way.
