### PR TITLE
[1.9] Change proxy to allow arguments currying without overwriting context

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -755,7 +755,7 @@ jQuery.extend({
 		// Simulated bind
 		args = core_slice.call( arguments, 2 );
 		proxy = function() {
-			return fn.apply( context, args.concat( core_slice.call( arguments ) ) );
+			return fn.apply( context || this, args.concat( core_slice.call( arguments ) ) );
 		};
 
 		// Set the guid of unique handler to the same of original handler, so it can be removed


### PR DESCRIPTION
jQuery currently does not have a curry function. Proxy does support arguments currying but will always overwrite the context. Sometimes I would like to only curry some arguments without setting an explicit context.

I'm not sure if this already has been suggested, as the change is very small and quite obvious. This enables me to use it to only curry arguments without an explicit context:

var cb = jQuery.proxy(fn, null, 'arg1', 'arg2');
cb.call(myobject, 'arg3');

The patch is very small and will not overwrite the context if it evaluates to false. Maybe this check should be more strict (typeof context == 'undefined' ? this : context)? I don't see a valid reason to set the context to something that evaluates to false!? What do you think?

Thanks for consideration and your time!
Have a nice day!
