### PR TITLE
Remove moot second argument from slice.call()

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -200,7 +200,7 @@ jQuery.fn = jQuery.prototype = {
 	},
 
 	toArray: function() {
-		return slice.call( this, 0 );
+		return slice.call( this );
 	},
 
 	// Get the Nth element in the matched element set OR

--- a/src/deferred.js
+++ b/src/deferred.js
@@ -100,7 +100,7 @@ jQuery.extend({
 
 	// Deferred helper
 	when: function( firstParam ) {
-		var args = sliceDeferred.call( arguments, 0 ),
+		var args = sliceDeferred.call( arguments ),
 			i = 0,
 			length = args.length,
 			pValues = new Array( length ),
@@ -112,7 +112,7 @@ jQuery.extend({
 			promise = deferred.promise();
 		function resolveFunc( i ) {
 			return function( value ) {
-				args[ i ] = arguments.length > 1 ? sliceDeferred.call( arguments, 0 ) : value;
+				args[ i ] = arguments.length > 1 ? sliceDeferred.call( arguments ) : value;
 				if ( !( --count ) ) {
 					deferred.resolveWith( deferred, args );
 				}
@@ -120,7 +120,7 @@ jQuery.extend({
 		}
 		function progressFunc( i ) {
 			return function( value ) {
-				pValues[ i ] = arguments.length > 1 ? sliceDeferred.call( arguments, 0 ) : value;
+				pValues[ i ] = arguments.length > 1 ? sliceDeferred.call( arguments ) : value;
 				deferred.notifyWith( promise, pValues );
 			};
 		}

--- a/src/event.js
+++ b/src/event.js
@@ -389,7 +389,7 @@ jQuery.event = {
 
 		var handlers = ( (jQuery._data( this, "events" ) || {} )[ event.type ] || []),
 			delegateCount = handlers.delegateCount,
-			args = [].slice.call( arguments, 0 ),
+			args = [].slice.call( arguments ),
 			run_all = !event.exclusive && !event.namespace,
 			special = jQuery.event.special[ event.type ] || {},
 			handlerQueue = [],


### PR DESCRIPTION
```
jQuery Size - compared to last make
  252748    (-15) jquery.js
   94811    (-10) jquery.min.js
   33637     (-3) jquery.min.js.gz
```

Micro-optimization I know, but it :feelsgood: getting rid of those moot zeros.
