### PR TITLE
New options creation code, allow enabling and unlocking the list

### DIFF
--- a/src/callbacks.js
+++ b/src/callbacks.js
@@ -26,7 +26,7 @@ function createOptions( options ) {
  *	options: an optional list of space-separated options that will change how
  *			the callback list behaves or a more traditional option object
  *
- * By default a callback list will self like an event callback list and can be
+ * By default a callback list will act like an event callback list and can be
  * "fired" multiple times.
  *
  * Possible options:


### PR DESCRIPTION
I've added some new options creation code to filter out random junk- for example $.Callbacks('memory fsdd unique') will only create the options unique and memory. While this doesn't do much now, it may help in the future and it does save some (very small amount ;) of RAM. The other thing, which is a bit more important is add the enabling and unlocking of lists. I've created a backup object, which takes a backup of the list, stack and memory (stack and memory are only if applicable) before locking/disabling the callbacks so that they can be unlocked or enabled and restored to full functionality if so wished. Please bear in mind that this is my first jQuery commit so I'm sorry if I messed up something. Also, I didn't do any testing because I ran this through jshint so there's no syntax errors, and the code I changed doesn't affect the functionality of callbacks, so I didn't do any unit tests. Thanks.
