### PR TITLE
1.9: Fixes #13200 - innerHTML in buildFragment need end tags

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -28,6 +28,8 @@ var nodeNames = "abbr|article|aside|audio|bdi|canvas|data|datalist|details|figca
 	rscriptType = /^$|\/(?:java|ecma)script/i,
 	rscriptTypeMasked = /^true\/(.*)/,
 	rcleanScript = /^\s*<!(?:\[CDATA\[|--)|(?:\]\]|--)>\s*$/g,
+
+	// We have to close these tags to support XHTML (#13200)
 	wrapMap = {
 		option: [ 1, "<select multiple='multiple'>", "</select>" ],
 		legend: [ 1, "<fieldset>", "</fieldset>" ],


### PR DESCRIPTION
Thus by reverting 9ae6b1a019553e95a6205d5c42ff7fa25e7a482e :-(

/cc @dmethvin
