### PR TITLE
Make noConflict more developer-friendly

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -350,7 +350,7 @@ jQuery.extend = jQuery.fn.extend = function() {
 jQuery.extend({
 	noConflict: function( deep ) {
 		if ( window.$ === jQuery ) {
-			if (_$) {
+			if ( typeof _$ === 'undefined' ) {
 				window.$ = _$;
 			}
 			else {


### PR DESCRIPTION
When using noConflict, jQuery replaces `$` with `undefined` if it was empty before.

Unfortunately, that means that the default `$` of the browsers is not put back.

This commmit solves this.

It is only developer-centric, as it can help to have QS quickly available.
