### PR TITLE
updated Grunt to 0.4.1 (needed for node 0.10.0 compatibility)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
 	"dependencies": {},
 	"devDependencies": {
 		"grunt-compare-size": "~0.4.0",
-		"grunt-git-authors": "1.0.0",
+		"grunt-git-authors": "1.2.0",
 		"grunt-update-submodules": "0.2.0",
-		"grunt-contrib-watch": "0.1.4",
+		"grunt-contrib-watch": "0.3.1",
 		"grunt-contrib-jshint": "0.1.1rc6",
-		"grunt-contrib-uglify": "0.1.1rc6",
+		"grunt-contrib-uglify": "0.1.2",
 		"grunt": "0.4.1",
 		"testswarm": "0.2.2"
 	},


### PR DESCRIPTION
Also, updated some other dependencies (there were some now not needed rc versions required).
