### PR TITLE
Fix test for #13937 ticket

### DIFF
--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -2133,7 +2133,11 @@ asyncTest( ".finish() is applied correctly when multiple elements were animated 
 		ok( elems.eq( 0 ).queue().length, "non-empty queue for preceding element" );
 		ok( elems.eq( 2 ).queue().length, "non-empty queue for following element" );
 		elems.stop( true );
-		start();
+
+		// setTimeout needed in order to avoid setInterval/setTimeout execution bug in FF
+		window.setTimeout(function() {
+			start();
+		}, 1000 );
 	}, 100 );
 });
 


### PR DESCRIPTION
Did you notice test for #13937 being unstable (http://swarm.jquery.org/result/394435) in FF? That test sometimes fails, reporting that some animations are still running. Did you wander why?

When <code>jQuery#finish</code> called, it creates new animation in order to lead all queued animations to end CSS values, those animations than gets removed from <code>jQuery.timers</code> array from <a href="https://github.com/jquery/jquery/blob/master/src/effects.js#L674">jQuery.fx.tick</a> method, which is called every <a href="https://github.com/jquery/jquery/blob/master/src/effects.js#L705">13ms</a>.

QUnit method <code>start</code> (which is used in <a href="https://github.com/jquery/jquery/blob/master/test/unit/effects.js#L2136">#13937</a> test) uses <code>setTimeout</code> method in order to "<a href="https://github.com/jquery/qunit/blob/master/qunit/qunit.js#L468">...avoid any current callbacks</a>".

So basically it's look like this –

``` js
setInterval(function() {
    // clear jQuery.timers
}, 13 );

setTimeout(function() {
    // check jQuery.timers
    // and this is sometimes jQuery.timers.length === 1, which is wrong
}, 13 )
```

This is all happens because sometimes FF executes <code>setInterval</code> function later than <code>setTimeout</code> function, even if timeout that passed to <code>setTimeout</code> function is much bigger than the one that passed to <code>setInterval</code> function.

It always happens if tab that executes that code, is not in focus, but it sometimes happens even when tab in "focus". Which is illustrated in <a href="http://jsfiddle.net/D4FBA/show/">this</a> example. Go to the page in FF, than immediately move focus to another tab, wait a bit, then go back and look at the console.

/cc @gibson042
