### PR TITLE
Fixes #9646 - IE7: Cloning of form-elements and changing their names also changes the name of the elements that are cloned.

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -530,7 +530,15 @@ if ( !getSetAttribute ) {
 				ret = elem.ownerDocument.createAttribute( name );
 				elem.setAttributeNode( ret );
 			}
-			return ( ret.value = value + "" );
+
+			ret.value = value += "";
+
+			// #9646
+			if ( name !== "value" && value !== elem.getAttribute( name ) ) {
+				elem.setAttribute( name, value );
+			}
+
+			return value;
 		}
 	};
 

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -151,6 +151,28 @@ test( "attr(String)", function() {
 
 	$form = jQuery("#form").attr( "enctype", "multipart/form-data" );
 	equal( $form.prop("enctype"), "multipart/form-data", "Set the enctype of a form (encoding in IE6/7 #6743)" );
+
+});
+
+test( "attr(String) on cloned elements, #9646", function() {
+	expect( 3 );
+
+	var div,
+		input = jQuery("<input name='tester' />");
+
+	input.attr("name");
+
+	strictEqual( input.clone( true ).attr( "name", "test" )[ 0 ].name, "test", "Name attribute should be changed on cloned element" );
+
+	div = jQuery("<div id='tester' />");
+	div.attr("id");
+
+	strictEqual( div.clone( true ).attr( "id", "test" )[ 0 ].id, "test", "Id attribute should be changed on cloned element" );
+
+	input = jQuery("<input value='tester' />");
+	input.attr("value");
+
+	strictEqual( input.clone( true ).attr( "value", "test" )[ 0 ].value, "test", "Value attribute should be changed on cloned element" );
 });
 
 test( "attr(String) in XML Files", function() {


### PR DESCRIPTION
Problem is not limited to only input element and name property (attribute), test case can be reproduced on all elements and all attributes (properties), except for value attribute.
