### PR TITLE
fixes #12537, element.css('filter') returns undefined in IE9

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -290,7 +290,9 @@ if ( window.getComputedStyle ) {
 
 		if ( computed ) {
 
-			ret = computed[ name ];
+			// getPropertyValue is only needed for .css('filter') in IE9, see #12537
+			ret = computed.getPropertyValue( name ) || computed[ name ];
+
 			if ( ret === "" && !jQuery.contains( elem.ownerDocument, elem ) ) {
 				ret = jQuery.style( elem, name );
 			}

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -782,6 +782,13 @@ test("certain css values of 'normal' should be convertable to a number, see #862
 	ok( jQuery.isNumeric( parseFloat( el.css("fontWeight") ) ), "css('fontWeight') not convertable to number, see #8627" );
 });
 
+// only run this test in IE9+
+if ( document.documentMode === 9 ) {
+	test( ".css('filter') returns a string in IE9+, see #12537", 1, function() {
+		equal( jQuery("<div style='-ms-filter:\"progid:DXImageTransform.Microsoft.gradient(startColorstr=#FFFFFF, endColorstr=#ECECEC)\";'></div>").css("filter"), "progid:DXImageTransform.Microsoft.gradient(startColorstr=#FFFFFF, endColorstr=#ECECEC)", "IE9 returns the correct value from css('filter')." );
+	});
+}
+
 test( "cssHooks - expand", function() {
 	expect( 15 );
 	var result,

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -1689,7 +1689,7 @@ asyncTest( "non-px animation handles non-numeric start (#11971)", 2, function() 
 	var foo = jQuery("#foo"),
 		initial = foo.css("backgroundPositionX");
 
-	if ( initial == null ) {
+	if ( !initial ) {
 		expect(1);
 		ok( true, "Style property not understood" );
 		start();


### PR DESCRIPTION
```
Running "compare_size:files" (compare_size) task
Sizes - compared to master
    265318      (+114)  dist/jquery.js                                         
     93461       (+23)  dist/jquery.min.js                                     
     33443       (+12)  dist/jquery.min.js.gz      
```
