### PR TITLE
fixes #10693, generalizes the "test something in an iframe" code

### DIFF
--- a/test/data/testinit.js
+++ b/test/data/testinit.js
@@ -119,4 +119,36 @@ function url(value) {
 			oldActive = jQuery.active;
 		}
 	};
+
+	this.testIframe = function( fileName, name, fn ) {
+
+		test(name, function() {
+			// pause execution for now
+			stop();
+
+			// load fixture in iframe
+			var iframe = loadFixture(),
+				win = iframe.contentWindow,
+				interval = setInterval( function() {
+					if ( win && win.jQuery && win.jQuery.isReady ) {
+						clearInterval( interval );
+						// continue
+						start();
+						// call actual tests passing the correct jQuery instance to use
+						fn.call( this, win.jQuery, win, win.document );
+						document.body.removeChild( iframe );
+						iframe = null;
+					}
+				}, 15 );
+		});
+
+		function loadFixture() {
+			var src = "./data/" + fileName + ".html?" + parseInt( Math.random()*1000, 10 ),
+				iframe = jQuery("<iframe />").css({
+					width: 500, height: 500, position: "absolute", top: -600, left: -600, visibility: "hidden"
+				}).appendTo("body")[0];
+			iframe.contentWindow.location = src;
+			return iframe;
+		}
+	};
 }());

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -11,7 +11,7 @@ test("disconnected node", function() {
 
 var supportsScroll = false;
 
-testoffset("absolute", function($, iframe) {
+testIframe("offset/absolute", "absolute", function($, iframe) {
 	expect(4);
 
 	var doc = iframe.document, tests;
@@ -51,7 +51,7 @@ testoffset("absolute", function($, iframe) {
 	forceScroll.remove();
 });
 
-testoffset("absolute", function( jQuery ) {
+testIframe("offset/absolute", "absolute", function( jQuery ) {
 	expect(178);
 
 	// get offset tests
@@ -136,7 +136,7 @@ testoffset("absolute", function( jQuery ) {
 	});
 });
 
-testoffset("relative", function( jQuery ) {
+testIframe("offset/relative", "relative", function( jQuery ) {
 	expect(60);
 
 	// IE is collapsing the top margin of 1px
@@ -197,7 +197,7 @@ testoffset("relative", function( jQuery ) {
 	});
 });
 
-testoffset("static", function( jQuery ) {
+testIframe("offset/static", "static", function( jQuery ) {
 	expect(80);
 
 	// IE is collapsing the top margin of 1px
@@ -264,7 +264,7 @@ testoffset("static", function( jQuery ) {
 	});
 });
 
-testoffset("fixed", function( jQuery ) {
+testIframe("offset/fixed", "fixed", function( jQuery ) {
 	expect(30);
 
 	var tests = [
@@ -331,7 +331,7 @@ testoffset("fixed", function( jQuery ) {
 	}
 });
 
-testoffset("table", function( jQuery ) {
+testIframe("offset/table", "table", function( jQuery ) {
 	expect(4);
 
 	equal( jQuery("#table-1").offset().top, 6, "jQuery('#table-1').offset().top" );
@@ -341,7 +341,7 @@ testoffset("table", function( jQuery ) {
 	equal( jQuery("#th-1").offset().left, 10, "jQuery('#th-1').offset().left" );
 });
 
-testoffset("scroll", function( jQuery, win ) {
+testIframe("offset/scroll", "scroll", function( jQuery, win ) {
 	expect(24);
 
 	var ie = jQuery.browser.msie && parseInt( jQuery.browser.version, 10 ) < 8;
@@ -399,7 +399,7 @@ testoffset("scroll", function( jQuery, win ) {
 	strictEqual( jQuery().scrollLeft(), null, "jQuery().scrollLeft(100) testing setter on empty jquery object" );
 });
 
-testoffset("body", function( jQuery ) {
+testIframe("offset/body", "body", function( jQuery ) {
 	expect(2);
 
 	equal( jQuery("body").offset().top, 1, "jQuery('#body').offset().top" );
@@ -466,35 +466,3 @@ test("fractions (see #7730 and #7885)", function() {
 
 	div.remove();
 });
-
-function testoffset(name, fn) {
-
-	test(name, function() {
-		// pause execution for now
-		stop();
-
-		// load fixture in iframe
-		var iframe = loadFixture(),
-			win = iframe.contentWindow,
-			interval = setInterval( function() {
-				if ( win && win.jQuery && win.jQuery.isReady ) {
-					clearInterval( interval );
-					// continue
-					start();
-					// call actual tests passing the correct jQuery isntance to use
-					fn.call( this, win.jQuery, win );
-					document.body.removeChild( iframe );
-					iframe = null;
-				}
-			}, 15 );
-	});
-
-	function loadFixture() {
-		var src = "./data/offset/" + name + ".html?" + parseInt( Math.random()*1000, 10 ),
-			iframe = jQuery("<iframe />").css({
-				width: 500, height: 500, position: "absolute", top: -600, left: -600, visibility: "hidden"
-			}).appendTo("body")[0];
-		iframe.contentWindow.location = src;
-		return iframe;
-	}
-}

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -6,47 +6,7 @@
 
 module("selector - jQuery only", { teardown: moduleTeardown });
 
-/**
- * Loads an iframe for the selector context
- * @param {String} fileName - Name of the html file to load
- * @param {String} name - Test name
- * @param {Function} fn - Test callback containing the tests to run
- */
-var testIframe = function( fileName, name, fn ) {
-
-	var loadFixture = function() {
-
-		// Creates iframe with cache disabled
-		var src = "./data/selector/" + fileName + ".html?" + parseInt( Math.random()*1000, 10 ),
-			iframe = jQuery("<iframe />").css({
-				width: 500, height: 500, position: "absolute", top: -600, left: -600, visibility: "hidden"
-			}).appendTo("body")[0];
-		iframe.contentWindow.location = src;
-		return iframe;
-	};
-
-	test(name, function() {
-		// pause execution for now
-		stop();
-
-		// load fixture in iframe
-		var iframe = loadFixture(),
-			win = iframe.contentWindow,
-			interval = setInterval( function() {
-				if ( win && win.jQuery && win.jQuery.isReady ) {
-					clearInterval( interval );
-					// continue
-					start();
-					// call actual tests passing the correct jQuery instance to use
-					fn.call( this, win.jQuery, win, win.document );
-					document.body.removeChild( iframe );
-					iframe = null;
-				}
-			}, 15 );
-	});
-};
-
-testIframe("html5_selector", "attributes - jQuery.attr", function( jQuery, window, document ) {
+testIframe("selector/html5_selector", "attributes - jQuery.attr", function( jQuery, window, document ) {
 	expect(34);
 
 	/**
@@ -61,7 +21,7 @@ testIframe("html5_selector", "attributes - jQuery.attr", function( jQuery, windo
 		}
 		return r;
 	}
-			   
+
 	/**
 	 * Asserts that a select matches the given IDs * @example t("Check for something", "//[a]", ["foo", "baar"]);
 	 * @param {String} a - Assertion name
@@ -72,7 +32,7 @@ testIframe("html5_selector", "attributes - jQuery.attr", function( jQuery, windo
 		var f = jQuery(b).get(),
 			s = "",
 			i = 0;
-		
+
 		for ( ; i < f.length; i++ ) {
 			s += (s && ",") + '"' + f[i].id + '"';
 		}
@@ -132,7 +92,7 @@ testIframe("html5_selector", "attributes - jQuery.attr", function( jQuery, windo
 	t( "Improperly named form elements do not interfere with form selections (#9570)", "form[name='formName']", ["form1"]);
 });
 
-testIframe("sizzle_cache", "Sizzle cache collides with multiple Sizzles on a page", function( jQuery, window, document ) {
+testIframe("selector/sizzle_cache", "Sizzle cache collides with multiple Sizzles on a page", function( jQuery, window, document ) {
 	var $cached = window.$cached;
 
 	expect(3);


### PR DESCRIPTION
I know, I know... "stop futzing with the test suite."

But I'm about to do another ticket that requires an iframe test in a different module, and I couldn't bear to copy and paste the functionality a third time. This PR will allow me (and others) to write IFRAME unit tests quickly and easily without copypasta.
