### PR TITLE
Fix IE10 bug when cloning an object element without a parentNode

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -440,7 +440,13 @@ function cloneFixAttributes( src, dest ) {
 	// the proprietary classid attribute value (rather than the type
 	// attribute) to identify the type of content to display
 	if ( nodeName === "object" ) {
-		dest.outerHTML = src.outerHTML;
+		// The official HTML5 specs read that a NO_MODIFICATION_ALLOWED_ERR
+		// needs to be thrown if the parent is a Document
+		// http://html5.org/specs/dom-parsing.html#dom-element-outerhtml
+		// IE10 throws NoModificationAllowedError if parent node is null
+		if ( dest.parentNode ) {
+			dest.outerHTML = src.outerHTML;
+		}
 
 		// This path appears unavoidable for IE9. When cloning an object
 		// element in IE9, the outerHTML strategy above is not sufficient.


### PR DESCRIPTION
This fix addresses the one failing test that I noticed when running the jQuery unit test suite against IE10.

Not too long ago a similar fix was added to workaround an issue with IE9 https://github.com/jquery/jquery/commit/2795a8390c1986200bf4e00158dbf3ad2da8d898

As it turns out IE10 throws a NoModificationAllowedError when setting the outerHTML of an element with a null parentNode. This behavior is different than IE9 and previous versions. I looked into the HTML5 spec and it says that the NO_MODIFICATION_ALLOWED_ERR error should be thrown if the parent is a Document http://html5.org/specs/dom-parsing.html#dom-element-outerhtml My guess is that IE10 took that new spec and took it a little further.

In order to get around the issue, I am checking if the destination node has a parentNode before assigning to the outerHTML property. With this change IE10/9/8/7/6 all pass the current unit tests along with latest FF and Chrome releases. The code inside the cloneFixAttributes function that I modified is really to fix IE in the first place, so other browsers aren't really affected too much.

I initially also added a check to verify that the nodeType was not 9 (Node.DOCUMENT_NODE), but the code block that I changed only pertains to the `object` nodeName and I can't think of a use case where it's parentNode would ever be a document, so I think it is safe to leave out this check and leave the fix as terse as possible to save some bytes ;) 

I may have been overgenerous with comments in this fix, but since it was an odd browser change I thought it might be helpful as I see other browser work arounds have similar comments. 
