### PR TITLE
Guarantee that JSON in data-* attributes will be loaded by `.data` (#7579)

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -1,6 +1,6 @@
 (function( jQuery ) {
 
-var rbrace = /^(?:\{.*\}|\[.*\])$/,
+var jsonData = /^(?:\{.*\}|\[.*\]|".*")$/,
 	rmultiDash = /([A-Z])/g;
 
 jQuery.extend({
@@ -333,9 +333,9 @@ function dataAttr( elem, key, data ) {
 				data = data === "true" ? true :
 				data === "false" ? false :
 				data === "null" ? null :
+				jsonData.test( data ) ? jQuery.parseJSON( data ) :
 				jQuery.isNumeric( data ) ? parseFloat( data ) :
-					rbrace.test( data ) ? jQuery.parseJSON( data ) :
-					data;
+				data;
 			} catch( e ) {}
 
 			// Make sure we set the data so it isn't changed later

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -298,7 +298,7 @@ test(".data(String) and .data(String, Object)", function() {
 });
 
 test("data-* attributes", function() {
-	expect(37);
+	expect(41);
 	var div = jQuery("<div>"),
 		child = jQuery("<div data-myobj='old data' data-ignored=\"DOM\" data-other='test'></div>"),
 		dummy = jQuery("<div data-myobj='old data' data-ignored=\"DOM\" data-other='test'></div>");
@@ -363,7 +363,11 @@ test("data-* attributes", function() {
 		.attr("data-empty", "")
 		.attr("data-space", " ")
 		.attr("data-null", "null")
-		.attr("data-string", "test");
+		.attr("data-string", "test")
+		.attr("data-single-quote", '"test')
+		.attr("data-jsonobj", '{ "foo": 42 }')
+		.attr("data-jsonarray", "[1, 2, 3]")
+		.attr("data-jsonstr", '"quoted"');
 
 	strictEqual( child.data("true"), true, "Primitive true read from attribute");
 	strictEqual( child.data("false"), false, "Primitive false read from attribute");
@@ -378,6 +382,10 @@ test("data-* attributes", function() {
 	strictEqual( child.data("space"), " ", "Empty string read from attribute");
 	strictEqual( child.data("null"), null, "Primitive null read from attribute");
 	strictEqual( child.data("string"), "test", "Typical string read from attribute");
+	strictEqual( child.data("single-quote"), '"test', "Single quote string read from attribute");
+	deepEqual( child.data("jsonobj"), { foo: 42 }, "JSON object read from attribute");
+	deepEqual( child.data("jsonarray"), [1, 2, 3], "JSON array read from attribute");
+	deepEqual( child.data("jsonstr"), "quoted", "JSON string read from attribute");
 
 	child.remove();
 


### PR DESCRIPTION
This patch should guarantee that any valid JSON data in `data-*` attributes will be correctly converted when read with the `.data(...)` method.

Currently `.data(…)` will correctly convert _most_ JSON values (singletons, numbers, arrays and objects), but it does not convert strings.

This change will make it safe to use `data-` attributes with arbitrary data, so long as it is first JSON encoded.

Backwards compatibility will only be broken in situations where the value of a `data-*` attribute matches `/^".*"$/`.

See also: http://bugs.jquery.com/ticket/7579

I'll make the appropriate documentation updates if this patch would otherwise be accepted.
