### PR TITLE
Optimisation: Use String instead of window.String.

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -266,7 +266,7 @@ jQuery.extend({
 		converters: {
 
 			// Convert anything to text
-			"* text": window.String,
+			"* text": String,
 
 			// Text to html (true = no transformation)
 			"text html": true,


### PR DESCRIPTION
Follows-up 22e28b01e60e87b2454f88ca128fb84916b13564.
