### PR TITLE
Fix HTTP:411 error on non-chunking web servers occuring during POST or PUT operations. 

### DIFF
--- a/src/ajax/xhr.js
+++ b/src/ajax/xhr.js
@@ -99,7 +99,7 @@ if ( jQuery.support.ajax ) {
 					// Do send the request
 					// This may raise an exception which is actually
 					// handled in jQuery.ajax (so no try/catch here)
-					xhr.send( ( s.hasContent && s.data ) || null );
+					xhr.send( ( s.hasContent && s.data ) || {} );
 
 					// Listener
 					callback = function( _, isAbort ) {


### PR DESCRIPTION
Problem description (old) is here: https://groups.google.com/forum/?fromgroups=#!topic/jquery-en/IoKJgc8jvcQ

Issue is that Nginx (without Chunkin support enabled, as found on Dotcloud) rejects PUT and POST delete requests as they don't have any message body. 

Many work around this in code by settings a data: {} attribute in params.  

My fix simply swaps {} for null as they are effectively the same and this will support more servers. 

I've checked against a few different servers, Apache & Nginx with and without chunking enabled, and this hasn't caused any problems that I've seen. 
