### PR TITLE
Fix #13019. Disconnected nodes with .replaceWith are a noop.

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -249,8 +249,7 @@ jQuery.fn.extend({
 	},
 
 	replaceWith: function( value ) {
-		var self = this,
-			isFunc = jQuery.isFunction( value );
+		var isFunc = jQuery.isFunction( value );
 
 		// Make sure that the elements are removed from the DOM before they are inserted
 		// this can help fix replacing a parent with child elements
@@ -258,17 +257,10 @@ jQuery.fn.extend({
 			value = jQuery( value ).detach();
 		}
 
-		return this.domManip( [ value ], true, function( elem, i ) {
+		return this.domManip( [ value ], true, function( elem ) {
 			var next, parent;
 
-			if ( isDisconnected( this ) ) {
-				// for disconnected elements, we simply replace
-				// with the new content in the set
-				self[ i ] = elem;
-				return;
-			}
-
-			if ( this.nodeType === 1 || this.nodeType === 11 ) {
+			if ( !isDisconnected( this ) && this.nodeType === 1 || this.nodeType === 11 ) {
 				next = this.nextSibling;
 				parent = this.parentNode;
 

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -1230,11 +1230,9 @@ var testReplaceWith = function( val ) {
 	QUnit.reset();
 
 	set = jQuery("<div/>").replaceWith(val("<span>test</span>"));
-	equal( set[0].nodeName.toLowerCase(), "span", "Replace the disconnected node." );
-	equal( set.length, 1, "Replace the disconnected node." );
-
-	// #11338
-	ok( jQuery("<div>1</div>").replaceWith( val("<span/>") ).is("span"), "#11338, Make sure disconnected node with content is replaced" );
+	equal( set[0].nodeName.toLowerCase(), "div", "No effect on a disconnected node." );
+	equal( set.length, 1, "No effect on a disconnected node." );
+	equal( set[0].childNodes.length, 0, "No effect on a disconnected node." );
 
 	non_existant = jQuery("#does-not-exist").replaceWith( val("<b>should not throw an error</b>") );
 	equal( non_existant.length, 0, "Length of non existant element." );
@@ -1286,43 +1284,6 @@ test( "replaceWith(string) for more than one element", function() {
 	jQuery("#foo p").replaceWith("<span>bar</span>");
 	equal(jQuery("#foo span").length, 3, "verify that all the three original element have been replaced");
 	equal(jQuery("#foo p").length, 0, "verify that all the three original element have been replaced");
-});
-
-test( "replaceWith(string) for collection with disconnected element", function() {
-
-	expect( 18 );
-
-	var testSet, newSet,
-		elem = jQuery("<div />");
-
-
-	QUnit.reset();
-	testSet = jQuery("#foo p").add( elem );
-	equal( testSet.length, 4, "ensuring that test data has not changed" );
-
-	newSet = testSet.replaceWith("<span>bar</span>");
-	equal( testSet.length, 4, "ensure that we still have the same number of elements" );
-	equal( jQuery("#foo span").length, 3, "verify that all the three original elements have been replaced" );
-	equal( jQuery("#foo p").length, 0, "verify that all the three original elements have been replaced" );
-	equal( testSet.filter("p").length, 3, "ensure we still have the original set of attached elements" );
-	equal( testSet.filter("div").length, 0, "ensure the detached element is not in the original set" );
-	equal( newSet.filter("p").length, 3, "ensure we still have the original set of attached elements in new set" );
-	equal( newSet.filter("div").length, 0, "ensure the detached element has been replaced in the new set" );
-	equal( newSet.filter("span").length, 1, "ensure the new element is in the new set" );
-
-	QUnit.reset();
-	testSet = elem.add( jQuery("#foo p") );
-	equal( testSet.length, 4, "ensuring that test data has not changed" );
-
-	testSet.replaceWith("<span>bar</span>");
-	equal( testSet.length, 4, "ensure that we still have the same number of elements" );
-	equal( jQuery("#foo span").length, 3, "verify that all the three original elements have been replaced" );
-	equal( jQuery("#foo p").length, 0, "verify that all the three original elements have been replaced" );
-	equal( testSet.filter("p").length, 3, "ensure we still have the original set of attached elements" );
-	equal( testSet.filter("div").length, 0, "ensure the detached element is not in the original set" );
-	equal( newSet.filter("p").length, 3, "ensure we still have the original set of attached elements in new set" );
-	equal( newSet.filter("div").length, 0, "ensure the detached element has been replaced in the new set" );
-	equal( newSet.filter("span").length, 1, "ensure the new element is in the new set" );
 });
 
 test( "replaceAll(String|Element|Array<Element>|jQuery)", function() {


### PR DESCRIPTION
We should just do nothing with disconnected elements here, as we do with `.before()` and `.after()`. It's actually more compatible with older versions I think, although some of that may be due to bugs in those versions. In any case it's -19 gzip so there's that. :smiley_cat: 

Compare this (1.8.3) to current -git:

http://jsfiddle.net/dmethvin/raR93/
