### PR TITLE
Fix #11949: use hasOwnProperty()

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -86,7 +86,7 @@ jQuery.event = {
 
 			// Init the event handler queue if we're the first
 			handlers = events[ type ];
-			if ( !handlers ) {
+			if ( !events.hasOwnProperty( type ) ) {
 				handlers = events[ type ] = [];
 				handlers.delegateCount = 0;
 


### PR DESCRIPTION
This guards against accessing things like handlers['toString'], which
has strange results and causes $('.foo').on('toString', function() {});
to trigger a JS error because handlers.toString.push is not a function.
