### PR TITLE
IE9 bugfix

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -329,7 +329,7 @@ jQuery.extend({
 
 			// In IE9+, Flash objects don't have .getAttribute (#12945)
 			// Support: IE9+
-			if ( typeof elem.getAttribute !== core_strundefined ) {
+			if (( typeof elem.getAttribute !== core_strundefined ) && (elem.getAttribute !== null)) {
 				ret =  elem.getAttribute( name );
 			}
 


### PR DESCRIPTION
![bug](https://f.cloud.github.com/assets/1155876/201481/95c198f2-80f4-11e2-9c80-c9d3e210c8ee.jpg)

For some reasons Internet explorer suppose, that typeof undefined function is Object :-/
It break uploadify, please accept this PR and lets microsoft will drop dead :)
