### PR TITLE
Update src/manipulation.js

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -27,9 +27,13 @@ wrapMap.th = wrapMap.td;
 jQuery.fn.extend({
 	text: function( value ) {
 		return jQuery.access( this, function( value ) {
-			return value === undefined ?
-				jQuery.text( this ) :
-				this.empty().append( ( this[0] && this[0].ownerDocument || document ).createTextNode( value ) );
+			if (value !== undefined) {
+                		this.empty();
+                		this[0].textContent = value;
+            		}
+            		return value === undefined ?
+                		jQuery.text( this ) :
+                		this;
 		}, null, value, arguments.length );
 	},
 


### PR DESCRIPTION
It code bring leak of memory (test in chrome 23.0.1271.97 m, windows 7). Because every call $('selector').text('any text'), create 2 DOM nodes, but .empty() can't remove they. Code for test http://jsfiddle.net/3RSWf/ (I tested with source from repository and v1.8.3) and result http://my.jetscreenshot.com/7184/20130106-r5yo-219kb . It pull request fix problem.
