### PR TITLE
Removed unneeded reference to `window.event`. #12610

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -360,7 +360,7 @@ jQuery.event = {
 	dispatch: function( event ) {
 
 		// Make a writable jQuery.Event from the native event object
-		event = jQuery.event.fix( event || window.event );
+		event = jQuery.event.fix( event );
 
 		var i, j, cur, ret, selMatch, matched, matches, handleObj, sel, related,
 			handlers = ( (jQuery._data( this, "events" ) || {} )[ event.type ] || []),


### PR DESCRIPTION
The need for `window.event` does not seem to be present for the current
set of support browser/platforms. Use of `event || window.event` syntax
seems only relevant when attaching event listeners via the following
syntax:

```
document.body.onclick = function(event){
  var e = event || window.event; // event is null in the case of IE6
  ...
}
```
