### PR TITLE
Allow triggered, simulated change events. Fixes #11500

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -819,8 +819,9 @@ if ( !jQuery.support.changeBubbles ) {
 					jQuery.event.add( this, "click._change", function( event ) {
 						if ( this._just_changed && !event.isTrigger ) {
 							this._just_changed = false;
-							jQuery.event.simulate( "change", this, event, true );
 						}
+						// Allow triggered, simulated change events (#11500)
+						jQuery.event.simulate( "change", this, event, true );
 					});
 				}
 				return false;
@@ -1067,4 +1068,3 @@ jQuery.each( ("blur focus focusin focusout load resize scroll unload click dblcl
 });
 
 })( jQuery );
-

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -2870,7 +2870,11 @@ test("fixHooks extensions", function() {
 test("trigger click on checkbox, fires change event", function() {
 	expect(1);
 
-	jQuery("#check2").on( "change", function() {
+	var check = jQuery("#check2");
+
+	check.on( "change", function() {
+		// get it?
+		check.off("change");
 		ok( true, "Change event fired as a result of triggered click" );
 	}).trigger("click");
 });


### PR DESCRIPTION
Tested and passing in:

IE6, 7, 8
IE9 (unaffected - doesn't take this logic path)
Chrome (unaffected - doesn't take this logic path)

Failing test preview:

<img src="http://gyazo.com/ea53cfce56c955f5bf161de173a6c624.png">

Passing IE8
<img src="http://gyazo.com/83f34c9257fb712ffd6b4a43836ac9b5.png">

IE6 & 7 screenshot available on request. I didn't think to take the screenshots until after I had already run them and I'm too impatient to wait for them to finish again.
