### PR TITLE
Fixes #14047 jQuery.data should not miss data-* w/ hyphenated property names

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -113,6 +113,7 @@ Data.prototype = {
 			cache : cache[ key ];
 	},
 	access: function( owner, key, value ) {
+		var stored;
 		// In cases where either:
 		//
 		//   1. No key was specified
@@ -126,7 +127,11 @@ Data.prototype = {
 		//
 		if ( key === undefined ||
 				((key && typeof key === "string") && value === undefined) ) {
-			return this.get( owner, key );
+
+			stored = this.get( owner, key );
+
+			return stored !== undefined ?
+				stored : this.get( owner, jQuery.camelCase(key) );
 		}
 
 		// [*]When the key is not a string, or both a key and value

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -529,6 +529,17 @@ test(".data should not miss preset data-* w/ hyphenated property names", functio
 	});
 });
 
+test("jQuery.data should not miss data-* w/ hyphenated property names #14047", function() {
+
+	expect(1);
+
+	var div = jQuery("<div/>");
+
+	div.data( "foo-bar", "baz" );
+
+	equal( jQuery.data(div[0], "foo-bar"), "baz", "data with property 'foo-bar' was correctly found");
+});
+
 test(".data should not miss attr() set data-* with hyphenated property names", function() {
 	expect(2);
 


### PR DESCRIPTION
http://bugs.jquery.com/ticket/14047
Signed-off-by: Rick Waldron waldron.rick@gmail.com
