### PR TITLE
Replaced `typeof` check in line 28 (offset.js) with a more efficient alternative

### DIFF
--- a/src/offset.js
+++ b/src/offset.js
@@ -25,7 +25,7 @@ jQuery.fn.offset = function( options ) {
 
 	// If we don't have gBCR, just use 0,0 rather than error
 	// BlackBerry 5, iOS 3 (original iPhone)
-	if ( typeof elem.getBoundingClientRect !== "undefined" ) {
+	if ( elem.getBoundingClientRect ) {
 		box = elem.getBoundingClientRect();
 	}
 	win = getWindow( doc );


### PR DESCRIPTION
[In `offset.js`](https://github.com/jquery/jquery/blob/master/src/offset.js#L28), there's no need to use the `typeof` operator to do the feature-detection (hence creating extra overhead) -- just check using boolean coercion.
