### PR TITLE
add a postinstall hook for building dist files with grunt + provide `main`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "jquery",
   "title": "jQuery",
+  "main": "./dist/jquery.js",
   "description": "New Wave JavaScript",
   "version": "1.8.0pre",
   "homepage": "http://jquery.com",
@@ -30,5 +31,8 @@
     "grunt": ">=0.3.9",
     "testswarm": "0.2.2"
   },
-  "keywords": []
+  "keywords": [],
+  "scripts": {
+    "postinstall": "./node_modules/grunt/bin/grunt"
+  }
 }


### PR DESCRIPTION
I believe package.json's require a main property (if index.js isn't present)...but i couldn't double check because commonjs.org is down at the moment :/

Anyways, I added a `postinstall` hook which will build a jquery dist file. 

Might be worth including...
