### PR TITLE
[1.10] remove the define.amd.jQuery check

### DIFF
--- a/src/exports.js
+++ b/src/exports.js
@@ -1,18 +1,13 @@
 // Expose jQuery to the global object
 window.jQuery = window.$ = jQuery;
 
-// Expose jQuery as an AMD module, but only for AMD loaders that
-// understand the issues with loading multiple versions of jQuery
-// in a page that all might call define(). The loader will indicate
-// they have special allowances for multiple jQuery versions by
-// specifying define.amd.jQuery = true. Register as a named module,
-// since jQuery can be concatenated with other files that may use define,
-// but not use a proper concatenation script that understands anonymous
-// AMD modules. A named AMD is safest and most robust way to register.
-// Lowercase jquery is used because AMD module names are derived from
-// file names, and jQuery is normally delivered in a lowercase file name.
-// Do this after creating the global so that if an AMD module wants to call
-// noConflict to hide this version of jQuery, it will work.
-if ( typeof define === "function" && define.amd && define.amd.jQuery ) {
+// Register as a named AMD module, since jQuery can be concatenated with other
+// files that may use define, but not via a proper concatenation script that
+// understands anonymous AMD modules. A named AMD is safest and most robust
+// way to register. Lowercase jquery is used because AMD module names are
+// derived from file names, and jQuery is normally delivered in a lowercase
+// file name. Do this after creating the global so that if an AMD module wants
+// to call noConflict to hide this version of jQuery, it will work.
+if ( typeof define === "function" && define.amd ) {
 	define( "jquery", [], function () { return jQuery; } );
 }

--- a/test/data/testinit.js
+++ b/test/data/testinit.js
@@ -19,9 +19,7 @@ function define( name, dependencies, callback ) {
 	amdDefined = callback();
 }
 
-define.amd = {
-	jQuery: true
-};
+define.amd = {};
 
 /**
  * Returns an array of elements with the given IDs


### PR DESCRIPTION
For 2.0 consideration:

Removes the `define.amd.jQuery` check in the AMD registration. In practice, AMD loaders just set this anyway as they wanted to load jQuery, and any error as a result of the loader not properly accounting for multiple jQuerys in the page would show up as loader errors. 

The loader gets blamed for the error, as it should, and jQuery does not. So removing it as it has become superfluous, and was probably an overly cautious measure.
