### PR TITLE
Fixed setting attributes for XML fragments. Fixes #12048

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -526,7 +526,7 @@ if ( !getSetAttribute ) {
 			// Set the existing or create a new attribute node
 			var ret = elem.getAttributeNode( name );
 			if ( !ret ) {
-				ret = document.createAttribute( name );
+				ret = elem.ownerDocument.createAttribute( name );
 				elem.setAttributeNode( ret );
 			}
 			return ( ret.value = value + "" );

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -40,6 +40,7 @@
     "testIframe": true,
     "testIframeWithCallback": true,
     "createDashboardXML": true,
+    "createXMLFragment": true,
     "moduleTeardown": true,
     "testFoo": true,
     "foobar": true,

--- a/test/data/testinit.js
+++ b/test/data/testinit.js
@@ -102,6 +102,21 @@ var createWithFriesXML = function() {
 	return jQuery.parseXML(string);
 };
 
+var createXMLFragment = function() {
+	var xml, frag;
+	if ( window.ActiveXObject ) {
+		xml = new ActiveXObject("msxml2.domdocument");
+	} else {
+		xml = document.implementation.createDocument("", "", null);
+	}
+
+	if ( xml ) {
+		frag = xml.createElement('data');
+	}
+
+	return frag;
+};
+
 var fireNative;
 if ( document.createEvent ) {
 	fireNative = function( node, type ) {

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -440,6 +440,17 @@ test("attr(String, Object) - Loaded via XML document", function() {
 	equal( titles[1], "Users", "attr() in XML context: Check second title" );
 });
 
+test("attr(String, Object) - Loaded via XML fragment", function() {
+	expect( 2 );
+	var frag = createXMLFragment(),
+		$frag = jQuery(frag);
+
+	$frag.attr("test", "some value");
+	equal( $frag.attr("test"), "some value", "set attribute" );
+	$frag.attr("test", null);
+	equal( $frag.attr("test"), undefined, "remove attribute" );
+});
+
 test("attr('tabindex')", function() {
 	expect( 8 );
 
@@ -520,7 +531,7 @@ test("removeAttr(String)", function() {
 	} catch(e) {
 		ok( false, "Removing contenteditable threw an error (#10429)" );
 	}
-	
+
 	$first = jQuery("<div Case='mixed'></div>");
 	equal( $first.attr("Case"), "mixed", "case of attribute doesn't matter" );
 	$first.removeAttr("Case");


### PR DESCRIPTION
XML fragments in IE <=8 that has not been attached to a DOM throws a
`Type Mismatch` when adding an attribute created using
`document.createAttribute`. Instead,
`elem.ownerDocument.createAttribute` is used.
