### PR TITLE
Remove unnec reassignment and return of name/origName;

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -29,7 +29,6 @@ function vendorPropName( style, name ) {
 
 	// check for vendor prefixed names
 	var capName = name.charAt(0).toUpperCase() + name.slice(1),
-		origName = name,
 		i = cssPrefixes.length;
 
 	while ( i-- ) {
@@ -38,8 +37,6 @@ function vendorPropName( style, name ) {
 			return name;
 		}
 	}
-
-	return origName;
 }
 
 jQuery.fn.css = function( name, value ) {


### PR DESCRIPTION
This removes redundant code that is already handled by the first condition

``` bash
jQuery Size - compared to last make
  251210    (-26) jquery.js
   93578    (-12) jquery.min.js
   33256     (-4) jquery.min.js.gz
```
