### PR TITLE
[1.9] Drop support for Firefox 3.6, Fixes #11994 

### DIFF
--- a/src/ajax/xhr.js
+++ b/src/ajax/xhr.js
@@ -90,12 +90,9 @@ if ( jQuery.support.ajax ) {
 						headers[ "X-Requested-With" ] = "XMLHttpRequest";
 					}
 
-					// Need an extra try/catch for cross domain requests in Firefox 3
-					try {
-						for ( i in headers ) {
-							xhr.setRequestHeader( i, headers[ i ] );
-						}
-					} catch( _ ) {}
+					for ( i in headers ) {
+						xhr.setRequestHeader( i, headers[ i ] );
+					}
 
 					// Do send the request
 					// This may raise an exception which is actually
@@ -104,81 +101,63 @@ if ( jQuery.support.ajax ) {
 
 					// Listener
 					callback = function( _, isAbort ) {
-
 						var status,
 							statusText,
 							responseHeaders,
 							responses,
 							xml;
 
-						// Firefox throws exceptions when accessing properties
-						// of an xhr when a network error occured
-						// http://helpful.knobs-dials.com/index.php/Component_returned_failure_code:_0x80040111_(NS_ERROR_NOT_AVAILABLE)
-						try {
+						// Was never called and is aborted or complete
+						if ( callback && ( isAbort || xhr.readyState === 4 ) ) {
 
-							// Was never called and is aborted or complete
-							if ( callback && ( isAbort || xhr.readyState === 4 ) ) {
+							// Only called once
+							callback = undefined;
 
-								// Only called once
-								callback = undefined;
-
-								// Do not keep as active anymore
-								if ( handle ) {
-									xhr.onreadystatechange = jQuery.noop;
-									if ( xhrOnUnloadAbort ) {
-										delete xhrCallbacks[ handle ];
-									}
-								}
-
-								// If it's an abort
-								if ( isAbort ) {
-									// Abort it manually if needed
-									if ( xhr.readyState !== 4 ) {
-										xhr.abort();
-									}
-								} else {
-									status = xhr.status;
-									responseHeaders = xhr.getAllResponseHeaders();
-									responses = {};
-									xml = xhr.responseXML;
-
-									// Construct response list
-									if ( xml && xml.documentElement /* #4958 */ ) {
-										responses.xml = xml;
-									}
-
-									// When requesting binary data, IE6-9 will throw an exception
-									// on any attempt to access responseText (#11426)
-									try {
-										responses.text = xhr.responseText;
-									} catch( _ ) {
-									}
-
-									// Firefox throws an exception when accessing
-									// statusText for faulty cross-domain requests
-									try {
-										statusText = xhr.statusText;
-									} catch( e ) {
-										// We normalize with Webkit giving an empty statusText
-										statusText = "";
-									}
-
-									// Filter status for non standard behaviors
-
-									// If the request is local and we have data: assume a success
-									// (success with no data won't get notified, that's the best we
-									// can do given current implementations)
-									if ( !status && s.isLocal && !s.crossDomain ) {
-										status = responses.text ? 200 : 404;
-									// IE - #1450: sometimes returns 1223 when it should be 204
-									} else if ( status === 1223 ) {
-										status = 204;
-									}
+							// Do not keep as active anymore
+							if ( handle ) {
+								xhr.onreadystatechange = jQuery.noop;
+								if ( xhrOnUnloadAbort ) {
+									delete xhrCallbacks[ handle ];
 								}
 							}
-						} catch( firefoxAccessException ) {
-							if ( !isAbort ) {
-								complete( -1, firefoxAccessException );
+
+							// If it's an abort
+							if ( isAbort ) {
+								// Abort it manually if needed
+								if ( xhr.readyState !== 4 ) {
+									xhr.abort();
+								}
+							} else {
+								status = xhr.status;
+								responseHeaders = xhr.getAllResponseHeaders();
+								responses = {};
+								xml = xhr.responseXML;
+
+								// Construct response list
+								if ( xml && xml.documentElement /* #4958 */ ) {
+									responses.xml = xml;
+								}
+
+								// When requesting binary data, IE6-9 will throw an exception
+								// on any attempt to access responseText (#11426)
+								try {
+									responses.text = xhr.responseText;
+								} catch( _ ) {
+								}
+
+								statusText = xhr.statusText;
+
+								// Filter status for non standard behaviors
+
+								// If the request is local and we have data: assume a success
+								// (success with no data won't get notified, that's the best we
+								// can do given current implementations)
+								if ( !status && s.isLocal && !s.crossDomain ) {
+									status = responses.text ? 200 : 404;
+								// IE - #1450: sometimes returns 1223 when it should be 204
+								} else if ( status === 1223 ) {
+									status = 204;
+								}
 							}
 						}
 

--- a/src/core.js
+++ b/src/core.js
@@ -513,17 +513,11 @@ jQuery.extend({
 
 	noop: function() {},
 
-	// Evaluates a script in a global context
-	// Workarounds based on findings by Jim Driscoll
-	// http://weblogs.java.net/blog/driscoll/archive/2009/09/08/eval-javascript-global-context
 	globalEval: function( data ) {
 		if ( data && core_rnotwhite.test( data ) ) {
-			// We use execScript on Internet Explorer
-			// We use an anonymous function so that context is window
-			// rather than jQuery in Firefox
-			( window.execScript || function( data ) {
-				window[ "eval" ].call( window, data );
-			} )( data );
+
+			// We use execScript on Internet Explorer and indirect call for others
+			( window.execScript || window[ "eval" ] )( data );
 		}
 	},
 


### PR DESCRIPTION
Line: https://github.com/jquery/jquery/blob/master/src/ajax/xhr.js#L94-98
Issue: http://bugs.jquery.com/ticket/1557
Links: http://ejohn.org/blog/cross-site-xmlhttprequest/,
http://www.nczonline.net/blog/2008/04/27/cross-domain-xhr-removed-from-firefox-3/

I can't reproduce the issue for Firefox 3.0.13, cross-site request is not working for me at all.
But, in firefox 3.6 cross-site requests working without try...catch

Line: https://github.com/jquery/jquery/blob/master/src/ajax/xhr.js#L117-183
Issue: http://bugs.jquery.com/ticket/8135

Problem happens for <code>getAllResponseHeaders</code> method in Firefox 3.6, which is no longer the case for Firefox 4.0

Line: https://github.com/jquery/jquery/blob/master/src/ajax/xhr.js#L159-164

Same as previous issue but this time for <code>statusText</code> prop

Line: https://github.com/jquery/jquery/blob/master/src/core.js#L536-538

There is no need for explicitly set function context in new FF

Did i miss something?
If you think its to early to remove this code or its unsave to remove those try...catch, then this PR and ticket might be used as future references.

CC @rwldrn, @jaubourg
