### PR TITLE
Fix #11787: remove jQuery.curCSS

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -317,9 +317,6 @@ jQuery.extend({
 	}
 });
 
-// DEPRECATED in 1.3, Use jQuery.css() instead
-jQuery.curCSS = jQuery.css;
-
 if ( document.defaultView && document.defaultView.getComputedStyle ) {
 	curCSS = function( elem, name ) {
 		var ret, defaultView, computedStyle, width,


### PR DESCRIPTION
Sizes - compared to master @ 7f2cc46955b35dc3d5a0526d0cb038d4a50b936b

```
    251316       (-76)  dist/jquery.js                                         
     92645       (-15)  dist/jquery.min.js                                     
     33163       (-11)  dist/jquery.min.js.gz
```
