### PR TITLE
Inline the boxModel test, and correct unit test.

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -82,6 +82,9 @@ jQuery.support = (function() {
 		// Where outerHTML is undefined, this still works
 		html5Clone: document.createElement("nav").cloneNode( true ).outerHTML !== "<:nav></:nav>",
 
+		// jQuery.support.boxModel DEPRECATED in 1.8 since we don't support Quirks Mode
+		boxModel: (document.compatMode === "CSS1Compat"),
+
 		// Will be defined later
 		submitBubbles: true,
 		changeBubbles: true,
@@ -94,9 +97,6 @@ jQuery.support = (function() {
 		pixelMargin: true,
 		boxSizingReliable: true
 	};
-
-	// jQuery.support.boxModel DEPRECATED in 1.8 since we don't support Quirks Mode
-	support.boxModel = (document.compatMode === "CSS1Compat");
 
 	// Make sure checked status is properly cloned
 	input.checked = true;

--- a/test/unit/support.js
+++ b/test/unit/support.js
@@ -1,6 +1,10 @@
 module("support", { teardown: moduleTeardown });
 
-ok( jQuery.support.boxModel, "jQuery.support.boxModel is perpetually true since 1.8" );
+test("boxModel", function() {
+	expect( 1 );
+
+	equal( jQuery.support.boxModel, document.compatMode === "CSS1Compat" , "jQuery.support.boxModel is sort of tied to quirks mode but unstable since 1.8" );
+});
 
 testIframeWithCallback( "body background is not lost if set prior to loading jQuery (#9238)", "support/bodyBackground", function( color, support ) {
 	expect( 2 );


### PR DESCRIPTION
Forward-porting from commit 0a2f93e6df6078072e0b574c368dea9bf1682476 to master.

Fixes:

```
Uncaught Error: ok() assertion outside test context, was
 at http://dev.local/Krinkle/jquery/test/unit/support.js:3:1
```
