### PR TITLE
Use isHidden inside jQuery#toggle in css module

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -108,15 +108,12 @@ jQuery.fn.extend({
 		return showHide( this );
 	},
 	toggle: function( fn, fn2 ) {
-		var bool = typeof fn === "boolean";
-
 		if ( jQuery.isFunction( fn ) && jQuery.isFunction( fn2 ) ) {
 			return eventsToggle.apply( this, arguments );
 		}
 
 		return this.each(function() {
-			var state = bool ? fn : jQuery( this ).is(":hidden");
-			showHide([ this ], state );
+			showHide([ this ], typeof fn === "boolean" ? fn : isHidden( this ) );
 		});
 	}
 });

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -561,8 +561,10 @@ test( "show() resolves correct default display, detached nodes (#10006)", functi
 });
 
 test("toggle()", function() {
-	expect(6);
-	var x = jQuery("#foo");
+	expect(8);
+	var div,
+		x = jQuery("#foo");
+
 	ok( x.is(":visible"), "is visible" );
 	x.toggle();
 	ok( x.is(":hidden"), "is hidden" );
@@ -575,6 +577,12 @@ test("toggle()", function() {
 	ok( x.is(":hidden"), "is hidden" );
 	x.toggle(true);
 	ok( x.is(":visible"), "is visible again" );
+
+	div = jQuery("<div style='display:none'><div></div></div>").appendTo("#qunit-fixture");
+	x = div.find("div");
+
+	strictEqual( x.toggle().css( "display" ), "none", "is hidden" );
+	strictEqual( x.toggle().css( "display" ), "block", "is visible" );
 });
 
 test("hide hidden elements (bug #7141)", function() {


### PR DESCRIPTION
Was retracing my steps after <a href="https://github.com/jquery/jquery/pull/876">this</a> and notice that <code>jQuery#toggle</code> in <code>src/css.js</code> uses <code>jQuery( this ).is(":hidden");</code> when it supposto be using isHidden function, that creates a bug, a small one, but bug nonetheless, which is illustrated in test assertion i added to this pull.

If this pull will be accepted, it should be committed after #876, because <code>isHidden</code> function was moved in therein. I think it would be preferable to add this to 1.8. Sorry this pull without a ticket, should you need one?
