### PR TITLE
`jQuery.extend(deep, [])` causes infinite loop with self-referential attributes

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -303,7 +303,7 @@ jQuery.extend = jQuery.fn.extend = function() {
 			// Extend the base object
 			for ( name in options ) {
 				// prevents accessors
-				if (!options.hasOwnProperty(name)) {
+				if ( !options.hasOwnProperty(name) ) {
 					continue;
 				}
 
@@ -311,7 +311,7 @@ jQuery.extend = jQuery.fn.extend = function() {
 				copy = options[ name ];
 
 				// Prevent never-ending loop
-				if ( target === copy || options == copy ) {
+				if ( target === copy || options === copy ) {
 					continue;
 				}
 


### PR DESCRIPTION
When jQuery tries to deep clone the object, it creates an infinite loop:

[jquery/src/core.js#L304](https://github.com/jquery/jquery/blob/0d9006531d2b991cdbf419e1b4b0b4e03a588b10/src/core.js#L304)

The important part is:

``` javascript
for ( name in options ) {
  src = target[ name ];
  copy = options[ name ];
```

In Ember there is a setting to turn on accessors and to extend native objects. This creates a method on an array like `array['[]']`, which just returns itself (`this`):

[ember-runtime/lib/mixins/enumerable.js#L623](https://github.com/emberjs/ember.js/blob/3d8a3b301de8f602bf9842c15099d11307f35e96/packages/ember-runtime/lib/mixins/enumerable.js#L623)

I think there are two bugs here:
1. That part of `$.extend` should be using `hasOwnProperty`, but I'm not entirely sure about this. It returns false on accessors.
2. I've added `if (options === copy) continue`, which wasn't covered with just `if (target === copy) continue`, which is the problem with a property pointing to itself.

Here is where I ran into the error in some code:

``` javascript
[].hasOwnProperty('length') // true
[].hasOwnProperty('[]') // false
var array = []
array['[]'] === array // true
```

Would adding this fix it you think?

``` javascript
for ( name in options ) {
  if (options.hasOwnProperty(name)) {
    src = target[ name ];
    copy = options[ name ];
  // ...
```

It looks like this is probably a jQuery bug but it's getting late so I can't quite tell.

Try running `$.extend(true, [])` in the web console with `Ember.USE_ACCESSORS = true`, and it should create an infinite loop.

_(came across this using the jquery-file-upload plugin with ember accessors, it doesn't work b/c the ajax call it's making passes the files array into the `$.extend` method [right here](https://github.com/blueimp/jQuery-File-Upload/blob/02efca019a3033c5320cbcc5f8bf01522de3c8b7/js/jquery.fileupload.js#L644))_
