### PR TITLE
WebKit looses checked state of radio input after clone if name attribute is placed after checked attribute.

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -129,6 +129,11 @@ jQuery.support = (function() {
 	support.radioValue = input.value === "t";
 
 	input.setAttribute("checked", "checked");
+
+	// #11217 - WebKit now passes the checkClone test, but looses the
+	// checked state when the name attribute is after the checked attribute
+	input.setAttribute( "name", "t" );
+
 	div.appendChild( input );
 	fragment = document.createDocumentFragment();
 	fragment.appendChild( div.lastChild );

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -265,7 +265,7 @@ test("unwrap()", function() {
 });
 
 var testAppend = function(valueObj) {
-	expect(41);
+	expect(46);
 	var defaultText = "Try them out:"
 	var result = jQuery("#first").append(valueObj("<b>buga</b>"));
 	equal( result.text(), defaultText + "buga", "Check if text appending works" );
@@ -315,6 +315,12 @@ var testAppend = function(valueObj) {
 	jQuery("form").append(valueObj("<input name='radiotest' type='radio' checked />"));
 	jQuery("form input[name=radiotest]").each(function(){
 		ok( jQuery(this).is(":checked"), "Append HTML5-formated checked radio");
+	}).remove();
+
+	QUnit.reset();
+	jQuery("form").append(valueObj("<input type='radio' checked='checked' name='radiotest' />"));
+	jQuery("form input[name=radiotest]").each(function(){
+		ok( jQuery(this).is(":checked"), "Append with name attribute after checked attribute");
 	}).remove();
 
 	QUnit.reset();


### PR DESCRIPTION
Fixes [#11217](http://bugs.jquery.com/ticket/11217)

  250413   (+177) jquery.js
   94252    (+27) jquery.min.js
   33453     (+8) jquery.min.js.gz
