### PR TITLE
No ticket: let subproject tests use their own fixture

### DIFF
--- a/test/data/testrunner.js
+++ b/test/data/testrunner.js
@@ -7,6 +7,80 @@ jQuery.noConflict();
 // We remove Sizzle's globalization in jQuery
 var Sizzle = Sizzle || jQuery.find;
 
+// Allow subprojects to test against their own fixtures
+var qunitModule = QUnit.module;
+function testSubproject( label, url, risTests ) {
+	module( "Subproject: " + label );
+
+	module = QUnit.module = function( name ) {
+		return qunitModule.apply( this, [ label + ": " + name ].concat( [].slice.call( arguments, 1 ) ) );
+	};
+
+	test( "Copy test fixture", function() {
+		expect(3);
+
+		// Don't let subproject tests jump the gun
+		QUnit.config.reorder = false;
+
+		stop();
+		jQuery.ajax( url, {
+			dataType: "html",
+			error: function( jqXHR, status ) {
+				ok( false, "Retrieved test page: " + status );
+			},
+			success: function( data ) {
+				var page, fixture, fixtureHTML,
+					oldFixture = jQuery("#qunit-fixture");
+
+				ok( data, "Retrieved test page" );
+				try {
+					page = jQuery( jQuery.parseHTML(
+						data.replace( /(<\/?)(?:html|head)\b/g, "$1div" ),
+						document,
+						true
+					) );
+
+					// Get the fixture, including content outside of #qunit-fixture
+					fixture = page.find("[id='qunit-fixture']");
+					fixtureHTML = fixture.html();
+					fixture.empty();
+					while ( fixture.length && !fixture.prevAll("[id^='qunit-']").length ) {
+						fixture = fixture.parent();
+					}
+					fixture = fixture.add( fixture.nextAll() );
+					ok( fixture.html(), "Found test fixture" );
+
+					// Replace the current fixture, again including content outside of #qunit-fixture
+					while ( oldFixture.length && !oldFixture.prevAll("[id^='qunit-']").length ) {
+						oldFixture = oldFixture.parent();
+					}
+					oldFixture.nextAll().remove();
+					oldFixture.replaceWith( fixture );
+
+					// WARNING: UNDOCUMENTED INTERFACE
+					QUnit.config.fixture = fixtureHTML;
+					QUnit.reset();
+					equal( jQuery("#qunit-fixture").html(), fixtureHTML, "Copied test fixture" );
+
+					// Include subproject tests
+					page.find("script[src]").add( page.filter("script[src]") ).filter(function() {
+						var src = jQuery( this ).attr("src");
+						if ( risTests.test( src ) ) {
+							this.src = url + src;
+							return true;
+						}
+					}).appendTo("head:first");
+				} catch ( x ) {
+					ok( false, "Failed to copy test fixture: " + ( x.message || x ) );
+				}
+			},
+			complete: function() {
+				start();
+			}
+		});
+	});
+}
+
 /**
  * QUnit hooks
  */

--- a/test/index.html
+++ b/test/index.html
@@ -40,8 +40,6 @@
 	<script src="unit/queue.js"></script>
 	<script src="unit/attributes.js"></script>
 	<script src="unit/event.js"></script>
-	<script src="../src/sizzle/test/unit/selector.js"></script>
-	<script src="../src/sizzle/test/unit/utilities.js"></script>
 	<script src="unit/selector.js"></script>
 	<script src="unit/traversing.js"></script>
 	<script src="unit/manipulation.js"></script>
@@ -53,6 +51,11 @@
 	<script src="unit/dimensions.js"></script>
 	<script src="unit/deprecated.js"></script>
 	<script src="unit/exports.js"></script>
+
+	<!-- Subproject tests must be last because they replace our test fixture -->
+	<script>
+		testSubproject( "Sizzle", "../src/sizzle/test/", /^unit\/.*\.js$/ );
+	</script>
 
 	<script>
 		// html5shiv, enabling HTML5 elements to be used with jQuery


### PR DESCRIPTION
Long-term, QUnit should make this easier with a documented interface, but we really should isolate the Sizzle and jQuery test fixtures as soon as possible.

This pull does accomplishes precisely that, allowing us to pull in the latest Sizzle without breaking unit tests.
