### PR TITLE
Add EditorConfig file denoting indentation styles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,36 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://EditorConfig.org
+
+root = true
+
+; All JavaScript files should use tabs unless specified otherwise
+[**.js]
+indent_style = tab
+
+[Makefile]
+indent_style = tab
+
+
+[speed/**.html]
+indent_style = tab
+
+[speed/**.css]
+indent_style = tab
+
+[speed/benchmarker.js]
+indent_style = space
+indent_size = 2
+
+
+[test/**.xml]
+indent_style = tab
+
+[test/**.php]
+indent_style = tab
+
+[test/**.html]
+indent_style = tab
+
+[test/**.css]
+indent_style = space
+indent_size = 8


### PR DESCRIPTION
This `.editorconfig` file defines the indentation style used in all JavaScript files under `src/` and also for the `Makefile`.  Request related to jquery/jquery-ui#606.

I did not add definitions for HTML, JS, or CSS files in the `build/` `speed/`, or `test/` directories because the indentation styles were not consistent enough for me to judge how they should be defined.

Below I noted some of the nuances of the indentation styles in the `build/` and `speed/` directories.  The `test/` directory also suffers from mixed indentation styles (sometimes in the same file).
#### build/

**tabs:**
- build/sizer.js
- build/release.js
- build/release-notes.js
- build/compile.js
- build/jshint-check.js
- build/freq.js
- build/release-notes.txt

**4 spaces:**
- build/lib/jshint.js

**8 spaces with 4 spaces for half indentation:**
- build/uglify.js (except for line 7 which uses a 4 column width tabstop)
- build/lib/parse-js.js
- build/lib/process.js
- build/lib/squeeze-more.js
#### speed/

**tabs:**
- speed/css.html
- speed/event.html
- speed/slice.vs.concat.html
- speed/jquery-basis.js (spaces mixed in on line 711)

**primarily 2 spaces (with 2 column width tabstops mixed in occasionally):**
- speed/closest.html
- speed/filter.html
- speed/find.html
- speed/index.html
- speed/benchmarker.js
- speed/benchmark.js

**no idea (heavily mixed spacing and tabbing style)**
- speed/benchmarker.css

If maintaining consistent indentation for the files in these directories is desirable, I suggest that each file's indentation style should be made self-consistent first.

For example something like this may be appropriate for `build/`:

```
[build/*.js]
indent_style = tab

[build/uglify.js]
indent_style = space
indent_size = 4

[build/lib/*.js]
indent_style = space
indent_size = 4
```
