### PR TITLE
Test: Clean up and fix misc issues

### DIFF
--- a/test/data/testinit.js
+++ b/test/data/testinit.js
@@ -1,10 +1,13 @@
-/*jshint multistr:true*/
+/*jshint multistr:true */
 
 var jQuery = this.jQuery || "jQuery", // For testing .noConflict()
 	$ = this.$ || "$",
 	originaljQuery = jQuery,
 	original$ = $,
 	hasPHP = true,
+	// Disable Ajax tests to reduce network strain
+	// Re-enabled (at least the variable should be declared)
+	isLocal = window.location.protocol === "file:",
 	amdDefined;
 
 /**
@@ -123,7 +126,7 @@ if ( document.createEvent ) {
  * @result "data/test.php?foo=bar&10538358345554"
  */
 function url( value ) {
-	return value + (/\?/.test(value) ? "&" : "?") + new Date().getTime() + "" + parseInt(Math.random()*100000);
+	return value + (/\?/.test(value) ? "&" : "?") + new Date().getTime() + "" + parseInt(Math.random() * 100000, 10);
 }
 
 (function () {
@@ -226,7 +229,7 @@ function url( value ) {
 				jQuery( "<iframe/>" ).attr( "src", url( "./data/" + fileName ) )
 			).appendTo( "body" );
 		});
-	}
+	};
 }());
 
 // Sandbox start for great justice

--- a/test/data/testrunner.js
+++ b/test/data/testrunner.js
@@ -123,7 +123,7 @@ function testSubproject( label, url, risTests ) {
 			}
 
 			fnTest.apply( this, arguments );
-		}
+		};
 	}
 }
 
@@ -166,9 +166,6 @@ QUnit.config.testTimeout = 20 * 1000; // 20 seconds
 	if ( !url || url.indexOf("http") !== 0 ) {
 		return;
 	}
-
-	// (Temporarily) Disable Ajax tests to reduce network strain
-	// isLocal = QUnit.isLocal = true;
 
 	document.write("<scr" + "ipt src='http://swarm.jquery.org/js/inject.js?" + (new Date).getTime() + "'></scr" + "ipt>");
 })();

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -2,8 +2,8 @@ module("core", { teardown: moduleTeardown });
 
 test("Unit Testing Environment", function () {
 	expect(2);
-	ok( hasPHP, "Running Unit tests without PHP is unsupported! The AJAX tests won't run without it and don't expect all tests to pass without it!" );
-	ok( !isLocal, "Unit tests shouldn't be run from file://, especially in Chrome. If you must test from file:// with Chrome, run it with the --allow-file-access-from-files flag!" );
+	ok( hasPHP, "Running in an environment with PHP support. The AJAX tests only run if the environment supports PHP!" );
+	ok( !isLocal, "Unit tests are not ran from file:// (especially in Chrome. If you must test from file:// with Chrome, run it with the --allow-file-access-from-files flag!)" );
 });
 
 test("Basic requirements", function() {
@@ -644,12 +644,12 @@ test("jQuery('html')", function() {
 	var li = "<li>very large html string</li>";
 	var html = ["<ul>"];
 	for ( i = 0; i < 50000; i += 1 ) {
-		html.push(li);
+		html[html.length] = li;
 	}
-	html.push("</ul>");
+	html[html.length] = "</ul>";
 	html = jQuery(html.join(""))[0];
-	equal( html.nodeName.toUpperCase(), "UL");
-	equal( html.firstChild.nodeName.toUpperCase(), "LI");
+	equal( html.nodeName.toLowerCase(), "ul");
+	equal( html.firstChild.nodeName.toLowerCase(), "li");
 	equal( html.childNodes.length, 50000 );
 });
 


### PR DESCRIPTION
We need to cut down on the un-interrupted sequence of instructions in the `core.js` unit test.

It is the only test module that is causing slow script warnings in IE6, and it is causing it frequently:

![](http://f.cl.ly/items/0b080v2w3A2f462N0j2b/browserstack-kjnf03d.png)

This commit cleans up some dirt and does a minor optimisation that might help IE a bit.
