### PR TITLE
Fix #11370: .siblings() shouldn't throw exception on a detached element

### DIFF
--- a/src/traversing.js
+++ b/src/traversing.js
@@ -204,7 +204,7 @@ jQuery.each({
 		return jQuery.dir( elem, "previousSibling", until );
 	},
 	siblings: function( elem ) {
-		return jQuery.sibling( elem.parentNode.firstChild, elem );
+		return jQuery.sibling( ( elem.parentNode || {} ).firstChild, elem );
 	},
 	children: function( elem ) {
 		return jQuery.sibling( elem.firstChild );

--- a/test/unit/traversing.js
+++ b/test/unit/traversing.js
@@ -414,7 +414,7 @@ test("andSelf()", function() {
 });
 
 test("siblings([String])", function() {
-	expect(6);
+	expect(7);
 	deepEqual( jQuery("#en").siblings().get(), q("sndp", "sap"), "Check for siblings" );
 	deepEqual( jQuery("#sndp").siblings(":has(code)").get(), q("sap"), "Check for filtered siblings (has code child element)" );
 	deepEqual( jQuery("#sndp").siblings(":has(a)").get(), q("en", "sap"), "Check for filtered siblings (has anchor child element)" );
@@ -422,6 +422,7 @@ test("siblings([String])", function() {
 	var set = q("sndp", "en", "sap");
 	deepEqual( jQuery("#en, #sndp").siblings().get(), set, "Check for unique results from siblings" );
 	deepEqual( jQuery("#option5a").siblings("option[data-attr]").get(), q("option5c"), "Has attribute selector in siblings (#9261)" );
+	equal( jQuery("<a/>").siblings().length, 0, "Detached elements have no siblings (#11370)" );
 });
 
 test("children([String])", function() {


### PR DESCRIPTION
jQuery Size - compared to 7226cf2800315e90b671db63f2b5f51150ad7e8e

```
  250202    (+10) jquery.js
   94225     (+6) jquery.min.js
   33459     (+4) jquery.min.js.gz
```
