### PR TITLE
[1.10] Ref #13353: capture onlyHandlers in jQuery.Event.isTrigger

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -235,7 +235,8 @@ jQuery.event = {
 			event :
 			new jQuery.Event( type, typeof event === "object" && event );
 
-		event.isTrigger = true;
+		// Trigger bitmask: & 1 for native handlers; & 2 for jQuery (always true)
+		event.isTrigger = onlyHandlers ? 2 : 3;
 		event.namespace = namespaces.join(".");
 		event.namespace_re = event.namespace ?
 			new RegExp( "(^|\\.)" + namespaces.join("\\.(?:.*\\.|)") + "(\\.|$)" ) :

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -985,7 +985,7 @@ test("trigger(type, [data], [fn])", function() {
 
 	jQuery( document ).off( "mouseenter mouseleave", "#firstp");
 
-	// Triggers handlrs and native
+	// Triggers handlers and native
 	// Trigger 5
 	$elem.bind("click", handler).trigger("click", [1, "2", "abc"]);
 
@@ -1471,21 +1471,42 @@ test("jQuery.Event( type, props )", function() {
 
 });
 
-test("jQuery.Event.currentTarget", function(){
-	expect(2);
+test("jQuery.Event properties", function(){
+	expect(12);
 
-	jQuery("<div><p><button>shiny</button></p></div>")
-		.on( "click", "p", function( e ){
-				equal( e.currentTarget, this, "Check delegated currentTarget on event" );
-		})
-		.find( "button" )
-			.on( "click", function( e ){
-				equal( e.currentTarget, this, "Check currentTarget on event" );
-			})
-			.trigger("click")
-			.off( "click" )
-		.end()
-		.off( "click" );
+	var handler,
+		$structure = jQuery("<div id='ancestor'><p id='delegate'><span id='target'>shiny</span></p></div>"),
+		$target = $structure.find("#target");
+
+	handler = function( e ) {
+		strictEqual( e.currentTarget, this, "currentTarget at " + this.id );
+		equal( e.isTrigger, 3, "trigger at " + this.id );
+	};
+	$structure.one( "click", handler );
+	$structure.one( "click", "p", handler );
+	$target.one( "click", handler );
+	$target[0].onclick = function( e ) {
+		strictEqual( e.currentTarget, this, "currentTarget at target (native handler)" );
+		equal( e.isTrigger, 3, "trigger at target (native handler)" );
+	};
+	$target.trigger("click");
+
+	$target.one( "click", function( e ) {
+		equal( e.isTrigger, 2, "triggerHandler at target" );
+	});
+	$target[0].onclick = function( e ) {
+		equal( e.isTrigger, 2, "triggerHandler at target (native handler)" );
+	};
+	$target.triggerHandler("click");
+
+	handler = function( e ) {
+		strictEqual( e.isTrigger, undefined, "native event at " + this.id );
+	};
+	$target.one( "click", handler );
+	$target[0].onclick = function( e ) {
+		strictEqual( e.isTrigger, undefined, "native event at target (native handler)" );
+	};
+	fireNative( $target[0], "click" );
 });
 
 test(".delegate()/.undelegate()", function() {


### PR DESCRIPTION
This is not a fix, but it does make it _possible_ to fix with a ([large](https://github.com/gibson042/jquery/compare/jquery:d79bf3517eda9b74883c68c255e82067449d3274...gibson042:13353)) plugin—at least for [#13353](http://bugs.jquery.com/ticket/13353).

I tried a [general solution](https://github.com/gibson042/jquery/compare/jquery:4083a19192069ac40eb0fe35c3f462ff1986838c...gibson042:13428) to also sweep in [#13428](http://bugs.jquery.com/ticket/13428), but unfortunately the interactions between focus and blur killed it for oldIE.
