### PR TITLE
adding $.reduce compliment to $.map utility method

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -735,6 +735,13 @@ jQuery.extend({
 		return ret.concat.apply( [], ret );
 	},
 
+	reduce: function(source, accumulator, iteratorFunction) {
+		this.each(source, function(index, value) {
+			accumulator = iteratorFunction.call(source, accumulator, index, value);
+		});
+		return accumulator;
+	},
+
 	// A global GUID counter for objects
 	guid: 1,
 


### PR DESCRIPTION
I've always wanted a reduce/inject method for jQuery to compliment the map method.  I can't count how many times I've used temp vars and $.each just to build an indexed object from an array.  I assume others have as well, but I imagine there's resistance to any bloat in the core, which I do understand.

Anyway... here's a $.reduce implementation.  Hopefully you think it's useful too.

Some examples:

```
var list_of_objects = [
  {id: "1332", text: "one", visible: true},
  {id: "4321", text: "two", visible: false},
  {id: "9292", text: "three", visible: true}
];

// params are the source, an accumulator that provides the 
// initial value, and an iterator function
$.reduce(list_of_objects, {}, function(output, i, obj){
  output[obj.id] = obj;
  return output;
});

// produces an object of objects indexed by the id
```

```
$.reduce([1,2,3,4], 0, function(sum, i, num){
  sum = sum + num;
  return sum;
});

// produces 10
```
