### PR TITLE
Rewrote the eq() method using a much faster implementation

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -262,9 +262,9 @@ jQuery.fn = jQuery.prototype = {
 
 	eq: function( i ) {
 		i = +i;
-		return i === -1 ?
-			this.slice( i ) :
-			this.slice( i, i + 1 );
+		return (i >= 0) ?
+			$(this[i]) :
+			$(this[this.length+i]);
 	},
 
 	first: function() {


### PR DESCRIPTION
Currently, the eq() method calls slice() internally, which does much more work than needed. By instead rewrapping the retrieved DOM element, eq() can be much faster.

See the jsPerf test below for statistics:
<a href='http://jsperf.com/elem-eq-vs-elem-e' target='_blank'>http://jsperf.com/elem-eq-vs-elem-e</a>
