### PR TITLE
jQuery.fold() and jQuery.fn.fold feature

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -286,6 +286,12 @@ jQuery.fn = jQuery.prototype = {
 		}));
 	},
 
+	fold: function( callback, current ) {
+		return jQuery.fold(this, function( current, elem, i ) {
+			return callback.call( elem, current, i, elem );
+		});
+	},
+
 	end: function() {
 		return this.prevObject || this.constructor(null);
 	},
@@ -766,6 +772,15 @@ jQuery.extend({
 
 		// Flatten any nested arrays
 		return ret.concat.apply( [], ret );
+	},
+
+	// folds elems to a single value
+	fold: function( elems, callback, current ) {
+
+		jQuery.each(elems, function (i, elem) {
+			current = callback(current, elem, i);
+		});
+		return current;
 	},
 
 	// A global GUID counter for objects


### PR DESCRIPTION
A method i often use to reduce a set of elements to a single value.

Use it like

```
var result = $(selector).fold( function (current) {
    return current + $(this).height();
}, 0);
```

Syntax is

```
.fold( callback, initialValue )
```

with

```
 callback( currentValue, index, element ) in the element's context
```

Maybe it is useful for others too... just a suggestion
