### PR TITLE
Test: Remove fixtures from QUnit.done hook.

### DIFF
--- a/test/data/testrunner.js
+++ b/test/data/testrunner.js
@@ -316,6 +316,11 @@ var Globals = (function() {
 		}
 	};
 
+	QUnit.done(function() {
+		// Remove out own fixtures outside #qunit-fixture
+		jQuery( "#nothiddendiv, #loadediframe, #dl" ).remove();
+	});
+
 	// jQuery-specific QUnit.reset
 	QUnit.reset = function() {
 


### PR DESCRIPTION
See also jquery/testswarm#197.

These are currently removed from the TestSwarm injector, however this is jQuery specific, and should be done from this end instead.
