### PR TITLE
Remove unnecessary arguments from .nth()

### DIFF
--- a/src/traversing.js
+++ b/src/traversing.js
@@ -186,10 +186,10 @@ jQuery.each({
 		return jQuery.dir( elem, "parentNode", until );
 	},
 	next: function( elem ) {
-		return jQuery.nth( elem, 2, "nextSibling" );
+		return jQuery.nth( elem, "nextSibling" );
 	},
 	prev: function( elem ) {
-		return jQuery.nth( elem, 2, "previousSibling" );
+		return jQuery.nth( elem, "previousSibling" );
 	},
 	nextAll: function( elem ) {
 		return jQuery.dir( elem, "nextSibling" );
@@ -260,12 +260,11 @@ jQuery.extend({
 		return matched;
 	},
 
-	nth: function( cur, result, dir, elem ) {
-		result = result || 1;
+	nth: function( cur, dir ) {
 		var num = 0;
 
 		for ( ; cur; cur = cur[dir] ) {
-			if ( cur.nodeType === 1 && ++num === result ) {
+			if ( cur.nodeType === 1 && num++ === 1 ) {
 				break;
 			}
 		}


### PR DESCRIPTION
Fixes [#11720](http://bugs.jquery.com/ticket/11720).

Passes in all supported browsers.

Uncompressed size: 252255 bytes.
Compressed size: 33333 bytes gzipped (93326 bytes minified).
-7 bytes gzipped
