### PR TITLE
Fix #12656. Make event shorthands an optional module.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,6 +51,7 @@ module.exports = function( grunt ) {
 				{ flag: "effects", src: "src/effects.js", needs: ["css"] },
 				{ flag: "offset", src: "src/offset.js", needs: ["css"] },
 				{ flag: "dimensions", src: "src/dimensions.js", needs: ["css"] },
+				{ flag: "event-alias", src: "src/event-alias.js" },
 				{ flag: "deprecated", src: "src/deprecated.js" },
 
 				"src/exports.js",

--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -19,6 +19,8 @@
 
 	"predef": [
 		"define",
+		"MouseEvent",
+		"KeyboardEvent",
 		"jQuery"
 	]
 }

--- a/src/event-alias.js
+++ b/src/event-alias.js
@@ -1,0 +1,11 @@
+jQuery.each( ("blur focus focusin focusout load resize scroll unload click dblclick " +
+	"mousedown mouseup mousemove mouseover mouseout mouseenter mouseleave " +
+	"change select submit keydown keypress keyup error contextmenu").split(" "), function( i, name ) {
+
+	// Handle event binding
+	jQuery.fn[ name ] = function( data, fn ) {
+		return arguments.length > 0 ?
+			this.on( name, null, data, fn ) :
+			this.trigger( name );
+	};
+});

--- a/src/event.js
+++ b/src/event.js
@@ -1,6 +1,4 @@
-var rkeyEvent = /^key/,
-	rmouseEvent = /^(?:mouse|contextmenu)|click/,
-	rfocusMorph = /^(?:focusinfocus|focusoutblur)$/,
+var rfocusMorph = /^(?:focusinfocus|focusoutblur)$/,
 	rtypenamespace = /^([^.]*)(?:\.(.+)|)$/;
 
 /*
@@ -458,10 +456,18 @@ jQuery.event = {
 		}
 
 		// Create a writable copy of the event object and normalize some properties
-		var i, prop,
+		var i, prop, copy,
 			originalEvent = event,
-			fixHook = jQuery.event.fixHooks[ event.type ] || {},
-			copy = fixHook.props ? this.props.concat( fixHook.props ) : this.props;
+			fixHook = this.fixHooks[ event.type ];
+
+		if ( !fixHook ) {
+			this.fixHooks[ event.type ] = fixHook =
+				(event instanceof MouseEvent) ? this.mouseHooks :
+				(event instanceof KeyboardEvent) ? this.keyHooks :
+				{};
+		}
+
+		copy = fixHook.props ? this.props.concat( fixHook.props ) : this.props;
 
 		event = jQuery.Event( originalEvent );
 
@@ -797,25 +803,5 @@ jQuery.fn.extend({
 
 	hover: function( fnOver, fnOut ) {
 		return this.mouseenter( fnOver ).mouseleave( fnOut || fnOver );
-	}
-});
-
-jQuery.each( ("blur focus focusin focusout load resize scroll unload click dblclick " +
-	"mousedown mouseup mousemove mouseover mouseout mouseenter mouseleave " +
-	"change select submit keydown keypress keyup error contextmenu").split(" "), function( i, name ) {
-
-	// Handle event binding
-	jQuery.fn[ name ] = function( data, fn ) {
-		return arguments.length > 0 ?
-			this.on( name, null, data, fn ) :
-			this.trigger( name );
-	};
-
-	if ( rkeyEvent.test( name ) ) {
-		jQuery.event.fixHooks[ name ] = jQuery.event.keyHooks;
-	}
-
-	if ( rmouseEvent.test( name ) ) {
-		jQuery.event.fixHooks[ name ] = jQuery.event.mouseHooks;
 	}
 });


### PR DESCRIPTION
Leaving this out saves about 125 bytes gzip. 

This can't be back-ported into 1.9 because we depend on the event name list to do the fixHook patching.

Looking for some advice on a couple of issues. 

First, the unit tests are filled with uses of shorthands so this can't be easily tested. Should I just make a pass through the tests and change them all, then create a small number of shorthand tests? It's a lot of changes, if we do it in the 2.0 branch I think we should do that in 1.9 as well to avoid spurious differences.

Second, what is the best name for this optional module? I named it `event-alias` with a dash to match the file name.
