### PR TITLE
Fixes #8545

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -1,11 +1,12 @@
 (function( jQuery ) {
 
 var rbrace = /^(?:\{.*\}|\[.*\])$/,
-	rmultiDash = /([A-Z])/g,
-	deletedIds = [];
+	rmultiDash = /([A-Z])/g;
 
 jQuery.extend({
 	cache: {},
+
+	deletedIds: [],
 
 	// Please use with caution
 	uuid: 0,
@@ -60,7 +61,7 @@ jQuery.extend({
 			// Only DOM nodes need a new unique ID for each element since their data
 			// ends up in the global cache
 			if ( isNode ) {
-				elem[ internalKey ] = id = deletedIds.pop() || ++jQuery.uuid;
+				elem[ internalKey ] = id = jQuery.deletedIds.pop() || ++jQuery.uuid;
 			} else {
 				id = internalKey;
 			}
@@ -213,7 +214,7 @@ jQuery.extend({
 		// We destroyed the cache and need to eliminate the expando on the node to avoid
 		// false lookups in the cache for entries that no longer exist
 		if ( isNode ) {
-			deletedIds.push( id );
+			jQuery.deletedIds.push( id );
 
 			// IE does not allow us to delete expando properties from nodes,
 			// nor does it have a removeAttribute function on Document nodes;

--- a/src/event.js
+++ b/src/event.js
@@ -626,9 +626,10 @@ jQuery.removeEvent = document.removeEventListener ?
 
 		if ( elem.detachEvent ) {
 
-			// #8545, preventing memory leaks for custom events in IE6-8
+			// #8545, #7054, preventing memory leaks for custom events in IE6-8 –
+			// detachEvent needed property on element, by name of that event, to properly expose it to GC
 			if ( typeof elem[ name ] === "undefined" ) {
-				elem[ name ] = undefined;
+				elem[ name ] = null;
 			}
 
 			elem.detachEvent( name, handle );

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -788,21 +788,20 @@ jQuery.extend({
 							jQuery.removeEvent( elem, type, data.handle );
 						}
 					}
+				}
 
-					// Null the DOM reference to avoid IE6/7/8 leak (#7054)
-					if ( data.handle ) {
-						data.handle.elem = null;
+				// Remove cache only if jQuery.event.remove was not removed it before
+				if ( cache[ id ] ) {
+					if ( deleteExpando ) {
+						delete elem[ jQuery.expando ];
+
+					} else if ( elem.removeAttribute ) {
+						elem.removeAttribute( jQuery.expando );
 					}
+
+					jQuery.deletedIds.push( id );
+					delete cache[ id ];
 				}
-
-				if ( deleteExpando ) {
-					delete elem[ jQuery.expando ];
-
-				} else if ( elem.removeAttribute ) {
-					elem.removeAttribute( jQuery.expando );
-				}
-
-				delete cache[ id ];
 			}
 		}
 	}


### PR DESCRIPTION
Example in ticket actually illustrated two leaks, in two functions - jQuery.removeEvent, jQuery.removeData.
1. jQuery.removeEvent - IE fails to properly detach custom event from element,
2. jQuery.removeData - delete operator in JScript implementation do not really remove property from object, it just marks it as a deleted, so property stored in object eternally, only if it will not be overwritten or if object itself will not be deleted.
