### PR TITLE
$.each(object,function(){}) will be wrong when a object has the length attribute.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -579,7 +579,7 @@ jQuery.extend({
 		var name,
 			i = 0,
 			length = obj.length,
-			isObj = length === undefined || jQuery.isFunction( obj );
+			isObj = (obj instanceof Object && length !== undefined) || length === undefined || jQuery.isFunction( obj );
 
 		if ( args ) {
 			if ( isObj ) {


### PR DESCRIPTION
###### When a object has the length attribute ,the $.each(object,function(){}) will be wrong.

---

**eg:**

``` js
var obj = {name: 'jazz',age : 22,length: 1000}
$.each(obj,function(idx,val){ console.log(idx,val)})
```

---
###### In the example above,it will print `undefined`  **1000** times , but in fact I hope print the all attributes of the obj.
