### PR TITLE
Removed an instance where copyIsArray was set, but would never be read.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -314,7 +314,6 @@ jQuery.extend = jQuery.fn.extend = function() {
 				// Recurse if we're merging plain objects or arrays
 				if ( deep && copy && ( jQuery.isPlainObject(copy) || (copyIsArray = jQuery.isArray(copy)) ) ) {
 					if ( copyIsArray ) {
-						copyIsArray = false;
 						clone = src && jQuery.isArray(src) ? src : [];
 
 					} else {


### PR DESCRIPTION
I don't think this the variable is ever read.

If I'm trying to revert some (weird) optimization/need to fill out a bug report, let me know.
