### PR TITLE
Drop support for FF 3.6 in ajax module

### DIFF
--- a/src/ajax/xhr.js
+++ b/src/ajax/xhr.js
@@ -89,7 +89,6 @@ if ( jQuery.support.ajax ) {
 						headers[ "X-Requested-With" ] = "XMLHttpRequest";
 					}
 
-					// Need an extra try/catch for cross domain requests in Firefox 3
 					for ( i in headers ) {
 						xhr.setRequestHeader( i, headers[ i ] );
 					}


### PR DESCRIPTION
Continuation of this <a href="https://github.com/jquery/jquery/pull/842">pull</a>
