### PR TITLE
Fix #11359: preserve contents for cloned scripts

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -456,6 +456,10 @@ function cloneFixAttributes( src, dest ) {
 	// cloning other types of input fields
 	} else if ( nodeName === "input" || nodeName === "textarea" ) {
 		dest.defaultValue = src.defaultValue;
+
+	// IE blanks contents when cloning scripts
+	} else if ( nodeName === "script" && dest.text !== src.text ) {
+		dest.text = src.text;
 	}
 
 	// Event data gets referenced instead of copied if the expando

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -1169,6 +1169,15 @@ test("clone()", function() {
 	equal( jQuery("body").clone().children()[0].id, "qunit-header", "Make sure cloning body works" );
 });
 
+test("clone(script type=non-javascript) (#11359)", function() {
+	expect(3);
+	var src = jQuery("<script type='text/filler'>Lorem ipsum dolor sit amet</script><q><script type='text/filler'>consectetur adipiscing elit</script></q>");
+	var dest = src.clone();
+	equal( dest[0].text, "Lorem ipsum dolor sit amet", "Cloning preserves script text" );
+	equal( dest.last().html(), src.last().html(), "Cloning preserves nested script text" );
+	ok( /^\s*<scr.pt\s+type=['"]?text\/filler['"]?\s*>consectetur adipiscing elit<\/scr.pt>\s*$/i.test( dest.last().html() ), "Cloning preserves nested script text" );
+});
+
 test("clone(form element) (Bug #3879, #6655)", function() {
 	expect(5);
 	var element = jQuery("<select><option>Foo</option><option selected>Bar</option></select>");


### PR DESCRIPTION
jQuery Size - compared to 7226cf2800315e90b671db63f2b5f51150ad7e8e

```
  250324   (+134) jquery.js
   94238    (+19) jquery.min.js
   33462     (+7) jquery.min.js.gz
```
