### PR TITLE
.ajax() : GET, HEAD unable to pass body content.

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -472,14 +472,14 @@ jQuery.extend({
 		s.type = s.type.toUpperCase();
 
 		// Determine if request has content
-		s.hasContent = !rnoContent.test( s.type );
+		s.hasContent = rnoContent.test( s.type ) && s.processData;
 
 		// Save the URL in case we're toying with the If-Modified-Since
 		// and/or If-None-Match header later on
 		cacheURL = s.url;
 
 		// More options handling for requests with no content
-		if ( !s.hasContent ) {
+		if ( s.hasContent ) {
 
 			// If data is available, append data to url
 			if ( s.data ) {


### PR DESCRIPTION
Even when passing `processData : false` .ajax() uses an regex check to determine whether or not a request is `GET` or `HEAD` which then automatically creates a query string for the request. 

This addresses code first introduced in [this](https://github.com/jquery/jquery/commit/981d1e08eb00f4b5c29ad1f3977a45e30c93ad70#src/ajax.js) commit. Basically what's happening is no matter what, `GET`/`HEAD` data will be forced to a query string, even when implicitly providing `processData : false` in the `settings`.
