### PR TITLE
Adds vim recovery file extensions to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ dist/.destination.json
 dist/.sizecache.json
 build/.sizecache.json
 node_modules
+
+# Vim recovery files
+*.swp
+*.swo


### PR DESCRIPTION
*.swp and *.swo files were not included in .gitignore.
