### PR TITLE
2.0: Remove DOMContentLoaded helper

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -59,6 +59,13 @@ var
 	// Used by jQuery.camelCase as callback to replace()
 	fcamelCase = function( all, letter ) {
 		return letter.toUpperCase();
+	},
+
+	// The ready event handler and self cleanup method
+	completed = function() {
+		document.removeEventListener( "DOMContentLoaded", completed, false );
+		window.removeEventListener( "load", completed, false );
+		jQuery.ready();
 	};
 
 jQuery.fn = jQuery.prototype = {
@@ -767,10 +774,10 @@ jQuery.ready.promise = function( obj ) {
 		} else {
 
 			// Use the handy event callback
-			document.addEventListener( "DOMContentLoaded", jQuery.ready, false );
+			document.addEventListener( "DOMContentLoaded", completed, false );
 
 			// A fallback to window.onload, that will always work
-			window.addEventListener( "load", jQuery.ready, false );
+			window.addEventListener( "load", completed, false );
 		}
 	}
 	return readyList.promise( obj );


### PR DESCRIPTION
Is <code>DOMContentLoaded</code> helper really needed? In 2.0, the only reason for its presence is to clean-up <code>DOMContentLoaded</code> listener, whereas <code>load</code> event is not cleared, so why one is removed and the other doesn't?

I think jQuery should clear either both events or none of them, in this pull i propose the second one.

/cc @rwldrn
