### PR TITLE
be more explicit about checking for null in $.map (#trac-11776)

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -751,7 +751,7 @@ jQuery.extend({
 			for ( ; i < length; i++ ) {
 				value = callback( elems[ i ], i, arg );
 
-				if ( value != null ) {
+				if ( value !== null ) {
 					ret[ ret.length ] = value;
 				}
 			}
@@ -761,7 +761,7 @@ jQuery.extend({
 			for ( key in elems ) {
 				value = callback( elems[ key ], key, arg );
 
-				if ( value != null ) {
+				if ( value !== null ) {
 					ret[ ret.length ] = value;
 				}
 			}


### PR DESCRIPTION
quick copy-paste from the ticket:

Given

`console.log($.map([ 1, undefined, , 2, null, 3 ], function (e, i) { return e; }));`

results in

`[ 1, 2, 3 ]`

where I'd expect

`[ 1, undefined, undefined, 2, 3 ]`

Underlying problem is that we compare using `value != null` instead of `value !== null`
