### PR TITLE
Test: Assert that removeClass(undefined) is chainable.

### DIFF
--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -1203,12 +1203,14 @@ test( "removeClass() removes duplicates", function() {
 });
 
 test("removeClass(undefined) is a no-op", function() {
-	expect( 1 );
+	expect( 2 );
 
 	var $div = jQuery("<div class='base second'></div>");
 	$div.removeClass( undefined );
 
 	ok( $div.hasClass("base") && $div.hasClass("second"), "Element still has classes after removeClass(undefined)" );
+
+	strictEqual( $div.removeClass( undefined ), $div, "Return of removeClass(undefined) is chainable" );
 });
 
 var testToggleClass = function(valueObj) {


### PR DESCRIPTION
Follows-up 227c49a4596423a125bdcb1d25a2263e526360db / gh-913.

Assert that the return value is strictEqual to `$div`. That way it doesn't just assert it being a harmless (e.g. that undefined doesn't mean "remove all classes", but "do nothing"), but also that it is still chainable.

@dmethvin
