### PR TITLE
[1.9] Adding jQuery.fx.start as a hook point - Fixes #12803

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -640,12 +640,18 @@ jQuery.fx.tick = function() {
 };
 
 jQuery.fx.timer = function( timer ) {
-	if ( timer() && jQuery.timers.push( timer ) && !timerId ) {
-		timerId = setInterval( jQuery.fx.tick, jQuery.fx.interval );
+	if ( timer() && jQuery.timers.push( timer ) ) {
+		jQuery.fx.start();
 	}
 };
 
 jQuery.fx.interval = 13;
+
+jQuery.fx.start = function() {
+	if ( !timerId ) {
+		timerId = setInterval( jQuery.fx.tick, jQuery.fx.interval );
+	}
+};
 
 jQuery.fx.stop = function() {
 	clearInterval( timerId );

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -1918,4 +1918,31 @@ jQuery.map([ "toggle", "slideToggle", "fadeToggle" ], function ( method ) {
 	});
 });
 
+test( "jQuery.fx.start & jQuery.fx.stop hook points", function() {
+	var oldStart = jQuery.fx.start,
+		oldStop = jQuery.fx.stop,
+		foo = jQuery({ foo: 0 });
+
+	expect( 3 );
+
+	jQuery.fx.start = function() {
+		ok( true, "start called" );
+	};
+	jQuery.fx.stop = function() {
+		ok( true, "stop called" );
+	};
+
+	// calls start
+	foo.animate({ foo: 1 }, { queue: false });
+	// calls start
+	foo.animate({ foo: 2 }, { queue: false });
+	foo.stop();
+	// calls stop
+	jQuery.fx.tick();
+
+	// cleanup
+	jQuery.fx.start = oldStart;
+	jQuery.fx.stop = oldStop;
+});
+
 } // if ( jQuery.fx )


### PR DESCRIPTION
The idea is to make "replacing" this as simple has having to implement the following logic:

``` javascript
var timerId;

jQuery.fx.start = function() {
    // could actually be called multiple times, so track your own state
    if ( !timerId ) {
        timerId = setInterval( jQuery.fx.tick, jQuery.fx.interval );
    }
};

jQuery.fx.stop = function() {
    clearInterval( timerId );
    timerId = null;
};
```

Sadly:

```
Sizes - compared to master @ 877306738f931a711c41d907e69fc8930f985830
    263723       (+66)  dist/jquery.js                                         
     91771       (+35)  dist/jquery.min.js                                     
     32682       (+12)  dist/jquery.min.js.gz   
```
