### PR TITLE
Update src/event.js - proposed fix for bug http://bugs.jquery.com/ticket/11464

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -668,7 +668,7 @@ jQuery.Event = function( src, props ) {
 	}
 
 	// Create a timestamp if incoming event doesn't have one
-	this.timeStamp = src && src.timeStamp || jQuery.now();
+	this.timeStamp = src && +src.timeStamp || jQuery.now();
 
 	// Mark it as fixed
 	this[ jQuery.expando ] = true;


### PR DESCRIPTION
Tested on the default Android 2.3 browser, and on the Android 2.3 Dolfin browser. Event timestamps are not being normalised to millisecond values, but in these Android browsers they are reported as Date objects. This commit is a proposed fix.
