### PR TITLE
Correct documentation of custom grunt task

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -225,7 +225,7 @@ module.exports = function( grunt ) {
 		//
 		// Becomes:
 		//
-		//   grunt build:*:*:-ajax:-dimensions:-effects:-offset
+		//   grunt build:*:*:+ajax:-dimensions:-effects:-offset
 
 		grunt.log.writeln( "Creating custom build...\n" );
 


### PR DESCRIPTION
The modifier for module names is not altered when the argument to the
"custom" grunt task is parsed.
