### PR TITLE
Fix QUnit configuration

### DIFF
--- a/test/data/testrunner.js
+++ b/test/data/testrunner.js
@@ -1,21 +1,36 @@
-jQuery.noConflict(); // Allow the test to run with other libs or jQuery's.
+/**
+ * Allow the test suite to run with other libs or jQuery's.
+ */
+jQuery.noConflict();
 
-// jQuery-specific QUnit.reset
+/**
+ * QUnit hooks
+ */
 (function() {
-	var reset = QUnit.reset,
-		ajaxSettings = jQuery.ajaxSettings;
+	// Keep a copy of the original
+	var ajaxSettings = jQuery.ajaxSettings;
 
-	QUnit.reset = function() {
-		reset.apply(this, arguments);
+	// Register hook
+	QUnit.testDone(function() {
 		jQuery.event.global = {};
 		jQuery.ajaxSettings = jQuery.extend({}, ajaxSettings);
-	};
+	});
 })();
 
-// load testswarm agent
+/**
+ * QUnit configuration
+ */
+// Max time for stop() and asyncTest() untill it aborts test
+// and start()'s the next test.
+QUnit.config.testTimeout = 5 * 1000; // 5 seconds
+
+/**
+ * Load the TestSwarm listener if swarmURL is in the address.
+ */
 (function() {
 	var url = window.location.search;
-	url = decodeURIComponent( url.slice( url.indexOf("swarmURL=") + 9 ) );
+	url = decodeURIComponent( url.slice( url.indexOf("swarmURL=") + "swarmURL=".length ) );
+
 	if ( !url || url.indexOf("http") !== 0 ) {
 		return;
 	}


### PR DESCRIPTION
- If an asynchronous test fails to report anything, the QUnit reporter must not hang
  forever, but continue after a certain time.
- By default QUnit.config.testTimeout is undefined, which means a stop() will indefinitely
  pause execution completely.
  Setting to 5 seconds now so that Async failures such as caused by 8fadc5ba01bc517ebb07736d5af9a965ed133a39
  in Opera (http://swarm.jquery.org/job/49/) don't cause TestSwarm to be halted for
  very long each run.
  
  This also ensures that other tests can be ran, because right now all tests run after
  the the one breaking asyncTest, are not tested. Instead QUnit just does nothing until
  the TestSwarm client decides to abort the iframe and abort the run entirely (by default
  only after 2 minutes!)
- Also fixed the ugly QUnit.reset overloading hack. There is a "testDone" hook now in
  QUnit, which is ran right after the one and only call to QUnit.reset() in the Test flow.
- Added some comments and indention
