### PR TITLE
2.0: Fixes #13200 - innerHTML in buildFragment need end tags

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -8,6 +8,8 @@ var rxhtmlTag = /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([\w:]+)[^>
 	rscriptType = /^$|\/(?:java|ecma)script/i,
 	rscriptTypeMasked = /^true\/(.*)/,
 	rcleanScript = /^\s*<!(?:\[CDATA\[|--)|(?:\]\]|--)>\s*$/g,
+
+	// We have to close these tags to support XHTML (#13200)
 	wrapMap = {
 
 		// Support: IE 9


### PR DESCRIPTION
Thus by reverting 9ae6b1a019553e95a6205d5c42ff7fa25e7a482e :-(

/cc @dmethvin
