### PR TITLE
Fix #11800. More than one executable in JS_ENGINE variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BUILD_DIR = build
 PREFIX = .
 DIST_DIR = ${PREFIX}/dist
 
-JS_ENGINE ?= `which node nodejs 2>/dev/null`
+JS_ENGINE ?= `which node 2>/dev/null || which nodejs 2>/dev/null`
 COMPILER = ${JS_ENGINE} ${BUILD_DIR}/uglify.js --unsafe
 POST_COMPILER = ${JS_ENGINE} ${BUILD_DIR}/post-compile.js
 


### PR DESCRIPTION
Expected one executable in JS_ENGINE variable, but currently it can receive two at the same time: /usr/bin/node and /usr/bin/nodejs.
