### PR TITLE
Expected element was missing for test

### DIFF
--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -64,7 +64,7 @@ test("attr(String)", function() {
 	equal( jQuery("#foo").attr("height"), undefined, "Non existent height attribute should return undefined" );
 
 	// [7472] & [3113] (form contains an input with name="action" or name="id")
-	var extras = jQuery("<input id='id' name='id' /><input name='name' name='name' /><input id='target' name='target' />").appendTo("#testForm");
+	var extras = jQuery("<input id='id' name='id' /><input id='name' name='name' /><input id='target' name='target' />").appendTo("#testForm");
 	equal( jQuery("#form").attr("action","newformaction").attr("action"), "newformaction", "Check that action attribute was changed" );
 	equal( jQuery("#testForm").attr("target"), undefined, "Retrieving target does not equal the input with name=target" );
 	equal( jQuery("#testForm").attr("target", "newTarget").attr("target"), "newTarget", "Set target successfully on a form" );


### PR DESCRIPTION
Test expects input elements having name='id', name='name', and name='target'. Additionally, these should have id='id', id='name', and id='target' respectively. No element was provided with id='id' or name='id', but rather one element had two name attributes (illegal) with the values 'id' and 'name' respectively.
