### PR TITLE
[1.9] wrapMap.param added to avoid IE wrong <param HTMLElement> string parsing...

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -39,7 +39,8 @@ var nodeNames = "abbr|article|aside|audio|bdi|canvas|data|datalist|details|figca
 		_default: [ 0, "", "" ]
 	},
 	safeFragment = createSafeFragment( document ),
-	fragmentDiv = safeFragment.appendChild( document.createElement("div") );
+	fragmentDiv = safeFragment.appendChild( document.createElement("div") ),
+	addMandatoryAttributes = function( elem ) { return elem; };
 
 wrapMap.optgroup = wrapMap.option;
 wrapMap.tbody = wrapMap.tfoot = wrapMap.colgroup = wrapMap.caption = wrapMap.thead;
@@ -49,7 +50,23 @@ wrapMap.th = wrapMap.td;
 // unless wrapped in a div with non-breaking characters in front of it.
 if ( !jQuery.support.htmlSerialize ) {
 	wrapMap._default = [ 1, "X<div>", "</div>" ];
-	wrapMap.param = [ 0, "", "" ];
+	// Fixes #11280
+	wrapMap.param = [ 1, "X<object>", "</object>" ];
+	// Fixes #11280. HTMLParam name attribute added to avoid IE6-8 parsing issue.
+	addMandatoryAttributes = function( elem ) {
+		// If it's a param
+		return elem.replace(/<param([^>]*)>/gi, function( m, s1, offset ) {
+			var name = s1.match( /name=["']([^"']*)["']/i );
+			return name ?
+				( name[1].length ?
+				// It has a name attr with a value
+				"<param" + s1 + ">" :
+				// It has name attr without a value
+				"<param" + s1.replace( name[0], "name='_" + offset +  "'" ) + ">" ) :
+				// No name attr
+				"<param name='_" + offset +  "' " + s1 + ">";
+		});
+	};
 }
 
 jQuery.fn.extend({
@@ -674,7 +691,7 @@ jQuery.extend({
 					tag = ( rtagName.exec( elem ) || ["", ""] )[1].toLowerCase();
 					wrap = wrapMap[ tag ] || wrapMap._default;
 					depth = wrap[0];
-					div.innerHTML = wrap[1] + elem + wrap[2];
+					div.innerHTML = wrap[1] + addMandatoryAttributes( elem ) + wrap[2];
 
 					// Move to the right depth
 					while ( depth-- ) {

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -470,15 +470,35 @@ test("append(Function)", function() {
 });
 
 test("append(param) to object, see #11280", function() {
-	expect(1);
+	expect(11);
 
 	var objectElement = document.createElement("object"),
-	    paramElement = jQuery("<param type='wmode' value='transparent' />");
+	    $objectElement = jQuery( objectElement ),
+	    paramElement = jQuery("<param type='wmode' value='transparent'/>"),
+	    paramElement2 = jQuery("<param name='' type='wmode2' value='transparent2' />"),
+	    paramElement3 = jQuery("<param type='wmode' name='foo' >"),
+	    newObject = jQuery("<object><param type='foo' ><param name='' value='foo2'/><param type='baz' name='bar'></object>");
+
+	equal( objectElement.childNodes.length, 0, "object did not have childNodes previously" );
 
 	document.body.appendChild( objectElement );
-	jQuery(objectElement).append( paramElement );
 
-	ok( true, "param element properly appended to object element" );
+	$objectElement.append( paramElement );
+	equal( $objectElement.children().length, 1, "param single insertion ok" );
+	equal( jQuery(objectElement.childNodes[0]).attr('type'), "wmode", "param.eq(0) has type=wmode" );
+
+	$objectElement.html( paramElement2 );
+	equal( $objectElement.children().length, 1, "param single insertion ok" );
+	equal( jQuery(objectElement.childNodes[0]).attr('type'), "wmode2", "param.eq(0) has type=wmode2" );
+
+	$objectElement.html( paramElement3 );
+	equal( $objectElement.children().length, 1, "param single insertion ok" );
+	equal( jQuery(objectElement.childNodes[0]).attr("name"), "foo", "param.eq(0) has name=foo" );
+
+	equal( newObject.children().length, 3, "param wrapper multiple insertion ok" );
+	equal( newObject.children().eq(0).attr("type"), "foo", "param.eq(0) has type=foo" );
+	equal( newObject.children().eq(1).attr("value"), "foo2", "param.eq(1) has value=foo2" );
+	equal( newObject.children().eq(2).attr("name"), "bar", "param.eq(2) has name=bar" );
 });
 
 test("append(Function) with incoming value", function() {


### PR DESCRIPTION
Ok, so this was not that simple. I did not implement the proper tests at the beginning and afterwards I found out what was the real problem.

The point is IE6-8 do not "properly" parse param elements without a name attribute ( with a non empty string value ).
And this "could make sense" taking into account the HTML 4.01 specs: http://www.w3.org/TR/html401/struct/objects.html#h-13.3.2

where the name attribute:

name        CDATA          #REQUIRED -- property name --

So div.innerHtml = "&lt;param type='foo' /&gt;"; does generate a HTMLUnknownElement as the div childNode
but div.innerHtml = "&lt;param type='foo'  name='bar' /&gt;"; works as expected

I haven't found a really elegant solution to this issue, but checking for param elements and inserting a dummy name attr in case is not there. 

And I don't even know if it's worthwhile fixing this IE behaviour.

I hope this is useful.
