### PR TITLE
Completes #11797: Maybe .progress() was cooler than I thought.

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -91,6 +91,8 @@ function Animation( elem, properties, options ) {
 				animation.tweens[ index ].run( percent );
 			}
 
+			deferred.notifyWith( elem, [ animation, percent, remaining ]);
+
 			if ( percent < 1 && length ) {
 				return remaining;
 			} else {
@@ -159,7 +161,8 @@ function Animation( elem, properties, options ) {
 	);
 
 	// attach callbacks from options
-	return animation.done( animation.opts.done, animation.opts.complete )
+	return animation.progress( animation.opts.progress )
+		.done( animation.opts.done, animation.opts.complete )
 		.fail( animation.opts.fail )
 		.always( animation.opts.always );
 }

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -1665,12 +1665,16 @@ asyncTest( "animate does not change start value for non-px animation (#7109)", 1
 	});
 });
 
-asyncTest("Animation callbacks (#11797)", 8, function() {
+asyncTest("Animation callbacks (#11797)", 12, function() {
 	var targets = jQuery("#foo").children(),
-		done = false;
+		done = false,
+		expectedProgress = 0;
 
 	targets.eq( 0 ).animate( {}, {
-		duration: 10,
+		duration: 1,
+		progress: function( anim, percent ) {
+			equal( percent, 0, "empty: progress 0" );
+		},
 		done: function() {
 			ok( true, "empty: done" );
 		},
@@ -1689,7 +1693,10 @@ asyncTest("Animation callbacks (#11797)", 8, function() {
 	targets.eq( 1 ).animate({
 		opacity: 0
 	}, {
-		duration: 10,
+		duration: 1,
+		progress: function( anim, percent ) {
+			equal( percent, 0, "stopped: progress 0" );
+		},
 		done: function() {
 			ok( false, "stopped: done" );
 		},
@@ -1707,7 +1714,12 @@ asyncTest("Animation callbacks (#11797)", 8, function() {
 	targets.eq( 2 ).animate({
 		opacity: 0
 	}, {
-		duration: 10,
+		duration: 1,
+		progress: function( anim, percent ) {
+			equal( percent, expectedProgress, "async: progress " + expectedProgress );
+			// once at 0, once at 1
+			expectedProgress++;
+		},
 		done: function() {
 			ok( true, "async: done" );
 		},


### PR DESCRIPTION
http://bugs.jquery.com/ticket/11797#comment:13

Adds `.progress( callback( anim, progress, remainingMS ) )` where progress is [0..1] and exposes it on options object.

CC @gibson042 @dmethvin @kswedberg 
