### PR TITLE
Do not try to parse the body of 204 No Content responses

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -629,6 +629,11 @@ jQuery.extend({
 					isSuccess = true;
 					statusText = "notmodified";
 
+				} else if ( status === 204 ) {
+					isSuccess = true;
+					statusText = "nocontent";
+
+
 				// If we have data
 				} else {
 					isSuccess = ajaxConvert( s, response );


### PR DESCRIPTION
Since jQuery 1.9, 204 are acts as errors.

Fix both http://bugs.jquery.com/ticket/13292 and http://bugs.jquery.com/ticket/13261 .

I'm sorry to not add tests but I was not able to setup the test environment (PHP ...)

I already patched it in my app, it works fine.

Regards.
