### PR TITLE
[1.9] make replaceWith() clone elements where required

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -285,18 +285,19 @@ jQuery.fn.extend({
 				return;
 			}
 
-			if ( this.nodeType === 1 ) {
+			if ( this.nodeType === 1 || this.nodeType === 11 ) {
 				next = this.nextSibling;
 				parent = this.parentNode;
 
+				jQuery( this ).remove();
+
 				if ( next ) {
-					next.parentNode.insertBefore( elem, this );
+					next.parentNode.insertBefore( elem, next );
 				} else {
 					parent.appendChild( elem );
 				}
 			}
 
-			jQuery( this ).remove();
 		});
 	},
 
@@ -352,7 +353,8 @@ jQuery.fn.extend({
 							this[i],
 						i === iNoClone ?
 							fragment :
-							jQuery.clone( fragment, true, true )
+							jQuery.clone( fragment, true, true ),
+						i
 					);
 				}
 			}

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -1170,7 +1170,6 @@ test("replaceWith(string) for more than one element", function(){
 	equal(jQuery("#foo p").length, 0, "verify that all the three original element have been replaced");
 });
 
-<<<<<<< HEAD
 test("replaceWith(string) for collection with disconnected element", function(){
 	expect(18);
 


### PR DESCRIPTION
I thought I'd try jQuery over the new [comprehensive test suite](https://github.com/ded/bonzo/blob/master/tests/dommanip_insertions.js) we have for the various insertion methods in [Bonzo](https://github.com/ded/bonzo) and discovered that jQuery's `replaceWith()` wasn't properly cloning where required.

Inside `replaceWith()` `this.each()` is used which then passes a singular collection for each element in `this` to `before()` or `append()` which then invokes `domManip()`, the clone check inside `domManip()` (see `iNoClone = results.cacheable || l - 1` -- `l` always == 1).

This change pulls the call to `domManip()` up into `replaceWith()` with the basic logic that used to be performed by `before()` and `append()` used where appropriate.

With love from @Ender!
