### PR TITLE
fix 11469: exclude margins from the properties that can't be negative.

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -636,9 +636,12 @@ jQuery.extend( jQuery.fx, {
 
 // Ensure props that can't be negative don't go there on undershoot easing
 jQuery.each( fxAttrs.concat.apply( [], fxAttrs ), function( i, prop ) {
-	jQuery.fx.step[ prop ] = function( fx ) {
-		jQuery.style( fx.elem, prop, Math.max(0, fx.now) + fx.unit );
-	};
+	// exclude marginTop, marginLeft, marginBottom and marginRight from this list
+	if ( prop.indexOf( "margin" ) ) {
+		jQuery.fx.step[ prop ] = function( fx ) {
+			jQuery.style( fx.elem, prop, Math.max(0, fx.now) + fx.unit );
+		};
+	}
 });
 
 if ( jQuery.expr && jQuery.expr.filters ) {


### PR DESCRIPTION
By fixing [#11415](http://bugs.jquery.com/ticket/11415) we broke the ability to animate margins to negative values.
Someone else reported this problem: http://bugs.jquery.com/ticket/11469

Here's a patch that solves it without reverting completely the fix for #11415.
