### PR TITLE
#12266 Fixes an IE9/10 Exception When a Cross-Domain iframe Exists

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -489,7 +489,7 @@ jQuery.buildFragment = function( args, context, scripts ) {
 		first = args[ 0 ];
 
 	// Set context from what may come in as undefined or a jQuery collection or a node
-	// Updated to fix #12266 where accessing context[0] could throw an exception in IE9 &
+	// Updated to fix #12266 where accessing context[0] could throw an exception in IE9/10 &
 	// also doubles as fix for #8950 where plain objects caused createDocumentFragment exception
 	context = context || document;
 	context = context instanceof jQuery ? context[0] : context;

--- a/test/data/manipulation/iframe-denied.html
+++ b/test/data/manipulation/iframe-denied.html
@@ -9,13 +9,13 @@
 		<script src="../../../dist/jquery.js"></script>
 		<script>
 			var script = document.getElementsByTagName( "script" )[ 0 ],
-            	div = document.createElement( "div" ),
-            	src = "http://google.com",
-            	success = true,
-            	error = "";
+				div = document.createElement( "div" ),
+				src = "http://google.com",
+				success = true,
+				error = "";
 
-            script.parentNode.appendChild( div );
-            div.innerHTML = "<iframe name=\"test\" src=\"" + src + "\">";
+			script.parentNode.appendChild( div );
+			div.innerHTML = "<iframe name=\"test\" src=\"" + src + "\">";
 
 			jQuery(function() {
 				try {

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -1908,7 +1908,7 @@ test("checked state is cloned with clone()", function(){
 	equal( jQuery(elem).clone().attr("id","clone")[0].checked, true, "Checked true state correctly cloned" );
 });
 
-testIframeWithCallback( "buildFragment works even if document[0] is iframe's window object in IE9 (#12266)", "manipulation/iframe-denied", function( test ) {
+testIframeWithCallback( "buildFragment works even if document[0] is iframe's window object in IE9/10 (#12266)", "manipulation/iframe-denied", function( test ) {
 	expect( 1 );
 
 	ok( test.status, test.description );


### PR DESCRIPTION
This Pull Request relates to [http://jqbug.com/12266](http://jqbug.com/12266). The issue involved getting an exception when trying to create nested elements such as `$( "<div><div></div></div>" )`. The initial jsFiddle used to recreate the issue was using a 3rd party script that injected an `iframe`. After some trial and error I've found a way to recreate this issue reliably in IE9/10 with a reduced test case. It was difficult to recreate under normal circumstances, so I used the `testIframeWithCallback` function and made a `test/data/manipulation/iframe-denied.html` file to assist in the testing process.

The trick was to create an `iframe` with a cross-domain source before DOM Ready. The interesting thing about IE9/10 is that anytime you add an `iframe` or an object to the DOM it will alias it's `window` object onto the `document`. For example, after adding an iframe to the DOM you can access that `iframe's` `window` object off of `document[0]`. 

![IE9 Debugger](http://f.cl.ly/items/0017361H070910022G32/12266-ie9-debugger.png)

Yes, that is weird and that is why `buildFragment` was throwing an exception because it was trying to access `context[0]`, which was the `window` object from a cross-domain `iframe`.

I testing this new Unit Test in IE6/7/8/9/10 before I applied the fix and it failed in IE9 & IE10 as expected. After applying the following fix the Unit Test passes in IE6/7/8/9/10 as well as all the other unit tests in the manipulation module.

``` diff
jQuery.buildFragment = function( args, context, scripts ) {
    var fragment, cacheable, cachehit,
        first = args[ 0 ];

        // Set context from what may come in as undefined or a jQuery collection or a node
+       // Updated to fix #12266 where accessing context[0] could throw an exception in IE9/10 &
+       // also doubles as fix for #8950 where plain objects caused createDocumentFragment exception
        context = context || document;
-       context = (context[0] || context).ownerDocument || context[0] || context;
+       context = context instanceof jQuery ? context[0] : context;
+       context = context.ownerDocument || context;

-       // Ensure that an attr object doesn't incorrectly stand in as a document object
-       // Chrome and Firefox seem to allow this to occur and will throw exception
-       // Fixes #8950
-       if ( typeof context.createDocumentFragment === "undefined" ) {
-           context = document;
-       }
        ...
};
```

The above change also accounts for the bug fix that was made for #8950 where plain objects caused a createDocumentFragment exception. The above fix passes the unit test added for #8950 which is still present in the manipulation test module. Therefore, I removed the patch for #8950 since the above code accounts for that scenario as well.

By fixing the security concern related to this issue and removing the fix for #8950, which is no longer needed, it reduces the overall size of jQuery!

``` text
Running "compare_size:files" (compare_size) task
Sizes - compared to master
    258224       (-51)  dist/jquery.js                                         
     92551       (-42)  dist/jquery.min.js                                     
     33117        (-5)  dist/jquery.min.js.gz   
```
