### PR TITLE
#13356 - Consistently clean up after .ready() handler

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -78,7 +78,7 @@ var
 	completed = function( event ) {
 
 		// readyState === "complete" is good enough for us to call the dom ready in oldIE
-		if ( document.addEventListener || event.type == "load" || document.readyState === "complete" ) {
+		if ( document.addEventListener || event.type === "load" || document.readyState === "complete" ) {
 			detach();
 			jQuery.ready();
 		}


### PR DESCRIPTION
It has been <a href="https://github.com/jquery/jquery/commit/dbf4926e31390ceda57730c68d40f34536803114">done</a> for 2.0 and it could be done for 1.9.1 too.
