### PR TITLE
2.0: Reduce isPlainObject

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -438,7 +438,7 @@ jQuery.extend({
 			return false;
 		}
 
-		// Firefox 17+ will throw on host objects. ie window.location
+		// Support: Firefox >16
 		try {
 			if ( obj.constructor &&
 					!core_hasOwn.call( obj.constructor.prototype, "isPrototypeOf" ) ) {


### PR DESCRIPTION
``` bash
Sizes - compared to master @ 5c8984efc4a8c0472bcdc514e744b063e8f98a61
    265248      (-462)  dist/jquery.js                                         
     92610       (-26)  dist/jquery.min.js                                     
     32792       (-15)  dist/jquery.min.js.gz 
```

Signed-off-by: Rick Waldron waldron.rick@gmail.com
