### PR TITLE
Fix #13809: Quote IdentifierNames reserved by any version of ECMA-262

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -315,7 +315,7 @@ jQuery.extend({
 		if ( nType !== 1 || !jQuery.isXMLDoc( elem ) ) {
 			name = name.toLowerCase();
 			hooks = jQuery.attrHooks[ name ] ||
-				( jQuery.expr.match.boolean.test( name ) ? boolHook : nodeHook );
+				( jQuery.expr.match["boolean"].test( name ) ? boolHook : nodeHook );
 		}
 
 		if ( value !== undefined ) {
@@ -354,7 +354,7 @@ jQuery.extend({
 				propName = jQuery.propFix[ name ] || name;
 
 				// Boolean attributes get special treatment (#10870)
-				if ( jQuery.expr.match.boolean.test( name ) ) {
+				if ( jQuery.expr.match["boolean"].test( name ) ) {
 					// Set corresponding property to false
 					if ( getSetInput && getSetAttribute || !ruseDefault.test( name ) ) {
 						elem[ propName ] = false;
@@ -462,7 +462,7 @@ boolHook = {
 		return name;
 	}
 };
-jQuery.each( jQuery.expr.match.boolean.source.match( /\w+/g ), function( i, name ) {
+jQuery.each( jQuery.expr.match["boolean"].source.match( /\w+/g ), function( i, name ) {
 	var getter = jQuery.expr.attrHandle[ name ] || jQuery.find.attr;
 
 	jQuery.expr.attrHandle[ name ] = getSetInput && getSetAttribute || !ruseDefault.test( name ) ?


### PR DESCRIPTION
cc @dmethvin @timmywil

Consensus was to rename the property, but Sizzle already quotes it and I'd rather not burn a semver major version bump over something so cosmetic and trivial. Thoughts?

```
   raw     gz Sizes                                                            
271993  80754 dist/jquery.js                                                   
 92981  32679 dist/jquery.min.js                                               

   raw     gz Compared to 1.x-master @ d605322c105f4edc37e9a6357af23c4cee53c2cc
    +9     +4 dist/jquery.js                                                   
    +9     +1 dist/jquery.min.js
```
