### PR TITLE
Fix in .text method when setting a value

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -34,7 +34,7 @@ jQuery.fn.extend({
 		return jQuery.access( this, function( value ) {
 			return value === undefined ?
 				jQuery.text( this ) :
-				this.empty().append( ( this[ 0 ] && this[ 0 ].ownerDocument || document ).createTextNode( value ) );
+				this.empty().append( ( this[ 0 ] && this[ 0 ].ownerDocument || document ).createTextNode( value ).textContent );
 		}, null, value, arguments.length );
 	},
 


### PR DESCRIPTION
After upgrading to jQuery 1.9.1 I had some errors involving .text method.
When setting a value, instead of the text I was getting [Object Text] in the element.

Example (console):

$('.brief').text('test')
[
<div class=​"brief">​[object Text]​</div>​
]

My fix put actual content in the element.
