### PR TITLE
Allow arbitrary length lists of deferreds in jQuery.when

### DIFF
--- a/src/deferred.js
+++ b/src/deferred.js
@@ -90,7 +90,7 @@ jQuery.extend({
 	// Deferred helper
 	when: function( subordinate /* , ..., subordinateN */ ) {
 		var i = 0,
-			resolveValues = core_slice.call( arguments ),
+			resolveValues = jQuery.isArray( arguments[0] ) && arguments[0] || core_slice.call( arguments ),
 			length = resolveValues.length,
 
 			// the count of uncompleted subordinates

--- a/test/unit/deferred.js
+++ b/test/unit/deferred.js
@@ -434,3 +434,22 @@ test( "jQuery.when - joined", function() {
 	deferreds.futureSuccess.resolve( 1 );
 	deferreds.futureError.reject( 0 );
 });
+
+test( "jQuery.when - array", function() {
+	var deferreds = [
+			jQuery.Deferred().resolve(1),
+			jQuery.Deferred().resolve(2),
+			jQuery.Deferred().resolve("test"),
+			jQuery.Deferred().resolve(false)
+		];
+
+	expect(4);
+
+	jQuery.when(deferreds)
+		.then(function(val1, val2, val3, val4) {
+			equal(val1, 1, "The first value resolved");
+			equal(val2, 2, "The second value resolved");
+			equal(val3, "test", "The third value resolved");
+			equal(val4, false, "The fourth value resolved");
+		});
+});


### PR DESCRIPTION
This feature is to allow for arbitrary length lists of deferred objects to be passed to jQuery.when for resolution/rejection.  This allows for a method signature comparable to async.parallel(), and would be extremely useful for async file loading, ajax requests, and more.
