### PR TITLE
Fixes #10515 - Implementation of iAH

### DIFF
--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -2229,3 +2229,101 @@ test( "Make sure specific elements with content created correctly (#13232)", 20,
 		ok( jQuery.nodeName( this, results[ i ] ) );
 	});
 });
+
+test( "Test insertAdjacentHTML implementation (#10515)", 39, function() {
+	var mark = jQuery("#mark"),
+		fragment = document.createDocumentFragment(),
+		p = jQuery("#firstp"),
+		table = jQuery("#table"),
+		set = jQuery("<div><div/></div>").children().add( fragment );
+
+	set.append( "<div/>", "text" );
+	equal( set[ 0 ].childNodes.length, 2, "Test append to element" );
+	equal( set[ 1 ].childNodes.length, 2, "Test append to document fragment" );
+
+	equal( set[ 0 ].childNodes[ 0 ].nodeType, 1, "Check first appended node type to element" );
+	equal( set[ 0 ].childNodes[ 1 ].nodeType, 3, "Check second appended node type to element" );
+
+	equal( set[ 1 ].childNodes[ 0 ].nodeType, 1, "Check first appended node type to document fragment" );
+	equal( set[ 1 ].childNodes[ 1 ].nodeType, 3, "Check second appended node type to document fragment" );
+
+	set = jQuery( document.createDocumentFragment() ).add( "<div/>" );
+	set.append( document.createElement("div") );
+
+	equal( set[ 0 ].childNodes[ 0 ].nodeType, 1, "Test append of an element and the text node to element" );
+	equal( set[ 1 ].childNodes[ 0 ].nodeType, 1, "Test append of an element and the text node to document fragment" );
+
+	set = jQuery( "<div><div/></div>" ).children().add( document.createTextNode("text") );
+
+	set.append( "<div/>", "text" );
+	equal( set[ 0 ].childNodes.length, 2, "Test append of an element and the text node to element" );
+	equal( set[ 0 ].childNodes.length, 2, "Test append of an element and the text node to document fragment" );
+
+	equal( set[ 0 ].childNodes[ 0 ].nodeType, 1, "Check first appended node type to element" );
+	equal( set[ 0 ].childNodes[ 1 ].nodeType, 3, "Check second appended node type to element" );
+
+	set = jQuery( document.createTextNode("text") );
+	set.append("test");
+
+	table.append("<tr><td>first</td></tr>", "<tr><td>second</td></tr>");
+	equal( table.find("td").length, 2, "Two td elements was correctly appended" );
+	equal( table.find("td:first").text(), "first", "Sequance of appended td elements is correct" );
+
+	table.empty();
+	table.prepend("<tr><td>first</td></tr>", "<tr><td>second</td></tr>");
+	equal( table.find("td").length, 2, "Two td elements was correctly prepended" );
+	equal( table.find("td:first").text(), "first", "Sequance of prepended td elements is correct" );
+
+	table.find("tr").append("<td>second</td>");
+	equal( table.find("td").length, 4, "td elements was correctly appended to tr element" );
+
+	table.find("tr").prepend("<td>second</td>");
+	equal( table.find("td").length, 6, "td elements was correctly prepended to tr element" );
+
+	p.after( "<script>ok( true, 'script element was added correctly' )</script>" );
+	p.before( "<script>ok( true, 'script element was added correctly' )</script>" );
+	p.prev().remove();
+
+	fragment = document.createDocumentFragment();
+
+	fragment.appendChild( jQuery("<div>test</div>")[ 0 ] );
+	p.before( "<script>ok( true, 'script element was added correctly' )</script>", fragment );
+
+	equal( p.prevAll().length, 2, "script element and document fragment was added correctly" );
+
+	ok( jQuery( p.prevAll()[ 1 ].nodeName, "script" ), "script element was added correctly" );
+	ok( jQuery( p.prevAll()[ 0 ].nodeName, "div" ), "div element inside of document fragment was added correctly" );
+
+	fragment.appendChild( jQuery("<div>test</div>")[ 0 ] );
+	p.before( fragment, "<script>ok( true, 'script element was added correctly' )</script>" );
+	ok( jQuery( p.prevAll()[ 1 ].nodeName, "script" ), "script element was added correctly" );
+	ok( jQuery( p.prevAll()[ 0 ].nodeName, "div" ), "div element inside of document fragment was added correctly" );
+
+	fragment.appendChild( jQuery("<div>test</div>")[ 0 ] );
+	mark.after( "<script>ok( true, 'script element was added correctly' )<\/script>", fragment );
+
+	equal( mark.nextAll().length, 2, "script element and document fragment was added correctly" );
+
+	ok( jQuery( mark.nextAll()[ 1 ].nodeName, "script" ), "script element was added correctly" );
+	ok( jQuery( mark.nextAll()[ 0 ].nodeName, "div" ), "div element inside of document fragment was added correctly" );
+
+	fragment.appendChild( jQuery("<div>test</div>")[ 0 ] );
+	mark.after( fragment, "<script>ok( true, 'script element was added correctly' )</script>" );
+	ok( jQuery( mark.nextAll()[ 1 ].nodeName, "script" ), "script element was added correctly" );
+	ok( jQuery( mark.nextAll()[ 0 ].nodeName, "div" ), "div element inside of document fragment was added correctly" );
+
+	ok( p.contents().append("<div/>"), "If append is applied to text node it should not throw exception" );
+
+	jQuery("head").append("<style>#firstp{height:1px;}</style>");
+
+	equal( p.css("height"), "1px", "style element appended correctly" );
+
+	set = jQuery("<div><div/></div>").children();
+
+	set.append( "<div>test</div>", document.createElement("div") );
+
+	equal( set.children().length, 2, "DOM-manip methods should work correctly with multiple type arguments" );
+
+	p.empty().prepend( "<div />", "<p><script>ok( true, 'script element was added correctly' );<\/script></p>" );
+	equal( p.find("*").length, 3, "DOM-manip methods should work correctly if one of the arguments has a script declaration" );
+});


