### PR TITLE
Fix IE6 $.ajaxTransport('+' + str, function(){}) case bug

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -72,7 +72,7 @@ function addToPrefiltersOrTransports( structure ) {
 			// For each dataType in the dataTypeExpression
 			while ( (dataType = dataTypes[i++]) ) {
 				// Prepend if requested
-				if ( dataType[0] === "+" ) {
+				if ( dataType.charAt(0) === "+" ) {
 					dataType = dataType.slice( 1 ) || "*";
 					(structure[ dataType ] = structure[ dataType ] || []).unshift( func );
 


### PR DESCRIPTION
IE6 do not support str[0] but str.charAt(0)
