### PR TITLE
Fix #13103, Add .finish() method to avoid boolean .stop() trap.

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -479,6 +479,9 @@ jQuery.fn.extend({
 			this.each( doAnimation ) :
 			this.queue( optall.queue, doAnimation );
 	},
+	finish: function( type ) {
+		return this.stop( type || "fx", false, true );
+	},
 	stop: function( type, clearQueue, gotoEnd ) {
 		var stopQueue = function( hooks ) {
 			var stop = hooks.stop;

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -667,6 +667,40 @@ test("stop(clearQueue, gotoEnd)", function() {
 	}, 100);
 });
 
+test("finish()", function() {
+	expect( 6 );
+	stop();
+
+	var cw,
+		minWidth = 100,
+		maxWidth = 500
+		$foo = jQuery("#foo");
+
+	$foo.css( "width", minWidth );
+	$foo.animate({ width: maxWidth }, 2000);
+	$foo.animate({ width: minWidth }, 2000);
+	$foo.animate({ width: maxWidth }, 2000);
+
+	setTimeout(function(){
+		cw = $foo.width(),
+		notEqual( cw, 0, "Animation occurred " + cw );
+		$foo.finish();
+		equal( $foo.width(), maxWidth, "finish() completed the first animation" );
+
+		setTimeout(function(){
+			equal( $foo.queue().length, 2, "The next animation continued" );
+			cw = $foo.width(),
+			notEqual( cw, maxWidth, "Animation occurred " + cw );
+
+			$foo.clearQueue().finish();
+			equal( $foo.width(), minWidth, "finish() completed the second animation" );
+			equal( $foo.queue().length, 0, "The animation queue is empty" );
+
+			start();
+		}, 250);
+	}, 250);
+});
+
 asyncTest( "stop( queue, ..., ... ) - Stop single queues", function() {
 	expect( 3 );
 	var saved,


### PR DESCRIPTION
This is filed against 2.0 but will need to be cherry-picked back into 1.9 as well.

Any better ideas about a name? Seems like `.finish()` is a good one. The docs need to clarify that if there are multiple animations queued that `.finish()` only finishes the current one, as the unit test shows.
