### PR TITLE
Partial fix for #7579

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -304,7 +304,8 @@ function dataAttr( elem, key, data ) {
 				data = data === "true" ? true :
 				data === "false" ? false :
 				data === "null" ? null :
-				jQuery.isNumeric( data ) ? +data :
+				// Only convert to a number if it doesn't lose precision
+				jQuery.isNumeric( data ) && +data + 1 != data ? +data :
 					rbrace.test( data ) ? jQuery.parseJSON( data ) :
 					data;
 			} catch( e ) {}

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -294,7 +294,7 @@ test(".data(String) and .data(String, Object)", function() {
 });
 
 test("data-* attributes", function() {
-	expect(38);
+	expect(40);
 	var div = jQuery("<div>"),
 		child = jQuery("<div data-myobj='old data' data-ignored=\"DOM\" data-other='test'></div>"),
 		dummy = jQuery("<div data-myobj='old data' data-ignored=\"DOM\" data-other='test'></div>");
@@ -357,9 +357,11 @@ test("data-* attributes", function() {
 		.attr("data-five", "5")
 		.attr("data-point", "5.5")
 		.attr("data-pointe", "5.5E3")
+		.attr("data-grande", "5.574E9")
 		.attr("data-hexadecimal", "0x42")
 		.attr("data-pointbad", "5..5")
 		.attr("data-pointbad2", "-.")
+		.attr("data-bigassnum", "123456789123456789123456789")
 		.attr("data-badjson", "{123}")
 		.attr("data-badjson2", "[abc]")
 		.attr("data-empty", "")
@@ -372,9 +374,11 @@ test("data-* attributes", function() {
 	strictEqual( child.data("five"), 5, "Primitive number read from attribute");
 	strictEqual( child.data("point"), 5.5, "Primitive number read from attribute");
 	strictEqual( child.data("pointe"), 5500, "Primitive number read from attribute");
+	strictEqual( child.data("grande"), 5.574E9, "Primitive big number read from attribute");
 	strictEqual( child.data("hexadecimal"), 66, "Hexadecimal number read from attribute");
 	strictEqual( child.data("pointbad"), "5..5", "Bad number read from attribute");
 	strictEqual( child.data("pointbad2"), "-.", "Bad number read from attribute");
+	strictEqual( child.data("bigassnum"), "123456789123456789123456789", "Bad bigass number read from attribute");
 	strictEqual( child.data("badjson"), "{123}", "Bad number read from attribute");
 	strictEqual( child.data("badjson2"), "[abc]", "Bad number read from attribute");
 	strictEqual( child.data("empty"), "", "Empty string read from attribute");


### PR DESCRIPTION
Don't know if this is the best way to do the job, but the idea is to only do the numeric conversion if it won't lose precision. The situations where numeric conversion is actually desired are probably rare compared to ones like `data-longnum="123456789123456789"` that lose precision.

If it wasn't likely to break so much code I'd love to just have `data-` attributes always return strings. It seems too late to reverse this now. This just unbreaks a few more common cases.

Thoughts?
