### PR TITLE
added Shiv check so show/hide work with Modernizr

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -658,9 +658,32 @@ function defaultDisplay( nodeName ) {
 	if ( !elemdisplay[ nodeName ] ) {
 
 		var body = document.body,
-			elem = jQuery( "<" + nodeName + ">" ).appendTo( body ),
+				elem,
+				display,
+				selector,
+				shiveddisplay;
+
+			// check that nodeName is in shived list
+		if ( window.html5 && window.html5.elements && window.html5.elements.indexOf( nodeName ) ) {
+			shiveddisplay = {
+				"article,aside,details,figcaption,figure,footer,header,hgroup,nav,section": "block",
+				"audio": "none",
+				"canvas,video": "inline-block"
+			};
+
+			// Pull display property from shived styles (html5shiv is the source
+			// for these selectors.
+			for (selector in shiveddisplay) {
+				if (selector.indexOf(nodeName) >= 0) {
+					display = shiveddisplay[selector];
+					break;
+				}
+			}
+		} else {
+			elem = jQuery( "<" + nodeName + ">" ).appendTo( body )
 			display = elem.css( "display" );
-		elem.remove();
+			elem.remove();
+		}
 
 		// If the simple way fails,
 		// get element's real default display by attaching it to a temp iframe


### PR DESCRIPTION
Patch for http://bugs.jquery.com/ticket/11520

.show() will now set article and other HTML5 tags to their "shived" value.

I realize this relates to an external/3rd-party library, but there seems to already be some precedence for "playing nice" along side Modernizr.

Not sure what the "policy" is for this sort of thing, but I'm happy to help come at this problem differently if a direct patch to jQuery is not the best route. Also, if the code formatting, variable names, or whatever are "off" just let me know. Happy to cleanup/fix/patch/whatever.

Thanks.
