### PR TITLE
Replace unnecessarily exposed jQuery.deletedIds array with private array (No ticket)

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -37,6 +37,10 @@ var
 	core_rnotwhite = /\S/,
 	core_rspace = /\s+/,
 
+	// Used in data, manipulation to track and reuse
+	// cache ids that have been deleted
+	core_deletedIds = [],
+
 	// IE doesn't match non-breaking spaces with \s
 	rtrim = core_rnotwhite.test("\xA0") ? (/^[\s\xA0]+|[\s\xA0]+$/g) : /^\s+|\s+$/g,
 

--- a/src/data.js
+++ b/src/data.js
@@ -4,8 +4,6 @@ var rbrace = /^(?:\{.*\}|\[.*\])$/,
 jQuery.extend({
 	cache: {},
 
-	deletedIds: [],
-
 	// Please use with caution
 	uuid: 0,
 
@@ -58,7 +56,7 @@ jQuery.extend({
 			// Only DOM nodes need a new unique ID for each element since their data
 			// ends up in the global cache
 			if ( isNode ) {
-				elem[ internalKey ] = id = jQuery.deletedIds.pop() || ++jQuery.uuid;
+				elem[ internalKey ] = id = core_deletedIds.pop() || ++jQuery.uuid;
 			} else {
 				id = internalKey;
 			}

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -821,7 +821,7 @@ jQuery.extend({
 							elem[ internalKey ] = null;
 						}
 
-						jQuery.deletedIds.push( id );
+						core_deletedIds.push( id );
 					}
 				}
 			}


### PR DESCRIPTION
Motivated by @gibson042 https://github.com/jquery/jquery/pull/887

``` bash
Sizes - compared to master
    258583       (+89)  dist/jquery.js                                         
     92532       (-28)  dist/jquery.min.js                                     
     33101        (-4)  dist/jquery.min.js.gz         
```

Signed-off-by: Rick Waldron waldron.rick@gmail.com
