### PR TITLE
Guard against exceptions when clearing safeChildNodes. Supplements #11356

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -727,10 +727,14 @@ jQuery.extend({
 					// to avoid hoarding elements. Fixes #11356
 					if ( div ) {
 						div.parentNode.removeChild( div );
-						remove = safeChildNodes[ safeChildNodes.length - 1 ];
 
-						if ( remove && remove.parentNode ) {
-							remove.parentNode.removeChild( remove );
+						// Guard against -1 index exceptions in FF3.6
+						if ( safeChildNodes.length > 0 ) {
+							remove = safeChildNodes[ safeChildNodes.length - 1 ];
+
+							if ( remove && remove.parentNode ) {
+								remove.parentNode.removeChild( remove );
+							}
 						}
 					}
 				}

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -1740,3 +1740,15 @@ test("jQuery.fragments cache expectations", function() {
 
 	equal( fragmentCacheSize(), 12, "12 entries exist in jQuery.fragments, 2" );
 });
+
+test("Guard against exceptions when clearing safeChildNodes", function() {
+	expect( 1 );
+
+	var div;
+
+	try {
+		div = jQuery("<div/><hr/><code/><b/>");
+	} catch(e) {}
+
+	ok( div && div.jquery, "Created nodes safely, guarded against exceptions on safeChildNodes[ -1 ]" );
+});


### PR DESCRIPTION
```
Checking jQuery against JSHint...
JSHint check passed.
jQuery Size - compared to last make
  251950   (+106) jquery.js
   94509    (+14) jquery.min.js
   33540     (+6) jquery.min.js.gz
```

Signed-off-by: Rick Waldron waldron.rick@gmail.com waldron.rick@gmail.com
