### PR TITLE
Move too-early assignment inside the if stmt where the var is actually used

### DIFF
--- a/src/callbacks.js
+++ b/src/callbacks.js
@@ -171,9 +171,9 @@ jQuery.Callbacks = function( options ) {
 			},
 			// Call all callbacks with the given context and arguments
 			fireWith: function( context, args ) {
-				args = args || [];
-				args = [ context, args.slice ? args.slice() : args ];
 				if ( list && ( !fired || stack ) ) {
+					args = args || [];
+					args = [ context, args.slice ? args.slice() : args ];
 					if ( firing ) {
 						stack.push( args );
 					} else {


### PR DESCRIPTION
This is a completely trivial (famous last words, I know...) optimization, moving an assignment inside an if statement where the variable is actually used.
