### PR TITLE
Add assertions for jQuery.when( array )

### DIFF
--- a/test/unit/deferred.js
+++ b/test/unit/deferred.js
@@ -315,7 +315,7 @@ test( "jQuery.Deferred.then - context", function() {
 
 test( "jQuery.when", function() {
 
-	expect( 34 );
+	expect( 37 );
 
 	// Some other objects
 	jQuery.each({
@@ -328,7 +328,8 @@ test( "jQuery.when", function() {
 		"false": false,
 		"null": null,
 		"undefined": undefined,
-		"a plain object": {}
+		"a plain object": {},
+		"an array": [ 1, 2, 3 ]
 
 	}, function( message, value ) {
 


### PR DESCRIPTION
It was pointed out in https://github.com/jquery/jquery/pull/1310 that there are currently no tests for jQuery.when( array ), so I figured it would be good to have some that assert the behavior that was defined in http://bugs.jquery.com/ticket/8256
