### PR TITLE
Fix #9469. Remove semi-functional .selector property.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -203,21 +203,14 @@ jQuery.fn = jQuery.prototype = {
 
 	// Take an array of elements and push it onto the stack
 	// (returning the new matched element set)
-	pushStack: function( elems, name, selector ) {
+	pushStack: function( elems ) {
 
 		// Build a new jQuery matched element set
 		var ret = jQuery.merge( this.constructor(), elems );
 
 		// Add the old object onto the stack (as a reference)
 		ret.prevObject = this;
-
 		ret.context = this.context;
-
-		if ( name === "find" ) {
-			ret.selector = this.selector + ( this.selector ? " " : "" ) + selector;
-		} else if ( name ) {
-			ret.selector = this.selector + "." + name + "(" + selector + ")";
-		}
 
 		// Return the newly-formed element set
 		return ret;

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -564,7 +564,7 @@ jQuery.each({
 				ret = ret.concat( elems );
 			}
 
-			return this.pushStack( ret, name, insert.selector );
+			return this.pushStack( ret );
 		}
 	};
 });

--- a/src/traversing.js
+++ b/src/traversing.js
@@ -25,7 +25,7 @@ jQuery.fn.extend({
 			});
 		}
 
-		ret = this.pushStack( "", "find", selector );
+		ret = this.pushStack( [] );
 
 		for ( i = 0, l = this.length; i < l; i++ ) {
 			length = ret.length;
@@ -44,6 +44,8 @@ jQuery.fn.extend({
 			}
 		}
 
+		// Needed because $( "selector", context ) becomes $( context ).find( "selector" )
+		ret.selector = ( this.selector ? this.selector + " " : "" ) + selector;
 		return ret;
 	},
 
@@ -62,11 +64,11 @@ jQuery.fn.extend({
 	},
 
 	not: function( selector ) {
-		return this.pushStack( winnow(this, selector, false), "not", selector);
+		return this.pushStack( winnow(this, selector, false) );
 	},
 
 	filter: function( selector ) {
-		return this.pushStack( winnow(this, selector, true), "filter", selector );
+		return this.pushStack( winnow(this, selector, true) );
 	},
 
 	is: function( selector ) {
@@ -103,7 +105,7 @@ jQuery.fn.extend({
 
 		ret = ret.length > 1 ? jQuery.unique( ret ) : ret;
 
-		return this.pushStack( ret, "closest", selectors );
+		return this.pushStack( ret );
 	},
 
 	// Determine the position of an element within
@@ -216,7 +218,7 @@ jQuery.each({
 			ret = ret.reverse();
 		}
 
-		return this.pushStack( ret, name, core_slice.call( arguments ).join(",") );
+		return this.pushStack( ret );
 	};
 });
 


### PR DESCRIPTION
Kind of sad, removing all this saves 54 bytes and passes unit tests without any changes. I kept the selector calc in `jQuery.fn.find()` because `$(selector, context)` needs it.
