### PR TITLE
using document.styleSheets.length in jQuery.each core tests instead of hardcoded styleSheets number

### DIFF
--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -1020,7 +1020,7 @@ test("jQuery.each(Object,Function)", function() {
 	jQuery.each(document.styleSheets, function(i){
 		stylesheet_count++;
 	});
-	equal(stylesheet_count, 2, "should not throw an error in IE while looping over document.styleSheets and return proper amount");
+	equal(stylesheet_count, document.styleSheets.length, "should not throw an error in IE while looping over document.styleSheets and return proper amount");
 
 });
 


### PR DESCRIPTION
removed hardcoded styleSheets number from core tests, using document.styleSheets.length instead:
- If in the future more stylesheets get added to the document, the hardcoded number won't need to be updated.
- Some browser plugins add stylesheets, making the tests to not pass. 
