### PR TITLE
Fix typos

### DIFF
--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -20,7 +20,7 @@ test( "jQuery.data & removeData, expected returns", function() {
 	);
 	deepEqual(
 		jQuery.data( elem, { goodnight: "moon" }), { goodnight: "moon" },
-		"jQuery.data( elem, key, obj ) returns obj"
+		"jQuery.data( elem, obj ) returns obj"
 	);
 	equal(
 		jQuery.removeData( elem, "hello" ), undefined,


### PR DESCRIPTION
The description is not exact, and is not identical with the following test case

```
    deepEqual(
        jQuery._data( elem, { goodnight: "moon" }), { goodnight: "moon" },
        "jQuery._data( elem, obj ) returns obj"
    );
```
