### PR TITLE
Simplification of replaceWith method

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -161,38 +161,28 @@ jQuery.fn.extend({
 	},
 
 	replaceWith: function() {
-		var
-			// Snapshot the DOM in case .domManip sweeps something relevant into its fragment
-			args = jQuery.map( this, function( elem ) {
-				return [ elem.nextSibling, elem.parentNode ];
-			}),
-			i = 0;
+		var arg = arguments[ 0 ];
 
 		// Make the changes, replacing each context element with the new content
 		this.domManip( arguments, function( elem ) {
-			var next = args[ i++ ],
-				parent = args[ i++ ];
+			arg = this.parentNode;
 
-			if ( parent ) {
-				// Don't use the snapshot next if it has moved (#13810)
-				if ( next && next.parentNode !== parent ) {
-					next = this.nextSibling;
-				}
-				jQuery( this ).remove();
-				parent.insertBefore( elem, next );
+			jQuery.cleanData( getAll( this ) );
+
+			if ( arg ) {
+				arg.replaceChild( elem, this );
 			}
-		// Allow new content to include elements from the context set
-		}, true );
+		});
 
 		// Force removal if there was no new content (e.g., from empty arguments)
-		return i ? this : this.remove();
+		return arg && (arg.length || arg.nodeType) ? this : this.remove();
 	},
 
 	detach: function( selector ) {
 		return this.remove( selector, true );
 	},
 
-	domManip: function( args, callback, allowIntersection ) {
+	domManip: function( args, callback ) {
 
 		// Flatten any nested arrays
 		args = core_concat.apply( [], args );
@@ -212,12 +202,12 @@ jQuery.fn.extend({
 				if ( isFunction ) {
 					args[ 0 ] = value.call( this, index, self.html() );
 				}
-				self.domManip( args, callback, allowIntersection );
+				self.domManip( args, callback );
 			});
 		}
 
 		if ( l ) {
-			fragment = jQuery.buildFragment( args, this[ 0 ].ownerDocument, false, !allowIntersection && this );
+			fragment = jQuery.buildFragment( args, this[ 0 ].ownerDocument, false, this );
 			first = fragment.firstChild;
 
 			if ( fragment.childNodes.length === 1 ) {

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -1011,13 +1011,16 @@ test( "replaceWith(string) for more than one element", function() {
 });
 
 test( "empty replaceWith (#13401; #13596)", 4, function() {
-	expect( 6 );
+	expect( 8 );
 
 	var $el = jQuery("<div/>"),
 		tests = {
 			"empty string": "",
 			"empty array": [],
-			"empty collection": jQuery("#nonexistent")
+			"empty collection": jQuery("#nonexistent"),
+
+			// in case of jQuery(...).replaceWith();
+			"empty undefined": undefined
 		};
 
 	jQuery.each( tests, function( label, input ) {


### PR DESCRIPTION
Not for 1.10.0 or 2.0.1.
It's smaller:

<pre>
   raw     gz Compared to master @ 997da31121b9d084ccba05a9bb1e258c8c8faaf0
  -440   -141 dist/jquery.js
   -78    -37 dist/jquery.min.js
</pre>

and faster: http://jsperf.com/simplified-replacewith

Although this code (as code in master) fails with self-replacement <a href="http://jsfiddle.net/gejGm/">cases</a>. But i suppose these are very edge stuff giving that jQuery lived with them since the beginning.

/cc @gibson042
