### PR TITLE
1.8 effects special easing

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -5,7 +5,7 @@ var fxNow, timerId, iframe, iframeDoc,
 	rfxtypes = /^(?:toggle|show|hide)$/,
 	rfxnum = /^([\-+]=)?((?:\d*\.)?\d+)([a-z%]*)$/i,
 	rrun = /\.run$/,
-	animationPrefilters = [],
+	animationPrefilters = [ defaultPrefilter ],
 	tweeners = {
 		"*": [function( prop, value ) {
 			var end, unit,
@@ -209,8 +209,12 @@ jQuery.Animation = jQuery.extend( Animation, {
 	}
 });
 
-Animation.prefilter(function( elem, props, opts ) {
-	var style = elem.style;
+function defaultPrefilter( elem, props, opts ) {
+	var index, prop, value, length, dataShow, tween,
+		style = elem.style,
+		orig = {},
+		handled = [],
+		hidden = jQuery( elem ).is(":hidden");
 
 	// height/width overflow pass
 	if ( elem.nodeType === 1 && ( props.height || props.width ) ) {
@@ -244,15 +248,9 @@ Animation.prefilter(function( elem, props, opts ) {
 			style.overflowY = opts.overflow[ 2 ];
 		});
 	}
-});
 
-// special case show/hide prefilter
-Animation.prefilter(function( elem, props, opts ) {
-	var index, prop, value, length, dataShow, tween,
-		orig = {},
-		handled = [],
-		hidden = jQuery( elem ).is(":hidden");
 
+	// show/hide pass
 	for ( index in props ) {
 		value = props[ index ];
 		if ( rfxtypes.exec( value ) ) {
@@ -295,7 +293,7 @@ Animation.prefilter(function( elem, props, opts ) {
 			}
 		}
 	}
-});
+}
 
 function Tween( elem, options, prop, end, easing ) {
 	return new Tween.prototype.init( elem, options, prop, end, easing );

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -1248,6 +1248,53 @@ test("animate with per-property easing", function(){
 
 });
 
+test("animate with CSS shorthand properties", function(){
+	expect(11);
+	stop();
+
+	var _default_count = 0,
+		_special_count = 0,
+		propsBasic = { padding: "10 20 30" },
+		propsSpecial = { padding: [ "1 2 3", "_special" ] };
+
+	jQuery.easing["_default"] = function(p) {
+		if ( p >= 1 ) {
+			_default_count++;
+		}
+		return p;
+	};
+
+	jQuery.easing["_special"] = function(p) {
+		if ( p >= 1 ) {
+			_special_count++;
+		}
+		return p;
+	};
+
+	jQuery("#foo")
+		.animate( propsBasic, 200, "_default", function() {
+			equal( this.style.paddingTop, "10px", "padding-top was animated" );
+			equal( this.style.paddingLeft, "20px", "padding-left was animated" );
+			equal( this.style.paddingRight, "20px", "padding-right was animated" );
+			equal( this.style.paddingBottom, "30px", "padding-bottom was animated" );
+			equal( _default_count, 4, "per-animation default easing called for each property" );
+			_default_count = 0;
+		})
+		.animate( propsSpecial, 200, "_default", function() {
+			equal( this.style.paddingTop, "1px", "padding-top was animated again" );
+			equal( this.style.paddingLeft, "2px", "padding-left was animated again" );
+			equal( this.style.paddingRight, "2px", "padding-right was animated again" );
+			equal( this.style.paddingBottom, "3px", "padding-bottom was animated again" );
+			equal( _default_count, 0, "per-animation default easing not called" );
+			equal( _special_count, 4, "special easing called for each property" );
+
+			jQuery(this).css("padding", "0");
+			delete jQuery.easing["_default"];
+			delete jQuery.easing["_special"];
+			start();
+		});
+});
+
 test("hide hidden elements (bug #7141)", function() {
 	expect(3);
 	QUnit.reset();


### PR DESCRIPTION
@gnarf37's explanation of the "special easing" issue from https://github.com/jquery/jquery/pull/731 inspired me to dig a little deeper. Subsequent investigation revealed that the counterintuitive behavior would actually result in a bug if one tried to animate a compound property like `.animate({ borderWidth: [ 10, "linear" ]})`. This changeset fixes the bug by moving the relevant logic in front of CSS compound property expansion.

Pull now and you'll get a bonus size reduction **PLUS** the ability to handle array-valued properties with all prefilters¹!

jQuery Size - compared to 54fab3174c7844959b374e98b453c048b60de0d0

```
  253601    (+40) jquery.js
   94059    (-16) jquery.min.js
   33503     (-1) jquery.min.js.gz
```

---

¹ Provided you use `this.originalProperties` and remember to cleanup like `this.opts.specialEasing[ jQuery.camelCase( prop ) ] = this.originalOptions.specialEasing[ prop ]`
