### PR TITLE
Fixing issue #8482

### DIFF
--- a/src/offset.js
+++ b/src/offset.js
@@ -138,6 +138,9 @@ jQuery.fn.extend({
 			while ( offsetParent && (!rroot.test(offsetParent.nodeName) && jQuery.css(offsetParent, "position") === "static") ) {
 				offsetParent = offsetParent.offsetParent;
 			}
+			if (!offsetParent) {
+				offsetParent = document.body;
+			}
 			return offsetParent;
 		});
 	}


### PR DESCRIPTION
If we have the following structure:

< body >
_______< map >
______________< area >

doing offsetParent.offsetParent at the area node will result in an undefined variable in IE.

This commit should ensure that offsetParent method always returns a valid value.
