### PR TITLE
Change step._default to detect cssHooks and use them

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -47,6 +47,8 @@ jQuery.extend({
 
 	// Exclude the following css properties to add px
 	cssNumber: {
+      "columns": true,
+      "columnCount": true,
 		"fillOpacity": true,
 		"fontWeight": true,
 		"lineHeight": true,

--- a/src/effects.js
+++ b/src/effects.js
@@ -620,12 +620,10 @@ jQuery.extend( jQuery.fx, {
 	},
 
 	step: {
-		opacity: function( fx ) {
-			jQuery.style( fx.elem, "opacity", fx.now );
-		},
-
 		_default: function( fx ) {
-			if ( fx.elem.style && fx.elem.style[ fx.prop ] != null ) {
+			if (jQuery.cssHooks[ fx.prop ]) {
+            jQuery.style( fx.elem, fx.prop, fx.now );
+         } else if ( fx.elem.style && fx.elem.style[ fx.prop ] != null ) {
 				fx.elem.style[ fx.prop ] = fx.now + fx.unit;
 			} else {
 				fx.elem[ fx.prop ] = fx.now;


### PR DESCRIPTION
This kills two birds by removing the need for the separate step.opacity function, and allow easier animation of cssHooked properties.  This would fit in nicely with bug #10679 (vendor support cssHooks).

This also adds a few column CSS properties to cssNumber.
