### PR TITLE
2.0: Remove now shim

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -844,9 +844,7 @@ jQuery.extend({
 				length ? fn( elems[0], key ) : emptyGet;
 	},
 
-	now: function() {
-		return ( new Date() ).getTime();
-	}
+	now: Date.now
 });
 
 jQuery.ready.promise = function( obj ) {


### PR DESCRIPTION
``` bash
Sizes - compared to master @ 5c8984efc4a8c0472bcdc514e744b063e8f98a61
    265668       (-42)  dist/jquery.js                                         
     92606       (-30)  dist/jquery.min.js                                     
     32800        (-7)  dist/jquery.min.js.gz                                  
```

Signed-off-by: Rick Waldron waldron.rick@gmail.com
