### PR TITLE
Remove obsolete test code. Fixes #11435

### DIFF
--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -184,9 +184,6 @@ test(".data()", function() {
 
 	var dataObj = div.data();
 
-	// TODO: Remove this hack which was introduced in 1.5.1
-	delete dataObj.toJSON;
-
 	deepEqual( dataObj, {test: "success"}, "data() get the entire data object" );
 	strictEqual( div.data("foo"), undefined, "Make sure that missing result is still undefined" );
 
@@ -197,9 +194,6 @@ test(".data()", function() {
 	jQuery(obj).data("foo", "baz");
 
 	dataObj = jQuery.extend(true, {}, jQuery(obj).data());
-
-	// TODO: Remove this hack which was introduced for 1.5.1
-	delete dataObj.toJSON;
 
 	deepEqual( dataObj, { foo: "baz" }, "Retrieve data object from a wrapped JS object (#7524)" );
 });


### PR DESCRIPTION
Pull request 500 changed jQuery.data()'s cache so that the private data contains the public data, and in so doing eliminated the side effect that .toJSON was included in the return value from .data() for plain JS objects. As a result, I think the test code that deletes .toJSON from the return value of .data() is no longer needed.