### PR DESCRIPTION
Based on @dmethvin <a href="https://github.com/jquery/jquery/pull/1095">idea</a>.
By opening this PR, i want, one way or another, to close <a href="http://bugs.jquery.com/ticket/10515">#10515</a>, but i'm not sure what a resolution of that ticket should be.

<h3>Perf tests</h3>

<dl>
<dt><code>jQuery.append</code></dt>
<dd><ul>
<li><a href="http://jsperf.com/jq-iah-append">big HTML-string</a></li>
<li><a href="http://jsperf.com/jq-iah-append/2">small HTML-string</a></li>
<li><a href="http://jsperf.com/jq-iah-append/3">big HTML-string, hidden element</a></li>
<li><a href="http://jsperf.com/jq-iah-append/9">small HTML-string, hidden element</a></li>
<li><a href="http://jsperf.com/jq-iah-append/7">big HTML-string, disconnected element</a></li>
<li><a href="http://jsperf.com/jq-iah-append/6">small HTML-string, disconnected element</a></li>
</ul></dd>

<dt><code>jQuery.prepend</code></dt>
<dd><ul>
<li><a href="http://jsperf.com/jq-iah-prepend">big HTML-string</a></li>
<li><a href="http://jsperf.com/jq-iah-prepend/2">small HTML-string</a></li>
<li><a href="http://jsperf.com/jq-iah-prepend/3">big HTML-string, hidden element</a></li>
<li><a href="http://jsperf.com/jq-iah-prepend/8">small HTML-string, hidden element</a></li>
<li><a href="http://jsperf.com/jq-iah-prepend/7">big HTML-string, disconnected element</a></li>
<li><a href="http://jsperf.com/jq-iah-prepend/6">small HTML-string, disconnected element</a></li>
</ul></dd>

<dt><code>jQuery.before</code></dt>
<dd><ul>
<li><a href="http://jsperf.com/jq-iah-before">big HTML-string</a></li>
<li><a href="http://jsperf.com/jq-iah-before/2">small HTML-string</a></li>
<li><a href="http://jsperf.com/jq-iah-before/3">big HTML-string, hidden element</a></li>
<li><a href="http://jsperf.com/jq-iah-before/6">small HTML-string, hidden element</a></li>
<li><a href="http://jsperf.com/jq-iah-before/7">big HTML-string, disconnected element</a></li>
<li><a href="http://jsperf.com/jq-iah-before/8">small HTML-string, disconnected element</a></li>
</ul></dd>

<dt><code>jQuery.after</code></dt>
<dd><ul>
<li><a href="http://jsperf.com/jq-iah-after">big HTML-string</a></li>
<li><a href="http://jsperf.com/jq-iah-after/2">small HTML-string</a></li>
<li><a href="http://jsperf.com/jq-iah-after/3">big HTML-string, hidden element</a></li>
<li><a href="http://jsperf.com/jq-iah-after/7">small HTML-string, hidden element</a></li>
<li><a href="http://jsperf.com/jq-iah-after/4">big HTML-string, disconnected element</a></li>
<li><a href="http://jsperf.com/jq-iah-after/6">small HTML-string, disconnected element</a></li>
</ul></dd>
</dl>


<h3>What's the takeaway?</h3>

This is a difference between <code>iAH</code> methods and current DOM-manipulation tactics –

<table>
<tr>
    <th>Conditions</th>
    <th>Results</th>
</tr>

<tr>
    <td>Big HTML-string, attached element</td>
    <td>Small speed increase in almost all browsers, considerable speed decrease in WebKit</td>
