### PR TITLE
fixes #11293, don't swap to measure dimensions unless the element is display:none

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -480,7 +480,7 @@ jQuery.each([ "height", "width" ], function( i, name ) {
 	jQuery.cssHooks[ name ] = {
 		get: function( elem, computed, extra ) {
 			if ( computed ) {
-				if ( elem.offsetWidth !== 0 ) {
+				if ( elem.offsetWidth !== 0 || curCSS( elem, "display" ) !== "none" ) {
 					return getWidthOrHeight( elem, name, extra );
 				} else {
 					return jQuery.swap( elem, cssShow, function() {

--- a/test/unit/dimensions.js
+++ b/test/unit/dimensions.js
@@ -299,6 +299,16 @@ test("outerWidth(true) returning % instead of px in Webkit, see #10639", functio
 	equal( el.outerWidth(true), 400, "outerWidth(true) and css('margin') returning % instead of px in Webkit, see #10639" );
 });
 
+test( "getting dimensions of zero width/height table elements shouldn't alter dimensions", function() {
+	expect( 1 );
+
+	var table = jQuery("<table><tbody><tr><td></td><td>a</td></tr><tr><td></td><td>a</td></tr></tbody></table>").appendTo("#qunit-fixture"),
+		elem = table.find("tr:eq(0) td:eq(0)");
+
+	table.find("td").css({ margin: 0, padding: 0 });
+	equal( elem.width(), elem.width(), "width() doesn't alter dimension values" );
+});
+
 test("box-sizing:border-box child of a hidden elem (or unconnected node) has accurate inner/outer/Width()/Height()  see #10413", function() {
 	expect(16);
 


### PR DESCRIPTION
http://jqbug.com/11293

```
Running "compare_size:files" (compare_size) task
Sizes - compared to master
    251207       (+44)  dist/jquery.js                                         
     92011       (+29)  dist/jquery.min.js                                     
     33094        (+9)  dist/jquery.min.js.gz     
```

One note:
- I really dislike that for elements that have offsetWidth 0, we attempt to make them visible by swapping out some css properties. Users really shouldn't be asking for measurements on hidden elements. I suppose we need it for back-compat, but I just really dislike it.
