### PR TITLE
fixes #10901, PHP required for unit tests, but still allow the tests to run

### DIFF
--- a/test/data/include_js.php
+++ b/test/data/include_js.php
@@ -69,8 +69,13 @@ die();
 ?>
 */
 
+hasPHP = false;
+
 // javascript fallback using src files in case this is not run on a PHP server!
-var files = [
+// please note that this fallback is for convenience only, and is not fully supported
+// i.e. don't expect all of the tests to work properly
+var baseURL = document.location.href.replace( /\/test\/.+/, "/"),
+	files = [
 		"core",
 		"callbacks",
 		"deferred",
@@ -97,5 +102,5 @@ var files = [
 	i = 0;
 
 for ( ; i < len; i++ ) {
-	document.write("<script src=\"../src/" + files[ i ] + ".js\"><"+"/script>");
+	document.write("<script src=\"" + baseURL + "src/" + files[ i ] + ".js\"><"+"/script>");
 }

--- a/test/data/testinit.js
+++ b/test/data/testinit.js
@@ -2,6 +2,7 @@ var jQuery = this.jQuery || "jQuery", // For testing .noConflict()
 	$ = this.$ || "$",
 	originaljQuery = jQuery,
 	original$ = $,
+	hasPHP = true,
 	amdDefined;
 
 /**
@@ -117,5 +118,5 @@ function url(value) {
 			equal( jQuery.active, 0, "No AJAX requests are still active" );
 			oldActive = jQuery.active;
 		}
-	}
+	};
 }());

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -1,11 +1,6 @@
 module("ajax", { teardown: moduleTeardown });
 
-// Safari 3 randomly crashes when running these tests,
-// but only in the full suite - you can run just the Ajax
-// tests and they'll pass
-//if ( !jQuery.browser.safari ) {
-
-if ( !isLocal ) {
+if ( !isLocal || hasPHP) {
 
 test("jQuery.ajax() - success callbacks", function() {
 	expect( 8 );
@@ -2332,5 +2327,3 @@ test("jQuery.ajax - active counter", function() {
 });
 
 }
-
-//}

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -1,5 +1,11 @@
 module("core", { teardown: moduleTeardown });
 
+test("Unit Testing Environment", function () {
+	expect(2);
+	ok( hasPHP, "Running Unit tests without PHP is unsupported! The AJAX tests won't run without it and don't expect all tests to pass without it!" );
+	ok( !isLocal, "Unit tests shouldn't be run from file://, especially in Chrome. If you must test from file:// with Chrome, run it with the --allow-file-access-from-files flag!" );
+});
+
 test("Basic requirements", function() {
 	expect(7);
 	ok( Array.prototype.push, "Array.push()" );


### PR DESCRIPTION
Let's try this again!

Please feel free to edit the text of the unit tests as you see fit.

Thanks!
