### PR TITLE
make code grunt-contrib-jshint 0.3.0 compatible

### DIFF
--- a/build/release.js
+++ b/build/release.js
@@ -180,7 +180,7 @@ function uploadToCDN( next ) {
 		});
 	});
 	cmds.push( next );
-	
+
 	steps.apply( this, cmds );
 }
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"grunt-git-authors": "1.2.0",
 		"grunt-update-submodules": "0.2.0",
 		"grunt-contrib-watch": "0.3.1",
-		"grunt-contrib-jshint": "0.1.1rc6",
+		"grunt-contrib-jshint": "0.3.0",
 		"grunt-contrib-uglify": "0.1.2",
 		"grunt": "0.4.1",
 		"testswarm": "0.2.2"

--- a/speed/benchmark.js
+++ b/speed/benchmark.js
@@ -4,7 +4,7 @@ function benchmark(fn, times, name){
 	var s = fn.indexOf('{')+1,
 		e = fn.lastIndexOf('}');
 	fn = fn.substring(s,e);
-	
+
 	return benchmarkString(fn, times, name);
 }
 

--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -3,15 +3,17 @@
 	"expr": true,
 	"newcap": false,
 	"quotmark": "double",
-	"regexdash": true,
 	"trailing": true,
 	"undef": true,
 	"unused": true,
+	"latedef": false,
+	"eqeqeq": true,
 	"maxerr": 100,
 
 	"eqnull": true,
 	"evil": true,
 	"sub": true,
