### PR TITLE
Fixes #8335 for 2.0, makes additional simplifications for data module and more

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -133,14 +133,14 @@ jQuery.fn.extend({
 			} else if ( type === core_strundefined || type === "boolean" ) {
 				if ( this.className ) {
 					// store className if set
-					jQuery._data( this, "__className__", this.className );
+					data_priv.set( this, "__className__", this.className );
 				}
 
 				// If the element has a class name or if we're passed "false",
 				// then remove the whole classname (if there was one, the above saved it).
 				// Otherwise bring back whatever was previously saved (if anything),
 				// falling back to the empty string if nothing was stored.
-				this.className = this.className || value === false ? "" : jQuery._data( this, "__className__" ) || "";
+				this.className = this.className || value === false ? "" : data_priv.get( this, "__className__" ) || "";
 			}
 		});
 	},

--- a/src/css.js
+++ b/src/css.js
@@ -65,7 +65,7 @@ function showHide( elements, show ) {
 			continue;
 		}
 
-		values[ index ] = jQuery._data( elem, "olddisplay" );
+		values[ index ] = data_priv.get( elem, "olddisplay" );
 		display = elem.style.display;
 		if ( show ) {
 			// Reset the inline display of this element to learn if it is
@@ -78,7 +78,7 @@ function showHide( elements, show ) {
 			// in a stylesheet to whatever the default browser style is
 			// for such an element
 			if ( elem.style.display === "" && isHidden( elem ) ) {
-				values[ index ] = jQuery._data( elem, "olddisplay", css_defaultDisplay(elem.nodeName) );
+				values[ index ] = data_priv.access( elem, "olddisplay", css_defaultDisplay(elem.nodeName) );
 			}
 		} else {
 
@@ -86,7 +86,7 @@ function showHide( elements, show ) {
 				hidden = isHidden( elem );
 
 				if ( display && display !== "none" || !hidden ) {
-					jQuery._data( elem, "olddisplay", hidden ? display : jQuery.css( elem, "display" ) );
+					data_priv.set( elem, "olddisplay", hidden ? display : jQuery.css(elem, "display") );
 				}
 			}
 		}

--- a/src/effects.js
+++ b/src/effects.js
@@ -318,7 +318,7 @@ function defaultPrefilter( elem, props, opts ) {
 
 	length = handled.length;
 	if ( length ) {
-		dataShow = jQuery._data( elem, "fxshow" ) || jQuery._data( elem, "fxshow", {} );
+		dataShow = data_priv.get( elem, "fxshow" ) || data_priv.access( elem, "fxshow", {} );
 		if ( "hidden" in dataShow ) {
 			hidden = dataShow.hidden;
 		}
@@ -336,7 +336,8 @@ function defaultPrefilter( elem, props, opts ) {
 		}
 		anim.done(function() {
 			var prop;
-			jQuery._removeData( elem, "fxshow" );
+
+			data_priv.remove( elem, "fxshow" );
 			for ( prop in orig ) {
 				jQuery.style( elem, prop, orig[ prop ] );
 			}
@@ -479,7 +480,7 @@ jQuery.fn.extend({
 					anim.stop( true );
 				};
 				// Empty animations, or finishing resolves immediately
-				if ( empty || jQuery._data( this, "finish" ) ) {
+				if ( empty || data_priv.get( this, "finish" ) ) {
 					anim.stop( true );
 				}
 			};
@@ -509,7 +510,7 @@ jQuery.fn.extend({
 			var dequeue = true,
 				index = type != null && type + "queueHooks",
 				timers = jQuery.timers,
-				data = jQuery._data( this );
+				data = data_priv.get( this );
 
 			if ( index ) {
 				if ( data[ index ] && data[ index ].stop ) {
@@ -545,7 +546,7 @@ jQuery.fn.extend({
 		}
 		return this.each(function() {
 			var index,
-				data = jQuery._data( this ),
+				data = data_priv.get( this ),
 				queue = data[ type + "queue" ],
 				hooks = data[ type + "queueHooks" ],
 				timers = jQuery.timers,

--- a/src/event.js
+++ b/src/event.js
@@ -196,10 +196,7 @@ jQuery.event = {
 		// Remove the expando if it's no longer used
 		if ( jQuery.isEmptyObject( events ) ) {
 			delete elemData.handle;
-
-			// removeData also checks for emptiness and clears the expando if empty
-			// so use it instead of delete
-			jQuery._removeData( elem, "events" );
+			data_priv.remove( elem, "events" );
 		}
 	},
 
@@ -287,7 +284,7 @@ jQuery.event = {
 				special.bindType || type;
 
 			// jQuery handler
-			handle = ( jQuery._data( cur, "events" ) || {} )[ event.type ] && jQuery._data( cur, "handle" );
+			handle = ( data_priv.get( cur, "events" ) || {} )[ event.type ] && data_priv.get( cur, "handle" );
 			if ( handle ) {
 				handle.apply( cur, data );
 			}
@@ -340,7 +337,7 @@ jQuery.event = {
 		var i, j, ret, matched, handleObj,
 			handlerQueue = [],
 			args = core_slice.call( arguments ),
-			handlers = ( jQuery._data( this, "events" ) || {} )[ event.type ] || [],
+			handlers = ( data_priv.get( this, "events" ) || {} )[ event.type ] || [],
 			special = jQuery.event.special[ event.type ] || {};
 
 		// Use the fix-ed jQuery.Event rather than the (read-only) native event

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -442,7 +442,7 @@ jQuery.extend({
 		return fragment;
 	},
 
-	cleanData: function( elems, /* internal */ acceptData ) {
+	cleanData: function( elems ) {
 		var data, elem, type,
 			l = elems.length,
 			i = 0,
@@ -451,7 +451,7 @@ jQuery.extend({
 		for ( ; i < l; i++ ) {
 			elem = elems[ i ];
 
-			if ( acceptData || jQuery.acceptData( elem ) ) {
+			if ( jQuery.acceptData( elem ) ) {
 
 				data = data_priv.access( elem );
 
@@ -468,7 +468,10 @@ jQuery.extend({
 				}
 			}
 			// Discard any remaining `private` and `user` data
-			data_discard( elem );
+			// One day we'll replace the dual arrays with a WeakMap and this won't be an issue.
+			// (Splices the data objects out of the internal cache arrays)
+			data_user.discard( elem );
+			data_priv.discard( elem );
 		}
 	}
 });

--- a/src/queue.js
+++ b/src/queue.js
@@ -4,12 +4,12 @@ jQuery.extend({
 
 		if ( elem ) {
 			type = ( type || "fx" ) + "queue";
-			queue = jQuery._data( elem, type );
+			queue = data_priv.get( elem, type );
 
 			// Speed up dequeue by getting out quickly if this is just a lookup
 			if ( data ) {
-				if ( !queue || jQuery.isArray(data) ) {
-					queue = jQuery._data( elem, type, jQuery.makeArray(data) );
+				if ( !queue || jQuery.isArray( data ) ) {
+					queue = data_priv.access( elem, type, jQuery.makeArray(data) );
 				} else {
 					queue.push( data );
 				}
@@ -57,10 +57,9 @@ jQuery.extend({
 	// not intended for public consumption - generates a queueHooks object, or returns the current one
 	_queueHooks: function( elem, type ) {
 		var key = type + "queueHooks";
-		return jQuery._data( elem, key ) || jQuery._data( elem, key, {
+		return data_priv.get( elem, key ) || data_priv.access( elem, key, {
 			empty: jQuery.Callbacks("once memory").add(function() {
-				jQuery._removeData( elem, type + "queue" );
-				jQuery._removeData( elem, key );
+				data_priv.remove( elem, [ type + "queue", key ] );
 			})
 		});
 	}
@@ -135,7 +134,7 @@ jQuery.fn.extend({
 		type = type || "fx";
 
 		while( i-- ) {
-			tmp = jQuery._data( elements[ i ], type + "queueHooks" );
+			tmp = data_priv.get( elements[ i ], type + "queueHooks" );
 			if ( tmp && tmp.empty ) {
 				count++;
 				tmp.empty.add( resolve );

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -177,14 +177,6 @@ test("jQuery.data(object/applet)", 25, function() {
 	dataTests( applet );
 });
 
-test("jQuery.data(comment)", 25, function() {
-	dataTests( document.createComment("") );
-});
-
-test("jQuery.data(text)", 25, function() {
-	dataTests( document.createTextNode("") );
-});
-
 test(".data()", function() {
 	expect(5);
 
@@ -691,4 +683,24 @@ test(".data doesn't throw when calling selection is empty. #13551", function() {
 	} catch ( e ) {
 		ok( false, e.message );
 	}
+});
+
+test("jQuery.acceptData", 6, function() {
+	ok( jQuery.acceptData( document ), "document" );
+	ok( jQuery.acceptData( document.documentElement ), "documentElement" );
+	ok( jQuery.acceptData( {} ), "object" );
+
+	ok( !jQuery.acceptData( document.createComment("") ), "comment" );
+	ok( !jQuery.acceptData( document.createTextNode("") ), "text" );
+	ok( !jQuery.acceptData( document.createDocumentFragment() ), "documentFragment" );
+});
+
+test("Check proper data removal of non-element descendants nodes (#8335)", 1, function() {
+    var div = jQuery("<div>text</div>"),
+        text = div.contents();
+
+    text.data( "test", "test" ); // This should be a noop.
+    div.remove();
+
+    ok( !text.data("test"), "Be sure data is not stored in non-element" );
 });

--- a/test/unit/queue.js
+++ b/test/unit/queue.js
@@ -253,6 +253,12 @@ test( ".promise(obj)", function() {
 	strictEqual( promise, obj, ".promise(type, obj) returns obj" );
 });
 
+test( "jQuery.queue should return array while manipulating the queue", 1, function() {
+	var div = document.createElement("div");
+
+	ok( jQuery.isArray( jQuery.queue( div, "fx", jQuery.noop ) ), "jQuery.queue should return an array while manipulating the queue" );
+});
+
 
 if ( jQuery.fn.stop ) {
 	test("delay() can be stopped", function() {
@@ -312,5 +318,4 @@ if ( jQuery.fn.stop ) {
 
 		foo.stop( false, true );
 	});
-
 } // if ( jQuery.fn.stop )


### PR DESCRIPTION
1) Use data_priv methods instead of jQuery._removeData and jQuery._data
2) Update couple comments in data module
3) Simplify Data methods
4) Remove needless, internal second argument of jQuery.cleanData
5) Add Data#accept method
6) Add tests for jQuery.acceptData and #8335
7) Add additional test for jQuery.queue

/cc @rwldrn