</tr>

<tr>
    <td>Small HTML-string, attached element</td>
    <td>All browsers shown good speed increase</td>
</tr>

<tr>
    <td>Big HTML-string, hidden element</td>
    <td>Slightly better results</td>
</tr>

<tr>
    <td>Small HTML-string, hidden element</td>
    <td>All browsers shown good speed increase</td>
</tr>

<tr>
    <td><code>jQuery#append/prepend</code>, big/small HTML-string, disconnected element</td>
    <td>Either equal or slightly better results</td>
</tr>

<tr>
    <td><code>jQuery#before/after</code>, big HTML-string, disconnected element</td>
    <td>Slightly better results for most cases, except Opera performed slightly worse</td>
</tr>

<tr>
    <td><code>jQuery#before/after</code>, small HTML-string, disconnected element</td>
    <td>All browsers shown good speed increase</td>
</tr>

</table>


<h3>Perf hit</h3>

In some situations <code>insertAdjacentHTML</code> method could not be applied, guards for that cases will slow down <code>jQuery#domManip</code> method –

<ul>
<li>If first argument for <code>iAH</code> is either <code>beforebegin</code> or <code>afterend</code> (affect <code>jQuery#before/after</code>), <code>insertAdjacentHTML</code> could not be applied if target element does not have parent element (obviously) or that element is document fragment (less obvious), although <code>iAH</code> could be used if first argument is <code>afterbegin</code> or <code>beforeend</code> (<code>jQuery#append/prepend</code>) for such an element, but it would reguire additional check inside <code>for</code> loop. Perf hit for <code>jQuery#append/prepend</code> methods applied to parentless element would be:
<ul>
<li><code>jQuery#append</code> – <a href="http://jsperf.com/jq-iah-append/4">big</a>/<a href="http://jsperf.com/jq-iah-append/5">small</a> HTML-string</a></li>
<li><code>jQuery#prepend</code> – <a href="http://jsperf.com/jq-iah-prepend/4">big</a>/<a href="http://jsperf.com/jq-iah-prepend/5">small</a> HTML-string</a></li>
</ul>

</li>

<li>HTML-string in IE9, could not be inserted to <code>table</code> element through <code>insertAdjacentHTML</code> method, plus in other browsers, that code path perform <a href="http://jsperf.com/iah-to-table">worse</a> then current way. Perf hit for bypassing <code>table</code> element as target node would be – <a href="http://jsperf.com/iah-to-table/3">http://jsperf.com/iah-to-table/3</a></li>

<li>Sometimes HTML-string must be wrapped, like when creating <code>tr</code> element, in such case if <code>insertAdjacentHTML</code> is not applied to <code>table</code> element that code would silently <a href="http://jsfiddle.net/tQ4K2/">fail</a>, therefore for that cases <code>iAH</code> path must not be taken, perf hit will be the same as for above <code>table</code> example</li>

<li><code>iAH</code> could not take <code>object</code> as an argument. Perf hit by circumventing <code>object</code> as an argument would be – <a href="http://jsperf.com/jq-iah-append-object">http://jsperf.com/jq-iah-append-object</a></li>

<li><code>document fragment</code> (and all other types of an node) does not have <code>insertAdjacentHTML</code> method, also <code>script</code> element should not be inserted that way. Perf hit for that cases would be – http://jsperf.com/jq-iah-append-to-documentfragment</li>
</ul>

<h4>As conclusion</h4>

Performance ratio of WebKit <code>iAH</code> in case of big HTML-string relative to current DOM-manipulation way is utterly depressing, one might even suggest that this happens due to regexp check, but it's not the <a href="http://jsperf.com/iah-append/5">case</a> – in that version of a <code>iAH</code> implementation regexp check is removed, which does not heavily change the picture. Solution for that problem might be size check of HTML-string.

Use of <code>jQuery#append</code> as an example of that idea – <a href="http://jsperf.com/jq-iah-append-limited-html">big</a>/<a href="http://jsperf.com/jq-iah-append-limited-html/2">small</a> HTML-string. This control is flatten disproportion in WebKit case, but it also decrease performance in other browsers.

I suppose big HTML-string is rarely acts as argument in jQuery's DOM-manipulation methods, maybe only in case when whole page should be reflowed, besides, 184 operation per second might be fast enough for that task, ergo it might be more productive to dwell on more optimistic small HTML-string's cases, given the idea that if whether or not <code>iAH</code> should be employed was made only by proceeding outcome most of other samples then decision would be little more obvious? As of perf hit examples (see above) – some of them are rare edge cases, some of them do not matter that much and some of them aren't that conclusive.

But considering all that, i'd say this research is showed a lot of arguments to not use <code>iAH</code> inside of <code>jQuery#domManip</code> at all.
