### PR TITLE
Added functionality in the load system.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -433,9 +433,16 @@ jQuery.extend({
 			// Handle it asynchronously to allow scripts the opportunity to delay ready
 			return setTimeout( jQuery.ready, 1 );
 		}
-
-		// Mozilla, Opera and webkit nightlies currently support this event
-		if ( document.addEventListener ) {
+		
+		// Mozilla, Presto, webkit and IE > 8 currently support this event
+		if ( document.addEventListener ) {		
+			// Catch cases where $(document).ready() is called after the
+			// The DOMContentLoaded is sent.
+			// IE 9 messes this up by calling it interactive while it is not (solved in IE10)
+			if ( navigator.appVersion.indexOf('IE 9.0') != -1 && document.readyState === "interactive" ) {
+				// Handle it asynchronously to allow scripts the opportunity to delay ready
+				return setTimeout( DOMContentLoaded, 1 );
+			}
 			// Use the handy event callback
 			document.addEventListener( "DOMContentLoaded", DOMContentLoaded, false );
 


### PR DESCRIPTION
Added a check to allow jQuery to be included in the DOM using @defer.
If the browser supports the addEventListener(), it supports the DOMContentLoaded.
gecko, webkit and IE10 follow the spec as is. <- That's to whom this is for, mostly
IE 9 shows "interactive" before the DOMContentLoaded event so it needs to be excluded from this.
Presto ignores defer and shows complete when it should show 'interactive' so it's already been taken care of.
IE 7 and IE8 won't even try to execute this because they don't support addEventListener()

If you have any problems with this code change just warn me. I can do some modifications if it's in my grasp.
