### PR TITLE
Added requestAnimationFrame back in (from v.1.6.2)

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -13,7 +13,10 @@ var elemdisplay = {},
 		// opacity animations
 		[ "opacity" ]
 	],
-	fxNow;
+	fxNow,
+	requestAnimationFrame = window.webkitRequestAnimationFrame ||
+		window.mozRequestAnimationFrame ||
+		window.oRequestAnimationFrame;
 
 jQuery.fn.extend({
 	show: function( speed, easing, callback ) {
@@ -447,7 +450,8 @@ jQuery.fx.prototype = {
 	// Start an animation from one number to another
 	custom: function( from, to, unit ) {
 		var self = this,
-			fx = jQuery.fx;
+			fx = jQuery.fx,
+			raf;
 
 		this.startTime = fxNow || createFxNow();
 		this.end = to;
@@ -472,7 +476,20 @@ jQuery.fx.prototype = {
 		};
 
 		if ( t() && jQuery.timers.push(t) && !timerId ) {
-			timerId = setInterval( fx.tick, fx.interval );
+			// Use requestAnimationFrame instead of setInterval if available
+			if ( requestAnimationFrame ) {
+				timerId = true;
+				raf = function() {
+					// When timerId gets set to null at any point, this stops
+					if ( timerId ) {
+						requestAnimationFrame( raf );
+						fx.tick();
+					}
+				};
+				requestAnimationFrame( raf );
+			} else {
+				timerId = setInterval( fx.tick, fx.interval );
+			}
 		}
 	},
 


### PR DESCRIPTION
Whilst I haven't added the 'shut off' flag in as discussed here: http://forum.jquery.com/topic/please-don-t-remove-requestanimationframe. The performance difference of requestAnimationFrame is noticable.
