### PR TITLE
"a" cannot be falsy at this point

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -22,7 +22,7 @@ jQuery.support = (function() {
 	a.style.cssText = "top:1px;float:left;opacity:.5";
 
 	// Can't get basic test support
-	if ( !all || !all.length || !a ) {
+	if ( !all || !all.length ) {
 		return {};
 	}
 


### PR DESCRIPTION
suggested by Morris at
http://blog.jquery.com/2012/08/30/jquery-1-8-1-released/#comment-532914

"a" cannot be falsy at this point, because a.style.cssText is used just a few lines above
