### PR TITLE
Remove the deprecated andSelf in favor of addBack. Fixes #13283

### DIFF
--- a/src/traversing.js
+++ b/src/traversing.js
@@ -136,8 +136,6 @@ jQuery.fn.extend({
 	}
 });
 
-jQuery.fn.andSelf = jQuery.fn.addBack;
-
 function sibling( cur, dir ) {
 	while ( (cur = cur[dir]) && cur.nodeType !== 1 ) {}
 

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -1546,7 +1546,7 @@ asyncTest( "hide, fadeOut and slideUp called on element width height and width =
 });
 
 asyncTest( "Handle queue:false promises", 10, function() {
-	var foo = jQuery( "#foo" ).clone().andSelf(),
+	var foo = jQuery( "#foo" ).clone().addBack(),
 		step = 1;
 
 	foo.animate({

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -43,7 +43,7 @@ test("Handler changes and .trigger() order", function() {
 	path = "";
 
 	markup
-		.find( "*" ).andSelf().on( "click", function( e ) {
+		.find( "*" ).addBack().on( "click", function( e ) {
 			path += this.nodeName.toLowerCase() + " ";
 		})
 		.filter( "b" ).on( "click", function( e ) {

--- a/test/unit/queue.js
+++ b/test/unit/queue.js
@@ -184,7 +184,7 @@ test("clearQueue() clears the fx queue", function() {
 });
 
 asyncTest( "fn.promise() - called when fx queue is empty", 3, function() {
-	var foo = jQuery( "#foo" ).clone().andSelf(),
+	var foo = jQuery( "#foo" ).clone().addBack(),
 		promised = false;
 
 	foo.queue( function( next ) {

--- a/test/unit/traversing.js
+++ b/test/unit/traversing.js
@@ -7,7 +7,7 @@ test( "find(String)", function() {
 	// using contents will get comments regular, text, and comment nodes
 	var j = jQuery("#nonnodes").contents();
 	equal( j.find("div").length, 0, "Check node,textnode,comment to find zero divs" );
-	equal( j.find("div").andSelf().length, 3, "Check node,textnode,comment to find zero divs, but preserves pushStack" );
+	equal( j.find("div").addBack().length, 3, "Check node,textnode,comment to find zero divs, but preserves pushStack" );
 
 	deepEqual( jQuery("#qunit-fixture").find("> div").get(), q( "foo", "nothiddendiv", "moretests", "tabindex-tests", "liveHandlerOrder", "siblingTest", "fx-test-group" ), "find child elements" );
 	deepEqual( jQuery("#qunit-fixture").find("> #foo, > #moretests").get(), q( "foo", "moretests" ), "find child elements" );
@@ -38,7 +38,7 @@ test( "find(node|jQuery object)", function() {
 	equal( $two.find( $first ).length, 0, "first is in the collection and not within two" );
 	equal( $two.find( $first ).length, 0, "first is in the collection and not within two(node)" );
 
-	equal( $two.find( $foo[ 0 ] ).andSelf().length, 2, "find preserves the pushStack, see #12009" );
+	equal( $two.find( $foo[ 0 ] ).addBack().length, 2, "find preserves the pushStack, see #12009" );
 });
 
 test("is(String|undefined)", function() {
@@ -689,4 +689,10 @@ test("index(no arg) #10977", function() {
 		div = fragment.appendChild( document.createElement("div") );
 
 	equal( jQuery( div ).index(), 0, "If jQuery#index called on element whos parent is fragment, it still should work correctly" );
+});
+
+test("drop addSelf support #13283", function() {
+	expect( 1 );
+
+	ok( typeof jQuery.fn.andSelf === "undefined", jQuery.fn.andSelf);
 });


### PR DESCRIPTION
Remove andSelf in traversing.js and replace its usage with addBack in test files.
