### PR TITLE
fixes #3838, $(document).height() incorrect in IE6

### DIFF
--- a/src/dimensions.js
+++ b/src/dimensions.js
@@ -42,8 +42,16 @@ jQuery.each( { Height: "height", Width: "width" }, function( name, type ) {
 			if ( elem.nodeType === 9 ) {
 				// Either scroll[Width/Height] or offset[Width/Height], whichever is greater
 				doc = elem.documentElement;
+
+				// when a window > document, IE6 reports a offset[Width/Height] > client[Width/Height]
+				// so we can't use max, as it'll choose the incorrect offset[Width/Height]
+				// instead we use the correct client[Width/Height]
+				// support:IE6
+				if ( doc[ clientProp ] >= doc[ scrollProp ] ) {
+					return doc[ clientProp ];
+				}
+
 				return Math.max(
-					doc[ clientProp ],
 					elem.body[ scrollProp ], doc[ scrollProp ],
 					elem.body[ offsetProp ], doc[ offsetProp ]
 				);

--- a/test/data/dimensions/documentLarge.html
+++ b/test/data/dimensions/documentLarge.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" dir="ltr" id="html">
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+	<style>
+		body {
+			width: 1000px;
+			height: 1000px;
+		}
+	</style>
+</head>
+<body>
+	<div>
+		<script src="../include_js.php"></script>
+	</div>
+</body>
+</html>

--- a/test/data/dimensions/documentSmall.html
+++ b/test/data/dimensions/documentSmall.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" dir="ltr" id="html">
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+</head>
+<body>
+	<div>
+		<script src="../include_js.php"></script>
+	</div>
+</body>
+</html>

--- a/test/unit/dimensions.js
+++ b/test/unit/dimensions.js
@@ -315,3 +315,17 @@ test("outerHeight()", function() {
 	div.remove();
 	jQuery.removeData($div[0], "olddisplay", true);
 });
+
+testIframe("dimensions/documentSmall", "window vs. small document", function( jQuery, window, document ) {
+	expect(2);
+
+	equal( jQuery( document ).height(), jQuery( window ).height(), "document height matches window height");
+	equal( jQuery( document ).width(), jQuery( window ).width(), "document width matches window width");
+});
+
+testIframe("dimensions/documentLarge", "window vs. large document", function( jQuery, window, document ) {
+	expect(2);
+
+	ok( jQuery( document ).height() > jQuery( window ).height(), "document height is larger than window height");
+	ok( jQuery( document ).width() > jQuery( window ).width(), "document width is larger than window width");
+});


### PR DESCRIPTION
```
jQuery Size - compared to last make
  251336   (+309) jquery.js
   94476    (+21) jquery.min.js
   33513     (+9) jquery.min.js.gz
```

a few notes, Thoughts please!:
1. there is a slightly smaller way to do this involving `Math.min` first which  saves 4 bytes, but clarity really suffers and the casual link as to why it works gets lost. I'd prefer to eat the 4 bytes.
2. I used a new convention: `// support:IE6` which helps facilitate the work I'm doing for http://jqbug.com/11164 . It's going to be used to highlight the true cost of supporting each browser, by explicitly calling out browser compat issues throughout the code rather than just in support.js
