### PR TITLE
`package.json` fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
 	"bugs": {
 		"url": "http://bugs.jquery.com"
 	},
-    "main": "dist/jquery.js",
-    "scripts": {
-        "install": "grunt"
-    },
+	"main": "dist/jquery.js",
+	"scripts": {
+		"install": "grunt"
+	},
 	"licenses": [
 		{
 			"type": "MIT",
@@ -30,7 +30,7 @@
 		"grunt-git-authors": ">=1.0.0",
 		"grunt": "~0.3.9",
 		"testswarm": "0.2.2"
-    },
+	},
 	"devDependencies": {
 	},
 	"keywords": []


### PR DESCRIPTION
## summary

this pull request makes 2 small modifications to `package.json` to allow listing it as a dependency.  this is important for projects like [mr](https://github.com/kriskowal/mr), which allow developers to use [`npm`](https://npmjs.org/) and [commonjs-style modules](http://wiki.commonjs.org/wiki/Packages/1.0) in client-side web development.
## steps to reproduce the problem
- create an `npm` package with the following `package.json`:
  
  ```
  {
      "name": "my-client-side-package",
      "version": "0.0.0",
      "dependencies": {
          "jquery": "git://github.com/jquery/jquery.git"
      }
  }
  ```
- from w/in the package's root directory, install the dependencies (at this point only jquery, of course):
  
  ```
  $ npm install
  ```
## expected behavior
- there should be a fully-built copy of jquery somewhere in `node_modules/jquery`
- the location should be properly specified, such that calling `requrie.resolve('jquery')` from within the client package's root directory resolves to `node_modules/jquery/dist/jquery.js`
## actual behavior
- there is no copy of `jquery.js` because:
  - the `grunt` command to build it was not listed in `scripts.install`
  - the build dependencies are listed as `devDependencies`, so they aren't installed in this configuration.
## why does this matter?

package managers like `npm` are every bit as useful for client-side development as they are for the server-side, but in order for them to be useable on the client-side, we need key libraries like jquery to provide the correct interface.

projects like [mr](https://github.com/kriskowal/mr), [csi](https://github.com/siq/csi), [volo](https://github.com/volojs/volo), and others aim to allow users to specify dependencies in a `package.json` file:

```
{
    "name": "my-project",
    ...
    "dependencies": {
        "jquery": "git://github.com/jquery/jquery.git"
    }
}
```

and then consume these libraries client-side:

```
var $ = requrie('jquery');

$(function() {
    // ...
});
```

this is possible with just a couple changes to jquery's `package.json`.
