### PR TITLE
Fix #10517. before() and after() on disconnected node should return multiple nodes

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -142,7 +142,7 @@ jQuery.fn.extend({
 	},
 
 	before: function() {
-		if ( this[0] && this[0].parentNode ) {
+		if ( !isDisconnected( this[0] ) ) {
 			return this.domManip(arguments, false, function( elem ) {
 				this.parentNode.insertBefore( elem, this );
 			});
@@ -155,7 +155,7 @@ jQuery.fn.extend({
 	},
 
 	after: function() {
-		if ( this[0] && this[0].parentNode ) {
+		if ( !isDisconnected( this[0] ) ) {
 			return this.domManip(arguments, false, function( elem ) {
 				this.parentNode.insertBefore( elem, this.nextSibling );
 			});
@@ -259,7 +259,7 @@ jQuery.fn.extend({
 	},
 
 	replaceWith: function( value ) {
-		if ( this[0] && this[0].parentNode && this[0].parentNode.nodeType != 11 ) {
+		if ( !isDisconnected( this[0] ) ) {
 			// Make sure that the elements are removed from the DOM before they are inserted
 			// this can help fix replacing a parent with child elements
 			if ( jQuery.isFunction( value ) ) {

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -917,6 +917,13 @@ test("before and after w/ empty object (#10812)", function() {
 	equal( res.wrapAll("<div/>").parent().text(), "()", "correctly appended text" );
 });
 
+test("before and after on disconnected node (#10517)", function() {
+	expect(2);
+	
+	equal( jQuery("<input type='checkbox'/>").before("<div/>").length, 2, "before() returned all elements" );
+	equal( jQuery("<input type='checkbox'/>").after("<div/>").length, 2, "after() returned all elements" );
+});
+
 test("insertBefore(String|Element|Array&lt;Element&gt;|jQuery)", function() {
 	expect(4);
 	var expected = "This is a normal link: bugaYahoo";


### PR DESCRIPTION
before() and after() now use isDisconnected() to make sure the parent node is not just a fragment.

changing replaceWith() to also use isDisconnected() makes this commit go from +3 to -7 for jquery.min.gz
