### PR TITLE
Works around a crashing browser bug affecting Android browser 2.3.x on some devices

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -81,7 +81,7 @@ function Animation( elem, properties, options ) {
 		tick = function() {
 			var currentTime = fxNow || createFxNow(),
 				remaining = Math.max( 0, animation.startTime + animation.duration - currentTime ),
-				percent = 1 - ( remaining / animation.duration || 0 ),
+				percent = animation.duration ? (1 - (remaining / animation.duration)) : 1,
 				index = 0,
 				length = animation.tweens.length;
 


### PR DESCRIPTION
This pull request works around a crashing browser bug affecting Android browser 2.3.x on some devices. The bug was triggered by code in `animate` that was introduce since 1.7.2. 

A bug against jQuery was filed here a couple of months ago: http://bugs.jquery.com/ticket/12497. The bug thread references a number of devices that exhibit this crash.

A simple example (without jQuery) of JS that will trigger this crashing browser bug is here: http://jsfiddle.net/wCQvh/

The workaround in this commit attempts to preserve the same logic as the previous code but avoids triggering the browser bug.
