### PR TITLE
fixes #12313, regression: .height() and .width() no longer fall back to CSS if offsetWidth is undefined.

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -411,7 +411,10 @@ function getWidthOrHeight( elem, name, extra ) {
 		valueIsBorderBox = true,
 		isBorderBox = jQuery.support.boxSizing && jQuery.css( elem, "boxSizing" ) === "border-box";
 
-	if ( val <= 0 ) {
+	// some non-html elements return undefined for offsetWidth, so check for null/undefined
+	// svg - https://bugzilla.mozilla.org/show_bug.cgi?id=649285
+	// MathML - https://bugzilla.mozilla.org/show_bug.cgi?id=491668
+	if ( val <= 0 || val == null ) {
 		// Fall back to computed then uncomputed css if necessary
 		val = curCSS( elem, name );
 		if ( val < 0 || val == null ) {


### PR DESCRIPTION
This "fix" fixes a regression in SVG, which I know we say we "won't fix", but was simple enough and was a regression in 1.8 when I changed an if from `val > 0` to a guard clause of `val <= 0`, which I thought was the opposite. However, both `undefined > 0` and `undefined <= 0` are false :-|

I did not include unit tests, however, because those would require us to be testing SVG and MathML, and is not something I'm interested in. I'm interested in fixing this regression and including an explanatory comment. If this means it doesn't get merged, so be it.

```
Running "compare_size:files" (compare_size) task
Sizes - compared to master
    258736       (+15)  dist/jquery.js                                         
     92790        (+9)  dist/jquery.min.js                                     
     33206        (-1)  dist/jquery.min.js.gz  
```
