### PR TITLE
Patch .on to throw an exception when handler is undefined in (types, selector, fn) mode

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -776,7 +776,7 @@ if ( !jQuery.support.submitBubbles ) {
 			});
 			// return undefined since we don't need an event listener
 		},
-		
+
 		postDispatch: function( event ) {
 			// If form was submitted by the user, bubble the event up the tree
 			if ( event._submit_bubble ) {
@@ -903,7 +903,14 @@ jQuery.fn.extend({
 
 		if ( data == null && fn == null ) {
 			// ( types, fn )
-			fn = selector;
+			if(jQuery.isFunction(selector)){
+				fn = selector;
+			}
+			else{
+				// (types, selector, undefined fn)
+				jQuery.error("Handler is undefined for " + this.selector + " : " + selector);
+				fn = false;
+			}
 			data = selector = undefined;
 		} else if ( fn == null ) {
 			if ( typeof selector === "string" ) {


### PR DESCRIPTION
If an event handler is undefined whenever `on` is used with a selector, the selector gets substituted for the handler. For example:

``` js
$("body").on("click", "div", null); 
//"div" is passed in as handler to jQuery.event.add
```

The bug occurs in `dispatch` when `apply` is called on `handler`. Since the handler is a string, `apply` fails.

The patch throws an exception using `jQuery.error` and specifies both the element and the selector in the exception message.

Test case: http://jsfiddle.net/qhjJ4/
