### PR TITLE
No ticket: Refactoring in Effects.js. Using data_priv.

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -304,7 +304,7 @@ function defaultPrefilter( elem, props, opts ) {
 
 
 	// show/hide pass
-	dataShow = jQuery._data( elem, "fxshow" ) || jQuery._data( elem, "fxshow", {} );
+	dataShow = data_priv.get( elem, "fxshow" );
 	for ( index in props ) {
 		value = props[ index ];
 		if ( rfxtypes.exec( value ) ) {
@@ -313,20 +313,19 @@ function defaultPrefilter( elem, props, opts ) {
 			if ( value === ( hidden ? "hide" : "show" ) ) {
 
 				// If there is dataShow left over from a stopped hide or show and we are going to proceed with show, we should pretend to be hidden
-				if( value === "show" && dataShow[ index ] !== undefined ) {
+				if( value === "show" && dataShow !== undefined && dataShow[ index ] !== undefined ) {
 					hidden = true;
 				} else {
-				continue;
-			}
+					continue;
+				}
 			}
 			handled.push( index );
 		}
 	}
 
 	length = handled.length;
-	if ( !length ) {
+	if ( length ) {
 		dataShow = data_priv.get( elem, "fxshow" ) || data_priv.access( elem, "fxshow", {} );
-	} else {
 		if ( "hidden" in dataShow ) {
 			hidden = dataShow.hidden;
 		}


### PR DESCRIPTION
I realized line 307 of Effects.js:
`dataShow = jQuery._data( elem, "fxshow" ) || jQuery._data( elem, "fxshow", {} );`
was not changed to use data_priv.

I made that modification myself, using `data_priv.get`. And added `dataShow !== undefined` in line 316, because it is possible for the `data_priv.get` to return an undefined object. This case happens in test 6 (  animate(Hash, Object, Function)  ) of Effects without that check.

Also, there is no more reason for the `if ( !length )` check in line 327. I was using it to destroy the object I was creating in line 307, a cleanup. It was a `jQuery._removeData( elem, "fxshow" );` when the data_priv change occurred, there was probably a merge conflict, so it was changed that to `data_priv.get` and `data_priv.access` in the proccess. We do not need it anymore anyway.
