### PR TITLE
Fixes #12956 - Improve cloneFixAttributes function

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -444,31 +444,26 @@ function cloneCopyEvent( src, dest ) {
 }
 
 function cloneFixAttributes( src, dest ) {
-	var nodeName;
+	var nodeName, data, e;
 
 	// We do not need to do anything for non-Elements
 	if ( dest.nodeType !== 1 ) {
 		return;
 	}
 
-	if ( !jQuery.support.noCloneEvent && dest.clearAttributes ) {
+	nodeName = dest.nodeName.toLowerCase();
 
-		// clearAttributes removes the attributes, which we don't want,
-		// but also removes the attachEvent events, which we *do* want
-		dest.clearAttributes();
+	// IE6-8 copies events bound via attachEvent when using cloneNode.
+	if ( !jQuery.support.noCloneEvent && dest[ jQuery.expando ] ) {
+		data = jQuery._data( dest );
 
-		// mergeAttributes, in contrast, only merges back on the
-		// original attributes, not the events
-		dest.mergeAttributes( src );
-	}
+		for ( e in data.events ) {
+			jQuery.removeEvent( dest, e, data.handle );
+		}
 
-	// Event data gets referenced instead of copied if the expando
-	// gets copied too
-	if ( dest[ jQuery.expando ] ) {
+		// Event data gets referenced instead of copied if the expando gets copied too
 		dest.removeAttribute( jQuery.expando );
 	}
-
-	nodeName = dest.nodeName.toLowerCase();
 
 	// IE blanks contents when cloning scripts, and tries to evaluate newly-set text
 	if ( nodeName === "script" && dest.text !== src.text ) {
@@ -637,19 +632,12 @@ jQuery.extend({
 
 		if ( (!jQuery.support.noCloneEvent || !jQuery.support.noCloneChecked) &&
 				(elem.nodeType === 1 || elem.nodeType === 11) && !jQuery.isXMLDoc(elem) ) {
-			// IE copies events bound via attachEvent when using cloneNode.
-			// Calling detachEvent on the clone will also remove the events
-			// from the original. In order to get around this, we use some
-			// proprietary methods to clear the events. Thanks to MooTools
-			// guys for this hotness.
 
 			// We eschew Sizzle here for performance reasons: http://jsperf.com/getall-vs-sizzle/2
 			destElements = getAll( clone );
 			srcElements = getAll( elem );
 
-			// Weird iteration because IE will replace the length property
-			// with an element if you are cloning the body and one of the
-			// elements on the page has a name or id of "length"
+			// Fix all IE cloning issues
 			for ( i = 0; (node = srcElements[i]) != null; ++i ) {
 				// Ensure that the destination node is not null; Fixes #9587
 				if ( destElements[i] ) {

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -3104,4 +3104,53 @@ test( "Namespace preserved when passed an Event (#12739)", function() {
 	equal( triggered, 3, "foo.bar triggered" );
 });
 
+test( "make sure events cloned correctly", 18, function() {
+	var clone,
+		fixture = jQuery("#qunit-fixture"),
+		checkbox = jQuery("#check1"),
+		p = jQuery("#firstp");
 
+	fixture.on( "click change", function( event, result ) {
+		ok( result,  event.type + " on original element is fired" );
+
+	}).on( "click", "#firstp", function( event, result ) {
+		ok( result, "Click on original child element though delegation is fired" );
+
+	}).on( "change", "#check1", function( event, result ) {
+		ok( result, "Change on original child element though delegation is fired" );
+	});
+
+	p.on("click", function( event, result ) {
+		ok( true, "Click on original child element is fired" );
+	});
+
+	checkbox.on("change", function( event, result ) {
+		ok( true, "Change on original child element is fired" );
+	});
+
+	fixture.clone().click().change(); // 0 events should be fired
+
+	clone = fixture.clone( true );
+
+	clone.find("p:first").trigger( "click", true ); // 3 events should fire
+	clone.find("#check1").trigger( "change", true ); // 3 events should fire
+	clone.remove();
+
+	clone = fixture.clone( true, true );
+	clone.find("p:first").trigger( "click", true ); // 3 events should fire
+	clone.find("#check1").trigger( "change", true ); // 3 events should fire
+
+	fixture.off();
+	p.off();
+	checkbox.off();
+
+	p.click(); // 0 should be fired
+	checkbox.change(); // 0 should be fired
+
+	clone.find("p:first").trigger( "click", true ); // 3 events should fire
+	clone.find("#check1").trigger( "change", true ); // 3 events should fire
+	clone.remove();
+
+	clone.find("p:first").click(); // 0 should be fired
+	clone.find("#check1").change(); // 0 events should fire
+});


### PR DESCRIPTION
Events bounded via addEventListener will not be cloned in IE, events bounded via attachEvent will, but in IE9-10, jQuery does not use attachEvent method and even if it did, clear(merge)Attributes hack would not work for those events anyway.

So for new IE, there is no reason to use this hack.

Expando property is not cloned in IE9-10 and it might not exist at all, but removeAttribute method is expensive to use, it would be better to check for existence of expando before trying to remove it.

I would perform clear(merge)Attributes hack only if expando property is exist, but it would affect user events bounded via attachEvent, i'm wondering - is it a real issue?

/cc @dmethvin
