### PR TITLE
Extract doScrollCheck function into a variable

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -904,23 +904,26 @@ jQuery.ready.promise = function( obj ) {
 			} catch(e) {}
 
 			if ( top && top.doScroll ) {
-				(function doScrollCheck() {
-					if ( !jQuery.isReady ) {
+				(function() {
+					var doScrollCheck = function() {
+						if ( !jQuery.isReady ) {
 
-						try {
-							// Use the trick by Diego Perini
-							// http://javascript.nwbox.com/IEContentLoaded/
-							top.doScroll("left");
-						} catch(e) {
-							return setTimeout( doScrollCheck, 50 );
+							try {
+								// Use the trick by Diego Perini
+								// http://javascript.nwbox.com/IEContentLoaded/
+								top.doScroll("left");
+							} catch(e) {
+								return setTimeout( doScrollCheck, 50 );
+							}
+
+							// detach all dom ready events
+							detach();
+
+							// and execute any waiting functions
+							jQuery.ready();
 						}
-
-						// detach all dom ready events
-						detach();
-
-						// and execute any waiting functions
-						jQuery.ready();
-					}
+					};
+					doScrollCheck();
 				})();
 			}
 		}


### PR DESCRIPTION
I ship jQuery in a product I work on, and we recently discovered one of the places our product is used runs a JavaScript minification tool that breaks jQuery. It only renames the doScrollCheck call site, not the function declaration.

I do not have control over the minification tool so I was hoping this harmless change can be made in the core code instead.

This commit simply extracts the doScrollCheck function into a variable which allows the minification tool to pick up the function rename correctly.
