### PR TITLE
fix grunt-compare-size dependency to v0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 	],
 	"dependencies": {},
 	"devDependencies": {
-		"grunt-compare-size": ">=0.1.0",
+		"grunt-compare-size": "~0.2.0",
 		"grunt-git-authors": ">=1.0.0",
 		"grunt": "~0.3.9",
 		"testswarm": "0.2.2"


### PR DESCRIPTION
Checking out the tag **1.8.3** and installing dependencies via `npm install` leads to **v3.0.1** of **grunt-compare-size**. However, the last compatible version of **grunt-compare-size** is **v.0.2.0**. 

Please merge this small change in package.json and update the jquery tag **1.8.3**, otherwise it's not possible to build jquery from scratch using this tag.
