### PR TITLE
Fix return value of elem.css('background-position')

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -149,21 +149,21 @@ jQuery.extend({
 					return elem.style.backgroundPosition;
 				}
 
-				var posX, posY, glue, i, len,
-					ret = curCSS( elem, "backgroundPosition" );
+				var posY, glue, i, len,
+					propName = "backgroundPosition",
+					ret = curCSS( elem, propName );
 
-				if ( ret !== "0% 0%" || !window.attachEvent ) {
+				if ( ret !== "0% 0%" ) {
 					return ret;
 				}
 
-				ret = [];
-				posX = curCSS( elem, "backgroundPositionX" );
-				posY = curCSS( elem, "backgroundPositionY" ).split( rmultiplebg );
-				glue = rmultiplebg.exec( posX ) || [""];
-				posX = posX.split( rmultiplebg );
+				ret = curCSS( elem, propName + "X" );
+				posY = curCSS( elem, propName + "Y" ).split( rmultiplebg );
+				glue = rmultiplebg.exec( ret ) || [""];
+				ret = ret.split( rmultiplebg );
 
-				for ( i = 0, len = posX.length; i < len; ++i ) {
-					ret[i] = posX[i] + " " + posY[i];
+				for ( i = 0, len = ret.length; i < len; ++i ) {
+					ret[i] += " " + posY[i];
 				}
 
 				return ret.join( glue[0] );

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -790,7 +790,7 @@ test( "css('backgroundPosition') should be valid value", function() {
 	notEqual( jQuery( "#test-backgroundPosition" ).css( "backgroundPosition" ), "0% 0%", "css('background-position') expands properly with not 0% 0%" );
 
 	// This test case is only supported in IE9
-	if ( window.attachEvent && jQuery.support.opacity ) {
+	if ( document.documentMode && document.documentMode === 9 ) {
 		jQuery( "<div id='test-backgroundPositionCSS3' style='background-color:#FFF' />" ).appendTo( "#qunit-fixture" );
 		equal( jQuery( "#test-backgroundPositionCSS3" ).css( "backgroundPosition" ), "10px 20px, 30px 40px", "css('background-position') of CSS3 expands properly with 10px 20px, 30px 40px" );
 	}


### PR DESCRIPTION
Fixed the undefined value in "IE<9",
And fixed a background-position bug in IE9.
#### Details of the background-position bug in IE9:
1. Set the background-position value by non-inline CSS
2. Set the background-\* value
3. The background-position value is changed to "0% 0%"

``` html
<style>
#foo {
  background-position: 10px 20px;
}
</style>

<div id="foo"></div>

<script>
var foo = jQuery( "#foo" );
alert( foo.css( "background-position" ) ); // 10px 20px
foo.css( "background-color", "#FFF" );
alert( foo.css( "background-position" ) ); // 0% 0% !!!
</script>
```
