### PR TITLE
[1.9 vote] jQuery.fn.data( callback( index, data ) ) - Fixes #12397

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -248,7 +248,7 @@ jQuery.fn.extend({
 		// Calls callback with index, data
 		if ( jQuery.isFunction( key ) ) {
 			return this.each( function( index ) {
-				key( index, jQuery( this ).data() );
+				key.call( this, index, jQuery( this ).data() );
 			});
 		}
 

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -656,12 +656,13 @@ test( "JSON data- attributes can have newlines", function() {
 	x.remove();
 });
 
-test( "jQuery.fn.data( callback ) (#12397)", 6, function() {
+test( "jQuery.fn.data( callback ) (#12397)", 9, function() {
 	var testHtml = "<div><hr data-test='0'><hr data-test='1'><hr data-test='2'></div>",
 		tests = jQuery( testHtml ).find( "hr" );
 	tests.data( function( index, data ) {
 		equal( data.test, index, "Value loaded from HTML correct" );
 		data.setTest = true;
+		equal( tests[ index ], this, "`this` of callback is element" );
 	});
 	tests.each( function() {
 		ok( jQuery( this ).data( "setTest" ), "Value was set from inside data callback" );


### PR DESCRIPTION
```
Sizes - compared to master
    258888      (+167)  dist/jquery.js                
     92841       (+60)  dist/jquery.min.js            
     33218       (+11)  dist/jquery.min.js.gz  
```

Proposal for a new signature to `jQuery.fn.data()`

Trac Ticket: http://jqbug.com/12397
