### PR TITLE
Use grunt option with grunt.util.spawn

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -260,7 +260,7 @@ module.exports = function( grunt ) {
 		grunt.log.writeln( "Creating custom build...\n" );
 
 		grunt.util.spawn({
-			cmd: process.platform === "win32" ? "grunt.cmd" : "grunt",
+			grunt: true,
 			args: [ "build:*:*:" + modules, "pre-uglify", "uglify", "dist" ]
 		}, function( err, result ) {
 			if ( err ) {


### PR DESCRIPTION
Detecting the `grunt` binary can be tricky as grunt can exists in many different ways. We found using `process.argv[0]` and `process.argv[1]` to be the most reliable so in Grunt v0.4 we added a `grunt: true` option to `grunt.util.spawn`.

This change will ensure spawning `grunt` will work with more environments and setups. Reference [this stackoverflow question](http://stackoverflow.com/questions/16131084/using-grunt-with-non-global-installation).

Thanks!
