### PR TITLE
Fix #12584: don't ignore disabled property of select-one options after form reset

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -225,26 +225,25 @@ jQuery.extend({
 		},
 		select: {
 			get: function( elem ) {
-				var value, i, max, option,
-					index = elem.selectedIndex,
-					values = [],
+				var value, option,
 					options = elem.options,
-					one = elem.type === "select-one";
-
-				// Nothing was selected
-				if ( index < 0 ) {
-					return null;
-				}
+					index = elem.selectedIndex,
+					one = elem.type === "select-one" || index < 0,
+					values = one ? null : [],
+					max = one ? index + 1 : options.length,
+					i = index < 0 ?
+						max :
+						one ? index : 0;
 
 				// Loop through all the selected options
-				i = one ? index : 0;
-				max = one ? index + 1 : options.length;
 				for ( ; i < max; i++ ) {
 					option = options[ i ];
 
-					// Don't return options that are disabled or in a disabled optgroup
-					if ( option.selected && (jQuery.support.optDisabled ? !option.disabled : option.getAttribute("disabled") === null) &&
-							(!option.parentNode.disabled || !jQuery.nodeName( option.parentNode, "optgroup" )) ) {
+					// oldIE doesn't update selected after form reset (#2551)
+					if ( ( option.selected || i === index ) &&
+							// Don't return options that are disabled or in a disabled optgroup
+							( jQuery.support.optDisabled ? !option.disabled : option.getAttribute("disabled") === null ) &&
+							( !option.parentNode.disabled || !jQuery.nodeName( option.parentNode, "optgroup" ) ) ) {
 
 						// Get the specific value for the option
 						value = jQuery( option ).val();
@@ -257,11 +256,6 @@ jQuery.extend({
 						// Multi-Selects return an array
 						values.push( value );
 					}
-				}
-
-				// Fixes Bug #2551 -- select.val() broken in IE after form.reset()
-				if ( one && !values.length && options.length ) {
-					return jQuery( options[ index ] ).val();
 				}
 
 				return values;

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -713,7 +713,7 @@ test("removeProp(String)", function() {
 });
 
 test("val()", function() {
-	expect( 20 + ( jQuery.fn.serialize ? 6 : 0 ) );
+	expect( 21 + ( jQuery.fn.serialize ? 6 : 0 ) );
 
 	document.getElementById("text1").value = "bla";
 	equal( jQuery("#text1").val(), "bla", "Check for modified value of input element" );
@@ -755,6 +755,12 @@ test("val()", function() {
 
 	jQuery("#select5").val(3);
 	equal( jQuery("#select5").val(), "3", "Check value on ambiguous select." );
+
+	strictEqual(
+		jQuery("<select name='select12584' id='select12584'><option value='1' disabled='disabled'>1</option></select>").val(),
+		null,
+		"Select-one with only option disabled (#12584)"
+	);
 
 	if ( jQuery.fn.serialize ) {
 		var checks = jQuery("<input type='checkbox' name='test' value='1'/><input type='checkbox' name='test' value='2'/><input type='checkbox' name='test' value=''/><input type='checkbox' name='test'/>").appendTo("#form");


### PR DESCRIPTION
Sizes - compared to master @ 6ad4a0ef3422f8c5b99428dbfdbb6000cbc4eca2

```
    265231      (-108)  dist/jquery.js                                         
     93498       (-33)  dist/jquery.min.js                                     
     33455        (-3)  dist/jquery.min.js.gz
```
