### PR TITLE
Fix #11809: Clear elements to avoid leaking memory

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -341,6 +341,9 @@ jQuery.fn.extend({
 				}
 			}
 
+			// Fix #11809: Avoid leaking memory
+			fragment = first = null;
+
 			if ( scripts.length ) {
 				jQuery.each( scripts, function( i, elem ) {
 					if ( elem.src ) {
@@ -708,7 +711,7 @@ jQuery.extend({
 		// Fix #11356: Clear elements from safeFragment
 		if ( div ) {
 			safe.removeChild( div );
-			div = safe = null;
+			elem = div = safe = null;
 		}
 
 		// Reset defaultChecked for any radios and checkboxes


### PR DESCRIPTION
Sizes - compared to master @ 375c44d9c715051940a1b9fa5fbafb5c021b6a96

```
    255997       (+75)  dist/jquery.js
     93067       (+11)  dist/jquery.min.js
     33481        (+4)  dist/jquery.min.js.gz
```
