### PR TITLE
BOM as a whitespace

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -913,9 +913,21 @@ if ( jQuery.browser.webkit ) {
 }
 
 // IE doesn't match non-breaking spaces with \s
-if ( rnotwhite.test( "\xA0" ) ) {
-	trimLeft = /^[\s\xA0]+/;
-	trimRight = /[\s\xA0]+$/;
+if ( rnotwhite.test ( "\xA0" ) ) {
+	// BOM is not a whitespace in EcmaScript 3
+	if ( rnotwhite.test ("\uFEFF") ) {
+		trimLeft = /^[\s\xA0\uFEFF]+/;
+		trimRight = /[\s\xA0\uFEFF]+$/;
+	} else {
+		trimLeft = /^[\s\xA0]+/;
+		trimRight = /[\s\xA0]+$/;
+	}
+} else {
+	// BOM is not a whitespace in EcmaScript 3
+	if ( rnotwhite.test ( "\uFEFF" ) ) {
+		trimLeft = /^[\s\uFEFF]+/;
+		trimRight = /[\s\uFEFF]+$/;
+	}
 }
 
 // All jQuery objects should point back to these


### PR DESCRIPTION
Due to changes in EcmaScript 5 (http://es5.github.com/#E , 15.10.2.12) Byte Order Mark character may be or may be not recognized as a whitespace depending on ES version implemented in browser.

For example, this code:

``` javascript
$.parseJSON("\uFEFF[]");
```

throws an error in older IEs while modern browsers returns array.
