### PR TITLE
fixes #11721, deprecate and remove internal uses of jQuery.support.boxModel

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -681,7 +681,7 @@ function defaultDisplay( nodeName ) {
 		// document to it; WebKit & Firefox won't allow reusing the iframe document.
 		if ( !iframeDoc || !iframe.createElement ) {
 			iframeDoc = ( iframe.contentWindow || iframe.contentDocument ).document;
-			iframeDoc.write( ( jQuery.support.boxModel ? "<!doctype html>" : "" ) + "<html><body>" );
+			iframeDoc.write("<!doctype html><html><body>");
 			iframeDoc.close();
 		}
 

--- a/src/offset.js
+++ b/src/offset.js
@@ -20,8 +20,8 @@ if ( "getBoundingClientRect" in document.documentElement ) {
 			win = getWindow( doc ),
 			clientTop  = docElem.clientTop  || body.clientTop  || 0,
 			clientLeft = docElem.clientLeft || body.clientLeft || 0,
-			scrollTop  = win.pageYOffset || jQuery.support.boxModel && docElem.scrollTop  || body.scrollTop,
-			scrollLeft = win.pageXOffset || jQuery.support.boxModel && docElem.scrollLeft || body.scrollLeft,
+			scrollTop  = win.pageYOffset || docElem.scrollTop,
+			scrollLeft = win.pageXOffset || docElem.scrollLeft,
 			top  = box.top  + scrollTop  - clientTop,
 			left = box.left + scrollLeft - clientLeft;
 
@@ -176,8 +176,7 @@ jQuery.each( {scrollLeft: "pageXOffset", scrollTop: "pageYOffset"}, function( me
 
 			if ( val === undefined ) {
 				return win ? (prop in win) ? win[ prop ] :
-					jQuery.support.boxModel && win.document.documentElement[ method ] ||
-						win.document.body[ method ] :
+					win.document.documentElement[ method ] :
 					elem[ method ];
 			}
 

--- a/src/support.js
+++ b/src/support.js
@@ -95,8 +95,10 @@ jQuery.support = (function() {
 		boxSizingReliable: true
 	};
 
-	// jQuery.boxModel DEPRECATED in 1.3, use jQuery.support.boxModel instead
-	jQuery.boxModel = support.boxModel = (document.compatMode === "CSS1Compat");
+	// jQuery.boxModel DEPRECATED in 1.3,
+	// jQuery.support.boxModel DEPRECATED in 1.8, but we're going to leave the property
+	// in for now and just set it to always true to not break userland scripts
+	jQuery.boxModel = support.boxModel = true;
 
 	// Make sure checked status is properly cloned
 	input.checked = true;

--- a/test/data/support/boxModelIE.html
+++ b/test/data/support/boxModelIE.html
@@ -1,9 +1,0 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"  "http://www.w3.org/TR/html4/loose.dtd">
-<html>
-<body>
-	<script src="../include_js.php"></script>
-	<script>
-	jQuery(function() { window.parent.iframeCallback( document.compatMode, jQuery.support.boxModel ) });
-	</script>
-</body>
-</html>

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -342,7 +342,7 @@ testIframe("offset/table", "table", function( jQuery ) {
 });
 
 testIframe("offset/scroll", "scroll", function( jQuery, win ) {
-	expect(24);
+	expect(26);
 
 	var ie = jQuery.browser.msie && parseInt( jQuery.browser.version, 10 ) < 8;
 
@@ -397,6 +397,12 @@ testIframe("offset/scroll", "scroll", function( jQuery, win ) {
 	notEqual( jQuery().scrollLeft(null), null, "jQuery().scrollLeft(null) testing setter on empty jquery object" );
 	strictEqual( jQuery().scrollTop(), null, "jQuery().scrollTop(100) testing setter on empty jquery object" );
 	strictEqual( jQuery().scrollLeft(), null, "jQuery().scrollLeft(100) testing setter on empty jquery object" );
+
+	// test setting scroll
+	jQuery( win ).scrollTop( 100 );
+	jQuery( win ).scrollLeft( 101 );
+	equal( jQuery( win ).scrollTop(), 100, "jQuery( win ).scrollTop() testing setter" );
+	equal( jQuery( win ).scrollLeft(), 101, "jQuery( win ).scrollLeft() testing setter" );
 });
 
 testIframe("offset/body", "body", function( jQuery ) {

--- a/test/unit/support.js
+++ b/test/unit/support.js
@@ -1,8 +1,6 @@
 module("support", { teardown: moduleTeardown });
 
-testIframeWithCallback( "proper boxModel in compatMode CSS1Compat (IE6 and IE7)", "support/boxModelIE", function( compatMode, boxModel ) {
-	ok( compatMode !== "CSS1Compat" || boxModel, "boxModel properly detected" );
-});
+ok( jQuery.support.boxModel, "jQuery.support.boxModel is perpetually true since 1.8" );
 
 testIframeWithCallback( "body background is not lost if set prior to loading jQuery (#9238)", "support/bodyBackground", function( color, support ) {
 	expect( 2 );


### PR DESCRIPTION
Wheee! jQuery no longer supports quirks mode, and that means we are always CSS1Compat. Also, determining the boxModel of a page is now meaningless considering individual elements can have different box-sizing values. 

Anyway, it's now persistently true, only to not break userland scripts, and we've removed all internal uses of it. 

P.S. we saved some bytes. Add 47 bytes to my bank account.

```
Running "compare_size:files" (compare_size) task
Sizes - compared to master
    251662      (-107)  dist/jquery.js

     92840      (-159)  dist/jquery.min.js

     33245       (-47)  dist/jquery.min.js.gz
```

P.S.S. I noticed we had no test coverage on setting scrollLeft and scrollTop in doing this PR.. so for fun ( and to receive extra bonus points from @rwaldron), I added some tests for them, so.... yeah.
