### PR TITLE
Allow an array of deferreds as first argument to .when() 

### DIFF
--- a/src/deferred.js
+++ b/src/deferred.js
@@ -90,7 +90,7 @@ jQuery.extend({
 	// Deferred helper
 	when: function( subordinate /* , ..., subordinateN */ ) {
 		var i = 0,
-			resolveValues = core_slice.call( arguments ),
+			resolveValues = $.isArray( subordinate ) ? subordinate : core_slice.call( arguments ),
 			length = resolveValues.length,
 
 			// the count of uncompleted subordinates


### PR DESCRIPTION
`.when()` currently does only support a list of individual arguments, to
pass an array of deferreds you'd have to use it as
`jQuery.when.apply(jQuery, array)`.

It would be easy, beneficial and (AFAICS non-breaking) to to allow an
array as the first argument.
