### PR TITLE
#12837 - Ensure each tick gets it's own fxNow

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -612,6 +612,8 @@ jQuery.fx.tick = function() {
 		timers = jQuery.timers,
 		i = 0;
 
+	fxNow = jQuery.now();
+
 	for ( ; i < timers.length; i++ ) {
 		timer = timers[ i ];
 		// Checks the timer has not already been removed
@@ -623,6 +625,7 @@ jQuery.fx.tick = function() {
 	if ( !timers.length ) {
 		jQuery.fx.stop();
 	}
+	fxNow = undefined;
 };
 
 jQuery.fx.timer = function( timer ) {

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -1818,6 +1818,35 @@ test( "Animate properly sets overflow hidden when animating width/height (#12117
 	});
 });
 
+test( "Each tick of the timer loop uses a fresh time (#12837)", function() {
+	var lastVal, current,
+		tmp = jQuery({
+			test: 0
+		});
+	expect( 3 );
+	tmp.animate({
+		test: 100
+	}, {
+		step: function( p, fx ) {
+			ok( fx.now !== lastVal, "Current value is not the last value: " + lastVal + " - " + fx.now );
+			lastVal = fx.now;
+		}
+	});
+	current = jQuery.now();
+	// intentionally empty, we want to spin wheels until the time changes.
+	while ( current === jQuery.now() ) { }
+
+	// now that we have a new time, run another tick
+	jQuery.fx.tick();
+
+	current = jQuery.now();
+	// intentionally empty, we want to spin wheels until the time changes.
+	while ( current === jQuery.now() ) { }
+
+	jQuery.fx.tick();
+	tmp.stop();
+});
+
 test( "Animations with 0 duration don't ease (#12273)", 1, function() {
 	jQuery.easing.test = function() {
 		ok( false, "Called easing" );


### PR DESCRIPTION
Leave the old stuff around for animations queued outside of this loop - Fixes #12837 - Thanks @chadparry

Based on discussion in gh-1015 and gh-1021

```
Sizes - compared to master @ 0ee94159023bebe1992c5281d0f4778b4f75ff0d
    266832       (+44)  dist/jquery.js                                         
     93120       (+16)  dist/jquery.min.js                                     
     33183        (+7)  dist/jquery.min.js.gz
```
