### PR TITLE
228ab3d followup 1: fix test failures

### DIFF
--- a/test/data/testinit.js
+++ b/test/data/testinit.js
@@ -64,11 +64,11 @@ function createComplexHTML() {
 	testFoo = "foo"; jQuery("#foo").html("foo"); \
 	ok( true, "inline script executed" ); \
 	/* ]]> */</script> \
-	<script src="' + service("echo", {
+	<script src="' + service("echo/", {
 		content: 'var testBar = "bar"; \
 		jQuery("#ap").html("bar"); \
 		ok( true, "remote script executed");'
-	}) + '"></script> \
+	}).replace( /&/g, "&amp;" ) + '"></script> \
 	blabla';
 }
 
@@ -158,10 +158,10 @@ function url( value ) {
 }
 
 function service( value, data ) {
-	var fragment = url( "data/ajax/" + ( value || "" ) );
+	var fragment = url( "data/ajax/" + value );
 	if ( data ) {
 		if ( typeof data !== "string" ) {
-			data = jQuery.param( data );
+			data = jQuery.param( data, false );
 		}
 		fragment += "&" + data;
 	}

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -32,7 +32,7 @@ module( "ajax", {
 
 	ajaxTest( "jQuery.ajax() - GET", 1, {
 		type: "GET",
-		url: service("echo"),
+		url: service("echo/"),
 		data: {
 			content: "bar"
 		},
@@ -63,7 +63,7 @@ module( "ajax", {
 
 	ajaxTest( "jQuery.ajax() - success", 8, {
 		setup: addGlobalEvents("ajaxStart ajaxStop ajaxSend ajaxComplete ajaxSuccess"),
-		url: service("echo"),
+		url: service("echo/"),
 		beforeSend: function() {
 			ok( true, "beforeSend" );
 		},
@@ -78,7 +78,7 @@ module( "ajax", {
 	ajaxTest( "jQuery.ajax() - success - (url, options)", 8, {
 		setup: addGlobalEvents("ajaxStart ajaxStop ajaxSend ajaxComplete ajaxSuccess"),
 		create: function( options ) {
-			return jQuery.ajax( service("echo"), options );
+			return jQuery.ajax( service("echo/"), options );
 		},
 		beforeSend: function() {
 			ok( true, "beforeSend" );
@@ -93,7 +93,7 @@ module( "ajax", {
 
 	ajaxTest( "jQuery.ajax() - success - late binding", 8, {
 		setup: addGlobalEvents("ajaxStart ajaxStop ajaxSend ajaxComplete ajaxSuccess"),
-		url: service("echo"),
+		url: service("echo/"),
 		beforeSend: function() {
 			ok( true, "beforeSend" );
 		},
@@ -111,7 +111,7 @@ module( "ajax", {
 
 	ajaxTest( "jQuery.ajax() - success - oncomplete binding", 8, {
 		setup: addGlobalEvents("ajaxStart ajaxStop ajaxSend ajaxComplete ajaxSuccess"),
-		url: service("echo"),
+		url: service("echo/"),
 		beforeSend: function() {
 			ok( true, "beforeSend" );
 		},
@@ -129,7 +129,7 @@ module( "ajax", {
 
 	ajaxTest( "jQuery.ajax() - error", 8, {
 		setup: addGlobalEvents("ajaxStart ajaxStop ajaxSend ajaxComplete ajaxError"),
-		url: service("error"),
+		url: service("error/"),
 		beforeSend: function() {
 			ok( true, "beforeSend" );
 		},
@@ -143,7 +143,7 @@ module( "ajax", {
 
 	ajaxTest( "jQuery.ajax() - abort - textStatus and errorThrown values", 4, [
 		{
-			url: service("echo"),
+			url: service("echo/"),
 			data: {
 				delay: 1
 			},
@@ -156,7 +156,7 @@ module( "ajax", {
 			}
 		},
 		{
-			url: service("echo"),
+			url: service("echo/"),
 			data: {
 				delay: 1
 			},
@@ -171,7 +171,7 @@ module( "ajax", {
 	]);
 
 	ajaxTest( "jQuery.ajax() - error - responseText", 1, {
-		url: service("echo"),
+		url: service("echo/"),
 		data: {
 			status: 400,
 			content: "plain text message"
@@ -185,7 +185,7 @@ module( "ajax", {
 		var previousUrl,
 			firstTime = true;
 		jQuery.ajax({
-			url: service("error"),
+			url: service("error/"),
 			error: function() {
 				if ( firstTime ) {
 					firstTime = false;
@@ -193,7 +193,7 @@ module( "ajax", {
 				} else {
 					ok ( true, "Test retrying with jQuery.ajax(this) works" );
 					jQuery.ajax({
-						url: service("error"),
+						url: service("error/"),
 						data: {
 							"x": 1
 						},
@@ -221,7 +221,7 @@ module( "ajax", {
 				xhr.setRequestHeader( "ajax-send", "test" );
 			});
 		},
-		url: service("headers/request"),
+		url: service("headers/request/"),
 		data: {
 			headers: "siMPle,SometHing-elsE,OthEr,ajax-send"
 		},
@@ -251,7 +251,7 @@ module( "ajax", {
 				xhr.setRequestHeader( "ajax-send", "test" );
 			});
 		},
-		url: service("headers/response"),
+		url: service("headers/response/"),
 		data: {
 			"Sample-Header": "sample value",
 			"Sample-Header2": "sample value 2",
@@ -271,7 +271,7 @@ module( "ajax", {
 	});
 
 	ajaxTest( "jQuery.ajax() - headers - Accept", 1, {
-		url: service("headers/request"),
+		url: service("headers/request/"),
 		data: {
 			headers: "accept"
 		},
@@ -288,7 +288,7 @@ module( "ajax", {
 
 	ajaxTest( "jQuery.ajax() - headers - contentType option", 2, [
 		{
-			url: service("headers/request"),
+			url: service("headers/request/"),
 			data: {
 				headers: "content-type"
 			},
@@ -298,7 +298,7 @@ module( "ajax", {
 			}
 		},
 		{
-			url: service("headers/request"),
+			url: service("headers/request/"),
 			data: {
 				headers: "content-type"
 			},
@@ -404,7 +404,7 @@ module( "ajax", {
 
 	ajaxTest( "jQuery.ajax() - abort", 9, {
 		setup: addGlobalEvents("ajaxStart ajaxStop ajaxSend ajaxError ajaxComplete"),
-		url: service("echo"),
+		url: service("echo/"),
 		data: {
 			delay: 1
 		},
@@ -452,12 +452,12 @@ module( "ajax", {
 				}, 0 );
 			},
 			requests: [{
-				url: service("echo"),
+				url: service("echo/"),
 				beforeSend: callback("beforeSend"),
 				success: callback("success"),
 				complete: callback("complete")
 			}, {
-				url: service("error"),
+				url: service("error/"),
 				beforeSend: callback("beforeSend"),
 				error: callback("error"),
 				complete: callback("complete")
@@ -472,7 +472,7 @@ module( "ajax", {
 			};
 		}
 		return {
-			url: service("error"),
+			url: service("error/"),
 			beforeSend: nocallback("beforeSend"),
 			error: nocallback("error"),
 			complete:  nocallback("complete")
@@ -480,7 +480,7 @@ module( "ajax", {
 	});
 
 	ajaxTest( "jQuery.ajax() - context - modification", 1, {
-		url: service("error"),
+		url: service("error/"),
 		context: {},
 		beforeSend: function() {
 			this.test = "foo";
@@ -501,12 +501,12 @@ module( "ajax", {
 				strictEqual( jQuery.ajaxSettings.context, obj, "Make sure the context is properly set in ajaxSettings." );
 			},
 			requests: [{
-				url: service("error"),
+				url: service("error/"),
 				error: function() {
 					strictEqual( this, obj, "Make sure the original object is maintained." );
 				}
 			}, {
-				url: service("error"),
+				url: service("error/"),
 				context: {},
 				error: function() {
 					ok( this !== obj, "Make sure overidding context is possible." );
@@ -518,7 +518,7 @@ module( "ajax", {
 	ajaxTest( "jQuery.ajax() - events - disable", 3, {
 		setup: addGlobalEvents(""),
 		global: false,
-		url: service("echo"),
+		url: service("echo/"),
 		beforeSend: function() {
 			ok( true, "beforeSend" );
 		},
@@ -531,7 +531,7 @@ module( "ajax", {
 	});
 
 	ajaxTest( "jQuery.ajax() - xml - non-namespace elements inside namespaced elements", 3, {
-		url: service("echo"),
+		url: service("echo/"),
 		data: {
 			contentType: "text/xml",
 			content: createWithFriesXML( true )
@@ -544,7 +544,7 @@ module( "ajax", {
 	});
 
 	ajaxTest( "jQuery.ajax() - xml - non-namespace elements inside namespaced elements (over JSONP)", 3, {
-		url: service("echo"),
+		url: service("echo/"),
 		data: {
 			content: createWithFriesXML( true )
 		},
@@ -557,7 +557,7 @@ module( "ajax", {
 	});
 
 	ajaxTest( "jQuery.ajax() - atom+xml", 2, {
-		url: service("echo"),
+		url: service("echo/"),
 		data: {
 			content: "<root><element /></root>",
 			contentType: "atom+xml"
@@ -588,7 +588,7 @@ module( "ajax", {
 	});
 
 	ajaxTest( "jQuery.ajax() - beforeSend", 1, {
-		url: service("error"),
+		url: service("error/"),
 		beforeSend: function( xml ) {
 			this.check = true;
 		},
@@ -600,7 +600,7 @@ module( "ajax", {
 	ajaxTest( "jQuery.ajax() - beforeSend, cancel request manually", 2, {
 		create: function() {
 			return jQuery.ajax({
-				url: service("error"),
+				url: service("error/"),
 				beforeSend: function( xhr ) {
 					ok( true, "beforeSend got called, canceling" );
 					xhr.abort();
@@ -627,7 +627,7 @@ module( "ajax", {
 			Globals.register("testBar");
 		},
 		dataType: "html",
-		url: service("echo"),
+		url: service("echo/"),
 		data: {
 			content: createComplexHTML()
 		},
@@ -640,7 +640,7 @@ module( "ajax", {
 	});
 
 	ajaxTest( "jQuery.ajax() - synchronous request", 1, {
-		url: service("echo"),
+		url: service("echo/"),
 		data: {
 			content: "hello world"
 		},
@@ -653,7 +653,7 @@ module( "ajax", {
 	});
 
 	ajaxTest( "jQuery.ajax() - synchronous request - callbacks", 2, {
-		url: service("echo"),
+		url: service("echo/"),
 		data: {
 			content: "hello world"
 		},
@@ -687,12 +687,12 @@ module( "ajax", {
 			start();
 		});
 
-		ok( jQuery.get( service("echo"), success ), "get" );
-		ok( jQuery.post( service("echo"), success ), "post" );
-		ok( jQuery.getScript( service("echo"), success ), "script" );
-		ok( jQuery.getJSON( service("echo?content=0"), success ), "json" );
+		ok( jQuery.get( service("echo/"), success ), "get" );
+		ok( jQuery.post( service("echo/"), success ), "post" );
+		ok( jQuery.getScript( service("echo/"), success ), "script" );
+		ok( jQuery.getJSON( service("echo/?content=0"), success ), "json" );
 		ok( jQuery.ajax({
-			url: service("echo"),
+			url: service("echo/"),
 			success: success
 		}), "generic" );
 	});
@@ -759,7 +759,7 @@ module( "ajax", {
 						strictEqual( data, "041275", "JSON results returned - " + this.type + " - " + options.title );
 					}
 				}, options );
-			tmp.url = service( "echo" + ( options.url || "" ) );
+			tmp.url = service( "echo/" + ( options.url || "" ) );
 			return tmp;
 		}
 
@@ -774,11 +774,11 @@ module( "ajax", {
 			}),
 			request({
 				title: "REST-like",
-				url: "/index.php/??"
+				url: "index.php/??"
 			}),
 			request({
 				title: "REST-like (with param)",
-				url: "/index.php/???content=\"041275\"",
+				url: "index.php/???content=\"041275\"",
 				beforeSend: function() {
 					delete this.data;
 				}
@@ -848,19 +848,16 @@ module( "ajax", {
 		ajaxTest( "jQuery.ajax() - JSONP - POST" + label, 3, [
 			request({
 				title: "no callback",
-				type: "POST",
-				url: "/"
+				type: "POST"
 			}),
 			request({
 				title: "data callback",
 				type: "POST",
-				url: "/",
 				data: "content=041275&callback=?"
 			}),
 			request({
 				title: "data obj callback",
 				type: "POST",
-				url: "/",
 				jsonp: "callback"
 			})
 		]);
@@ -929,7 +926,7 @@ module( "ajax", {
 	});
 
 	ajaxTest( "jQuery.ajax() - malformed JSON", 2, {
-		url: service("echo"),
+		url: service("echo/"),
 		data: {
 			content: "{bad: toTheBone}"
 		},
@@ -947,7 +944,7 @@ module( "ajax", {
 				return 42;
 			}
 		},
-		url: service("headers/response/index.php"),
+		url: service("headers/response/"),
 		data: {
 			"Content-Type": "application/json"
 		},
@@ -962,7 +959,7 @@ module( "ajax", {
 				ok( false, "content-type detected" );
 			}
 		},
-		url: service("headers/response/index.php"),
+		url: service("headers/response/"),
 		data: {
 			"Content-Type": "application/json"
 		},
@@ -975,7 +972,7 @@ module( "ajax", {
 	});
 
 	ajaxTest( "jQuery.ajax() - JSON - empty", 1, {
-		url: service("echo"),
+		url: service("echo/"),
 		dataType: "json",
 		error: function( _, __, error ) {
 			strictEqual( typeof error, "object", "error object for empty json response" );
@@ -1037,7 +1034,7 @@ module( "ajax", {
 
 	ajaxTest( "jQuery.ajax() - statusText", 4, [
 		{
-			url: service("echo"),
+			url: service("echo/"),
 			data: {
 				status: 200,
 				statusText: "Hello"
@@ -1048,7 +1045,7 @@ module( "ajax", {
 			}
 		},
 		{
-			url: service("echo"),
+			url: service("echo/"),
 			data: {
 				status: 404,
 				statusText: "Hello"
@@ -1060,7 +1057,7 @@ module( "ajax", {
 		}
 	]);
 
-	jQuery.each( [ "error", service("echo") ], function( isSuccess, url ) {
+	jQuery.each( [ service("error/"), service("echo/") ], function( isSuccess, url ) {
 		function statusCodes( title ) {
 			return {
 				200: function() {
@@ -1102,7 +1099,7 @@ module( "ajax", {
 				dataType = srcType + " " + dataType;
 			}
 			return {
-				url: service("echo"),
+				url: service("echo/"),
 				data: {
 					content: "\"041275\""
 				},
@@ -1124,7 +1121,7 @@ module( "ajax", {
 
 	ajaxTest( "jQuery.ajax() - overrideMimeType", 2, [
 		{
-			url: service("echo"),
+			url: service("echo/"),
 			data: {
 				content: "42"
 			},
@@ -1136,7 +1133,7 @@ module( "ajax", {
 			}
 		},
 		{
-			url: service("echo"),
+			url: service("echo/"),
 			data: {
 				content: "42"
 			},
@@ -1171,7 +1168,7 @@ module( "ajax", {
 	});
 
 	ajaxTest( "#2806 - jQuery.ajax() - data option - evaluate function values", 1, {
-		url: service("echo"),
+		url: service("echo/"),
 		data: {
 			content: function() {
 				return "value";
@@ -1219,7 +1216,7 @@ module( "ajax", {
 		},
 		{
 			create: function() {
-				return jQuery.ajax( service("echo") );
+				return jQuery.ajax( service("echo/") );
 			},
 			done: function() {
 				ok( true, "With only string URL argument" );
@@ -1227,7 +1224,7 @@ module( "ajax", {
 		},
 		{
 			create: function() {
-				return jQuery.ajax( service("echo"), {});
+				return jQuery.ajax( service("echo/"), {});
 			},
 			done: function() {
 				ok( true, "With string URL param and map" );
@@ -1237,7 +1234,7 @@ module( "ajax", {
 			create: function( options ) {
 				return jQuery.ajax( options );
 			},
-			url: service("echo"),
+			url: service("echo/"),
 			success: function() {
 				ok( true, "With only map" );
 			}
@@ -1246,7 +1243,7 @@ module( "ajax", {
 	
 	jQuery.each( [ " - Same Domain", " - Cross Domain" ], function( crossDomain, label ) {
 		ajaxTest( "#8205 - jQuery.ajax() - JSONP - re-use callbacks name" + label, 2, {
-			url: service("echo"),
+			url: service("echo/"),
 			data: {
 				content: "42"
 			},
@@ -1321,7 +1318,7 @@ module( "ajax", {
 	test( "#11743 - jQuery.ajax() - script, throws exception", 1, function() {
 		raises(function() {
 			jQuery.ajax({
-				url: service("echo"),
+				url: service("echo/"),
 				data: {
 					content: "SYNTAX ERROR"
 				},
@@ -1345,7 +1342,7 @@ module( "ajax", {
 
 		function request( option ) {
 			var options = {
-					url: service("echo/index.php"),
+					url: service("echo/"),
 					data: {
 						requestArray: "POST",
 						content: "hello"
@@ -1401,7 +1398,7 @@ module( "ajax", {
 
 	asyncTest( "jQuery.ajaxSetup()", 1, function() {
 		jQuery.ajaxSetup({
-			url: service("echo"),
+			url: service("echo/"),
 			data: {
 				content: "bar"
 			},
@@ -1420,7 +1417,7 @@ module( "ajax", {
 				timeout: 50
 			});
 		},
-		url: service("echo?delay=1"),
+		url: service("echo/?delay=1"),
 		error: function( _, status ) {
 			strictEqual( status, "timeout", "timed out" );
 		}
@@ -1434,7 +1431,7 @@ module( "ajax", {
 		},
 		type: "GET",
 		timeout: 15000,
-		url: service("echo?delay=1"),
+		url: service("echo/?delay=1"),
 		success: function() {
 			ok( true, "Check for local timeout" );
 		}
@@ -1451,14 +1448,14 @@ module( "ajax", {
 			ok( false, "Global event triggered" );
 		});
 
-		jQuery("#qunit-fixture").append("<script src='" + service( "echo", {
+		jQuery("#qunit-fixture").append("<script src='" + service( "echo/", {
 			requestArray: "GET",
 			content: "ok( true, \"script executed\" );"
 		}) + "'></script>");
 	});
 
 	asyncTest( "#11402 - jQuery.domManip() - script in comments are properly evaluated", 2, function() {
-		jQuery("#qunit-fixture").load( service( "echo", {
+		jQuery("#qunit-fixture").load( service( "echo/", {
 			content:
 				"<script>\n<!--\nok( true, \"script within html comments executed\" );\n-->\n</script>\n" +
 				"<script>\n<![CDATA[\nok( true, \"script within CDATA executed\" );\n]]>\n</script>"
@@ -1469,7 +1466,7 @@ module( "ajax", {
 
 	asyncTest( "jQuery.get( String, Hash, Function ) - parse xml and use text() on nodes", 2, function() {
 		var tabs = [ "blabla", "blublu" ];
-		jQuery.get( service( "echo", {
+		jQuery.get( service( "echo/", {
 			contentType: "text/xml",
 			content: createDashboardXML( true )
 		}), function( xml ) {
@@ -1486,7 +1483,7 @@ module( "ajax", {
 				content: "helloworld"
 			}
 		});
-		jQuery.get( service("echo"), function( data ) {
+		jQuery.get( service("echo/"), function( data ) {
 			strictEqual( data, "helloworld", "Data from ajaxSettings was used" );
 			start();
 		});
@@ -1496,7 +1493,7 @@ module( "ajax", {
 
 	asyncTest( "jQuery.getJSON( String, Hash, Function ) - JSON array", 1, function() {
 		jQuery.getJSON(
-			service("echo"),
+			service("echo/"),
 			{
 				"content": "[{ \"name\": \"John\", \"age\": 21 }, { \"name\": \"Peter\", \"age\": 25 }]"
 			},
@@ -1514,7 +1511,7 @@ module( "ajax", {
 	});
 
 	asyncTest( "jQuery.getJSON( String, Function ) - JSON object", 1, function() {
-		jQuery.getJSON( service( "echo", {
+		jQuery.getJSON( service( "echo/", {
 			content: "{ \"data\": { \"lang\": \"en\", \"length\": 25 } }"
 		}), function( json ) {
 			deepEqual( json, {
@@ -1540,14 +1537,14 @@ module( "ajax", {
 				return true;
 			}
 		};
-		jQuery.getJSON( service("echo"), function( json ) {
+		jQuery.getJSON( service("echo/"), function( json ) {
 			strictEqual( json, true, "Verifying return value" );
 			start();
 		});
 	});
 
 	asyncTest( "jQuery.getJSON( String, Function ) - JSON object with absolute url to local content", 1, function() {
-		jQuery.getJSON( window.location.href.replace( /[^\/]*$/, "" ) + service( "echo", {
+		jQuery.getJSON( window.location.href.replace( /[^\/]*$/, "" ) + service( "echo/", {
 			content: "{ \"data\": { \"lang\": \"en\", \"length\": 25 } }"
 		}), function( json ) {
 			deepEqual( json, {
@@ -1564,7 +1561,7 @@ module( "ajax", {
 
 	asyncTest( "jQuery.getScript( String, Function ) - with callback", 2, function() {
 		Globals.register("testBar");
-		jQuery.getScript( service("echo", {
+		jQuery.getScript( service("echo/", {
 			content: "var testBar = \"bar\"; ok( true, \"script executed\");"
 		}), function( data, _, jqXHR ) {
 			strictEqual( testBar, "bar", "Check if script was evaluated" );
@@ -1574,14 +1571,14 @@ module( "ajax", {
 
 	asyncTest( "jQuery.getScript( String, Function ) - no callback", 1, function() {
 		Globals.register("testBar");
-		jQuery.getScript( service("echo", {
+		jQuery.getScript( service("echo/", {
 			content: "var testBar = \"bar\"; ok( true, \"script executed\");"
 		}) ).done( start );
 	});
 
 	asyncTest( "#8082 - jQuery.getScript( String, Function ) - source as responseText", 2, function() {
 		Globals.register("testBar");
-		jQuery.getScript( service("echo", {
+		jQuery.getScript( service("echo/", {
 			content: "var testBar = \"bar\"; ok( true, \"script executed\");"
 		}), function( data, _, jqXHR ) {
 			strictEqual( data, jqXHR.responseText, "Same-domain script requests returns the source of the script" );
@@ -1598,7 +1595,7 @@ module( "ajax", {
 				strictEqual( this.type, "GET", "no data means GET request" );
 			}
 		});
-		jQuery("#first").load( service( "echo", {
+		jQuery("#first").load( service( "echo/", {
 			content: "<script>ok( true, \"html injected\" )</script>"
 		}), start );
 	});
@@ -1618,7 +1615,7 @@ module( "ajax", {
 				strictEqual( this.type, "GET", "null data means GET request" );
 			}
 		});
-		jQuery("#first").load(  service( "echo", {
+		jQuery("#first").load(  service( "echo/", {
 			content: "<script>ok( true, \"html injected\" )</script>"
 		}), null, start );
 	});
@@ -1630,14 +1627,14 @@ module( "ajax", {
 				strictEqual( this.type, "GET", "undefined data means GET request" );
 			}
 		});
-		jQuery("#first").load(  service( "echo", {
+		jQuery("#first").load(  service( "echo/", {
 			content: "<script>ok( true, \"html injected\" )</script>"
 		}), undefined, start );
 	});
 
 	// check if load can be called with only url
 	asyncTest( "jQuery.fn.load( URL_SELECTOR )", 1, function() {
-		jQuery("#first").load( service("echo", {
+		jQuery("#first").load( service("echo/", {
 			content: "<div class=\"user\"></div><div class=\"user\"></div><div></div>"
 		}) + " div.user", function() {
 			strictEqual( jQuery( this ).children("div").length, 2, "Verify that specific elements were injected" );
@@ -1646,7 +1643,7 @@ module( "ajax", {
 	});
 
 	asyncTest( "jQuery.fn.load( String, Function ) - simple: inject text into DOM", 2, function() {
-		jQuery("#first").load( service( "echo", {
+		jQuery("#first").load( service( "echo/", {
 			content: "INJECTED<script>ok( true, \"html injected\" )</script>"
 		}), function() {
 			ok( /^INJECTED/.test(jQuery("#first").text()), "Check if content was injected into the DOM" );
@@ -1664,7 +1661,7 @@ module( "ajax", {
 		Globals.register("testFoo");
 		Globals.register("testBar");
 
-		jQuery("#first").load( service( "echo", {
+		jQuery("#first").load( service( "echo/", {
 			content: createComplexHTML()
 		}), function() {
 			ok( jQuery("#first").html().match( /^html text/ ), "Check content after loading html" );
@@ -1675,7 +1672,7 @@ module( "ajax", {
 	});
 
 	asyncTest( "jQuery.fn.load( String, Function ) - check file with only a script tag", 3, function() {
-		jQuery("#first").load( service("echo", {
+		jQuery("#first").load( service("echo/", {
 			content: "<script>var testFoo = \"foo\"; jQuery(\"#foo\").html(\"foo\"); ok( true, \"script executed\" );</script>"
 		}), function() {
 			strictEqual( jQuery("#foo").html(), "foo", "Check if script evaluation has modified DOM");
@@ -1690,7 +1687,7 @@ module( "ajax", {
 				return "Hello World";
 			}
 		});
-		jQuery("<div/>").load( service("echo"), function( responseText ) {
+		jQuery("<div/>").load( service("echo/"), function( responseText ) {
 			strictEqual( jQuery( this ).html(), "Hello World", "Test div was filled with filtered data" );
 			strictEqual( responseText, "Hello World", "Test callback receives filtered data" );
 			start();
@@ -1735,7 +1732,7 @@ module( "ajax", {
 			jQuery.map([
 				{
 					type: "success",
-					url: service("echo")
+					url: service("echo/")
 				},
 				{
 					type: "error",
@@ -1765,7 +1762,7 @@ module( "ajax", {
 			strictEqual( s.dataType, "html", "Verify the load() dataType was html" );
 			start();
 		});
-		jQuery("#first").load( service("echo") );
+		jQuery("#first").load( service("echo/") );
 	});
 
 	test( "#10524 - jQuery.fn.load() - data specified in ajaxSettings is merged in", 1, function() {


### PR DESCRIPTION
cc @jaubourg, @Krinkle

I've opted to standardize on trailing slash because I'm not sure that none of these tests are specifically targeting directory index behavior. If I'm correct that they aren't, we should have each `index.php` file replace its parent directory and make no assumptions when referencing them (e.g., `test/data/ajax/echo/index.php` becomes `test/data/ajax/echo.php` and is requested as `data/ajax/echo.php`).
