### PR TITLE
Allow html() to operate on shadow roots. Fixes #13342.

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -214,9 +214,9 @@ jQuery.fn.extend({
 						elem = this[ i ] || {};
 
 						// Remove element nodes and prevent memory leaks
-                        // Only process nodes with innerHTML: in addition to
-                        // normal elements, this also picks up shadow roots.
-                        if ( elem.innerHTML !== undefined  ) {
+						// Only process nodes with innerHTML: in addition to
+						// normal elements, this also picks up shadow roots.
+						if ( elem.innerHTML !== undefined ) {
 							jQuery.cleanData( getAll( elem, false ) );
 							elem.innerHTML = value;
 						}

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -2228,11 +2228,11 @@ test( "Make sure specific elements with content created correctly (#13232)", 20,
 
 // Only run this test in Shadow DOM-capable browsers (currently, Chrome v26+).
 if ( HTMLElement.prototype.webkitCreateShadowRoot !== undefined ) {
-    test( "html(string) can work on shadow root", 2, function() {
-        var element = document.createElement( "div" );
-        var shadowRoot = element.webkitCreateShadowRoot();
-        equal( shadowRoot.childNodes.length, 0, "new shadow root has no children" );
-        jQuery( shadowRoot ).html( "<div>Hello</div>" );
-        equal( shadowRoot.childNodes.length, 1, "node was added to shadow root" );
-    });
+	test( "html(string) can work on shadow root", 2, function() {
+		var element = document.createElement( "div" );
+		var shadowRoot = element.webkitCreateShadowRoot();
+		equal( shadowRoot.childNodes.length, 0, "new shadow root has no children" );
+		jQuery( shadowRoot ).html( "<div>Hello</div>" );
+		equal( shadowRoot.childNodes.length, 1, "node was added to shadow root" );
+	});
 }


### PR DESCRIPTION
The relevant test in core.js was originally

elem.nodeType === 1
This check fails to apply to shadow roots, which are of nodeType === 11. Rather than hard-code that case in the line, however, it seemed better to handle the general case. The html() function should, in theory, be applicable to any element with an innerHTML property. So the test above has been updated to

elem.innerHTML !== undefined
All unit tests continue to pass, and the new check automatically picks up support of shadow roots (as well as any other node types that might someday sport an innerHTML property).

This request includes a unit test that specifically confirms the ability to invoke html() on a shadow root. Since shadow roots are only supported in WebKit (in Google Chrome Canary or Beta), the test is wrapped in a test for a version of WebKit that supports shadow roots. The test is skipped in all other browsers.
