### PR TITLE
Added order true to cssNumber object to keep px off of order css property value. Fixes #14049

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -173,6 +173,7 @@ jQuery.extend({
 		"fontWeight": true,
 		"lineHeight": true,
 		"opacity": true,
+		"order": true,
 		"orphans": true,
 		"widows": true,
 		"zIndex": true,

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -111,7 +111,7 @@ test("css(String|Hash)", function() {
 });
 
 test("css() explicit and relative values", function() {
-	expect(29);
+	expect( 30 );
 	var $elem = jQuery("#nothiddendiv");
 
 	$elem.css({ "width": 1, "height": 1, "paddingLeft": "1px", "opacity": 1 });
@@ -196,6 +196,9 @@ test("css() explicit and relative values", function() {
 
 	$elem.css( "opacity", "+=0.5" );
 	equal( $elem.css("opacity"), "1", "'+=0.5' on opacity (params)" );
+
+	$elem.css( "order", 2 );
+	equal( $elem.css("order"), "2", "2 on order" );
 });
 
 test("css(String, Object)", function() {


### PR DESCRIPTION
Added "order": true to the cssNumber object so when trying to update `order` via `.css()` they don't get 'px' added to the number.

Related unit test added.
