### PR TITLE
DOMNodeRemovedFromDocument & DOMNodeRemoved don't fire on nodes removed with remove

### DIFF
--- a/speed/jquery-basis.js
+++ b/speed/jquery-basis.js
@@ -4111,13 +4111,13 @@ jQuery.fn.extend({
 	remove: function( selector, keepData ) {
 		for ( var i = 0, elem; (elem = this[i]) != null; i++ ) {
 			if ( !selector || jQuery.filter( selector, [ elem ] ).length ) {
+				if ( elem.parentNode ) {
+					 elem.parentNode.removeChild( elem );
+				}
+
 				if ( !keepData && elem.nodeType === 1 ) {
 					jQuery.cleanData( elem.getElementsByTagName("*") );
 					jQuery.cleanData( [ elem ] );
-				}
-
-				if ( elem.parentNode ) {
-					 elem.parentNode.removeChild( elem );
 				}
 			}
 		}


### PR DESCRIPTION
In this example the functions bound to `DOMNodeRemovedFromDocument` & `DOMNodeRemoved` never go off because [`cleanData`](https://github.com/jquery/jquery/blob/master/speed/jquery-basis.js#L4518)(which strips off all events) is called before `elem.parentNode.removeChild( elem );` in [`remove`](https://github.com/jquery/jquery/blob/master/speed/jquery-basis.js#L4111).

```
<!DOCTYPE HTML>
<html><head>
<script src="http://code.jquery.com/jquery-1.7.2.js" />
<script>
    $(function(){
        var $div = $('<div>').appendTo('body');
        $div.on('DOMNodeRemovedFromDocument', function(){
            console.log('div removed from document');
        });
        $div.on('DOMNodeRemoved', function(){
            console.log('div removed');
        });
        $div.remove();
    });
</script>
</head><body></body></html>
```

To fix this issue I've swapped the order in `remove` so that the element is removed from the dom first then `cleanData` is run.

This should fix [this issue](http://forum.jquery.com/topic/problem-with-bindings-and-domnoderemoved-and-domnoderemovedfromdocument-events).
