### PR TITLE
JSHint Option Discussion

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -8,7 +8,6 @@
 	"unused": true,
 	"latedef": false,
 	"eqeqeq": true,
-	"maxerr": 100,
 
 	"eqnull": true,
 	"sub": true,


### PR DESCRIPTION
Ignore the commit. I just wanted to have this discussion in GitHub and we don't have issues turned on :-)

The following options are currently used in our various code repos:

<table>
<thead>
<tr>
  <th>option</th>
  <th colspan="3">jquery</th>
  <th colspan="3">jquery-ui</th>
  <th colspan="2">jquery-mobile</th>
  <th colspan="3">sizzle</th>
  <th colspan="2">qunit</th>
</tr>
</thead>
<tbody>
<tr>
  <td>bitwise</td>

  <td></td>
  <td></td>
  <td></td>

  <td></td>
  <td></td>
  <td></td>

  <td></td>
  <td></td>

  <td></td>
  <td></td>
  <td></td>

  <td>✓</td>
  <td>✓</td>
</tr>
<tr>
  <td>boss</td>

  <td></td>
  <td>✓</td>
  <td></td>

  <td></td>
  <td></td>
  <td></td>

  <td></td>
  <td>✓</td>

  <td>✓</td>
  <td></td>
  <td></td>

  <td></td>
  <td></td>
</tr>
<tr>
  <td>camelcase</td>

  <td></td>
  <td></td>
  <td></td>

  <td></td>
  <td></td>
  <td></td>

  <td></td>
  <td></td>

  <td></td>
  <td></td>
  <td></td>

  <td>✓</td>
  <td>✓</td>
</tr>
<tr>
  <td>curly</td>

  <td>✓</td>
  <td>✓</td>
  <td>✓</td>

  <td>✓</td>
  <td>✓</td>
  <td>✓</td>

  <td>✓</td>
  <td>✓</td>

  <td>✓</td>
  <td>✓</td>
  <td>✓</td>

  <td>✓</td>
  <td>✓</td>
</tr>
<tr>
  <td>eqnull</td>

  <td></td>
  <td>✓</td>
  <td>✓</td>

  <td>✓</td>
  <td>✓</td>
  <td>✓</td>

  <td>✓</td>
  <td>✓</td>

  <td>✓</td>
  <td>✓</td>
  <td>✓</td>

  <td></td>
  <td></td>
</tr>
<tr>
  <td>eqeqeq</td>

  <td>✓</td>
  <td>✓</td>
  <td></td>

  <td>✓</td>
  <td>✓</td>
  <td>✓</td>

  <td>✓</td>
  <td>✓</td>

  <td>✓</td>
  <td></td>
  <td></td>

  <td>✓</td>
  <td>✓</td>
</tr>
<tr>
  <td>expr</td>

  <td></td>
  <td>✓</td>
  <td>✓</td>

  <td>✓</td>
  <td>✓</td>
  <td>✓</td>

  <td>✓</td>
  <td></td>

  <td>✓</td>
  <td>✓</td>
  <td>✓</td>

  <td></td>
  <td></td>
</tr>
<tr>
  <td>forin</td>

  <td></td>
  <td></td>
  <td></td>

  <td></td>
  <td></td>
  <td></td>

  <td></td>
  <td></td>

  <td></td>
  <td></td>
  <td></td>

  <td>✓</td>
  <td>✓</td>
</tr>
<tr>
  <td>immed</td>

  <td></td>
  <td></td>
  <td></td>

  <td></td>
  <td></td>
  <td></td>

  <td></td>
  <td></td>

  <td></td>
  <td></td>
  <td></td>

  <td>✓</td>
  <td>✓</td>
</tr>
<tr>
  <td>latedef</td>

  <td>✓</td>
  <td>✘</td>
  <td></td>

  <td></td>
  <td>✓</td>
  <td>✓</td>

  <td></td>
  <td>✓</td>

  <td>✘</td>
  <td></td>
  <td></td>

  <td>✘</td>
  <td>✘</td>
</tr>
<tr>
  <td>newcap</td>

  <td></td>
  <td>✘</td>
  <td></td>

  <td></td>
  <td></td>
  <td></td>

  <td></td>
  <td>✓</td>

  <td>✘</td>
  <td></td>
  <td></td>

  <td>✓</td>
  <td>✓</td>
</tr>
<tr>
  <td>noarg</td>

  <td>✓</td>
  <td></td>
  <td></td>

  <td>✓</td>
  <td>✓</td>
  <td>✓</td>

  <td>✓</td>
  <td>✓</td>

  <td></td>
  <td></td>
  <td></td>

  <td>✓</td>
  <td>✓</td>
