### PR TITLE
Fix #11827: jQuery.clean does not support SVG elements

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -20,6 +20,7 @@ var nodeNames = "abbr|article|aside|audio|bdi|canvas|data|datalist|details|figca
 	rleadingWhitespace = /^\s+/,
 	rxhtmlTag = /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([\w:]+)[^>]*)\/>/ig,
 	rtagName = /<([\w:]+)/,
+    rxmlnsName = /xmlns=\"([^\"]*)\"/,
 	rtbody = /<tbody/i,
 	rhtml = /<|&#?\w+;/,
 	rnoInnerhtml = /<(?:script|style|link)/i,
@@ -40,7 +41,11 @@ var nodeNames = "abbr|article|aside|audio|bdi|canvas|data|datalist|details|figca
 		area: [ 1, "<map>", "</map>" ],
 		_default: [ 0, "", "" ]
 	},
-	safeFragment = createSafeFragment( document ),
+    wrapMapNS = {
+        'http://www.w3.org/2000/svg': [1, "<svg xmlns='http://www.w3.org/2000/svg'>", "</svg>"],
+        _default: [0, "", ""]
+    },
+    safeFragment = createSafeFragment(document),
 	fragmentDiv = safeFragment.appendChild( document.createElement("div") );
 
 wrapMap.optgroup = wrapMap.option;
@@ -653,8 +658,10 @@ jQuery.extend({
 					elem = elem.replace(rxhtmlTag, "<$1></$2>");
 
 					// Go to html and back, then peel off extra wrappers
-					tag = ( rtagName.exec( elem ) || ["", ""] )[1].toLowerCase();
-					wrap = wrapMap[ tag ] || wrapMap._default;
+					tag = (rtagName.exec(elem) || ["", ""])[1].toLowerCase();
+					ns = (rxmlnsName.exec(elem.toLowerCase()) || ["", ""])[1].replace(/\/+$/, "");
+					wrap = wrapMap[tag] || wrapMap._default;
+					wrap = wrapMapNS[ns] || wrap;
 					depth = wrap[0];
 					div.innerHTML = wrap[1] + elem + wrap[2];
 

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -1493,6 +1493,12 @@ test("empty()", function() {
 	equal( j.html(), "", "Check node,textnode,comment empty works" );
 });
 
+test("jquery.clean with svg elements (#11827)", function() {
+	expect(1);
+	var elem = jQuery['clean'](['<rect xmlns="http://www.w3.org/2000/svg" width="10"></rect>']);
+	equal( elem[0].width.baseVal.value, 10, "Check if SVG element was created with a valid baseVal for width" );
+});
+
 test("jQuery.cleanData", function() {
 	expect(14);
 


### PR DESCRIPTION
So far svg elements were not converted correctly.

If the corresponding XML namespace is given ('http://www.w3.org/2000/svg'), an appropriate wrapper element
will be created now.
