### PR TITLE
Fixes #6724: Wrong $(window).height() in Mobile Safari

### DIFF
--- a/src/dimensions.js
+++ b/src/dimensions.js
@@ -31,7 +31,10 @@ jQuery.each( { Height: "height", Width: "width" }, function( name, type ) {
 			var doc, orig, ret;
 
 			if ( jQuery.isWindow( elem ) ) {
-				return window[ "inner" + name ] || elem.document.documentElement[ clientProp ];
+				// As of 5/8/2012 this will yield incorrect results for Mobile Safari, but there
+				// isn't a whole lot we can do. See pull request at this URL for discussion:
+				// https://github.com/jquery/jquery/pull/764
+				return elem.document.documentElement[ clientProp ];
 			}
 
 			// Get document width or height

--- a/test/unit/dimensions.js
+++ b/test/unit/dimensions.js
@@ -34,8 +34,7 @@ function testWidth( val ) {
 	equal( blah.width( val(10) ), blah, "Make sure that setting a width on an empty set returns the set." );
 	equal( blah.width(), null, "Make sure 'null' is returned on an empty set");
 
-	var $window = jQuery(window);
-	equal( $window.width(), window.innerWidth || document.documentElement.clientWidth, "Window width is equal to width reported by window/document." );
+	equal( jQuery(window).width(), document.documentElement.clientWidth, "Window width is equal to width reported by window/document." );
 
 	jQuery.removeData($div[0], "olddisplay", true);
 }
@@ -91,13 +90,7 @@ function testHeight( val ) {
 	equal( blah.height( val(10) ), blah, "Make sure that setting a height on an empty set returns the set." );
 	equal( blah.height(), null, "Make sure 'null' is returned on an empty set");
 
-	// This test is a little bit strange because it targets a bug that only affects iOS Mobile Safari.
-	// See the discussion about this test here for more: https://github.com/jquery/jquery/pull/764#r776477
-	var $window = jQuery(window),
-	    originalScroll = $window.scrollTop();
-	$window.scroll(150);
-	equal( $window.height(), window.innerHeight || document.documentElement.clientHeight, "Window height stays equal to window.innerHeight after scroll." );
-	$window.scroll(originalScroll);
+	equal( jQuery(window).height(), document.documentElement.clientHeight, "Window width is equal to width reported by window/document." );
 
 	jQuery.removeData($div[0], "olddisplay", true);
 }


### PR DESCRIPTION
Greetings all,

This is my first jQuery pull request, so please do bear with me. I know I probably missed some detail in terms of style, testing, or something. :)

This is a fix for issue #6724, where the value of `$(window).height()` is always the value of the window height minus the address bar and debug console. The problem is that the value returned for `$(window).height` is accurate until you scroll. At which point the value of `window.innerHeight` is adjusted to reflect the correct height of the drawable area the Browser is using, but the `document`'s height properties are not.

This patch fixes the issue by returning `window.innerHeight` for `$(window).height()` if it exists. If it doesn't exist, it will attempt to use height parameters from document and its children. Tests for the dimensions module are passing in the latest Chrome, Firefox, and Mobile Safari.

Size changes:

```
jQuery Size - compared to last make
  252813    (+26) jquery.js
   94786    (+15) jquery.min.js
   33650    (+15) jquery.min.js.gz
```

Let me know what I did wrong! :)
