### PR TITLE
2.0: Removes attachEvent paths for jQuery.ready()

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -378,11 +378,6 @@ jQuery.extend({
 			return;
 		}
 
-		// Make sure body exists, at least, in case IE gets a little overzealous (ticket #5443).
-		if ( !document.body ) {
-			return setTimeout( jQuery.ready );
-		}
-
 		// Remember that the DOM is ready
 		jQuery.isReady = true;
 


### PR DESCRIPTION
I couldn't wait until next Monday.

``` bash
Sizes - compared to master @ 5c8984efc4a8c0472bcdc514e744b063e8f98a61
    264496     (-1214)  dist/jquery.js                                         
     92254      (-382)  dist/jquery.min.js                                     
     32694      (-113)  dist/jquery.min.js.gz  
```

Signed-off-by: Rick Waldron waldron.rick@gmail.com
