### PR TITLE
Simplification of css_defaultDisplay helper (fix #12723)

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -6,7 +6,7 @@ var curCSS, iframe,
 	rnumsplit = new RegExp( "^(" + core_pnum + ")(.*)$", "i" ),
 	rnumnonpx = new RegExp( "^(" + core_pnum + ")(?!px)[a-z%]+$", "i" ),
 	rrelNum = new RegExp( "^([+-])=(" + core_pnum + ")", "i" ),
-	elemdisplay = { BODY: "block" },
+	elemdisplay = {},
 
 	cssShow = { position: "absolute", visibility: "hidden", display: "block" },
 	cssNormalTransform = {
@@ -78,7 +78,7 @@ function showHide( elements, show ) {
 			// in a stylesheet to whatever the default browser style is
 			// for such an element
 			if ( elem.style.display === "" && isHidden( elem ) ) {
-				values[ index ] = data_priv.access( elem, "olddisplay", css_defaultDisplay(elem.nodeName) );
+				values[ index ] = data_priv.access( elem, "olddisplay", defaultDisplay(elem.nodeName) );
 			}
 		} else {
 
@@ -412,7 +412,7 @@ function getWidthOrHeight( elem, name, extra ) {
 }
 
 // Try to determine the default display value of an element
-function css_defaultDisplay( nodeName ) {
+function defaultDisplay( nodeName ) {
 	var doc = document,
 		display = elemdisplay[ nodeName ];
 
@@ -421,15 +421,16 @@ function css_defaultDisplay( nodeName ) {
 
 		// If the simple way fails, read from inside an iframe
 		if ( display === "none" || !display ) {
+
 			// Use the already-created iframe if possible
 			iframe = ( iframe ||
 				jQuery("<iframe frameborder='0' width='0' height='0'/>")
-				.css( "cssText", "display:block !important" )
 			).appendTo( doc.documentElement );
 
-			// Always write a new HTML skeleton so Webkit and Firefox don't choke on reuse
-			doc = ( iframe[0].contentWindow || iframe[0].contentDocument ).document;
-			doc.write("<!doctype html><html><body>");
+			doc = iframe[ 0 ].contentDocument;
+
+			// Support: IE
+			doc.write();
 			doc.close();
 
 			display = actualDisplay( nodeName, doc );
@@ -443,11 +444,18 @@ function css_defaultDisplay( nodeName ) {
 	return display;
 }
 
-// Called ONLY from within css_defaultDisplay
+// Called only from within defaultDisplay
 function actualDisplay( name, doc ) {
 	var elem = jQuery( doc.createElement( name ) ).appendTo( doc.body ),
-		display = jQuery.css( elem[0], "display" );
-	elem.remove();
+
+		// getDefaultComputedStyle might be reliably used only on attached element
+		display = window.getDefaultComputedStyle ?
+			window.getDefaultComputedStyle( elem[ 0 ] ).display : jQuery.css( elem[ 0 ], "display" );
+
+	// We don't have any data stored on the element,
+	// so use "detach" method as fast way to get rid of the element
+	elem.detach();
+
 	return display;
 }
 

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -544,21 +544,29 @@ test( "show() resolves correct default display for detached nodes", function(){
 	span.remove();
 });
 
-test("show() resolves correct default display #10227", function() {
-	expect(2);
+test("show() resolves correct default display #10227", 4, function() {
 
-	var body = jQuery("body");
+	var html = jQuery( document.documentElement ),
+		body = jQuery("body");
 	body.append(
-		"<p id='ddisplay'>a<style>body{display:none}</style></p>"
+		"<p class='ddisplay'>a<style>body{display:none}</style></p>"
 	);
 
-	equal( body.css("display"), "none", "Initial display: none" );
+	equal( body.css("display"), "none", "Initial display for body element: none" );
 
 	body.show();
-	equal( body.css("display"), "block", "Correct display: block" );
+	equal( body.css("display"), "block", "Correct display for body element: block" );
 
-	jQuery("#ddisplay").remove();
-	QUnit.expectJqData( body[0], "olddisplay" );
+	body.append(
+		"<p class='ddisplay'>a<style>html{display:none}</style></p>"
+	);
+
+	equal( html.css("display"), "none", "Initial display for html element: none" );
+
+	html.show();
+	equal( html.css("display"), "block", "Correct display for html element: block" );
+
+	jQuery(".ddisplay").remove();
 });
 
 test("show() resolves correct default display when iframe display:none #12904", function() {


### PR DESCRIPTION
1) Fix #12723: use getDefaultComputedStyle method in FF to circumvent iframe path
2) Rename helper "css_defaultDisplay" to "defaultDisplay" since it used only in css module 3) Take away fix for #10227 ticket, as it is no longer needed.
4) Improve test for #10227 fix - iframe of defaultDisplay helper appended to html element,
    so check correct default display for html element too
5) Simplify iframe creation

/cc @mikesherov, @rwldrn
