### PR TITLE
Move offset check to the back in JQUERY.EXPR.FILTERS.HIDDEN to optimize ...

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -597,7 +597,7 @@ jQuery(function() {
 
 if ( jQuery.expr && jQuery.expr.filters ) {
 	jQuery.expr.filters.hidden = function( elem ) {
-		return ( elem.offsetWidth === 0 && elem.offsetHeight === 0 ) || (!jQuery.support.reliableHiddenOffsets && ((elem.style && elem.style.display) || curCSS( elem, "display" )) === "none");
+		return (!jQuery.support.reliableHiddenOffsets && ((elem.style && elem.style.display) || curCSS( elem, "display" )) === "none") || ( elem.offsetWidth === 0 && elem.offsetHeight === 0 );
 	};
 
 	jQuery.expr.filters.visible = function( elem ) {


### PR DESCRIPTION
...performance. Fixes #12885.

I did not test it because the instructions on how to run grunt are incomplete/broken. The 'grunt && grunt watch' command does build jQuery.js but no tests are run and no (web)server is started. AFAIK, grunt watch is not meant for this task. Shouldn't it be grunt test?