</tr>
<tr>
  <td>noempty</td>

  <td>✓</td>
  <td></td>
  <td></td>

  <td></td>
  <td></td>
  <td></td>

  <td></td>
  <td></td>

  <td></td>
  <td></td>
  <td></td>

  <td>✓</td>
  <td>✓</td>
</tr>
<tr>
  <td>nonew</td>

  <td></td>
  <td></td>
  <td></td>

  <td></td>
  <td></td>
  <td></td>

  <td></td>
  <td></td>

  <td></td>
  <td></td>
  <td></td>

  <td>✓</td>
  <td>✓</td>
</tr>
<tr>
  <td>onevar</td>

  <td></td>
  <td></td>
  <td></td>

  <td>✓</td>
  <td>✓</td>
  <td>✓</td>

  <td>✓</td>
  <td></td>

  <td></td>
  <td></td>
  <td></td>

  <td>✓</td>
  <td>✘</td>
</tr>
<tr>
  <td>plusplus</td>

  <td></td>
  <td></td>
  <td></td>

  <td></td>
  <td></td>
  <td></td>

  <td></td>
  <td></td>

  <td></td>
  <td></td>
  <td></td>

  <td>✘</td>
  <td>✘</td>
</tr>
<tr>
  <td>proto</td>

  <td></td>
  <td></td>
  <td></td>

  <td></td>
  <td></td>
  <td></td>

  <td></td>
  <td></td>

  <td></td>
  <td></td>
  <td></td>

  <td>✓</td>
  <td></td>
</tr>
<tr>
  <td>quotmark</td>

  <td>✓</td>
  <td>✓</td>
  <td>✓</td>

  <td></td>
  <td>✓</td>
  <td>✓</td>

  <td></td>
  <td></td>

  <td>✓</td>
  <td></td>
  <td>✓</td>

  <td>✓</td>
  <td>✘</td>
</tr>
<tr>
  <td>smarttabs</td>

  <td></td>
  <td></td>
  <td>✓</td>

  <td></td>
  <td></td>
  <td></td>

  <td></td>
  <td></td>

  <td>✓</td>
  <td>✓</td>
  <td>✓</td>

  <td></td>
  <td></td>
</tr>
<tr>
  <td>sub</td>

  <td></td>
  <td>✓</td>
  <td>✓</td>

  <td></td>
  <td></td>
  <td></td>

  <td></td>
  <td>✓</td>

  <td>✓</td>
  <td>✓</td>
  <td>✓</td>

  <td>✓</td>
  <td></td>
</tr>
<tr>
  <td>trailing</td>

  <td>✓</td>
  <td>✓</td>
  <td>✓</td>

  <td>✓</td>
  <td>✓</td>
  <td>✓</td>

  <td>✓</td>
  <td></td>

  <td>✓</td>
  <td>✓</td>
  <td>✓</td>

  <td>✓</td>
  <td>✓</td>
</tr>
<tr>
  <td>undef</td>

  <td>✓</td>
  <td>✓</td>
  <td>✓</td>

  <td>✓</td>
  <td>✓</td>
  <td>✓</td>

  <td>✓</td>
  <td>✓</td>

  <td>✓</td>
  <td>✓</td>
  <td>✓</td>

  <td>✓</td>
  <td>✓</td>
</tr>
<tr>
  <td>unused</td>

  <td>✓</td>
  <td>✓</td>
  <td></td>

  <td>✓</td>
  <td>✓</td>
  <td>✓</td>

  <td>✓</td>
  <td></td>

  <td>✓</td>
  <td>✓</td>
  <td></td>

  <td>✓</td>
  <td>✓</td>
</tr>
</tbody>
</table>


The three columns for each project are: root, js source, tests.
- jquery-mobile doesn't have a `.jshintrc` specifically for tests.
- sizzle is root, speed, tests.
- qunit doesn't have a `.jshintrc` specifically for js source.

✘ means the option is explicitly disabled (set to `false`).

---

I'd like us to agree on a baseline of options that must be enabled in all projects. Once we have that list, we should update our `.jshintrc` files to have the options alphabetized and grouped:

``` json
{
    "common1": true,
    "common2": true,
    "common3": true,

    "repoSpecific1": true,
    "repoSpecific2": true,

    "globals": {
        "repoGlobal1": true,
        "repoGlobal2": false
    }
}
```

---

Proposed common options:

``` json
{
    "boss": true,
    "curly": true,
    "eqeqeq": true,
    "eqnull": true,
    "expr": true,
    "immed": true,
    "noarg": true,
    "onevar": true,
    "quotmark": "double",
    "smarttabs": true,
    "trailing": true,
    "undef": true,
    "unused": true
}
```
