### PR TITLE
No ticket: remove selector and context properties

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -167,8 +167,6 @@ jQuery.fn = jQuery.prototype = {
 						this[0] = elem;
 					}
 
-					this.context = document;
-					this.selector = selector;
 					return this;
 				}
 
@@ -184,8 +182,8 @@ jQuery.fn = jQuery.prototype = {
 
 		// HANDLE: $(DOMElement)
 		} else if ( selector.nodeType ) {
-			this.context = this[0] = selector;
 			this.length = 1;
+			this[0] = selector;
 			return this;
 
 		// HANDLE: $(function)
@@ -194,16 +192,8 @@ jQuery.fn = jQuery.prototype = {
 			return rootjQuery.ready( selector );
 		}
 
-		if ( selector.selector !== undefined ) {
-			this.selector = selector.selector;
-			this.context = selector.context;
-		}
-
 		return jQuery.makeArray( selector, this );
 	},
-
-	// Start with an empty selector
-	selector: "",
 
 	// The default length of a jQuery object is 0
 	length: 0,
@@ -233,7 +223,6 @@ jQuery.fn = jQuery.prototype = {
 
 		// Add the old object onto the stack (as a reference)
 		ret.prevObject = this;
-		ret.context = this.context;
 
 		// Return the newly-formed element set
 		return ret;

--- a/src/traversing.js
+++ b/src/traversing.js
@@ -29,10 +29,7 @@ jQuery.fn.extend({
 			jQuery.find( selector, self[ i ], ret );
 		}
 
-		// Needed because $( selector, context ) becomes $( context ).find( selector )
-		ret = this.pushStack( len > 1 ? jQuery.unique( ret ) : ret );
-		ret.selector = this.selector ? this.selector + " " + selector : selector;
-		return ret;
+		return this.pushStack( len > 1 ? jQuery.unique( ret ) : ret );
 	},
 
 	has: function( target ) {
@@ -70,26 +67,25 @@ jQuery.fn.extend({
 		).length;
 	},
 
-	closest: function( selectors, context ) {
+	closest: function( selector, context ) {
 		var cur,
 			i = 0,
 			l = this.length,
 			ret = [],
-			pos = rneedsContext.test( selectors ) || typeof selectors !== "string" ?
-				jQuery( selectors, context || this.context ) :
-				0;
+			pos = ( typeof selector !== "string" || rneedsContext.test( selector ) ) &&
+				jQuery( selector, context );
 
 		for ( ; i < l; i++ ) {
 			for ( cur = this[i]; cur && cur !== context; cur = cur.parentNode ) {
 				// Always skip document fragments
 				if ( cur.nodeType < 11 && (pos ?
-					pos.index(cur) > -1 :
+					pos.index(cur) >= 0 :
 
 					// Don't pass non-elements to Sizzle
 					cur.nodeType === 1 &&
-						jQuery.find.matchesSelector(cur, selectors)) ) {
+						jQuery.find.matchesSelector(cur, selector)) ) {
 
-					cur = ret.push( cur );
+					ret.push( cur );
 					break;
 				}
 			}

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -72,7 +72,7 @@ test("jQuery()", function() {
 	equal( jQuery("").length, 0, "jQuery('') === jQuery([])" );
 	equal( jQuery("#").length, 0, "jQuery('#') === jQuery([])" );
 
-	equal( jQuery(obj).selector, "div", "jQuery(jQueryObj) == jQueryObj" );
+	deepEqual( jQuery(obj).get(), obj.get(), "jQuery(jQueryObj) == jQueryObj" );
 
 	// can actually yield more than one, when iframes are included, the window is an array as well
 	equal( jQuery(window).length, 1, "Correct number of elements generated for jQuery(window)" );
@@ -156,49 +156,6 @@ test("jQuery(selector, context)", function() {
 	deepEqual( jQuery("div p", "#qunit-fixture").get(), q("sndp", "en", "sap"), "Basic selector with string as context" );
 	deepEqual( jQuery("div p", q("qunit-fixture")[0]).get(), q("sndp", "en", "sap"), "Basic selector with element as context" );
 	deepEqual( jQuery("div p", jQuery("#qunit-fixture")).get(), q("sndp", "en", "sap"), "Basic selector with jQuery object as context" );
-});
-
-test( "selector state", function() {
-	expect( 18 );
-
-	var test;
-
-	test = jQuery( undefined );
-	equal( test.selector, "", "Empty jQuery Selector" );
-	equal( test.context, undefined, "Empty jQuery Context" );
-
-	test = jQuery( document );
-	equal( test.selector, "", "Document Selector" );
-	equal( test.context, document, "Document Context" );
-
-	test = jQuery( document.body );
-	equal( test.selector, "", "Body Selector" );
-	equal( test.context, document.body, "Body Context" );
-
-	test = jQuery("#qunit-fixture");
-	equal( test.selector, "#qunit-fixture", "#qunit-fixture Selector" );
-	equal( test.context, document, "#qunit-fixture Context" );
-
-	test = jQuery("#notfoundnono");
-	equal( test.selector, "#notfoundnono", "#notfoundnono Selector" );
-	equal( test.context, document, "#notfoundnono Context" );
-
-	test = jQuery( "#qunit-fixture", document );
-	equal( test.selector, "#qunit-fixture", "#qunit-fixture Selector" );
-	equal( test.context, document, "#qunit-fixture Context" );
-
-	test = jQuery( "#qunit-fixture", document.body );
-	equal( test.selector, "#qunit-fixture", "#qunit-fixture Selector" );
-	equal( test.context, document.body, "#qunit-fixture Context" );
-
-	// Test cloning
-	test = jQuery( test );
-	equal( test.selector, "#qunit-fixture", "#qunit-fixture Selector" );
-	equal( test.context, document.body, "#qunit-fixture Context" );
-
-	test = jQuery( document.body ).find("#qunit-fixture");
-	equal( test.selector, "#qunit-fixture", "#qunit-fixture find Selector" );
-	equal( test.context, document.body, "#qunit-fixture find Context" );
 });
 
 test( "globalEval", function() {

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -487,9 +487,9 @@ testIframe("offset/body", "body", function( $ ) {
 test("chaining", function() {
 	expect(3);
 	var coords = { "top":  1, "left":  1 };
-	equal( jQuery("#absolute-1").offset(coords).selector, "#absolute-1", "offset(coords) returns jQuery object" );
-	equal( jQuery("#non-existent").offset(coords).selector, "#non-existent", "offset(coords) with empty jQuery set returns jQuery object" );
-	equal( jQuery("#absolute-1").offset(undefined).selector, "#absolute-1", "offset(undefined) returns jQuery object (#5571)" );
+	equal( jQuery("#absolute-1").offset(coords).jquery, jQuery.fn.jquery, "offset(coords) returns jQuery object" );
+	equal( jQuery("#non-existent").offset(coords).jquery, jQuery.fn.jquery, "offset(coords) with empty jQuery set returns jQuery object" );
+	equal( jQuery("#absolute-1").offset(undefined).jquery, jQuery.fn.jquery, "offset(undefined) returns jQuery object (#5571)" );
 });
 
 test("offsetParent", function(){


### PR DESCRIPTION
As far as I can tell, the `context` property of jQuery collections exists only to let [jquery-migrate](https://github.com/jquery/jquery-migrate) monkey-patch `.live` and `.die`, and `selector` is completely unnecessary. We should move necessary code into that plugin and cut our undocumented ties with the past.

```
   raw     gz Sizes
271181  80511 dist/jquery.js
 92655  32561 dist/jquery.min.js

   raw     gz Compared to 1.x-master @ 4f786ba4d2a5544cb48f589d2659d6cab84efc34
  -477   -140 dist/jquery.js
  -213    -86 dist/jquery.min.js
```
