### PR TITLE
2.0: Remove JSON.parse shim

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -496,9 +496,7 @@ jQuery.extend({
 		return jQuery.merge( [], parsed.childNodes );
 	},
 
-	parseJSON: function( data ) {
-		return window.JSON.parse( data );
-	},
+	parseJSON: JSON.parse,
 
 	// Cross-browser xml parsing
 	parseXML: function( data ) {


### PR DESCRIPTION
``` bash
Sizes - compared to master @ 5c8984efc4a8c0472bcdc514e744b063e8f98a61
    264821      (-889)  dist/jquery.js                                         
     92264      (-372)  dist/jquery.min.js                                     
     32650      (-157)  dist/jquery.min.js.gz  
```

Signed-off-by: Rick Waldron waldron.rick@gmail.com
