### PR TITLE
fixes #11724, $(document).height() changed in Firefox 12, but breaks #3838

### DIFF
--- a/src/dimensions.js
+++ b/src/dimensions.js
@@ -23,20 +23,14 @@ jQuery.each( { Height: "height", Width: "width" }, function( name, type ) {
 
 				// Get document width or height
 				if ( elem.nodeType === 9 ) {
-					// Either scroll[Width/Height] or offset[Width/Height], whichever is greater
 					doc = elem.documentElement;
 
-					// when a window > document, IE6 reports a offset[Width/Height] > client[Width/Height]
-					// so we can't use max, as it'll choose the incorrect offset[Width/Height]
-					// instead we use the correct client[Width/Height]
-					// support:IE6
-					if ( doc[ clientProp ] >= doc[ scrollProp ] ) {
-						return doc[ clientProp ];
-					}
-
+					// Either scroll[Width/Height] or offset[Width/Height] or client[Width/Height], whichever is greatest
+					// unfortunately, this causes bug #3838 in IE6 only, but there is currently no good, small way to fix it.
 					return Math.max(
 						elem.body[ scrollProp ], doc[ scrollProp ],
-						elem.body[ offsetProp ], doc[ offsetProp ]
+						elem.body[ offsetProp ], doc[ offsetProp ],
+						doc[ clientProp ]
 					);
 				}
 

--- a/test/data/dimensions/documentSmall.html
+++ b/test/data/dimensions/documentSmall.html
@@ -2,6 +2,16 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" dir="ltr" id="html">
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+	<style>
+		html {
+			/**
+			 * we need to null out border-width, because it causes bug #3838
+			 * and until we drop IE6, this test will fail in IE6 if we didn't
+			 * special case this situation.
+			 **/
+			border-width: 0;
+		}
+	</style>
 </head>
 <body>
 	<div>

--- a/test/unit/dimensions.js
+++ b/test/unit/dimensions.js
@@ -393,16 +393,16 @@ test("setters with and without box-sizing:border-box", function(){
 	equal( el.outerHeight( 129, true ).height(), expected + 5, "test border-box innerHeight(int, true) by roundtripping" );
 });
 
-testIframe("dimensions/documentSmall", "window vs. small document", function( jQuery, window, document ) {
+testIframe( "dimensions/documentSmall", "window vs. small document", function( jQuery, window, document ) {
 	expect(2);
 
-	equal( jQuery( document ).height(), jQuery( window ).height(), "document height matches window height");
-	equal( jQuery( document ).width(), jQuery( window ).width(), "document width matches window width");
+	equal( jQuery( document ).height(), jQuery( window ).height(), "document height matches window height" );
+	equal( jQuery( document ).width(), jQuery( window ).width(), "document width matches window width" );
 });
 
-testIframe("dimensions/documentLarge", "window vs. large document", function( jQuery, window, document ) {
+testIframe( "dimensions/documentLarge", "window vs. large document", function( jQuery, window, document ) {
 	expect(2);
 
-	ok( jQuery( document ).height() > jQuery( window ).height(), "document height is larger than window height");
-	ok( jQuery( document ).width() > jQuery( window ).width(), "document width is larger than window width");
+	ok( jQuery( document ).height() > jQuery( window ).height(), "document height is larger than window height" );
+	ok( jQuery( document ).width() > jQuery( window ).width(), "document width is larger than window width" );
 });


### PR DESCRIPTION
I'd rather #3838 be broken than #11724
