### PR TITLE
2.0: Remove isArray shim

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -414,9 +414,7 @@ jQuery.extend({
 		return jQuery.type(obj) === "function";
 	},
 
-	isArray: Array.isArray || function( obj ) {
-		return jQuery.type(obj) === "array";
-	},
+	isArray: Array.isArray,
 
 	isWindow: function( obj ) {
 		return obj != null && obj == obj.window;


### PR DESCRIPTION
``` bash
Sizes - compared to master @ 5c8984efc4a8c0472bcdc514e744b063e8f98a61
    265647       (-63)  dist/jquery.js                                         
     92595       (-41)  dist/jquery.min.js                                     
     32797       (-10)  dist/jquery.min.js.gz 
```

Signed-off-by: Rick Waldron waldron.rick@gmail.com
