### PR TITLE
Exchanged $0 for $& in .replace()

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -358,7 +358,7 @@ jQuery.fn.extend({
 							dataType: "script"
 						});
 					} else {
-						jQuery.globalEval( ( elem.text || elem.textContent || elem.innerHTML || "" ).replace( rcleanScript, "/*$0*/" ) );
+						jQuery.globalEval( ( elem.text || elem.textContent || elem.innerHTML || "" ).replace( rcleanScript, "/*$&*/" ) );
 					}
 
 					if ( elem.parentNode ) {


### PR DESCRIPTION
The $0 notation seems to be supported only by IE 9.
Notation $& works in other browsers.

Tested in FF (11, 12, 13 Beta), Opera (11), Chorme (18, 20 Beta), Safari (5.1.5), IE (9, 9 in compatibility mode, 8, 7, 6)
