### PR TITLE
Fix #11367: Custom events on form fail if it has an input with the same name

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -369,7 +369,10 @@ jQuery.event = {
 
 					// Prevent re-triggering of the same event, since we already bubbled it above
 					jQuery.event.triggered = type;
-					elem[ type ]();
+					// Ensure it is a method we're calling
+					if( typeof elem[ type ] == 'function' ) {
+						elem[ type ]();
+					}
 					jQuery.event.triggered = undefined;
 
 					if ( old ) {


### PR DESCRIPTION
http://bugs.jquery.com/ticket/11367
