### PR TITLE
Preserve change delegation. Fixes 11796.

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -835,13 +835,13 @@ if ( !jQuery.support.changeBubbles ) {
 			jQuery.event.add( this, "beforeactivate._change", function( e ) {
 				var elem = e.target;
 
-				if ( rformElems.test( elem.nodeName ) && !elem._change_attached ) {
+				if ( rformElems.test( elem.nodeName ) && !jQuery._data( elem, "_change_attached" ) ) {
 					jQuery.event.add( elem, "change._change", function( event ) {
 						if ( this.parentNode && !event.isSimulated && !event.isTrigger ) {
 							jQuery.event.simulate( "change", this.parentNode, event, true );
 						}
 					});
-					elem._change_attached = true;
+					jQuery._data( elem, "_change_attached", true );
 				}
 			});
 		},

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -464,10 +464,6 @@ function cloneFixAttributes( src, dest ) {
 	// Event data gets referenced instead of copied if the expando
 	// gets copied too
 	dest.removeAttribute( jQuery.expando );
-
-	// Clear flags for bubbling special change/submit events, they must
-	// be reattached when the newly cloned events are first activated
-	dest.removeAttribute( "_change_attached" );
 }
 
 jQuery.buildFragment = function( args, context, scripts ) {

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -1098,6 +1098,38 @@ test( "submit event bubbles on copied forms (#11649)", function(){
 	$testForm.off( "submit", noSubmit );
 });
 
+test( "change event bubbles on copied forms (#11796)", function(){
+	expect( 3 );
+	
+	var $formByClone, $formByHTML,
+		$form = jQuery("#form"),
+		$fixture = jQuery("#qunit-fixture"),
+		$wrapperDiv = jQuery("<div/>").appendTo( $fixture );
+	
+	function delegatedChange() {
+		ok( true, "Make sure change event bubbles up." );
+		return false;
+	}
+	
+	// Attach a delegated change handler to the form
+	$fixture.on( "change", "form", delegatedChange );
+	
+	// Trigger change event to introduce the _change_attached property
+	$form.find("select[name=select1]").val("1").change();
+	
+	// Copy the form via .clone() and .html()
+	$formByClone = $form.clone( true, true ).removeAttr("id");
+	$formByHTML = jQuery( $fixture.html() ).filter("#form").removeAttr("id");
+	$wrapperDiv.append( $formByClone, $formByHTML );
+	
+	// Check change bubbling on the copied forms
+	$wrapperDiv.find("form select[name=select1]").val("2").change();
+	
+	// Clean up
+	$wrapperDiv.remove();
+	$fixture.off( "change", "form", delegatedChange );
+});
+
 test("trigger(eventObject, [data], [fn])", function() {
 	expect(28);
 


### PR DESCRIPTION
Under the following circumstances, a change event will not bubble to an ancestor element.

1) When jQuery.support.changeBubbles is false (IE < 9)
2) When a change event-handler is bound to the element via event delegation.
3) When a descendant element triggers a change event.

You can see the bug here:
http://jsfiddle.net/MoonScript/hcAYz/

Select a value from the 1st dropdown to see that the change event was captured via jQuery (result: 1, 2 or 3). Click the "Add a select" button to copy the select element via .html() and insert it into the DOM. When you select a value from the new dropdown, you'll see that the change event is NOT captured by jQuery (the "result" does not change), because it contained the _change_attached="true" attribute, so jQuery ignored it during its change delegation process.

Fix can be seen here, with jQuery built from this branch:
http://jsfiddle.net/MoonScript/hcAYz/4/
