### PR TITLE
Fix #13855: line-height animations

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -164,7 +164,7 @@ jQuery.extend({
 		}
 	},
 
-	// Exclude the following css properties to add px
+	// Don't automatically add "px" to these possibly-unitless properties
 	cssNumber: {
 		"columnCount": true,
 		"fillOpacity": true,

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -1371,35 +1371,42 @@ test("Do not append px to 'fill-opacity' #9548", 1, function() {
 	});
 });
 
-test("line-height animates appropriately (#13855)", function() {
-	expect( 6 );
+test("line-height animates correctly (#13855)", function() {
+	expect( 12 );
 	stop();
 
 	var
-		animated = jQuery("#firstp").css( "line-height", "50px" ).add(
-			jQuery("#sndp").css( "line-height", 4 )
-		),
-		getHeight = function( el ) {
+		animated = jQuery(
+			"<p style='line-height: 4;'>unitless</p>" +
+			"<p style='line-height: 50px;'>px</p>" +
+			"<p style='line-height: 120%;'>percent</p>" +
+			"<p style='line-height: 1.5em;'>em</p>"
+		).appendTo("#qunit-fixture"),
+		initialHeight = jQuery.map( animated, function( el ) {
 			return jQuery( el ).height();
-		},
-		initialHeight = jQuery.map( animated, getHeight );
+		});
 
 	animated.animate( { "line-height": "hide" }, 1500 );
 	setTimeout(function() {
-		var height = jQuery.map( animated, getHeight );
-		ok( height[ 0 ] < initialHeight[ 0 ], "Pixel: upper bound" );
-		ok( height[ 0 ] > initialHeight[ 0 ] / 2, "Pixel: lower bound" );
-		ok( height[ 1 ] < initialHeight[ 1 ], "Unitless: upper bound" );
-		ok( height[ 1 ] > initialHeight[ 1 ] / 2, "Unitless: lower bound" );
+		animated.each(function( i ) {
+			var label = jQuery.text( this ),
+				initial = initialHeight[ i ],
+				height = jQuery( this ).height();
+			ok( height < initial, "hide " + label + ": upper bound" );
+			ok( height > initial / 2, "hide " + label + ": lower bound" );
+		});
 		animated.stop( true, true ).hide().animate( { "line-height": "show" }, 1500 );
 		setTimeout(function() {
-			var height = jQuery.map( animated, getHeight );
-			ok( height[ 0 ] < initialHeight[ 0 ] / 2, "Pixel: upper bound" );
-			ok( height[ 1 ] < initialHeight[ 1 ] / 2, "Unitless: upper bound" );
+			animated.each(function( i ) {
+				var label = jQuery.text( this ),
+					initial = initialHeight[ i ],
+					height = jQuery( this ).height();
+				ok( height < initial / 2, "show " + label + ": upper bound" );
+			});
 			animated.stop( true, true );
 			start();
-		}, 500 );
-	}, 500 );
+		}, 400 );
+	}, 400 );
 });
 
 // Start 1.8 Animation tests


### PR DESCRIPTION
cc @dmethvin @gnarf37

As it turns out, we can fix line-height animations after all.

I'd also like to land an analog in 1.10.0, but it could wait for 1.10.1 if that's deemed to be the better approach since this missed beta 1.

```
   raw     gz Sizes                                                            
242403  71913 dist/jquery.js                                                   
 83348  29192 dist/jquery.min.js                                               

   raw     gz Compared to master @ 1debe49ac7d9379ede44e873e4a2ebaa10dfb0b6    
   +46    +33 dist/jquery.js                                                   
   -12     -9 dist/jquery.min.js
```
