### PR TITLE
Rename .andSelf to .addBack, deprecate .andSelf (#9800)

### DIFF
--- a/src/traversing.js
+++ b/src/traversing.js
@@ -143,10 +143,12 @@ jQuery.fn.extend({
 			jQuery.unique( all ) );
 	},
 
-	andSelf: function() {
+	addBack: function() {
 		return this.add( this.prevObject );
 	}
 });
+
+jQuery.fn.andSelf = jQuery.fn.addBack;
 
 // A painfully simple check to see if an element is disconnected
 // from a document (should be improved, where feasible).

--- a/test/unit/traversing.js
+++ b/test/unit/traversing.js
@@ -402,12 +402,12 @@ test("has(Arrayish)", function() {
 	deepEqual( simple.get(), q("qunit-fixture"), "Only adds elements once" );
 });
 
-test("andSelf()", function() {
+test("addBack()", function() {
 	expect(4);
-	deepEqual( jQuery("#en").siblings().andSelf().get(), q("sndp", "en", "sap"), "Check for siblings and self" );
-	deepEqual( jQuery("#foo").children().andSelf().get(), q("foo", "sndp", "en", "sap"), "Check for children and self" );
-	deepEqual( jQuery("#sndp, #en").parent().andSelf().get(), q("foo","sndp","en"), "Check for parent and self" );
-	deepEqual( jQuery("#groups").parents("p, div").andSelf().get(), q("qunit-fixture", "ap", "groups"), "Check for parents and self" );
+	deepEqual( jQuery("#en").siblings().addBack().get(), q("sndp", "en", "sap"), "Check for siblings and self" );
+	deepEqual( jQuery("#foo").children().addBack().get(), q("foo", "sndp", "en", "sap"), "Check for children and self" );
+	deepEqual( jQuery("#sndp, #en").parent().addBack().get(), q("foo","sndp","en"), "Check for parent and self" );
+	deepEqual( jQuery("#groups").parents("p, div").addBack().get(), q("qunit-fixture", "ap", "groups"), "Check for parents and self" );
 });
 
 test("siblings([String])", function() {


### PR DESCRIPTION
This wasn't voted on for 1.8 but there has been a ticket around for a while so let's give it the old up-or-down for 1.8. The `.andSelf` always did seem to be pretty poorly worded. Considering the implementation with `.add` it seems natural to call this `.addBack`. 
