### PR TITLE
Let the props in $(html, props) be any jQuery.fn method.

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -281,17 +281,6 @@ jQuery.extend({
 		}
 	},
 
-	attrFn: {
-		val: true,
-		css: true,
-		html: true,
-		text: true,
-		data: true,
-		width: true,
-		height: true,
-		offset: true
-	},
-
 	attr: function( elem, name, value, pass ) {
 		var ret, hooks, notxml,
 			nType = elem.nodeType;
@@ -301,7 +290,7 @@ jQuery.extend({
 			return;
 		}
 
-		if ( pass && name in jQuery.attrFn ) {
+		if ( pass && jQuery.isFunction( jQuery.fn[ name ] ) ) {
 			return jQuery( elem )[ name ]( value );
 		}
 


### PR DESCRIPTION
This avoids special cases since we can eliminate attrFn. It does create some ambiguity since someone may add a plugin on jQuery.fn and change the meaning of one of the props. This does not bother me since I think this signature is an incredibly bad idea anyway. Rather than deprecate it, we can enhance it beyond repair!

This signature does have a very small unit test in core.js, and this changes passes that test. 
