### PR TITLE
Make jQuery.trim consistent with ECMAScript 5 String.prototype.trim cross browser.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -37,8 +37,8 @@ var
 	core_rnotwhite = /\S/,
 	core_rspace = /\s+/,
 
-	// IE doesn't match non-breaking spaces with \s
-	rtrim = core_rnotwhite.test("\xA0") ? (/^[\s\xA0]+|[\s\xA0]+$/g) : /^\s+|\s+$/g,
+	// IE doesn't match many whitespace characters with \s
+	rtrim = core_rnotwhite.test("\xA0") ? /^[\s\xA0\uFEFF\u1680\u180E\u2000-\u200A\u202F\u205F\u3000]+|[\s\xA0\uFEFF\u1680\u180E\u2000-\u200A\u202F\u205F\u3000]+$/g : /^\s+|\s+$/g,
 
 	// A simple way to check for HTML strings
 	// Prioritize #id over <tag> to avoid XSS via location.hash (#9521)

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -264,7 +264,7 @@ test("noConflict", function() {
 });
 
 test("trim", function() {
-	expect(9);
+	expect(28);
 
 	var nbsp = String.fromCharCode(160);
 
@@ -278,6 +278,26 @@ test("trim", function() {
 	equal( jQuery.trim( null ), "", "Null" );
 	equal( jQuery.trim( 5 ), "5", "Number" );
 	equal( jQuery.trim( false ), "false", "Boolean" );
+
+	equal( jQuery.trim(" ").length, 0, "space should be trimmed");
+	equal( jQuery.trim("\xA0").length, 0, "nbsp should be trimmed");
+	equal( jQuery.trim("\uFEFF").length, 0, "zwsp should be trimmed");
+	equal( jQuery.trim("\u1680").length, 0, "ogham should be trimmed");
+	equal( jQuery.trim("\u180E").length, 0, "mvs should be trimmed");
+	equal( jQuery.trim("\u2000").length, 0, "enq should be trimmed");
+	equal( jQuery.trim("\u2001").length, 0, "emq should be trimmed");
+	equal( jQuery.trim("\u2002").length, 0, "ensp should be trimmed");
+	equal( jQuery.trim("\u2003").length, 0, "emsp should be trimmed");
+	equal( jQuery.trim("\u2004").length, 0, "tpemsp should be trimmed");
+	equal( jQuery.trim("\u2005").length, 0, "fpemsp should be trimmed");
+	equal( jQuery.trim("\u2006").length, 0, "spemsp should be trimmed");
+	equal( jQuery.trim("\u2007").length, 0, "fsp should be trimmed");
+	equal( jQuery.trim("\u2008").length, 0, "psp should be trimmed");
+	equal( jQuery.trim("\u2009").length, 0, "tsp should be trimmed");
+	equal( jQuery.trim("\u200A").length, 0, "hsp should be trimmed");
+	equal( jQuery.trim("\u202F").length, 0, "nnbsp should be trimmed");
+	equal( jQuery.trim("\u205F").length, 0, "mmsp should be trimmed");
+	equal( jQuery.trim("\u3000").length, 0, "isp should be trimmed");
 });
 
 test("type", function() {


### PR DESCRIPTION
This adds 41 bytes when gzipped.

There is also a bit of history around the trim function and the way it's done. Most recently https://github.com/jquery/jquery/commit/26bdbb806eeb1d8e1881b3fc11ff298eb4d1dca0 and back in 1.4.3 there was this http://forum.jquery.com/topic/faster-jquery-trim#14737000000647377.

See http://jsfiddle.net/MHzar/1/ in Chrome or Firefox then in IE8 for a difference.

---

Section 15.5.4.20 of ECMAScript 5 standard, definition of String.prototype.trim()
15.5.4.20 String.prototype.trim ( )
…
3. Let T be a String value that is a copy of S with both leading and trailing white space removed. The definition
of white space is the union of WhiteSpace and LineTerminator.

Section 7.2 defines White Space as

```
Code                  Unit                                  Value
\u0009 -              Tab -                                 <TAB>
\u000B -              Vertical Tab -                        <VT>
\u000C -              Form Feed -                           <FF>
\u0020 -              Space -                               <SP>
\u00A0 -              No-break space -                      <NBSP>
\uFEFF -              Byte Order Mark -                     <BOM>
Other category (Zs) - Any other Unicode "space separator" - <USP>
```

 Note the bit about "Any other Unicode 'space separator'".
Unicode Zs or Space Separators (http://www.fileformat.info/info/unicode/category/Zs/list.htm)
\uFEFF
\u1680
\u180E
\u2000-\u200A
\u202F
\u205F
\u3000
