### PR TITLE
Fixes #10417

### DIFF
--- a/src/ajax/xhr.js
+++ b/src/ajax/xhr.js
@@ -190,7 +190,7 @@ if ( xhrSupported ) {
 					} else if ( xhr.readyState === 4 ) {
 						// (IE6 & IE7) if it's in cache and has been
 						// retrieved directly we need to fire the callback
-						setTimeout( callback, 0 );
+						setTimeout( callback );
 					} else {
 						handle = ++xhrId;
 						if ( xhrOnUnloadAbort ) {

--- a/src/core.js
+++ b/src/core.js
@@ -386,7 +386,7 @@ jQuery.extend({
 
 		// Make sure body exists, at least, in case IE gets a little overzealous (ticket #5443).
 		if ( !document.body ) {
-			return setTimeout( jQuery.ready, 1 );
+			return setTimeout( jQuery.ready );
 		}
 
 		// Remember that the DOM is ready
@@ -854,7 +854,7 @@ jQuery.ready.promise = function( obj ) {
 		// discovered by ChrisS here: http://bugs.jquery.com/ticket/12282#comment:15
 		if ( document.readyState === "complete" ) {
 			// Handle it asynchronously to allow scripts the opportunity to delay ready
-			setTimeout( jQuery.ready, 1 );
+			setTimeout( jQuery.ready );
 
 		// Standards-based browsers support DOMContentLoaded
 		} else if ( document.addEventListener ) {

--- a/src/effects.js
+++ b/src/effects.js
@@ -51,7 +51,7 @@ var fxNow, timerId,
 function createFxNow() {
 	setTimeout(function() {
 		fxNow = undefined;
-	}, 0 );
+	});
 	return ( fxNow = jQuery.now() );
 }
 


### PR DESCRIPTION
This patch does not introduce <code>jQuery.later</code> or <code>jQuery.soon</code>, given that @timmywil concerns are <a href="http://bugs.jquery.com/ticket/10417#reply-to-comment-16">valid</a>, <code>jQuery.later</code> should be added only if it can reduce size of jQuery source.

This could be achieved without adding any new method, but by simply removing <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/timers.html#timers">optional</a> second argument in function call – to my knowledge, all browsers has support for that signature.

/cc @gibson042, @gnarf37
