### PR TITLE
Implement custom deferred functions

### DIFF
--- a/src/deferred.js
+++ b/src/deferred.js
@@ -6,8 +6,17 @@ jQuery.extend({
 				[ "resolve", "done", jQuery.Callbacks("once memory"), "resolved" ],
 				[ "reject", "fail", jQuery.Callbacks("once memory"), "rejected" ],
 				[ "notify", "progress", jQuery.Callbacks("memory") ]
-			],
-			state = "pending",
+			];
+		
+		// Add in custom methods
+		var orig_tuples = tuples.slice(0);
+		if (customs) {
+			jQuery.each(customs, function(i, custom) {
+				tuples.unshift( [ custom[0], custom[1], jQuery.Callbacks("memory")  ] );
+			});
+		}
+		
+		var state = "pending",
 			promise = {
 				state: function() {
 					return state;
@@ -19,7 +28,7 @@ jQuery.extend({
 				then: function( /* fnDone, fnFail, fnProgress */ ) {
 					var fns = arguments;
 					return jQuery.Deferred(function( newDefer ) {
-						jQuery.each( tuples, function( i, tuple ) {
+						jQuery.each( orig_tuples, function( i, tuple ) {
 							var action = tuple[ 0 ],
 								fn = jQuery.isFunction( fns[ i ] ) && fns[ i ];
 							// deferred[ done | fail | progress ] for forwarding actions to newDefer
@@ -36,7 +45,7 @@ jQuery.extend({
 							});
 						});
 						fns = null;
-					}).promise();
+					}, customs).promise();
 				},
 				// Get a promise for this deferred
 				// If obj is provided, the promise aspect is added to the object
@@ -48,13 +57,6 @@ jQuery.extend({
 
 		// Keep pipe for back-compat
 		promise.pipe = promise.then;
-
-		// Add in custom methods
-		if (customs) {
-			jQuery.each(customs, function(i, custom) {
-				tuples.unshift( [ custom[0], custom[1], jQuery.Callbacks("memory")  ] );
-			});
-		}
 
 		// Add list-specific methods
 		jQuery.each( tuples, function( i, tuple ) {

--- a/test/unit/deferred.js
+++ b/test/unit/deferred.js
@@ -446,13 +446,39 @@ test( "jQuery.deferred custom", function() {
 	var def = jQuery.Deferred(function() {}, [["mycustom", "mycustomcb"]]);
 
 	def.promise().mycustomcb(function(str) {
+		
 		if (str == "test_string") {
 			ok( true, "Called back with right value" );
 		} else {
 			ok( false, "Called back with wrong value");
 		}
+		
 	});
 
 	def.mycustom("test_string");
+
+});
+
+test( "jQuery.deferred custom chained", function() {
+
+	expect(2);
+
+	var def = jQuery.Deferred(function() {}, [["mycustom", "mycustomcb"]]);
+
+	def.promise().done(function() {
+		
+		ok(true, "Done was called");
+		
+	}).mycustomcb(function(str) {
+		
+		if (str == "test_string") {
+			ok( true, "Called back with right value" );
+		} else {
+			ok( false, "Called back with wrong value");
+		}
+		
+	});
+
+	def.mycustom("test_string").resolve();
 
 });


### PR DESCRIPTION
We implemented using deferred / promises as part of our JS API. However I wanted to allow some additional custom callbacks.

This patch simply allows anyone to create a new deferred object but with additional custom methods on them. For now, they are simply like the notify / progress message, in that they do not affect any other methods and are not final.

Usage:

``` javascript
// Provider sets up deferred with extra arg
var deferred = jQuery.Deferred( false, [ [ "callUserStart", "userStart" ] ] );
var promise = deferred.promise();

// The user can subscribe
promise.userStart(function(str) { alert(str); });

// The provider can call the user code
deferred.callUserStart("hello");
```

Test case included. Custom methods are included in the same way as the standard methods, but before them - so the standards will override them. Thus it is not possible for anyone calling jQuery.deferred() to be able to change the fundamental methods that people would expect to be there.
