### PR TITLE
2.0: Remove inArray shim

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -666,25 +666,7 @@ jQuery.extend({
 	},
 
 	inArray: function( elem, arr, i ) {
-		var len;
-
-		if ( arr ) {
-			if ( core_indexOf ) {
-				return core_indexOf.call( arr, elem, i );
-			}
-
-			len = arr.length;
-			i = i ? i < 0 ? Math.max( 0, len + i ) : i : 0;
-
-			for ( ; i < len; i++ ) {
-				// Skip accessing in sparse arrays
-				if ( i in arr && arr[ i ] === elem ) {
-					return i;
-				}
-			}
-		}
-
-		return -1;
+		return core_indexOf.call( arr, elem, i );
 	},
 
 	merge: function( first, second ) {


### PR DESCRIPTION
``` bash
Sizes - compared to master @ 5c8984efc4a8c0472bcdc514e744b063e8f98a61
    265423      (-287)  dist/jquery.js                                         
     92529      (-107)  dist/jquery.min.js                                     
     32764       (-43)  dist/jquery.min.js.gz
```

Signed-off-by: Rick Waldron waldron.rick@gmail.com
