### PR TITLE
[2.1] Remove obsolete getPreventDefault() usage

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -620,8 +620,7 @@ jQuery.Event = function( src, props ) {
 
 		// Events bubbling up the document may have been marked as prevented
 		// by a handler lower down the tree; reflect the correct value.
-		this.isDefaultPrevented = ( src.defaultPrevented ||
-			src.getPreventDefault && src.getPreventDefault() ) ? returnTrue : returnFalse;
+		this.isDefaultPrevented = src.defaultPrevented ? returnTrue : returnFalse;
 
 	// Event type
 	} else {


### PR DESCRIPTION
[event.defaultPrevented](https://developer.mozilla.org/en-US/docs/Web/API/event.defaultPrevented) is supported in IE9+ as well as all other major browsers, so I think it's pretty safe to remove the check for getPreventDefault() in the 2.0 branch.

I've ran the unittests in IE9 and signed the CLA, so hopefully, this is good to merge.
