### PR TITLE
[1.9] Fix bug 12531, attribute selectors can now contain html

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -229,6 +229,7 @@ Z</textarea>
 			</datalist>
 		</form>
 		<div id="moretests">
+			<div id="lookslikehtml" title="<h1>html</h1>">find this by its title attribute</div>
 			<form>
 				<div id="checkedtest" style="display:none;">
 					<input type="radio" name="checkedtestradios" checked="checked"/>

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -988,7 +988,7 @@ test("addClass(Function)", function() {
 });
 
 test("addClass(Function) with incoming value", function() {
-	expect(48);
+	expect(49);
 	var div = jQuery("div"), old = div.map(function(){
 		return jQuery(this).attr("class") || "";
 	});
@@ -1062,7 +1062,7 @@ test("removeClass(Function) - simple", function() {
 });
 
 test("removeClass(Function) with incoming value", function() {
-	expect(48);
+	expect(49);
 
 	var $divs = jQuery("div").addClass("test"), old = $divs.map(function(){
 		return jQuery(this).attr("class");

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -27,7 +27,7 @@ test("jQuery()", function() {
 		div = jQuery("<div/><hr/><code/><b/>"),
 		exec = false,
 		lng = "",
-		expected = 26,
+		expected = 24,
 		attrObj = {
 			"click": function() { ok( exec, "Click executed." ); },
 			"text": "test",
@@ -140,14 +140,12 @@ test("jQuery()", function() {
 	elem.remove();
 
 	equal( jQuery(" <div/> ").length, 1, "Make sure whitespace is trimmed." );
-	equal( jQuery(" a<div/>b ").length, 1, "Make sure whitespace and other characters are trimmed." );
 
 	for ( i = 0; i < 128; i++ ) {
 		lng += "12345678";
 	}
 
 	equal( jQuery(" <div>" + lng + "</div> ").length, 1, "Make sure whitespace is trimmed on long strings." );
-	equal( jQuery(" a<div>" + lng + "</div>b ").length, 1, "Make sure whitespace and other characters are trimmed on long strings." );
 });
 
 test("selector state", function() {

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -57,6 +57,12 @@ if ( jQuery.css ) {
 	});
 }
 
+// http://bugs.jquery.com/ticket/12531
+test("attributes look like html", function() {
+	expect( 1 );
+	ok(jQuery("div[title='<h1>html</h1>']")[0] === document.getElementById("lookslikehtml"), "Find Elements that have attributes that look like html");
+});
+
 test("disconnected nodes", function() {
 	expect( 4 );
 	var $opt = jQuery('<option></option>').attr("value", "whipit").appendTo("#qunit-fixture").detach();


### PR DESCRIPTION
html creation should be done using jQuery.parseHTML, but it can still be done with jQuery(htmlString) when htmlString begins with a "<"

http://bugs.jquery.com/ticket/12531
