### PR TITLE
If module is defined as null before jQuery, an error is thrown

### DIFF
--- a/src/exports.js
+++ b/src/exports.js
@@ -1,4 +1,4 @@
-if ( typeof module === "object" && typeof module.exports === "object" ) {
+if ( typeof module === "object" && module && typeof module.exports === "object" ) {
 	// Expose jQuery as module.exports in loaders that implement the Node
 	// module pattern (including browserify). Do not create the global, since
 	// the user will be storing it themselves locally, and globals are frowned


### PR DESCRIPTION
If `module = null` is included before jQuery, an error is thrown because null is an object but module.exports is not a property of it. 

This checks to make sure module is a truthy value before checking its properties.
typeof null = "object"
typeof {} = "object"
typeof null.prop = JS error
typeof {}.prop = undefined

Not entirely sure how to write a test for this. If someone wants to point me in a direction, I'll gladly try it out.
