### PR TITLE
[1.9] Fixes #13183: Wrong animation  initial value calculation (1.9.0rc1)

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -265,7 +265,7 @@ jQuery.extend({
 		}
 
 		// Return, converting to number if forced or a qualifier was provided and val looks numeric
-		if ( extra ) {
+		if ( extra === "" || extra ) {
 			num = parseFloat( val );
 			return extra === true || jQuery.isNumeric( num ) ? num || 0 : val;
 		}

--- a/src/effects.js
+++ b/src/effects.js
@@ -427,11 +427,11 @@ Tween.propHooks = {
 				return tween.elem[ tween.prop ];
 			}
 
-			// passing a non empty string as a 3rd parameter to .css will automatically
+			// passing an empty string as a 3rd parameter to .css will automatically
 			// attempt a parseFloat and fallback to a string if the parse fails
 			// so, simple values such as "10px" are parsed to Float.
 			// complex values such as "rotate(1rad)" are returned as is.
-			result = jQuery.css( tween.elem, tween.prop, "auto" );
+			result = jQuery.css( tween.elem, tween.prop, "" );
 			// Empty strings, null, undefined and "auto" are converted to 0.
 			return !result || result === "auto" ? 0 : result;
 		},

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -283,14 +283,31 @@ test("animate native inline width/height", function() {
 	}
 });
 
-test("animate block width/height", function() {
-	expect(3);
+test( "animate block width/height", function() {
+	expect( 3 );
 	stop();
-	jQuery("#foo").css({ display: "block", width: 20, height: 20 }).animate({ width: 42, height: 42 }, 100, function() {
-		equal( jQuery(this).css("display"), "block", "inline-block was not set on block element when animating width/height" );
-		equal( this.offsetWidth, 42, "width was animated" );
-		equal( this.offsetHeight, 42, "height was animated" );
-		start();
+
+	jQuery("<div>").appendTo("#qunit-fixture").css({
+		display: "block",
+		width: 20,
+		height: 20,
+		paddingLeft: 60
+	}).animate({
+		width: 42,
+		height: 42
+	}, {
+		duration: 100,
+		step: function() {
+			if ( jQuery( this ).width() > 42 ) {
+				ok( false, "width was incorrectly augmented during animation" );
+			}
+		},
+		complete: function() {
+			equal( jQuery( this ).css("display"), "block", "inline-block was not set on block element when animating width/height" );
+			equal( jQuery( this ).width(), 42, "width was animated" );
+			equal( jQuery( this ).height(), 42, "height was animated" );
+			start();
+		}
 	});
 });
 


### PR DESCRIPTION
Still investigating why this is or isn't a problem in 2.0, but here's the fix in 1.9
