### PR TITLE
Whitespace before ? to avoid confusion

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -561,7 +561,7 @@ jQuery.event = {
 			event.metaKey = event.ctrlKey;
 		}
 
-		return fixHook.filter? fixHook.filter( event, originalEvent ) : event;
+		return fixHook.filter ? fixHook.filter( event, originalEvent ) : event;
 	},
 
 	special: {


### PR DESCRIPTION
In `event.fix`
