### PR TITLE
Removed the second hyphen in the rmsPrefix

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -58,7 +58,7 @@ var
 	rsingleTag = /^<(\w+)\s*\/?>(?:<\/\1>|)$/,
 
 	// Matches dashed string for camelizing
-	rmsPrefix = /^-ms-/,
+	rmsPrefix = /^-ms/,
 	rdashAlpha = /-([\da-z])/gi,
 
 	// Used by jQuery.camelCase as callback to replace()
@@ -530,7 +530,7 @@ jQuery.extend({
 	// Convert dashed to camelCase; used by the css and data modules
 	// Microsoft forgot to hump their vendor prefix (#9572)
 	camelCase: function( string ) {
-		return string.replace( rmsPrefix, "ms-" ).replace( rdashAlpha, fcamelCase );
+		return string.replace( rmsPrefix, "ms" ).replace( rdashAlpha, fcamelCase );
 	},
 
 	nodeName: function( elem, name ) {


### PR DESCRIPTION
Removed the second hyphen in the rmsPrefix (it wasn't a bug, but it appears more efficient this way).
