### PR TITLE
fixes #10901, officially makes PHP a dependency for unit tests

### DIFF
--- a/test/data/include_js.php
+++ b/test/data/include_js.php
@@ -69,33 +69,4 @@ die();
 ?>
 */
 
-// javascript fallback using src files in case this is not run on a PHP server!
-var files = [
-		"core",
-		"callbacks",
-		"deferred",
-		"support",
-		"data",
-		"queue",
-		"attributes",
-		"event",
-		"sizzle/sizzle",
-		"sizzle-jquery",
-		"traversing",
-		"manipulation",
-		"css",
-		"ajax",
-		"ajax/jsonp",
-		"ajax/script",
-		"ajax/xhr",
-		"effects",
-		"offset",
-		"dimensions",
-		"exports"
-	],
-	len = files.length,
-	i = 0;
-
-for ( ; i < len; i++ ) {
-	document.write("<script src=\"../src/" + files[ i ] + ".js\"><"+"/script>");
-}
+hasPHP = false;

--- a/test/data/testinit.js
+++ b/test/data/testinit.js
@@ -2,6 +2,7 @@ var jQuery = this.jQuery || "jQuery", // For testing .noConflict()
 	$ = this.$ || "$",
 	originaljQuery = jQuery,
 	original$ = $,
+	hasPHP = true,
 	amdDefined;
 
 /**
@@ -117,5 +118,5 @@ function url(value) {
 			equal( jQuery.active, 0, "No AJAX requests are still active" );
 			oldActive = jQuery.active;
 		}
-	}
+	};
 }());

--- a/test/data/testrunner.js
+++ b/test/data/testrunner.js
@@ -20,8 +20,5 @@ jQuery.noConflict(); // Allow the test to run with other libs or jQuery's.
 		return;
 	}
 
-	// (Temporarily) Disable Ajax tests to reduce network strain
-	// isLocal = QUnit.isLocal = true;
-
 	document.write("<scr" + "ipt src='http://swarm.jquery.org/js/inject.js?" + (new Date).getTime() + "'></scr" + "ipt>");
 })();

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -5,8 +5,6 @@ module("ajax", { teardown: moduleTeardown });
 // tests and they'll pass
 //if ( !jQuery.browser.safari ) {
 
-if ( !isLocal ) {
-
 test("jQuery.ajax() - success callbacks", function() {
 	expect( 8 );
 
@@ -2330,7 +2328,5 @@ test("jQuery.ajax - abort in prefilter", function() {
 test("jQuery.ajax - active counter", function() {
     ok( jQuery.active == 0, "ajax active counter should be zero: " + jQuery.active );
 });
-
-}
 
 //}

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -127,18 +127,16 @@ test("attr(String)", function() {
 	equal( $form.prop("enctype"), "multipart/form-data", "Set the enctype of a form (encoding in IE6/7 #6743)" );
 });
 
-if ( !isLocal ) {
-	test("attr(String) in XML Files", function() {
-		expect(3);
-		stop();
-		jQuery.get("data/dashboard.xml", function( xml ) {
-			equal( jQuery( "locations", xml ).attr("class"), "foo", "Check class attribute in XML document" );
-			equal( jQuery( "location", xml ).attr("for"), "bar", "Check for attribute in XML document" );
-			equal( jQuery( "location", xml ).attr("checked"), "different", "Check that hooks are not attached in XML document" );
-			start();
-		});
+test("attr(String) in XML Files", function() {
+	expect(3);
+	stop();
+	jQuery.get("data/dashboard.xml", function( xml ) {
+		equal( jQuery( "locations", xml ).attr("class"), "foo", "Check class attribute in XML document" );
+		equal( jQuery( "location", xml ).attr("for"), "bar", "Check for attribute in XML document" );
+		equal( jQuery( "location", xml ).attr("checked"), "different", "Check that hooks are not attached in XML document" );
+		start();
 	});
-}
+});
 
 test("attr(String, Function)", function() {
 	expect(2);
@@ -392,21 +390,19 @@ test("attr(jquery_method)", function(){
 	equal( elem.style.paddingRight, "1px", "attr({...})");
 });
 
-if ( !isLocal ) {
-	test("attr(String, Object) - Loaded via XML document", function() {
-		expect(2);
-		stop();
-		jQuery.get("data/dashboard.xml", function( xml ) {
-			var titles = [];
-			jQuery( "tab", xml ).each(function() {
-				titles.push( jQuery(this).attr("title") );
-			});
-			equal( titles[0], "Location", "attr() in XML context: Check first title" );
-			equal( titles[1], "Users", "attr() in XML context: Check second title" );
-			start();
+test("attr(String, Object) - Loaded via XML document", function() {
+	expect(2);
+	stop();
+	jQuery.get("data/dashboard.xml", function( xml ) {
+		var titles = [];
+		jQuery( "tab", xml ).each(function() {
+			titles.push( jQuery(this).attr("title") );
 		});
+		equal( titles[0], "Location", "attr() in XML context: Check first title" );
+		equal( titles[1], "Users", "attr() in XML context: Check second title" );
+		start();
 	});
-}
+});
 
 test("attr('tabindex')", function() {
 	expect(8);

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -1,5 +1,10 @@
 module("core", { teardown: moduleTeardown });
 
+test("Unit Testing Environment", function () {
+	expect(1);
+	ok( hasPHP, "Unit tests need to be run on a server that has PHP" );
+});
+
 test("Basic requirements", function() {
 	expect(7);
 	ok( Array.prototype.push, "Array.push()" );
@@ -203,7 +208,6 @@ test( "globalEval", function() {
 	window.globalEvalTest = undefined;
 });
 
-if ( !isLocal ) {
 test("browser", function() {
 	stop();
 
@@ -223,7 +227,6 @@ test("browser", function() {
 		start();
 	});
 });
-}
 
 test("noConflict", function() {
 	expect(7);
@@ -544,7 +547,6 @@ test("XSS via location.hash", function() {
 	};
 });
 
-if ( !isLocal ) {
 test("isXMLDoc - XML", function() {
 	expect(3);
 	stop();
@@ -555,7 +557,6 @@ test("isXMLDoc - XML", function() {
 		start();
 	});
 });
-}
 
 test("isWindow", function() {
 	expect( 14 );
@@ -632,7 +633,6 @@ test("jQuery('html', context)", function() {
 	equal($span.length, 1, "Verify a span created with a div context works, #1763");
 });
 
-if ( !isLocal ) {
 test("jQuery(selector, xml).text(str) - Loaded via XML document", function() {
 	expect(2);
 	stop();
@@ -645,7 +645,6 @@ test("jQuery(selector, xml).text(str) - Loaded via XML document", function() {
 		start();
 	});
 });
-}
 
 test("end()", function() {
 	expect(3);

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -1201,7 +1201,6 @@ test("clone(multiple selected options) (Bug #8129)", function() {
 
 });
 
-if (!isLocal) {
 test("clone() on XML nodes", function() {
 	expect(2);
 	stop();
@@ -1216,7 +1215,6 @@ test("clone() on XML nodes", function() {
 		start();
 	});
 });
-}
 
 test("html(undefined)", function() {
 	expect(1);


### PR DESCRIPTION
Stops the nonsense, and officially fails a unit test if the tests aren't running on PHP. Hopefully, in the future, this can be ported to only depend on Node, but this'll do in the meantime until all of the PHP can be converted to JS.
