### PR TITLE
Fix loading of appcached files on Android and JQuery Mobile

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -608,6 +608,11 @@ jQuery.extend({
 			if ( responses ) {
 				response = ajaxHandleResponses( s, jqXHR, responses );
 			}
+			
+			if ( status === 0 ) {
+			    // Android 2.2+ returns 0 for appcached files sometimes
+			    status = 200;
+			}
 
 			// If successful, handle type chaining
 			if ( status >= 200 && status < 300 || status === 304 ) {


### PR DESCRIPTION
Sometimes at least old Androids (tested with 2.2) report to JQuery Mobile that a page was loaded with status == 0, but the content is perfectly available in case the page was not loaded over the network, but obtained from local appcache. JQuery resolves this request as 'error', while it should be a successful one.
