### PR TITLE
Fix #12838: hook point for non-jQuery.ajax synchronous script fetch/execute in domManip

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -681,17 +681,6 @@ jQuery.extend({
 
 	getScript: function( url, callback ) {
 		return jQuery.get( url, undefined, callback, "script" );
-	},
-
-	_evalSrc: function( url ) {
-		return jQuery.ajax({
-			url: url,
-			type: "GET",
-			dataType: "text",
-			async: false,
-			global: false,
-			success: jQuery.globalEval
-		});
 	}
 });
 

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -334,7 +334,7 @@ jQuery.fn.extend({
 
 							if ( node.src ) {
 								// Hope ajax is available...
-								jQuery._evalSrc( node.src );
+								jQuery._evalUrl( node.src );
 							} else {
 								jQuery.globalEval( node.textContent.replace( rcleanScript, "" ) );
 							}
@@ -533,6 +533,17 @@ jQuery.extend({
 			// Discard any remaining `private` and `user` data
 			data_discard( elem );
 		}
+	},
+
+	_evalUrl: function( url ) {
+		return jQuery.ajax({
+			url: url,
+			type: "GET",
+			dataType: "text",
+			async: false,
+			global: false,
+			success: jQuery.globalEval
+		});
 	}
 });
 

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -1682,14 +1682,6 @@ module( "ajax", {
 		});
 	});
 
-//----------- jQuery._evalSrc()
-
-	test( "jQuery._evalSrc()", 2, function() {
-		Globals.register("testBar");
-		jQuery._evalSrc( url("data/test.js") );
-		strictEqual( window["testBar"], "bar", "Script was evaluated" );
-	});
-
 //----------- jQuery.fn.load()
 
 	// check if load can be called with only url

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -2045,14 +2045,19 @@ test( "html() - script exceptions bubble (#11743)", function() {
 		ok( false, "Exception ignored" );
 	}, "Exception bubbled from inline script" );
 
-	var onerror = window.onerror;
-	window.onerror = function() {
-		ok( true, "Exception thrown in remote script" );
-		window.onerror = onerror;
-	};
+	if ( jQuery.ajax ) {
+		var onerror = window.onerror;
+		window.onerror = function() {
+			ok( true, "Exception thrown in remote script" );
+			window.onerror = onerror;
+		};
 
-	jQuery("#qunit-fixture").html("<script src='data/badcall.js'></script>");
-	ok( true, "Exception ignored" );
+		jQuery("#qunit-fixture").html("<script src='data/badcall.js'></script>");
+		ok( true, "Exception ignored" );
+	} else {
+		ok( true, "No jQuery.ajax" );
+		ok( true, "No jQuery.ajax" );
+	}
 });
 
 test( "checked state is cloned with clone()", function() {
@@ -2092,7 +2097,7 @@ testIframeWithCallback( "buildFragment works even if document[0] is iframe's win
 
 test( "script evaluation (#11795)", function() {
 
-	expect( 11 );
+	expect( 13 );
 
 	var scriptsIn, scriptsOut,
 		fixture = jQuery("#qunit-fixture").empty(),
@@ -2133,6 +2138,44 @@ test( "script evaluation (#11795)", function() {
 	fixture.append( scriptsOut.detach() );
 	deepEqual( fixture.children("script").get(), scriptsOut.get(), "Scripts detached without reevaluation" );
 	objGlobal.ok = isOk;
+
+	if ( jQuery.ajax ) {
+		Globals.register("testBar");
+		jQuery("#qunit-fixture").append( "<script src='" + url("data/test.js") + "'/>" );
+		strictEqual( window["testBar"], "bar", "Global script evaluation" );
+	} else {
+		ok( true, "No jQuery.ajax" );
+		ok( true, "No jQuery.ajax" );
+	}
+});
+
+test( "jQuery._evalUrl (#12838)", function() {
+
+	expect( 5 );
+
+	var message, expectedArgument,
+		ajax = jQuery.ajax,
+		evalUrl = jQuery._evalUrl;
+
+	message = "jQuery.ajax implementation";
+	expectedArgument = 1;
+	jQuery.ajax = function( input ) {
+		equal( ( input.url || input ).slice( -1 ), expectedArgument, message );
+		expectedArgument++;
+	};
+	jQuery("#qunit-fixture").append("<script src='1'/><script src='2'/>");
+	equal( expectedArgument, 3, "synchronous execution" );
+
+	message = "custom implementation";
+	expectedArgument = 3;
+	jQuery._evalUrl = jQuery.ajax;
+	jQuery.ajax = function( options ) {
+		strictEqual( options, {}, "Unexpected call to jQuery.ajax" );
+	};
+	jQuery("#qunit-fixture").append("<script src='3'/><script src='4'/>");
+
+	jQuery.ajax = ajax;
+	jQuery._evalUrl = evalUrl;
 });
 
 test( "wrapping scripts (#10470)", function() {


### PR DESCRIPTION
I'm not thrilled about the name, but at least it's unambiguous.

Sizes - compared to master @ c2d6847de09a52496f78baebc04f317e11ece6d2

```
    264083       (+44)  dist/jquery.js                                         
     92059       (+60)  dist/jquery.min.js                                     
     32626       (+11)  dist/jquery.min.js.gz
```
