### PR TITLE
retrieve css left value with px unit

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -528,7 +528,7 @@ jQuery(function() {
 					if ( computed ) {
 						computed = curCSS( elem, prop );
 						// if curCSS returns percentage, fallback to offset
-						return rnumnonpx.test( computed ) ?
+						return computed === "auto" || rnumnonpx.test( computed ) ?
 							jQuery( elem ).position()[ prop ] + "px" :
 							computed;
 					}

--- a/src/support.js
+++ b/src/support.js
@@ -78,14 +78,14 @@ jQuery.support = (function( support ) {
 		// Check box-sizing and margin behavior
 		body.appendChild( container ).appendChild( div );
 		div.innerHTML = "";
-		div.style.cssText = "box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;padding:1px;border:1px;display:block;width:4px;margin-top:1%;position:absolute;top:1%;";
+		div.style.cssText = "box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;padding:1px;border:1px;display:block;width:4px;margin-top:1%;position:absolute;";
 
 		support.boxSizing = div.offsetWidth === 4;
 		support.doesNotIncludeMarginInBodyOffset = body.offsetTop !== 1;
 
 		// Use window.getComputedStyle because jsdom on node.js will break without it.
 		if ( window.getComputedStyle ) {
-			support.pixelPosition = ( window.getComputedStyle( div, null ) || {} ).top !== "1%";
+			support.pixelPosition = ( window.getComputedStyle( div, null ) || {} ).top !== "auto";
 			support.boxSizingReliable = ( window.getComputedStyle( div, null ) || { width: "4px" } ).width === "4px";
 
 			// Check if div with explicit width and no margin-right incorrectly

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -856,6 +856,17 @@ test( "css opacity consistency across browsers (#12685)", function() {
 	equal( Math.round( el.css("opacity") * 100 ), 20, "remove opacity override" );
 });
 
+
+test( "left px value across browser (#12685)", function() {
+    expect( 1 );
+
+    var fixture = jQuery("#qunit-fixture"),
+        el = jQuery("<div style='position: absolute;padding: 20px;'>" +
+            "<div style='position: absolute'></div></div>").appendTo(fixture);
+
+    equal( el.find("div").css("left"), "20px" );
+});
+
 test( ":visible/:hidden selectors", function() {
 	expect( 13 );
 


### PR DESCRIPTION
I can not open bugs.jquery.com, so there is no issue number.
# bug reproduction:

open 
http://jsfiddle.net/yiminghe/nBRgE/
in ie9 ie10 chrome firefox
# expect

alert left value with px unit in all browser
(since jquery handles % specially, then it should handle auto too.)
# actual

alert auto except in firefox
