### PR TITLE
Fix Manipulation Clone Unit Tests. Related to gh-870

### DIFF
--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -1173,7 +1173,8 @@ test("clone() (#8070)", function () {
 });
 
 test("clone()", function() {
-	expect(39);
+	expect( 44 );
+
 	equal( "This is a normal link: Yahoo", jQuery("#en").text(), "Assert text for #en" );
 	var clone = jQuery("#yahoo").clone();
 	equal( "Try them out:Yahoo", jQuery("#first").append(clone).text(), "Check for clone" );
@@ -1255,7 +1256,32 @@ test("clone()", function() {
 
 	clone = div.clone(true);
 	equal( clone.length, 1, "One element cloned" );
-	// equal( clone.html(), div.html(), "Element contents cloned" );
+	(function checkForAttributes( $ ) {
+		// IE6/7 adds some extra parameters so just test for existance of a defined set
+		var parameters = ["height", "width", "classid"],
+			$divObject = div.find("object"),
+			$cloneObject = clone.find("object");
+
+		$.each( parameters, function(index, parameter)  {
+			equal( $cloneObject.attr(parameter), $divObject.attr(parameter), "Element attributes cloned: " + parameter );
+		});
+	})( jQuery );
+	(function checkForParams() {
+		// IE6/7/8 adds a bunch of extram param elements so just test for those that are trying to clone
+		var params = {};
+
+		clone.find("param").each(function(index, param) {
+			params[param.attributes.name.nodeValue.toLowerCase()] =
+				param.attributes.value.nodeValue.toLowerCase();
+		});
+
+		div.find("param").each(function(index, param) {
+			var actualValue = params[param.attributes.name.nodeValue.toLowerCase()],
+				expectedValue = param.attributes.value.nodeValue.toLowerCase();
+
+			equal( actualValue, expectedValue, "Param cloned: " + param.attributes.name.nodeValue );
+		});
+	})();
 	equal( clone[0].nodeName.toUpperCase(), "DIV", "DIV element cloned" );
 
 	// and here's a valid one.


### PR DESCRIPTION
This pull request is related to gh-870 where I added a patch to fix cloning in IE10

As we reviewed the patch it was found that there was a commented unit test in the clone() test on line #1258
https://github.com/jquery/jquery/blob/master/test/unit/manipulation.js#L1258

``` javascript
// equal( clone.html(), div.html(), "Element contents cloned" );
```

The clone was working fine in oldIE, but the unit test was failing because the `.html()` was not exactly the same. oldIE was either changing the case of params or inserting a whole bunch of extra params during the clone. 

The fix that was recommended was to check only a subset of the attributes on the object element and to check to make sure the cloned object had at least had the params that the original object element had.

I put the tests in an IIFE to protect any variables I used from the surrounding code and I named them in an attempt to describe the intent of the test.

I updated the expect to 44 instead of 39 because the unit tests adds 5 addition assertions as you can see in the following screenshot http://cl.ly/image/3P0B2M1b0B0S

I've ran the manipulation unit tests against IE6/7/8/9/10 in BrowserStack and also Opera/Firefox/Safai locally on my MacBook Pro
