### PR TITLE
Fix requirements in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,15 @@ In the spirit of open source software development, jQuery always encourages comm
 What you need to build your own jQuery
 --------------------------------------
 
-In order to build jQuery, you need to have GNU make 3.8 or later, Node.js/npm latest, and git 1.7 or later.
+In order to build jQuery, you need to have Node.js/npm latest and git 1.7 or later.
 (Earlier versions might work OK, but are not tested.)
 
 Windows users have two options:
 
-1. Install [msysgit](https://code.google.com/p/msysgit/) (Full installer for official Git),
-   [GNU make for Windows](http://gnuwin32.sourceforge.net/packages/make.htm), and a
-   [binary version of Node.js](http://nodejs.org). Make sure all three packages are installed to the same
+1. Install [msysgit](https://code.google.com/p/msysgit/) (Full installer for official Git) and a
+   [binary version of Node.js](http://nodejs.org). Make sure all two packages are installed to the same
    location (by default, this is C:\Program Files\Git).
-2. Install [Cygwin](http://cygwin.com/) (make sure you install the git, make, and which packages), and
+2. Install [Cygwin](http://cygwin.com/) (make sure you install the git and which packages), and
    a [binary version of Node.js](http://nodejs.org/).
 
 Mac OS users should install Xcode (comes on your Mac OS install DVD, or downloadable from
@@ -31,7 +30,7 @@ Mac OS users should install Xcode (comes on your Mac OS install DVD, or download
 [Homebrew](http://mxcl.github.com/homebrew/). Once Homebrew is installed, run `brew install git` to install git,
 and `brew install node` to install Node.js.
 
-Linux/BSD users should use their appropriate package managers to install make, git, and Node.js, or build from source
+Linux/BSD users should use their appropriate package managers to install git and Node.js, or build from source
 if you swing that way. Easy-peasy.
 
 


### PR DESCRIPTION
Node.js is now available native on Windows.
The binary installer is officially distributed.
