### PR TITLE
Fixes #13471. When no explicit type, and no registered type, continue to event namespace removal. (2.x)

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -147,6 +147,15 @@ jQuery.event = {
 			// Unbind all events (on this namespace, if provided) for the element
 			if ( !type ) {
 				for ( type in events ) {
+					// Bug #13471
+					// In cases where no "type" was ever specified, the recursive call to
+					// jQuery.event.remove() will bring us right back to the same place, eventually
+					// resulting in a RangeError or stack overflow.
+					// This is avoided by with a continue statement whenever
+					// the "type" is an empty string
+					if ( type === "" ) {
+						continue;
+					}
 					jQuery.event.remove( elem, type + types[ t ], handler, selector, true );
 				}
 				continue;

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -1941,6 +1941,22 @@ test("undelegate() with only namespaces", function() {
 	equal( count, 1, "no more .ns after undelegate");
 });
 
+test("No RangeError when jQuery.on(.ns, ...).off(.ns) #13471", function() {
+	expect(1);
+	var result,
+			was = "not ";
+
+	try {
+		jQuery({}).on( ".ns", jQuery.noop ).off( ".ns" );
+		result = true;
+	} catch ( e ) {
+		result = false;
+		was = "";
+	}
+
+	ok( result, "RangeError " + was + "thrown" );
+});
+
 test("Non DOM element events", function() {
 	expect(1);
 


### PR DESCRIPTION
Signed-off-by: Rick Waldron waldron.rick@gmail.com
