### PR TITLE
2.0: reduced xhr transport

### DIFF
--- a/test/data/ajax/unreleasedXHR.html
+++ b/test/data/ajax/unreleasedXHR.html
@@ -1,0 +1,25 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html>
+<head>
+<meta http-equiv="content-type" content="text/html; charset=utf-8">
+<title>Attempt to block tests because of dangling XHR requests (IE)</title>
+<script type="text/javascript" src="../../../dist/jquery.js"></script>
+<script type="text/javascript">
+window.onunload = function() {};
+jQuery(function() {
+	setTimeout(function() {
+		var parent = window.parent;
+		document.write("");
+		parent.iframeCallback();
+	}, 200 );
+	var number = 50;
+	while( number-- ) {
+		jQuery.ajax("../name.php?wait=600");
+	}
+});
+</script>
+</head>
+<body>
+<!-- empty body -->
+</body>
+</html>

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -30,6 +30,11 @@ module( "ajax", {
 
 //----------- jQuery.ajax()
 
+	testIframeWithCallback( "XMLHttpRequest - Attempt to block tests because of dangling XHR requests (IE)", "ajax/unreleasedXHR.html", function() {
+		expect( 1 );
+		ok( true, "done" );
+	});
+
 	ajaxTest( "jQuery.ajax() - success callbacks", 8, {
 		setup: addGlobalEvents("ajaxStart ajaxStop ajaxSend ajaxComplete ajaxSuccess"),
 		url: url("data/name.html"),


### PR DESCRIPTION
- removes oldIE tricks
- use of `onload` and `onerror`, not `onreadystatechange`, which makes the whole `isLocal` logic unnecessary
- always get `responseText`, never `responseXML`, just use the internal converter when needs be (removes a lot of controls regarding how (in)valid `responseXML` actually is)

One unit test changed but for the better: `throws` option will now have ajax throw in an event loop which is awesome for the use case (throw exceptions when executing scripts in domManip).

-244 bytes min/gzipped
