### PR TITLE
Fix #11925: Pass eventHandle as second argument to special.teardown.

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -201,7 +201,7 @@ jQuery.event = {
 			// Remove generic event handler if we removed something and no more handlers exist
 			// (avoids potential for endless recursion during removal of special event handlers)
 			if ( eventType.length === 0 && origCount !== eventType.length ) {
-				if ( !special.teardown || special.teardown.call( elem, namespaces ) === false ) {
+				if ( !special.teardown || special.teardown.call( elem, namespaces, elemData.handle ) === false ) {
 					jQuery.removeEvent( elem, type, elemData.handle );
 				}
 

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -1372,6 +1372,21 @@ test("Submit event can be stopped (#11049)", function() {
 	form.remove();
 });
 
+test("on(beforeunload) creates/deletes window property instead of adding/removing event listener", function() {
+	expect(3);
+
+	equal( window.onbeforeunload, null, "window property is null/undefined up until now" );
+
+	var handle = function () {};
+	jQuery(window).on( "beforeunload", handle );
+
+	equal( typeof window.onbeforeunload, "function", "window property is set to a function");
+
+	jQuery(window).off( "beforeunload", handle );
+
+	equal( window.onbeforeunload, null, "window property has been unset to null/undefined" );
+})
+
 test("jQuery.Event( type, props )", function() {
 
 	expect(5);


### PR DESCRIPTION
- Fixes [#11925](http://bugs.jquery.com/ticket/11925).
- Added unit test to confirm.
  The third assertion fails without the fix in ./src/event.js

Sizes - compared to master (80295ed)

```
    253503       (+17)  dist/jquery.js                                         
     92468        (+9)  dist/jquery.min.js                                     
     33208        (+5)  dist/jquery.min.js.gz   
```
