### PR TITLE
#9945 - .width() returns percentage if a parent element has display = none.

### DIFF
--- a/test/unit/dimensions.js
+++ b/test/unit/dimensions.js
@@ -458,4 +458,44 @@ testIframe( "dimensions/documentLarge", "window vs. large document", function( j
 	ok( jQuery( document ).width() > jQuery( window ).width(), "document width is larger than window width" );
 });
 
+test("percentage width elements in hidden divs not returning width in PX - see #9945", function() {
+	expect(8);
+
+	var el = jQuery( "<div style='width: 500px;'></div>" );
+	var el_child = jQuery( "<div></div>" );
+	var el_child1 = jQuery( "<div></div>" );
+	var el_child2 = jQuery( "<div></div>" );
+	var el_child3 = jQuery( "<div style='width: 50%'></div> ");
+	el.append( el_child );
+	el.append( el_child1 );
+	el.append( el_child2 );
+	el.append( el_child3 );
+	el.appendTo( "#qunit-fixture" );
+
+	// test fourth parent, or root element, with display = none
+	el.css( "display", "none" );
+	equal( el_child3.width(), 250, "element width should be accurate and in px when container element (root) is display = none" );
+	equal( el.css( "display" ), "none", "hidden element should still be hidden" );
+	el.css( "display", "block" );
+
+	// test third parent with display = none
+	el_child.css( "display", "none" );
+	equal( el_child3.width(), 250, "element width should be accurate and in px when container element (first child) is display = none" );
+	equal( el_child.css( "display" ), "none", "hidden element should still be hidden" );
+	el_child.css( "display", "block" );
+
+	// test second parent with display = none
+	el_child1.css( "display", "none" );
+	equal( el_child3.width(), 250, "element width should be accurate and in px when container element (second child) is display = none" );
+	equal( el_child1.css( "display" ), "none", "hidden element should still be hidden" );
+	el_child1.css( "display", "block" );
+
+	// test third parent with display = none
+	el_child2.css( "display", "none" );
+	equal( el_child3.width(), 250, "element width should be accurate and in px when container element (third child) is display = none" );
+	equal( el_child2.css( "display" ), "none", "hidden element should still be hidden" );
+	el_child2.css( "display", "block" );
+
+});
+
 }


### PR DESCRIPTION
Not sure if this is considered a browser bug, but the behavior is consistent in recent versions of Safari, Firefox, Chrome, and Opera.  The solution here was to quickly set display = block, get the width using window.getComputedStyle, and re-set display = none for any parent that had display = none.

I didn't see any other way, using the DOM, to get the accurate width in pixels.  I'd like some feedback on whether you guys think this is an appropriate solution or if it seems too "hackish."  

This is my first pull request, so I apologize if I've overlooked something in the process, or I've left out some information.  Please just let me know and I will include whatever's necessary.
