### PR TITLE
Specifies variable in grunt-compare-size options.cache to match .gitignore file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,6 +7,7 @@ module.exports = function( grunt ) {
 			"dist/jquery.min.map",
 			"dist/jquery.min.js"
 		],
+    gzip = require("gzip-js"),
 		readOptionalJSON = function( filepath ) {
 			var data = {};
 			try {
@@ -19,8 +20,13 @@ module.exports = function( grunt ) {
 		pkg: grunt.file.readJSON("package.json"),
 		dst: readOptionalJSON("dist/.destination.json"),
 		compare_size: {
-			files: ["dist/jquery*.js"],
+			files: [ "dist/jquery.js", "dist/jquery.min.js" ],
 			options: {
+				compress: {
+					gz: function( contents ) {
+						return gzip.zip( contents, {} ).length;
+					}
+				},
 				cache: "dist/.sizecache.json"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 		"grunt-contrib-jshint": "0.1.1rc6",
 		"grunt-contrib-uglify": "0.1.2",
 		"grunt": "0.4.1",
+		"gzip-js": "0.3.1",
 		"testswarm": "0.2.2"
 	},
 	"keywords": []


### PR DESCRIPTION
Just noticed in my internal build and pulled the docs from https://github.com/rwldrn/grunt-compare-size#documentation and the project's .gitignore

Build works as expected when modified:

``` bash
# Current upstream/master
$ grunt compare_size
# output
$ git status -s
?? .sizecache.json


# Pull Request
$ grunt compare_size
# output
$ git status -s
$ 
```
