### PR TITLE
Fix for #13514.Set selectedIdx to 0 if a 'wrong' value is set as dropdown-list value

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -282,10 +282,10 @@ jQuery.extend({
 						optionSet = true;
 					}
 				}
-												
+				
+				// force browsers to behave consistently when non-matching value is set
 				if ( !optionSet ) {
-					// force IE9 to behave like other browsers when a non-matching value is set on a select-one element
-					elem.selectedIndex = elem.type === "select-one" ? 0 : -1;
+					elem.selectedIndex = -1;
 				}
 				return values;
 			}

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -850,7 +850,7 @@ test("val() with non-matching values on dropdown list", function() {
 	expect( 3 );
 	
 	jQuery("#select5").val( "" );
-	equal( jQuery("#select5").val(), "3", "Non-matching set on select-one" );
+	equal( jQuery("#select5").val(), null, "Non-matching set on select-one" );
 	
 	var select6 = jQuery("<select multiple id=\"select6\"><option value=\"1\">A</option><option value=\"2\">B</option></select>").appendTo("#form");
 	jQuery(select6).val( "nothing" );


### PR DESCRIPTION
This commit fixes the issue described in the bug ticket when a dropdown-list is set to a value which doesnt match with any of its options' value.