+	"boss": true,
 
 	"browser": true,
 	"wsh": true,

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -445,8 +445,8 @@ jQuery.extend({
 			parts = rurl.exec( s.url.toLowerCase() );
 			s.crossDomain = !!( parts &&
 				( parts[ 1 ] !== ajaxLocParts[ 1 ] || parts[ 2 ] !== ajaxLocParts[ 2 ] ||
-					( parts[ 3 ] || ( parts[ 1 ] === "http:" ? 80 : 443 ) ) !=
-						( ajaxLocParts[ 3 ] || ( ajaxLocParts[ 1 ] === "http:" ? 80 : 443 ) ) )
+					( parts[ 3 ] || ( parts[ 1 ] === "http:" ? "80" : "443" ) ) !==
+						( ajaxLocParts[ 3 ] || ( ajaxLocParts[ 1 ] === "http:" ? "80" : "443" ) ) )
 			);
 		}
 

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -279,14 +279,14 @@ jQuery.extend({
 					options = elem.options,
 					values = jQuery.makeArray( value ),
 					i = options.length;
-				
+
 				while ( i-- ) {
 					option = options[ i ];
 					if ( (option.selected = jQuery.inArray( jQuery(option).val(), values ) >= 0) ) {
 						optionSet = true;
 					}
 				}
-				
+
 				// force browsers to behave consistently when non-matching value is set
 				if ( !optionSet ) {
 					elem.selectedIndex = -1;

--- a/src/core.js
+++ b/src/core.js
@@ -435,6 +435,7 @@ jQuery.extend({
 	},
 
 	isWindow: function( obj ) {
+		/* jshint eqeqeq: false */
 		return obj != null && obj == obj.window;
 	},
 

--- a/src/data.js
+++ b/src/data.js
@@ -169,7 +169,9 @@ function internalRemoveData( elem, name, pvt ) {
 		jQuery.cleanData( [ elem ], true );
 
 	// Use delete when supported for expandos or `cache` is not a window per isWindow (#10080)
+	/* jshint eqeqeq: false */
 	} else if ( jQuery.support.deleteExpando || cache != cache.window ) {
+		/* jshint eqeqeq: true */
 		delete cache[ id ];
 
 	// When all else fails, null

--- a/src/effects.js
+++ b/src/effects.js
@@ -175,7 +175,7 @@ function Animation( elem, properties, options ) {
 }
 
 function propFilter( props, specialEasing ) {
-	var value, name, index, easing, hooks;
+	var index, name, easing, value, hooks;
 
 	// camelCase, specialEasing and expand cssHook pass
 	for ( index in props ) {
@@ -242,7 +242,7 @@ jQuery.Animation = jQuery.extend( Animation, {
 });
 
 function defaultPrefilter( elem, props, opts ) {
-	/*jshint validthis:true */
+	/* jshint validthis: true */
 	var prop, index, length,
 		value, dataShow, toggle,
 		tween, hooks, oldfire,
@@ -451,8 +451,8 @@ Tween.propHooks = {
 	}
 };
 
-// Remove in 2.0 - this supports IE8's panic based approach
-// to setting things on disconnected nodes
+// Support: IE <=9
+// Panic based approach to setting things on disconnected nodes
 
 Tween.propHooks.scrollTop = Tween.propHooks.scrollLeft = {
 	set: function( tween ) {

--- a/src/event.js
+++ b/src/event.js
@@ -67,7 +67,7 @@ jQuery.event = {
 			tmp = rtypenamespace.exec( types[t] ) || [];
 			type = origType = tmp[1];
 			namespaces = ( tmp[2] || "" ).split( "." ).sort();
-			
+
 			// There *must* be a type, no attaching namespace-only handlers
 			if ( !type ) {
 				continue;
@@ -412,7 +412,9 @@ jQuery.event = {
 		// Avoid non-left-click bubbling in Firefox (#3861)
 		if ( delegateCount && cur.nodeType && (!event.button || event.type !== "click") ) {
 
+			/* jshint eqeqeq: false */
 			for ( ; cur != this; cur = cur.parentNode || this ) {
+				/* jshint eqeqeq: true */
 
 				// Don't check non-elements (#13208)
 				// Don't process clicks on disabled elements (#6911, #8165, #11382, #11764)

--- a/test/data/testrunner.js
+++ b/test/data/testrunner.js
@@ -337,7 +337,7 @@ var Globals = (function() {
 		} else {
 			delete jQuery.ajaxSettings;
 		}
-		
+
 		// Cleanup globals
 		Globals.cleanup();
 

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -199,7 +199,7 @@ module( "ajax", {
 				tmp.push( i, ": ", requestHeaders[ i ], "\n" );
 			}
 			tmp = tmp.join("");
-			
+
 			strictEqual( data, tmp, "Headers were sent" );
 			strictEqual( xhr.getResponseHeader("Sample-Header"), "Hello World", "Sample header received" );
 
@@ -299,7 +299,7 @@ module( "ajax", {
 			samePort = loc.port || ( loc.protocol === "http:" ? 80 : 443 ),
 			otherPort = loc.port === 666 ? 667 : 666,
 			otherProtocol = loc.protocol === "http:" ? "https:" : "http:";
-			
+
 		return [
 			request(
 				loc.protocol + "//" + loc.host + ":" + samePort,
@@ -390,7 +390,7 @@ module( "ajax", {
 			}]
 		};
 	});
-		
+
 	ajaxTest( "jQuery.ajax() - events without context", 3, function() {
 		function nocallback( msg ) {
 			return function() {
@@ -601,9 +601,9 @@ module( "ajax", {
 	});
 
 	ajaxTest( "jQuery.ajax() - cache", 12, function() {
-		
+
 		var re = /_=(.*?)(&|$)/g;
-		
+
 		function request( url, title ) {
 			return {
 				url: url,
@@ -620,7 +620,7 @@ module( "ajax", {
 				error: true
 			};
 		}
-		
+
 		return [
 			request(
 				"data/text.php",
@@ -1356,7 +1356,7 @@ module( "ajax", {
 			}
 		}
 	]);
-	
+
 	jQuery.each( [ " - Same Domain", " - Cross Domain" ], function( crossDomain, label ) {
 		ajaxTest( "#8205 - jQuery.ajax() - JSONP - re-use callbacks name" + label, 2, {
 			url: "data/jsonp.php",
@@ -1401,7 +1401,7 @@ module( "ajax", {
 	});
 
 	jQuery.each( [ "as argument", "in settings object" ], function( inSetting, title ) {
-		
+
 		function request( url, test ) {
 			return {
 				create: function() {
@@ -1412,14 +1412,14 @@ module( "ajax", {
 				}
 			};
 		}
-		
+
 		ajaxTest( "#10093 - jQuery.ajax() - falsy url " + title, 4, [
 			request( "", "empty string" ),
 			request( false ),
 			request( null ),
 			request( undefined )
 		]);
-		
+
 	});
 
 	ajaxTest( "#11151 - jQuery.ajax() - parse error body", 2, {
@@ -1492,7 +1492,7 @@ module( "ajax", {
 				request()
 			]
 		});
-		
+
 	});
 
 	ajaxTest( "#13276 - jQuery.ajax() - compatibility between XML documents from ajax requests and parsed string", 1, {
@@ -1510,7 +1510,7 @@ module( "ajax", {
 			strictEqual( ajaxXML.find("tab").length, 3, "Parsed node was added properly" );
 		}
 	});
-	
+
 	ajaxTest( "#13292 - jQuery.ajax() - converter is bypassed for 204 requests", 3, {
 		url: "data/nocontent.php",
 		dataType: "testing",
@@ -1744,7 +1744,7 @@ module( "ajax", {
 	});
 
 //----------- jQuery.fn.load()
-	
+
 	// check if load can be called with only url
 	asyncTest( "jQuery.fn.load( String )", 2, function() {
 		jQuery.ajaxSetup({

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -852,17 +852,17 @@ test( "val()", function() {
 
 test("val() with non-matching values on dropdown list", function() {
 	expect( 3 );
-	
+
 	jQuery("#select5").val( "" );
 	equal( jQuery("#select5").val(), null, "Non-matching set on select-one" );
-	
+
 	var select6 = jQuery("<select multiple id=\"select6\"><option value=\"1\">A</option><option value=\"2\">B</option></select>").appendTo("#form");
 	jQuery(select6).val( "nothing" );
 	equal( jQuery(select6).val(), null, "Non-matching set (single value) on select-multiple" );
-	
+
 	jQuery(select6).val( ["nothing1", "nothing2"] );
 	equal( jQuery(select6).val(), null, "Non-matching set (array of values) on select-multiple" );
-	
+
 	select6.remove();
 });
 


### PR DESCRIPTION
I also turned the `eqeqeq` option on, disabling it only in a few places where loose window comparisons are needed for oldIE.
