### PR TITLE
[No ticket] Simplification of jQuery#contents method

### DIFF
--- a/src/traversing.js
+++ b/src/traversing.js
@@ -179,9 +179,7 @@ jQuery.each({
 		return jQuery.sibling( elem.firstChild );
 	},
 	contents: function( elem ) {
-		return jQuery.nodeName( elem, "iframe" ) ?
-			elem.contentDocument || elem.contentWindow.document :
-			jQuery.merge( [], elem.childNodes );
+		return elem.contentDocument || jQuery.merge( [], elem.childNodes );
 	}
 }, function( name, fn ) {
 	jQuery.fn[ name ] = function( until, selector ) {


### PR DESCRIPTION
Since <code>contentDocument</code> property is supported by IE9-10, use of <code>contentWindow.document</code> is no longer required
