### PR TITLE
2.0: Reduced parseXML

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -539,7 +539,7 @@ jQuery.extend({
 			return null;
 		}
 
-		// IE9 will throw on ill-formed XML
+		// Support: IE9
 		try {
 			tmp = new DOMParser();
 			xml = tmp.parseFromString( data , "text/xml" );


### PR DESCRIPTION
``` bash
Sizes - compared to master @ 5c8984efc4a8c0472bcdc514e744b063e8f98a61
    265560      (-150)  dist/jquery.js                                         
     92531      (-105)  dist/jquery.min.js                                     
     32766       (-41)  dist/jquery.min.js.gz  
```

Signed-off-by: Rick Waldron waldron.rick@gmail.com
