### PR TITLE
String concatenation instead of join

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -250,7 +250,7 @@ jQuery.fn = jQuery.prototype = {
 	},
 
 	slice: function( b, e ) {
-		return this.pushStack(  core_slice.slice.call( this, b, e ),
+		return this.pushStack(  core_slice.call( this, b, e ),
                         "slice", "" + ( !e ? b : b+","+e ) );
 	},
 


### PR DESCRIPTION
Since `slice` only takes two arguments it's better to specify these two and build the name for `pushStack` by string concatenation instead of the slower `join` on the `arguments` object.

This change results in both less code and a performance boost of `slice` with up to ~50% (tested in latest Firefox and Chrome).

Check [this JSPerf](http://jsperf.com/wrapped-array-index-vs-eq/2)

Credits to [seutje](https://github.com/seutje) for the heads up!
