### PR TITLE
Remove $("body") case in favor of $(document.body)

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -90,15 +90,6 @@ jQuery.fn = jQuery.prototype = {
 			return this;
 		}
 
-		// The body element only exists once, optimize finding it
-		if ( selector === "body" && !context && document.body ) {
-			this.context = document;
-			this[0] = document.body;
-			this.selector = selector;
-			this.length = 1;
-			return this;
-		}
-
 		// Handle HTML strings
 		if ( typeof selector === "string" ) {
 			// Are we dealing with HTML string or an ID?


### PR DESCRIPTION
I am not sure why we want to special-case `$("body")`, especially at the cost of 26 bytes. `$(document.body)` is actually 2x faster so that's the best way to get the body element. I doubt this is a hot code path for anyone.

If a special case is good, perhaps a more general check for tags that uses `getElementsByTagName` since that will lift more boats?

http://jsperf.com/body-vs-head

jQuery Size - compared to last make
  252300   (-246) jquery.js
   93733    (-99) jquery.min.js
   33325    (-26) jquery.min.js.gz
