### PR TITLE
Fixes #12752: Added OS-switch for grunt task "custom"

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -230,7 +230,7 @@ module.exports = function( grunt ) {
 		grunt.log.writeln( "Creating custom build...\n" );
 
 		grunt.utils.spawn({
-			cmd: (process.platform === "win32" ? "grunt.cmd" : "grunt"),
+			cmd: process.platform === "win32" ? "grunt.cmd" : "grunt",
 			args: [ "build:*:*:" + modules, "min" ]
 		}, function( err, result ) {
 			if ( err ) {


### PR DESCRIPTION
Added OS-switch for grunt task "custom", to make use of grunt.cmd on  Windows operating systems.

See http://bugs.jquery.com/ticket/12752 for details.
