### PR TITLE
Changed hover() (and it's unit test) to optionally accept an object with 'over' and 'out' properties

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -1033,7 +1033,7 @@ jQuery.fn.extend({
 	},
 
 	hover: function( fnOver, fnOut ) {
-		return this.mouseenter( fnOver ).mouseleave( fnOut || fnOver );
+		return this.mouseenter( fnOver.over || fnOver ).mouseleave( fnOver.out || fnOut || fnOver );
 	}
 });
 

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -795,6 +795,9 @@ test("hover() and hover pseudo-event", function() {
 
 	jQuery("#firstp")
 		.hover(handler1, handler2)
+		.mouseenter().mouseleave().unbind("mouseenter", handler1)
+		.unbind("mouseleave", handler2)
+		.hover({ over: handler1, out: handler2 })
 		.mouseenter().mouseleave()
 		.unbind("mouseenter", handler1)
 		.unbind("mouseleave", handler2)
@@ -803,7 +806,7 @@ test("hover() and hover pseudo-event", function() {
 		.unbind("mouseenter mouseleave", handler1)
 		.mouseenter().mouseleave();
 
-	equal( times, 4, "hover handlers fired" );
+	equal( times, 6, "hover handlers fired" );
 
 	var balance = 0;
 	jQuery( "#firstp" )


### PR DESCRIPTION
This makes hover() more pleasant when using coffeescript. Example:
$('#foo').hover
..over: ->
....alert 'hovering over'
..out: ->
....alert 'hovering out'
Note: the change is tiny but people would appreciate this, see
http://stackoverflow.com/questions/6463052/how-to-pass-two-anonymous-functions-as-arguments-in-coffescript
