### PR TITLE
Source url

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -218,7 +218,7 @@ jQuery.fn.extend({
 					.find( selector ) :
 
 				// If not, just inject the full result
-				responseText );
+				responseText, this.url );
 
 		});
 
@@ -988,7 +988,7 @@ function ajaxConvert( s, response ) {
 			// If found converter is not an equivalence
 			if ( conv !== true ) {
 				// Convert with 1 or 2 converters accordingly
-				response = conv ? conv( response ) : conv2( conv1(response) );
+				response = conv ? conv( response, s ) : conv2( conv1(response,s), s );
 			}
 		}
 	}

--- a/src/ajax/script.js
+++ b/src/ajax/script.js
@@ -9,8 +9,8 @@ jQuery.ajaxSetup({
 		script: /javascript|ecmascript/
 	},
 	converters: {
-		"text script": function( text ) {
-			jQuery.globalEval( text );
+		"text script": function( text, s ) {
+			jQuery.globalEval( text, s.url );
 			return text;
 		}
 	}

--- a/src/core.js
+++ b/src/core.js
@@ -537,14 +537,14 @@ jQuery.extend({
 	// Evaluates a script in a global context
 	// Workarounds based on findings by Jim Driscoll
 	// http://weblogs.java.net/blog/driscoll/archive/2009/09/08/eval-javascript-global-context
-	globalEval: function( data ) {
+	globalEval: function( data, sourceURL ) {
 		if ( data && rnotwhite.test( data ) ) {
 			// We use execScript on Internet Explorer
 			// We use an anonymous function so that context is window
 			// rather than jQuery in Firefox
 			( window.execScript || function( data ) {
 				window[ "eval" ].call( window, data );
-			} )( data );
+			} )( sourceURL ? ( data + "\n//@ sourceURL=" + sourceURL ) : data );
 		}
 	},
 

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -127,12 +127,12 @@ jQuery.fn.extend({
 		}).end();
 	},
 
-	append: function() {
-		return this.domManip(arguments, true, function( elem ) {
+	append: function( fromSource, value, sourceURL ) {
+		return this.domManip( fromSource === true ? [ value ] : arguments, true, function( elem ) {
 			if ( this.nodeType === 1 ) {
 				this.appendChild( elem );
 			}
-		});
+		}, sourceURL );
 	},
 
 	prepend: function() {
@@ -210,7 +210,7 @@ jQuery.fn.extend({
 		});
 	},
 
-	html: function( value ) {
+	html: function( value, sourceURL ) {
 		return jQuery.access( this, function( value ) {
 			var elem = this[0] || {},
 				i = 0,
@@ -247,7 +247,7 @@ jQuery.fn.extend({
 			}
 
 			if ( elem ) {
-				this.empty().append( value );
+				this.empty().append( true, value, sourceURL );
 			}
 		}, null, value, arguments.length );
 	},
@@ -290,7 +290,7 @@ jQuery.fn.extend({
 		return this.remove( selector, true );
 	},
 
-	domManip: function( args, table, callback ) {
+	domManip: function( args, table, callback, sourceURL ) {
 		var results, first, fragment, iNoClone,
 			i = 0,
 			value = args[0],
@@ -300,7 +300,7 @@ jQuery.fn.extend({
 		// We can't cloneNode fragments that contain checked, in WebKit
 		if ( !jQuery.support.checkClone && l > 1 && typeof value === "string" && rchecked.test( value ) ) {
 			return this.each(function() {
-				jQuery(this).domManip( args, table, callback );
+				jQuery(this).domManip( args, table, callback, sourceURL );
 			});
 		}
 
@@ -308,7 +308,7 @@ jQuery.fn.extend({
 			return this.each(function(i) {
 				var self = jQuery(this);
 				args[0] = value.call( this, i, table ? self.html() : undefined );
-				self.domManip( args, table, callback );
+				self.domManip( args, table, callback, sourceURL );
 			});
 		}
 
@@ -350,7 +350,7 @@ jQuery.fn.extend({
 							dataType: "script"
 						});
 					} else {
-						jQuery.globalEval( ( elem.text || elem.textContent || elem.innerHTML || "" ).replace( rcleanScript, "/*$0*/" ) );
+						jQuery.globalEval( ( elem.text || elem.textContent || elem.innerHTML || "" ).replace( rcleanScript, "/*$0*/" ), sourceURL );
 					}
 
 					if ( elem.parentNode ) {


### PR DESCRIPTION
http://bugs.jquery.com/ticket/11484

Not sure about this one. Adding the sourceURL parameter to `globalEval` was pretty straight-forward, as was adding the ajax options object as a second parameter to converters so that the `"text script"` converter in `ajax/script.js` is able to provide said sourceURL parameter.

However, when it comes to `load`, seeing as inline scripts need to refer to the loaded document as sourceURL, it's a bit hackish: has to pass through `html` then `append` then `domManip`. I'm particularly not happy with the change of signature of `append`.
