### PR TITLE
refactor jsonp.js for size and clarity

### DIFF
--- a/src/ajax/jsonp.js
+++ b/src/ajax/jsonp.js
@@ -28,8 +28,7 @@ jQuery.ajaxPrefilter( "json jsonp", function( s, originalSettings, jqXHR ) {
 			rjsonp.test( data );
 
 	// Handle iff the expected data type is "jsonp" or we have a parameter to set
-	if ( s.dataTypes[ 0 ] === "jsonp" || hasCallback &&
-		( replaceInUrl || replaceInData ) ) {
+	if ( s.dataTypes[ 0 ] === "jsonp" || replaceInUrl || replaceInData ) {
 
 		// Get callback name, remembering preexisting value associated with it
 		callbackName = s.jsonpCallback = jQuery.isFunction( s.jsonpCallback ) ?


### PR DESCRIPTION
As [requested](https://github.com/jquery/jquery/pull/744#issuecomment-5235926) by @jaubourg.

jQuery Size - compared to d3b61de52084353646e1abee7dc7a76c63237b9b

```
  252839   (+276) jquery.js
   93756    (-28) jquery.min.js
   33297    (-46) jquery.min.js.gz
```

Comments:
- You were right; this module is **_nuts**_
- The refactoring does alter behavior in extreme edge cases where `jsonpCallback` is "=?" or "??", because the current version treats an identity `replace` as failure and falls back to appending something like "&callback==?" or "&callback=??" (respectively) on the URL. I've assumed this to be irrelevant and/or invalid, and thus subject to change.
- I don't really trust my JSONP tests... can @jaubourg or someone else please confirm that everything still works as expected?
