### PR TITLE
Fixes #8744

### DIFF
--- a/src/ajax/jsonp.js
+++ b/src/ajax/jsonp.js
@@ -24,7 +24,7 @@ jQuery.ajaxPrefilter( "json jsonp", function( s, originalSettings, jqXHR ) {
 		var responseContainer,
 			jsonpCallback = s.jsonpCallback =
 				jQuery.isFunction( s.jsonpCallback ) ? s.jsonpCallback() : s.jsonpCallback,
-			previous = window[ jsonpCallback ],
+			previous = window[ jsonpCallback ] || jQuery.noop,
 			url = s.url,
 			data = s.data,
 			replace = "$1" + jsonpCallback + "$2";

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -1449,7 +1449,7 @@ jQuery.each( [ "Same Domain", "Cross Domain" ] , function( crossDomain , label )
 			jsonpCallback: "functionToCleanUp",
 			success: function(data){
 				ok( data.data, "JSON results returned (GET, custom callback name to be cleaned up)" );
-				strictEqual( window.functionToCleanUp, undefined, "Callback was removed (GET, custom callback name to be cleaned up)" );
+				strictEqual( window.functionToCleanUp, jQuery.noop, "Callback was removed (GET, custom callback name to be cleaned up)" );
 				plus();
 				var xhr;
 				jQuery.ajax({
@@ -1464,7 +1464,7 @@ jQuery.each( [ "Same Domain", "Cross Domain" ] , function( crossDomain , label )
 				});
 				xhr.error(function() {
 					ok( true, "Ajax error JSON (GET, custom callback name to be cleaned up)" );
-					strictEqual( window.functionToCleanUp, undefined, "Callback was removed after early abort (GET, custom callback name to be cleaned up)" );
+					strictEqual( window.functionToCleanUp, jQuery.noop, "Callback was removed after early abort (GET, custom callback name to be cleaned up)" );
 					plus();
 				});
 			},


### PR DESCRIPTION
Based on this comment -- http://bugs.jquery.com/ticket/8744#reply-to-comment-26

I dont really get it. Yes, we cannot cancel ajax download via script injection, yes, it probably should be fixed on browser side. But why not workaround it, since we can? Generated jsonp-functions already forever stored in global object, but they equal to undefined, if they will be equal to no-op function problem will be fixed. So why not?
