### PR TITLE
Fix #12436, make delegated events fast again.

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -81,6 +81,7 @@ jQuery.event = {
 				handler: handler,
 				guid: handler.guid,
 				selector: selector,
+				needsContext: selector && jQuery.expr.match.needsContext.test( selector ),
 				namespace: namespaces.join(".")
 			}, handleObjIn );
 
@@ -393,7 +394,9 @@ jQuery.event = {
 						sel = handleObj.selector;
 
 						if ( selMatch[ sel ] === undefined ) {
-							selMatch[ sel ] = jQuery( sel, this ).index( cur ) >= 0;
+							selMatch[ sel ] = handleObj.needsContext ?
+								jQuery( sel, this ).index( cur ) >= 0 :
+								jQuery.find( sel, this, null, [ cur ] ).length;
 						}
 						if ( selMatch[ sel ] ) {
 							matches.push( handleObj );


### PR DESCRIPTION
This retains the rooted-at-delegateTarget behavior, still needs to be perf tested but I wanted to exercise botio.

Sizes - compared to master  :elephant:
    261698      (+169)  dist/jquery.js
     92892       (+96)  dist/jquery.min.js
     33248       (+27)  dist/jquery.min.js.gz
