### PR TITLE
Easing: Only use the state to calculate the value. Fixes #11284

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -400,11 +400,11 @@ jQuery.extend({
 	},
 
 	easing: {
-		linear: function( p, n, firstNum, diff ) {
-			return firstNum + diff * p;
+		linear: function( p ) {
+			return p;
 		},
-		swing: function( p, n, firstNum, diff ) {
-			return ( ( -Math.cos( p*Math.PI ) / 2 ) + 0.5 ) * diff + firstNum;
+		swing: function( p ) {
+			return ( -Math.cos( p*Math.PI ) / 2 ) + 0.5;
 		}
 	},
 


### PR DESCRIPTION
```
jQuery Size - compared to last make
  250157    (-78) jquery.js
   94203    (-22) jquery.min.js
   33436     (-9) jquery.min.js.gz
```
