### PR TITLE
move jQuery.fn.size to deprecated

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -179,11 +179,6 @@ jQuery.fn = jQuery.prototype = {
 	// The default length of a jQuery object is 0
 	length: 0,
 
-	// The number of elements contained in the matched element set
-	size: function() {
-		return this.length;
-	},
-
 	toArray: function() {
 		return core_slice.call( this );
 	},

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -3,4 +3,9 @@
 
 jQuery.fn.andSelf = jQuery.fn.addBack;
 
+// The number of elements contained in the matched element set
+jQuery.fn.size = function() {
+	return this.length;
+};
+
 // })();


### PR DESCRIPTION
Pros:
- deprecated code is in the proper module
- -7 bytes minified gzipped when excluding deprecated (with regards to custom:-deprecated without moving jQuery.fn.size)

Cons:
- +2 bytes minified gzipped for the full build.

Ticket: http://bugs.jquery.com/ticket/13744
