### PR TITLE
Fix bug caused with the 'xmldom' library

### DIFF
--- a/src/traversing.js
+++ b/src/traversing.js
@@ -183,7 +183,7 @@ jQuery.each({
 	contents: function( elem ) {
 		return jQuery.nodeName( elem, "iframe" ) ?
 			elem.contentDocument || elem.contentWindow.document :
-			jQuery.merge( [], elem.childNodes );
+			jQuery.merge( [], elem.childNodes || []);
 	}
 }, function( name, fn ) {
 	jQuery.fn[ name ] = function( until, selector ) {


### PR DESCRIPTION
The jQuery.contents method will break if the 'childNodes' property is null or undefined. This happens when combining jsdom with xmldom(https://github.com/jindw/xmldom)
