### PR TITLE
Remove object markup fixture; create programmatically; Supplements #10324

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -135,7 +135,6 @@
 				<param name="p1" value="x1" />
 				<param name="p2" value="x2" />
 			</object>
-			<object id="object2"><param name="object2test" value="test"></param></object>​
 
 			<span id="台北Táiběi"></span>
 			<span id="台北" lang="中文"></span>

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -563,7 +563,7 @@ test("IE8 serialization bug", function () {
 
 	wrapper.html("<div></div><article></article>");
 	equal( wrapper.children("article").length, 1, "HTML5 elements are insertable with .html()");
-	
+
 	wrapper.html("<div></div><link></link>");
 	equal( wrapper.children("link").length, 1, "Link elements are insertable with .html()");
 });
@@ -571,7 +571,7 @@ test("IE8 serialization bug", function () {
 test("html() object element #10324", function() {
 	expect( 1 );
 
-	var object = jQuery("#object2"),
+	var object = jQuery("<object id='object2'><param name='object2test' value='test'></param></object>​").appendTo("#qunit-fixture"),
 			clone = object.clone();
 
 	equal( clone.html(), object.html(), "html() returns correct innerhtml of cloned object elements" );


### PR DESCRIPTION
IE7:

<img src="http://gyazo.com/78dbefc8d9357bf95488493523b76937.png">

IE8:

<img src="http://gyazo.com/25596adbd2408dab9d361577c26c2598.png">

Signed-off-by: Rick Waldron waldron.rick@gmail.com waldron.rick@gmail.com
