### PR TITLE
Remove superfluous "@" in license header of the minified build

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -39,7 +39,7 @@ module.exports = function( grunt ) {
 		pkg: "<json:package.json>",
 		dst: readOptionalJSON("dist/.destination.json"),
 		meta: {
-			banner: "/*! jQuery v@<%= pkg.version %> jquery.com | jquery.org/license */"
+			banner: "/*! jQuery v<%= pkg.version %> jquery.com | jquery.org/license */"
 		},
 		compare_size: {
 			files: distpaths


### PR DESCRIPTION
Not sure why it was introduced in grunt.js, but I think it's just a typo.
