### PR TITLE
fix submodule update when jquery is itself a submodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ submoduleclean: clean
 # --merge	doesn't work when doing an initial clone, thus test if we have non-existing
 #	submodules, then do an real update
 update_submodules:
-	@@if [ -d .git ]; then \
+	@@if [ -e .git ]; then \
 		if git submodule status | grep -q -E '^-'; then \
 			git submodule update --init --recursive; \
 		else \


### PR DESCRIPTION
When jquery is itself a submodule in a git repository, .git
will be a file, not a directory.  jquery must still update the
submodules on which it depends in that case.
