### PR TITLE
got a bit overzealous with converting to pixel, followup to #12018

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -290,7 +290,7 @@ if ( window.getComputedStyle ) {
 			// Chrome < 17 and Safari 5.0 uses "computed value" instead of "used value" for margin-right
 			// Safari 5.1.7 (at least) returns percentage for a larger set of values, but width seems to be reliably pixels
 			// this is against the CSSOM draft spec: http://dev.w3.org/csswg/cssom/#resolved-values
-			if ( rnumnonpx.test( ret ) && !rposition.test( name ) ) {
+			if ( rnumnonpx.test( ret ) && rmargin.test( name ) ) {
 				width = style.width;
 				minWidth = style.minWidth;
 				maxWidth = style.maxWidth;


### PR DESCRIPTION
this fixes a test fail.

At some point in the future, however, we should discuss that test: "non-px animations preserve numeric start", because i believe it's methodology is a bit flimsy and that we actually CAN convert backgroundPositionX to pixel, although it's a bit slower. Anyway, perhaps we should discuss that for 1.9
