### PR TITLE
Updated Makefile to support installations where "which" returns multiple matches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BUILD_DIR = build
 PREFIX = .
 DIST_DIR = ${PREFIX}/dist
 
-JS_ENGINE ?= `which node nodejs 2>/dev/null`
+JS_ENGINE ?= `which node nodejs 2>/dev/null | head -n1`
 COMPILER = ${JS_ENGINE} ${BUILD_DIR}/uglify.js --unsafe
 POST_COMPILER = ${JS_ENGINE} ${BUILD_DIR}/post-compile.js
 


### PR DESCRIPTION
Some distributions place the nodejs executable in both /usr/bin/node and /usr/bin/nodejs, resulting in the line `JS_ENGINE ?= `which node nodejs`` at line 8 in the `Makefile` to consist of multiple lines. This causes `Make` to fail with the following messages:

```
$ make
/bin/sh: 1: test: /usr/bin/node: unexpected operator
You must have NodeJS installed in order to minify jQuery.
/bin/sh: 1: test: /usr/bin/node: unexpected operator
You must have NodeJS installed in order to test jQuery against JSHint.
/bin/sh: 1: test: /usr/bin/node: unexpected operator
You must have NodeJS installed in order to size jQuery.
jQuery build complete.
```

The patch pipes the output from `which` into `head -n1` to select the first result.
This has been tested on Debian Wheezy.
