### PR TITLE
fixes #12587, 'hidden' selector doesn't work for SVG images in Firefox

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -601,7 +601,8 @@ jQuery(function() {
 
 if ( jQuery.expr && jQuery.expr.filters ) {
 	jQuery.expr.filters.hidden = function( elem ) {
-		return ( elem.offsetWidth === 0 && elem.offsetHeight === 0 ) || (!jQuery.support.reliableHiddenOffsets && ((elem.style && elem.style.display) || curCSS( elem, "display" )) === "none");
+		return ( elem.offsetWidth === 0 && elem.offsetHeight === 0 ) ||
+			( ( !jQuery.support.reliableHiddenOffsets || elem.offsetWidth == null ) && ((elem.style && elem.style.display) || curCSS( elem, "display" )) === "none");
 	};
 
 	jQuery.expr.filters.visible = function( elem ) {

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -626,6 +626,14 @@ test(":visible selector works properly on table elements (bug #4512)", function 
 	equal(jQuery("#table td:visible").length, 1, "hidden cell is not perceived as visible");
 });
 
+test( ":visible selector works properly on svg elements (bug #12587)", 2, function () {
+	var svgVisible = jQuery("<svg xmlns='http://www.w3.org/2000/svg' style='display:block;width:50px;height:50px;' version='1.1'><circle cx='100' cy='50' r='40' stroke='black' stroke-width='2' fill='blue'/></svg>").appendTo("#qunit-fixture"),
+		svgHidden = jQuery("<svg xmlns='http://www.w3.org/2000/svg' style='display:none;' version='1.1'><circle cx='100' cy='50' r='40' stroke='black' stroke-width='2' fill='blue'/></svg>").appendTo("#qunit-fixture");
+
+	ok( svgVisible.is(":visible"), "visible svg is :visible" );
+	ok( svgHidden.is(":hidden"), "visible svg is :hidden" );
+});
+
 test(":visible selector works properly on children with a hidden parent (bug #4512)", function () {
 	expect(1);
 	jQuery("#table").css("display", "none").html("<tr><td>cell</td><td>cell</td></tr>");


### PR DESCRIPTION
```
Running "compare_size:files" (compare_size) task
Sizes - compared to master
    265240       (+36)  dist/jquery.js                                         
     93461       (+23)  dist/jquery.min.js                                     
     33438        (+7)  dist/jquery.min.js.gz 
```
