### PR TITLE
Fix responseXML problem with none async request

### DIFF
--- a/src/ajax/xhr.js
+++ b/src/ajax/xhr.js
@@ -133,6 +133,10 @@ if ( xhrSupported ) {
 									status = xhr.status;
 									responseHeaders = xhr.getAllResponseHeaders();
 
+									if ( "object" === typeof xhr.responseXML ) {
+										responses.xml = xhr.responseXML;
+									}
+
 									// When requesting binary data, IE6-9 will throw an exception
 									// on any attempt to access responseText (#11426)
 									if ( typeof xhr.responseText === "string" ) {


### PR DESCRIPTION
Two examples:
jQuery v1.9 : doesn't work as expected
http://jsfiddle.net/kein1945/UjPEk/

jQuery v1.6.4 : work correct. Object contains responseXML field
http://jsfiddle.net/kein1945/UjPEk/1/

Actually version 2.0 doesn't work too.
