### PR TITLE
Avoid try-catch in oldIE, fixes test failures in oldIE

### DIFF
--- a/src/offset.js
+++ b/src/offset.js
@@ -11,8 +11,7 @@ jQuery.fn.offset = function( options ) {
 			});
 	}
 
-	var docElem, body, win, clientTop, clientLeft, scrollTop, scrollLeft, top, left,
-		box = {},
+	var box, docElem, body, win, clientTop, clientLeft, scrollTop, scrollLeft, top, left,
 		elem = this[ 0 ],
 		doc = elem && elem.ownerDocument;
 
@@ -26,15 +25,12 @@ jQuery.fn.offset = function( options ) {
 
 	docElem = doc.documentElement;
 
-	try {
-		box = elem.getBoundingClientRect();
-	} catch(e) {}
-
 	// Make sure we're not dealing with a disconnected DOM node
-	if ( !box.top || !jQuery.contains( docElem, elem ) ) {
-		return { top: box.top || 0, left: box.left || 0 };
+	if ( !jQuery.contains( docElem, elem ) ) {
+		return { top: 0, left: 0 };
 	}
 
+	box = elem.getBoundingClientRect();
 	win = getWindow( doc );
 	clientTop  = docElem.clientTop  || body.clientTop  || 0;
 	clientLeft = docElem.clientLeft || body.clientLeft || 0;


### PR DESCRIPTION
My IE6/7 updated themselfs to IE8, i did not notice that when i run the tests :-(.
Okey, in order to understand why jQuery need a try-catch i did additional checks, based on – https://github.com/jquery/jquery/commit/cf672a2e7a886cac5ae62f6772c6b4b43b19a2fc#commitcomment-159402

There is three types of disconnected nodes, when – 

<ol>
<li>parentNode == null</li>
<li>parentNode == documentFragment</li>
<li>some of parents of the node is parentNode == null or parentNode == documentFragment</li>
</ol>


IE6/7 throws an exception only in first case, for other disconnected nodes it will return 0.
This means jQuery do not need a try-catch, only test for any type of disconnected nodes. There should not be any speed diff, and it saves 16 bytes.
