### PR TITLE
Fixes #4624

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -315,7 +315,7 @@ jQuery.extend({
 		isLocal: rlocalProtocol.test( ajaxLocParts[ 1 ] ),
 		global: true,
 		type: "GET",
-		contentType: "application/x-www-form-urlencoded",
+		contentType: "application/x-www-form-urlencoded; charset=UTF-8",
 		processData: true,
 		async: true,
 		/*


### PR DESCRIPTION
http://bugs.jquery.com/ticket/4624 Although the default charset in ajax requests considered to be as UTF-8, it is better explicitly define it.
