### PR TITLE
Fix #13315 for IE9: compare typeof xmlNode.method to var instead of literal "undefined" for safer uglification

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -134,7 +134,7 @@ jQuery.fn.extend({
 				}
 
 			// Toggle whole class name
-			} else if ( type === "undefined" || type === "boolean" ) {
+			} else if ( type === core_strundefined || type === "boolean" ) {
 				if ( this.className ) {
 					// store className if set
 					jQuery._data( this, "__className__", this.className );
@@ -296,7 +296,7 @@ jQuery.extend({
 		}
 
 		// Fallback to prop when attributes are not supported
-		if ( typeof elem.getAttribute === "undefined" ) {
+		if ( typeof elem.getAttribute === core_strundefined ) {
 			return jQuery.prop( elem, name, value );
 		}
 
@@ -329,7 +329,7 @@ jQuery.extend({
 
 			// In IE9+, Flash objects don't have .getAttribute (#12945)
 			// Support: IE9+
-			if ( typeof elem.getAttribute !== "undefined" ) {
+			if ( typeof elem.getAttribute !== core_strundefined ) {
 				ret =  elem.getAttribute( name );
 			}
 

--- a/src/core.js
+++ b/src/core.js
@@ -5,6 +5,10 @@ var
 	// The deferred used on DOM ready
 	readyList,
 
+	// Support: IE9
+	// For `typeof xmlNode.method` instead of `xmlNode.method !== undefined`
+	core_strundefined = typeof undefined,
+
 	// Use the correct document accordingly with window argument (sandbox)
 	document = window.document,
 	location = window.location,

--- a/src/event.js
+++ b/src/event.js
@@ -51,7 +51,7 @@ jQuery.event = {
 			eventHandle = elemData.handle = function( e ) {
 				// Discard the second event of a jQuery.event.trigger() and
 				// when an event is called after a page has unloaded
-				return typeof jQuery !== "undefined" && (!e || jQuery.event.triggered !== e.type) ?
+				return typeof jQuery !== core_strundefined && (!e || jQuery.event.triggered !== e.type) ?
 					jQuery.event.dispatch.apply( eventHandle.elem, arguments ) :
 					undefined;
 			};

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -563,7 +563,6 @@ function restoreScript( elem ) {
 
 	if ( match ) {
 		elem.type = match[ 1 ];
-
 	} else {
 		elem.removeAttribute("type");
 	}

--- a/src/offset.js
+++ b/src/offset.js
@@ -25,7 +25,7 @@ jQuery.fn.offset = function( options ) {
 
 	// If we don't have gBCR, just use 0,0 rather than error
 	// BlackBerry 5, iOS 3 (original iPhone)
-	if ( typeof elem.getBoundingClientRect !== "undefined" ) {
+	if ( typeof elem.getBoundingClientRect !== core_strundefined ) {
 		box = elem.getBoundingClientRect();
 	}
 	win = getWindow( doc );


### PR DESCRIPTION
+13 bytes to jquery.min.js.gz
