### PR TITLE
Adding the ability to chain deferred objects together directly

### DIFF
--- a/src/deferred.js
+++ b/src/deferred.js
@@ -49,8 +49,24 @@ jQuery.extend({
 			},
 			deferred = {};
 
-		// Keep pipe for back-compat
-		promise.pipe = promise.then;
+		// Synonymous with then when passing done, fail, and progress handlers, but can also be used to chain
+		// deferred objects without filtering
+		promise.pipe = function( /* deferred | fnDone, fnFail, fnProgress */ ) {
+			var args = arguments,
+				deferred;
+
+			// Duck typed check for whether or not this object can be chained
+			function isDeferredObject(obj) {
+				return obj && obj.resolve && obj.reject && obj.notify;
+			}
+
+			if (arguments.length === 1 && isDeferredObject(arguments[0])) {
+				deferred = arguments[0];
+				args = [deferred.resolve, deferred.reject, deferred.notify];
+			}
+
+			return promise.then.apply(this, args);
+		},
 
 		// Add list-specific methods
 		jQuery.each( tuples, function( i, tuple ) {

--- a/test/unit/deferred.js
+++ b/test/unit/deferred.js
@@ -10,11 +10,20 @@ jQuery.each( [ "", " - new operator" ], function( _, withNew ) {
 
 	test( "jQuery.Deferred" + withNew, function() {
 
-		expect( 23 );
+		expect( 24 );
 
 		var defer = createDeferred();
 
-		strictEqual( defer.pipe, defer.then, "pipe is an alias of then" );
+		var pipedDefer = createDeferred();
+		pipedDefer.done(function() {
+			ok( true, "Chained deferred resolved when target resolved" );
+		});
+
+		var defer2 = createDeferred();
+		defer2.pipe(pipedDefer);
+		defer2.resolve();
+
+		ok( pipedDefer.state() == "resolved", "Chained deferred is resolved" );
 
 		createDeferred().resolve().done(function() {
 			ok( true, "Success on resolve" );


### PR DESCRIPTION
This adds the ability for deferred objects to be directly chained together. This saves users from having to say do1.then(do2.resolve, do2.reject, do2.notify).

Extending the pipe method to be more than just a synonym for then, and also adding a corresponding test method.
