### PR TITLE
Format @DATE to ISO 8601 format. Fixes #12725.

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -370,7 +370,7 @@ module.exports = function( grunt ) {
 				.replace( "@DATE", function () {
 					var date = new Date();
 
-					return [date.getFullYear(), date.getMonth() + 1, date.getDate()].join("-");
+					return [ date.getFullYear(), date.getMonth() + 1, date.getDate() ].join( "-" );
 				} );
 
 			// Write concatenated source to file


### PR DESCRIPTION
To avoid non-ASCII characters from showing up in localized date formats, we'll use ISO 8601 (YYYY-MM-DD) format.

**Trac ticket:** http://bugs.jquery.com/ticket/12725
