### PR TITLE
corrected some oldIE-related comments, reverted some workarounds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,10 +207,12 @@ This will only run the "css" module tests. This will significantly speed up your
 **ALWAYS RUN THE FULL SUITE BEFORE COMMITTING AND PUSHING A PATCH!**
 
 
-### jQuery supports the following browsers:
+### jQuery 2.x supports the following browsers:
 
 * Chrome Current-1
 * Safari Current-1
 * Firefox Current-1
-* IE 6+
+* IE 9+
 * Opera Current-1
+
+jQuery 1.x additionally supports IE6+.

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -8,7 +8,7 @@ var
 	ajax_rquery = /\?/,
 	rhash = /#.*$/,
 	rts = /([?&])_=[^&]*/,
-	rheaders = /^(.*?):[ \t]*([^\r\n]*)\r?$/mg, // IE leaves an \r character at EOL
+	rheaders = /^(.*?):[ \t]*([^\r\n]*)$/mg,
 	// #7653, #8125, #8152: local protocol detection
 	rlocalProtocol = /^(?:about|app|app-storage|.+-extension|file|res|widget):$/,
 	rnoContent = /^(?:GET|HEAD)$/,

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -23,11 +23,8 @@ jQuery.fn.extend({
 	removeProp: function( name ) {
 		name = jQuery.propFix[ name ] || name;
 		return this.each(function() {
-			// try/catch handles cases where IE balks (such as removing a property on window)
-			try {
-				this[ name ] = undefined;
-				delete this[ name ];
-			} catch( e ) {}
+			this[ name ] = undefined;
+			delete this[ name ];
 		});
 	},
 
@@ -249,7 +246,7 @@ jQuery.extend({
 				for ( ; i < max; i++ ) {
 					option = options[ i ];
 
-					// oldIE doesn't update selected after form reset (#2551)
+					// IE6-9 doesn't update selected after form reset (#2551)
 					if ( ( option.selected || i === index ) &&
 							// Don't return options that are disabled or in a disabled optgroup
 							( jQuery.support.optDisabled ? !option.disabled : option.getAttribute("disabled") === null ) &&

--- a/src/core.js
+++ b/src/core.js
@@ -133,13 +133,7 @@ jQuery.fn = jQuery.prototype = {
 					// Check parentNode to catch when Blackberry 4.6 returns
 					// nodes that are no longer in the document #6963
 					if ( elem && elem.parentNode ) {
-						// Handle the case where IE and Opera return items
-						// by name instead of ID
-						if ( elem.id !== match[2] ) {
-							return rootjQuery.find( selector );
-						}
-
-						// Otherwise, we inject the element directly into the jQuery object
+						// Inject the element directly into the jQuery object
 						this.length = 1;
 						this[0] = elem;
 					}

--- a/src/effects.js
+++ b/src/effects.js
@@ -279,7 +279,7 @@ function defaultPrefilter( elem, props, opts ) {
 	// height/width overflow pass
 	if ( elem.nodeType === 1 && ( "height" in props || "width" in props ) ) {
 		// Make sure that nothing sneaks out
-		// Record all 3 overflow attributes because IE does not
+		// Record all 3 overflow attributes because IE9-10 do not
 		// change the overflow attribute when overflowX and
 		// overflowY are set to the same value
 		opts.overflow = [ style.overflow, style.overflowX, style.overflowY ];


### PR DESCRIPTION
I've spent some time looking for IE workarounds left in the code; I tried to test which ones might be still needed - and then update comments so that it's clear workarounds weren't needed just for oldIE - and reverted a few workarounds.

Now, I'm not 100% sure if all those decisions were correct so bare with me. I've run the full jQuery test suite and my changes didn't introduce any new bugs. I'll now add inline comments to the lines I've changed explaining my motives.

There are just a few issues I didn't know what to do about:

1) ajax.js, lines 42-52: wrapping accessing `location.href` in try-catch to account for some location properties becoming write-only after changing `document.domain`.
Bug report linked didn't have any test case and my naive attempts didn't produce anything significant. I created a simple test case: http://jsfiddle.net/ZgcNN/2/ but even IE6 passes it each time so I guess it's not that simple. Is there any way to test if this workaround is still needed? Any ideas?

2) ajax.js, lines 175-177: Exclude scripts to avoid IE 'Permission Denied' errors.
Is the mentioned error the only reason why scripts are excluded here? If so, I might try to test further but if it's not that maybe the comment should be changed.
