### PR TITLE
only call jQuery(this) if necessary in $.fn.val

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -182,15 +182,14 @@ jQuery.fn.extend({
 		isFunction = jQuery.isFunction( value );
 
 		return this.each(function( i ) {
-			var val,
-				self = jQuery(this);
+			var val;
 
 			if ( this.nodeType !== 1 ) {
 				return;
 			}
 
 			if ( isFunction ) {
-				val = value.call( this, i, self.val() );
+				val = value.call( this, i, jQuery( this ).val() );
 			} else {
 				val = value;
 			}


### PR DESCRIPTION
This changes $.fn.val to only call jQuery(this) when it is used (when a function instead of value is passed to .val()).

Also saves a few bytes:
   raw     gz
   -15     -8 dist/jquery.js
    -4     -3 dist/jquery.min.js
