### PR TITLE
XML DOM attrs with uppercase can now be removed with removeAttr(). Fixes #11547

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -356,7 +356,12 @@ jQuery.extend({
 			i = 0;
 
 		if ( value && elem.nodeType === 1 ) {
-			attrNames = value.toLowerCase().split( rspace );
+
+			if ( !jQuery.isXMLDoc( elem ) ) {
+				value = value.toLowerCase();
+			}
+
+			attrNames = value.split( rspace );
 			l = attrNames.length;
 
 			for ( ; i < l; i++ ) {

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -1192,3 +1192,16 @@ test("coords returns correct values in IE6/IE7, see #10828", function() {
 	area = map.html("<area shape='rect' href='#' alt='a' /></map>").find("area");
 	equal( area.attr("coords"), undefined, "did not retrieve coords correctly");
 });
+
+test("Handle cased attributes on XML DOM correctly in removeAttr()", function() {
+	expect(1);
+
+	var xmlStr = "<root><item fooBar='123' /></root>",
+		$xmlDoc = jQuery( jQuery.parseXML( xmlStr ) ),
+		$item = $xmlDoc.find( "item" ),
+		el = $item[0];
+
+	$item.removeAttr( "fooBar" );
+
+	equal( el.attributes.length, 0, "attribute with upper case did not get removed" );
+});


### PR DESCRIPTION
Fixes an unconditional .toLowerCase() call on the name of the attribute to be removed in the .removeAttr(). Since XML is case sensitive this should not happen for XML DOM documents.
