### PR TITLE
Fixes #12569

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -153,7 +153,7 @@ jQuery.support = (function() {
 	// are used, namely in IE. Short-circuiting here helps us to
 	// avoid an eval call (in setAttribute) which can cause CSP
 	// to go haywire. See: https://developer.mozilla.org/en/Security/CSP
-	if ( div.attachEvent ) {
+	if ( !div.addEventListener ) {
 		for ( i in {
 			submit: true,
 			change: true,


### PR DESCRIPTION
Switches the bubbling support check to run only if addEVentListener is undefined, not if we detect an IE only function to provide better IE only support checks
