### PR TITLE
fixes #8627, .animate() fails on letterSpacing in IE

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -15,7 +15,13 @@ var curCSS, iframe, iframeDoc,
 	cssPrefixes = [ "Webkit", "O", "Moz", "ms" ],
 	rposition = /^(top|right|bottom|left)$/,
 
-	eventsToggle = jQuery.fn.toggle;
+	eventsToggle = jQuery.fn.toggle,
+
+	cssNormalTransform = {
+		letterSpacing : 0,
+		fontWeight: 400,
+		lineHeight : 1
+	};
 
 // return a css property mapped to a potentially vendor prefixed property
 function vendorPropName( style, name ) {
@@ -235,8 +241,13 @@ jQuery.extend({
 			val = curCSS( elem, name );
 		}
 
+		//convert "normal" to computed value
+		if ( val === "normal" && name in cssNormalTransform ) {
+			val = cssNormalTransform[ name ];
+		}
+
 		// Return, converting to number if forced or a qualifier was provided and val looks numeric
-		if ( numeric || extra ) {
+		if ( numeric || extra !== undefined ) {
 			num = parseFloat( val );
 			return numeric || jQuery.isNumeric( num ) ? num || 0 : val;
 		}

--- a/src/effects.js
+++ b/src/effects.js
@@ -365,19 +365,20 @@ Tween.prototype.init.prototype = Tween.prototype;
 Tween.propHooks = {
 	_default: {
 		get: function( tween ) {
-			var parsed, result;
+			var result;
 
 			if ( tween.elem[ tween.prop ] != null &&
 				(!tween.elem.style || tween.elem.style[ tween.prop ] == null) ) {
 				return tween.elem[ tween.prop ];
 			}
 
-			result = jQuery.css( tween.elem, tween.prop );
-			// Empty strings, null, undefined and "auto" are converted to 0,
-			// complex values such as "rotate(1rad)" are returned as is,
-			// simple values such as "10px" are parsed to Float.
-			return isNaN( parsed = parseFloat( result ) ) ?
-				!result || result === "auto" ? 0 : result : parsed;
+			// passing any value as a 4th paramter to .css will automatically
+			// attempt a parseFloat and fallback to a string if the parse fails
+			// so, simple values such as "10px" are parsed to Float.
+			// complex values such as "rotate(1rad)" are returned as is.
+			result = jQuery.css( tween.elem, tween.prop, false, "" );
+			// Empty strings, null, undefined and "auto" are converted to 0.
+			return !result || result === "auto" ? 0 : result;
 		},
 		set: function( tween ) {
 			// use step hook for back compat - use cssHook if its there - use .style if its

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -732,6 +732,14 @@ test("css('width') and css('height') should respect box-sizing, see #11004", fun
 	equal( el_dis.css("height"), el_dis.css("height", el_dis.css("height")).css("height"), "css('height') is not respecting box-sizing for disconnected element, see #11004");
 });
 
+test("certain css values of 'normal' should be convertable to a number, see #8627", function() {
+	var el = jQuery("<div style='letter-spacing:normal;font-weight:normal;line-height:normal;'>test</div>").appendTo("#qunit-fixture");
+
+	ok( jQuery.isNumeric( parseFloat( el.css("letterSpacing") ) ), "css('letterSpacing') not convertable to number, see #8627" );
+	ok( jQuery.isNumeric( parseFloat( el.css("fontWeight") ) ), "css('fontWeight') not convertable to number, see #8627" );
+	ok( jQuery.isNumeric( parseFloat( el.css("lineHeight") ) ), "css('lineHeight') not convertable to number, see #8627" );
+});
+
 test( "cssHooks - expand", function() {
 	expect( 15 );
 	var result,


### PR DESCRIPTION
size diff:

```
Running "compare_size:files" (compare_size) task
Sizes - compared to master
    251944      (+324)  dist/jquery.js                                         
     92807       (+66)  dist/jquery.min.js                                     
     33274       (+39)  dist/jquery.min.js.gz  
```

Interesting to note that some browsers convert normal to a pixel value already and never truly return `normal` from `getComputedStyle`. That's why the units just check for something that's convertable to a number, and therefore useful for animating.

Also, used some of the new auto-parsefloat stuff that @gibson042 added to .css to simplify the logic for transforming the result from css.
