### PR TITLE
Fixes #11905 - Bad license URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
   "licenses": [
     {
       "type": "MIT",
-      "url": "http://github.com/jquery/jquery/blob/master/MIT-LICENSE.txt"
+      "url": "http://www.opensource.org/licenses/MIT"
     },
     {
       "type": "GPL",
-      "url": "http://github.com/jquery/jquery/blob/master/GPL-LICENSE.txt"
+      "url": "http://www.opensource.org/licenses/GPL-2.0"
     }
   ],
   "dependencies": {},


### PR DESCRIPTION
Corrects the URLs in package.json to point to the right URL on github
