### PR TITLE
Delete automatically-generated jsonp callbacks on cleanup.

### DIFF
--- a/src/ajax/jsonp.js
+++ b/src/ajax/jsonp.js
@@ -24,6 +24,7 @@ jQuery.ajaxPrefilter( "json jsonp", function( s, originalSettings, jqXHR ) {
 			jsonpCallback = s.jsonpCallback =
 				jQuery.isFunction( s.jsonpCallback ) ? s.jsonpCallback() : s.jsonpCallback,
 			previous = window[ jsonpCallback ],
+			previousExists = jsonpCallback in window,
 			url = s.url,
 			data = s.data,
 			replace = "$1" + jsonpCallback + "$2";
@@ -51,8 +52,12 @@ jQuery.ajaxPrefilter( "json jsonp", function( s, originalSettings, jqXHR ) {
 
 		// Clean-up function
 		jqXHR.always(function() {
-			// Set callback back to previous value
-			window[ jsonpCallback ] = previous;
+			// Set callback back to previous value, or delete if necessary
+			if ( previousExists ) {
+				window[ jsonpCallback ] = previous;
+			} else {
+				delete window[ jsonpCallback ];
+			}
 			// Call if it was a function and we have a response
 			if ( responseContainer && jQuery.isFunction( previous ) ) {
 				window[ jsonpCallback ]( responseContainer[ 0 ] );


### PR DESCRIPTION
Currently automatically-generated jsonp callbacks get set to undefined after the request completes, but not actually removed as properties of the window object. Thus they have a tendency to build up. This (hopefully) fixes that.
