### PR TITLE
Add list of keyCodes

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -18,6 +18,44 @@ function safeActiveElement() {
 }
 
 /*
+ * List of keyCodes
+ */
+jQuery.keyCode = {
+	BACKSPACE: 8,
+	TAB: 9,
+	ENTER: 13,
+	SHIFT: 16,
+	CONTROL: 17,
+	ALT: 18,
+	CAPS_LOCK: 20,
+	ESCAPE: 27,
+	SPACE: 32,
+	PAGE_UP: 33,
+	PAGE_DOWN: 34,
+	END: 35,
+	HOME: 36,
+	LEFT: 37,
+	UP: 38,
+	RIGHT: 39,
+	DOWN: 40,
+	INSERT: 45,
+	DELETE: 46,
+	COMMAND: 91,
+	COMMAND_LEFT: 91,
+	WINDOWS: 91,
+	COMMAND_RIGHT: 93,
+	MENU: 93,
+	NUMPAD_MULTIPLY: 106,
+	NUMPAD_ADD: 107,
+	NUMPAD_ENTER: 108,
+	NUMPAD_SUBTRACT: 109,
+	NUMPAD_DECIMAL: 110,
+	NUMPAD_DIVIDE: 111,
+	COMMA: 188,
+	PERIOD: 190
+};
+
+/*
  * Helper functions for managing events -- not part of the public interface.
  * Props to Dean Edwards' addEvent library for many of the ideas.
  */


### PR DESCRIPTION
Excuse me if this has been already discussed and I missed it. But, have you considered listing the keyCodes in here before? It's used by our sibling projects [UI](https://github.com/jquery/jquery-ui/blob/master/ui/jquery.ui.core.js#L22) and [Mobile](https://github.com/jquery/jquery-mobile/blob/master/js/jquery.mobile.core.js#L101). If so, this commit adds the unified-unique-keys from both projects.

Perhaps the downsize would be the extra bits below.

```
 raw     gz Compared to master @ 18cccd04a6f69018242bce96ef905bc5d3be6ff8
+514   +323 dist/jquery.js
+381   +317 dist/jquery.min.js
```

In percentage.

```
 raw     gz Compared to master @ 18cccd04a6f69018242bce96ef905bc5d3be6ff8
+0.21%   +0.45% dist/jquery.js
+0.45%   +1.08% dist/jquery.min.js
```
