### PR TITLE
new sourceMappingURL syntax

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -115,7 +115,7 @@ module.exports = function( grunt ) {
 						"/*! jQuery v<%= pkg.version %> | " +
 						"(c) 2005, 2013 jQuery Foundation, Inc. | " +
 						"jquery.org/license\n" +
-						"//@ sourceMappingURL=jquery.min.map\n" +
+						"//# sourceMappingURL=jquery.min.map\n" +
 						"*/\n"
 				}
 			}


### PR DESCRIPTION
"//@ sourceMappingURL=" source mapping URL declaration is deprecated, "//# sourceMappingURL=" declaration should be used instead.
