### PR TITLE
fixes #12282, sometimes IE10 and lower have document.readyState == "interactive" way too early

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -830,9 +830,11 @@ jQuery.ready.promise = function( obj ) {
 
 		readyList = jQuery.Deferred();
 
-		// Catch cases where $(document).ready() is called after the
-		// browser event has already occurred.
-		if ( document.readyState === "complete" || ( document.readyState !== "loading" && document.addEventListener ) ) {
+		// Catch cases where $(document).ready() is called after the browser event has already occurred.
+		// IE10 and lower don't handle "interactive" properly... use a weak inference to detect it
+		// hey, at least it's not a UA sniff
+		// discovered by ChrisS here: http://bugs.jquery.com/ticket/12282#comment:15
+		if ( document.attachEvent ? document.readyState === "complete" : document.readyState !== "loading" ) {
 			// Handle it asynchronously to allow scripts the opportunity to delay ready
 			setTimeout( jQuery.ready, 1 );
 

--- a/test/data/event/partialLoadReady.php
+++ b/test/data/event/partialLoadReady.php
@@ -1,0 +1,40 @@
+<?php
+//try very hard to disable output buffering
+@ini_set("output_buffering", 0);
+@apache_setenv("no-gzip", 1);
+@ini_set("zlib.output_compression", 0);
+ob_start();
+?>
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html>
+<head>
+<meta http-equiv="content-type" content="text/html; charset=utf-8">
+<title>Test case for jQuery ticket #12282</title>
+</head>
+<body>
+
+<h1>TEST</h1>
+<script type="text/javascript" src="../../../dist/jquery.js"></script>
+<script type="text/javascript">
+jQuery( document ).ready(function() {
+	window.parent.iframeCallback( jQuery('#container').length === 1 );
+});
+</script>
+
+<?php
+//send the top of the document without sending the bottom portion
+echo str_repeat(" ", 1024 * 8), "\n";
+ob_flush();
+?>
+
+<h2>Sleeping for 1 seconds (simulating server side process)</h2>
+
+<?php
+//sleep for a bit, simulating a server side process
+sleep(1);
+?>
+
+<div id="container">ready</h2>
+</body>
+</html>

--- a/test/data/testinit.js
+++ b/test/data/testinit.js
@@ -223,7 +223,7 @@ function url( value ) {
 				}, 0 );
 			};
 			iframe = jQuery( "<div/>" ).append(
-				jQuery( "<iframe/>" ).attr( "src", url("./data/" + fileName + ".html") )
+				jQuery( "<iframe/>" ).attr( "src", url( "./data/" + fileName ) )
 			).appendTo( "body" );
 		});
 	}

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -2888,28 +2888,33 @@ test("fixHooks extensions", function() {
 // which breaks order of execution on async loaded files
 // also need PHP to make the incepted IFRAME hang
 if ( hasPHP ) {
-	testIframeWithCallback( "jQuery.ready promise", "event/promiseReady", function( isOk ) {
+	testIframeWithCallback( "jQuery.ready promise", "event/promiseReady.html", function( isOk ) {
 		expect(1);
 		ok( isOk, "$.when( $.ready ) works" );
 	});
 
-	// oldIE needs all subresources to be loaded before it can gaurantee the document is truly ready to be interacted with
-	if( document.addEventListener ) {
-		testIframeWithCallback( "jQuery.ready synchronous load with long loading iframe", "event/syncReadyLongLoad", function( isOk ) {
+	testIframeWithCallback( "jQuery.ready synchronous load with long loading subresources", "event/syncReady.html", function( isOk ) {
+		expect(1);
+		ok( isOk, "jQuery loaded synchronously fires ready when the DOM can truly be interacted with" );
+	});
+
+	testIframeWithCallback( "jQuery.ready synchronous load with partially loaded page", "event/partialLoadReady.php", function( isOk ) {
+		expect(1);
+		ok( isOk, "jQuery loaded synchronously fires ready when the DOM can truly be interacted with" );
+	});
+
+	// allIE needs all subresources and full page to be loaded before it can gaurantee the document is truly ready to be interacted with
+	if( !document.attachEvent ) {
+		testIframeWithCallback( "jQuery.ready synchronous load with long loading iframe", "event/syncReadyLongLoad.html", function( isOk ) {
 			expect(1);
 			ok( isOk, "jQuery loaded synchronously fires ready before all sub-resources are loaded" );
 		});
 
-		testIframeWithCallback( "jQuery.ready asynchronous load with long loading iframe", "event/asyncReady", function( isOk ) {
+		testIframeWithCallback( "jQuery.ready asynchronous load with long loading iframe", "event/asyncReady.html", function( isOk ) {
 			expect(1);
 			ok( isOk, "jQuery loaded asynchronously fires ready before all sub-resources are loaded" );
 		});
 	}
-
-	testIframeWithCallback( "jQuery.ready synchronous load with long loading subresources", "event/syncReady", function( isOk ) {
-		expect(1);
-		ok( isOk, "jQuery loaded synchronously fires ready when the DOM can truly be interacted with" );
-	});
 }
 
 (function(){

--- a/test/unit/support.js
+++ b/test/unit/support.js
@@ -7,7 +7,7 @@ test("boxModel", function() {
 });
 
 if ( jQuery.css ) {
-	testIframeWithCallback( "body background is not lost if set prior to loading jQuery (#9238)", "support/bodyBackground", function( color, support ) {
+	testIframeWithCallback( "body background is not lost if set prior to loading jQuery (#9238)", "support/bodyBackground.html", function( color, support ) {
 		expect( 2 );
 		var i,
 			passed = true,
@@ -33,7 +33,7 @@ if ( jQuery.css ) {
 	});
 }
 
-testIframeWithCallback( "A background on the testElement does not cause IE8 to crash (#9823)", "support/testElementCrash", function() {
+testIframeWithCallback( "A background on the testElement does not cause IE8 to crash (#9823)", "support/testElementCrash.html", function() {
 	expect(1);
 	ok( true, "IE8 does not crash" );
 });


### PR DESCRIPTION
With tests! Conclusive, repeatable proof! 

```
Running "compare_size:files" (compare_size) task
Sizes - compared to master
    258460      (+121)  dist/jquery.js                                         
     92618        (-7)  dist/jquery.min.js                                     
     33134        (+1)  dist/jquery.min.js.gz   
```
