### PR TITLE
Optimization of array operations

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -171,15 +171,9 @@ jQuery.fn = jQuery.prototype = {
 	// Take an array of elements and push it onto the stack
 	// (returning the new matched element set)
 	pushStack: function( elems, name, selector ) {
+
 		// Build a new jQuery matched element set
-		var ret = this.constructor();
-
-		if ( jQuery.isArray( elems ) ) {
-			core_push.apply( ret, elems );
-
-		} else {
-			jQuery.merge( ret, elems );
-		}
+		var ret = jQuery.merge( this.constructor(), elems );
 
 		// Add the old object onto the stack (as a reference)
 		ret.prevObject = this;

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -146,10 +146,11 @@ jQuery.fn.extend({
 			return this.domManip(arguments, false, function( elem ) {
 				this.parentNode.insertBefore( elem, this );
 			});
-		} else if ( arguments.length ) {
+		}
+
+		if ( arguments.length ) {
 			var set = jQuery.clean( arguments );
-			set.push.apply( set, this.toArray() );
-			return this.pushStack( set, "before", arguments );
+			return this.pushStack( jQuery.merge( set, this ), "before", this.selector );
 		}
 	},
 
@@ -158,10 +159,11 @@ jQuery.fn.extend({
 			return this.domManip(arguments, false, function( elem ) {
 				this.parentNode.insertBefore( elem, this.nextSibling );
 			});
-		} else if ( arguments.length ) {
-			var set = this.pushStack( this, "after", arguments );
-			set.push.apply( set, jQuery.clean(arguments) );
-			return set;
+		}
+
+		if ( arguments.length ) {
+			var set = jQuery.clean( arguments );
+			return this.pushStack( jQuery.merge( this, set ), "after", this.selector );
 		}
 	},
 

--- a/src/traversing.js
+++ b/src/traversing.js
@@ -201,7 +201,7 @@ jQuery.each({
 	contents: function( elem ) {
 		return jQuery.nodeName( elem, "iframe" ) ?
 			elem.contentDocument || elem.contentWindow.document :
-			jQuery.makeArray( elem.childNodes );
+			jQuery.merge( [], elem.childNodes );
 	}
 }, function( name, fn ) {
 	jQuery.fn[ name ] = function( until, selector ) {


### PR DESCRIPTION
Couple of them.

Line: https://github.com/jquery/jquery/blob/master/src/core.js#L178

<code>jQuery#pushStack</code> uses <code>push.apply</code>, if first argument is array, but what interesting is that <code>jQuery.merge</code> usually faster then or equal with <code>push.apply</code> – http://jsperf.com/push-vs-jquery-merge

Line: https://github.com/jquery/jquery/blob/master/src/traversing.js#L204

Here used <code>jQuery.makeArray</code>, which then goes straight to <code>jQuery.merge</code>, in order to decrease function call stack it's probably better to use <code>jQuery.merge</code>

Lines: https://github.com/jquery/jquery/blob/master/src/manipulation.js#L163,
        https://github.com/jquery/jquery/blob/master/src/manipulation.js#L151

Same thing with push, but also, there is a small "bug" – http://jsfiddle.net/rpuPs/
