### PR TITLE
inline support test for saving bytes, and correct unit test from @dmethvin

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -82,6 +82,9 @@ jQuery.support = (function() {
 		// Where outerHTML is undefined, this still works
 		html5Clone: document.createElement("nav").cloneNode( true ).outerHTML !== "<:nav></:nav>",
 
+		// jQuery.support.boxModel DEPRECATED in 1.8 since we don't support Quirks Mode
+		boxModel: (document.compatMode === "CSS1Compat"),
+
 		// Will be defined later
 		submitBubbles: true,
 		changeBubbles: true,
@@ -94,9 +97,6 @@ jQuery.support = (function() {
 		pixelMargin: true,
 		boxSizingReliable: true
 	};
-
-	// jQuery.support.boxModel DEPRECATED in 1.8 since we don't support Quirks Mode
-	support.boxModel = (document.compatMode === "CSS1Compat");
 
 	// Make sure checked status is properly cloned
 	input.checked = true;

--- a/test/unit/support.js
+++ b/test/unit/support.js
@@ -1,6 +1,6 @@
 module("support", { teardown: moduleTeardown });
 
-ok( jQuery.support.boxModel, "jQuery.support.boxModel is perpetually true since 1.8" );
+equal( jQuery.support.boxModel, document.compatMode === "CSS1Compat" , "jQuery.support.boxModel is sort of tied to quirks mode but unstable since 1.8" );
 
 testIframeWithCallback( "body background is not lost if set prior to loading jQuery (#9238)", "support/bodyBackground", function( color, support ) {
 	expect( 2 );


### PR DESCRIPTION
```
Running "compare_size:files" (compare_size) task
Sizes - compared to master
    251640        (-7)  dist/jquery.js                                         
     92891        (-2)  dist/jquery.min.js                                     
     33270        (-3)  dist/jquery.min.js.gz  
```
