### PR TITLE
A different jQuery.when command (when2)

### DIFF
--- a/src/deferred.js
+++ b/src/deferred.js
@@ -137,5 +137,87 @@ jQuery.extend({
 		}
 
 		return deferred.promise();
-	}
+	},
+
+	when2: function( subordinates, options ) {
+                var i = 0,
+                        resolveValues = subordinates ? core_slice.call( subordinates ) : [],
+                        length = resolveValues.length,
+                        resolveContexts = length ? new Array( length ) : window,
+                        remaining = length,
+                        promiseArgCount = 0,
+                        resolveOnFirstSuccess = options && options.resolveOnFirstSuccess,
+                        failOnFirstError = !options || options.failOnFirstError,
+
+                        // the master Deferred.
+                        deferred = jQuery.Deferred(),
+
+                        doneFunc = function( i ) {
+                                return function( value ) {
+                                        if ( deferred.state() === "pending" ) {
+                                                --remaining;
+                                                resolveContexts[ i ] = this;
+                                                resolveValues[ i ] = arguments.length > 1 ? core_slice.call( arguments ) : value;
+                                                if ( resolveOnFirstSuccess ) {
+                                                        deferred.resolveWith( this, [ i, resolveValues[i] ] );
+                                                } else {
+                                                        remaining || deferred.resolveWith( resolveContexts, resolveValues );
+                                                }
+                                        }
+                                };
+                        },
+
+                        failFunc = function( i ) {
+                                if ( failOnFirstError ) {
+                                        return function( value ) {
+                                                if ( deferred.state() === "pending" ) {
+                                                        value = arguments.length > 1 ? core_slice.call( arguments ) : value;
+                                                        deferred.rejectWith( this, [ i, value ]);
+                                                }
+                                        };
+                                } else {
+                                        return function( value ) {
+                                                if ( deferred.state() === "pending" ) {
+                                                        resolveContexts[ i ] = this;
+                                                        resolveValues[ i ] = arguments.length > 1 ? core_slice.call( arguments ) : value;
+                                                        if ( !( --remaining ) ) {
+                                                                deferred.resolveWith( resolveContexts, resolveValues );
+                                                        }
+                                                }
+                                        };
+                                }
+                        },
+
+                        progressFunc = function( i ) {
+                                return function( value ) {
+                                        if ( deferred.state() === "pending" ) {
+                                                value = arguments.length > 1 ? core_slice.call( arguments ) : value;
+                                                deferred.notifyWith( this, [ i, value ] );
+                                        }
+                                };
+                        };
+
+                // add listeners to Deferred subordinates; treat others as resolved
+                for ( ; i < length; i++ ) {
+                        if ( resolveValues[ i ] && jQuery.isFunction( resolveValues[ i ].promise ) ) {
+                                promiseArgCount++;
+                                resolveValues[ i ].promise()
+                                        .done( doneFunc( i ) )
+                                        .fail( failFunc( i ) )
+                                        .progress( progressFunc( i ) );
+                        } else {
+                                if ( deferred.state() === "pending" && resolveOnFirstSuccess ) {
+                                        deferred.resolveWith( window, [ i, resolveValues[i] ] );
+                                }
+                                resolveContexts[ i ] = window;
+                                --remaining;
+                        }
+                }
+
+                if ( deferred.state() === "pending" && promiseArgCount === 0) {
+                        deferred.resolveWith( resolveContexts, resolveValues );
+                }
+
+                return deferred.promise();
+        }
 });

--- a/test/unit/deferred.js
+++ b/test/unit/deferred.js
@@ -434,3 +434,336 @@ test( "jQuery.when - joined", function() {
 	deferreds.futureSuccess.resolve( 1 );
 	deferreds.futureError.reject( 0 );
 });
+
+test( "jQuery.when2", function() {
+
+	expect( 61 );
+
+	// Some other objects
+	jQuery.each({
+		"an empty string": "",
+		"a non-empty string": "some string",
+		"zero": 0,
+		"a number other than zero": 1,
+		"true": true,
+		"false": false,
+		"null": null,
+		"undefined": undefined,
+		"a plain object": {}
+	}, function( message, value ) {
+		ok(
+			jQuery.isFunction(
+				jQuery.when2( [ value ] ).done(function( resolveValue ) {
+					deepEqual( this, [ window ], "Context is [ the global object ] with " + message );
+					strictEqual( resolveValue, value, "Test the promise was resolved with " + message );
+				}).promise
+			),
+			"Test " + message + " triggers the creation of a new Promise"
+		);
+
+		// When resolving on first success, we get a non-list context and done function
+		// is called with an index (always zero here) and the resolved value.
+		jQuery.when2( [ value ], { resolveOnFirstSuccess: true } ).done(function( index, resolveValue ) {
+			deepEqual( this, window, "Context is the global object with resolveOnFirstSuccess with " + message );
+			strictEqual( index, 0, "Test the resolved deferred index is with " + message );
+			strictEqual( resolveValue, value, "Test the promise was resolved immediately with " + message );
+		});
+	});
+
+	ok(
+		jQuery.isFunction(
+			jQuery.when2().done(function( resolveValue ) {
+				strictEqual( this, window, "Test the promise was resolved with window as its context" );
+				strictEqual( resolveValue, undefined, "Test the promise was resolved with no parameter" );
+			}).promise
+		),
+		"Test calling when2 with no parameter triggers the creation of a new Promise"
+	);
+
+	var cache,
+		context = {};
+
+	jQuery.when2( [ jQuery.Deferred().resolveWith( context ) ] ).done(function() {
+		deepEqual( this, [ context ], "when2( [ promise ] ) propagates context" );
+	});
+
+	jQuery.each([ 1, 2, 3 ], function( k, i ) {
+
+		jQuery.when2([ cache || jQuery.Deferred(function() {
+				this.resolve( i );
+			})
+		]).done(function( value ) {
+
+			strictEqual( value, 1, "Function executed" + ( i > 1 ? " only once" : "" ) );
+			cache = value;
+		});
+
+	});
+});
+
+test( "jQuery.when2 - done (all)", function() {
+
+	expect( 3 );
+
+	var defer1 = jQuery.Deferred(),
+		defer2 = jQuery.Deferred();
+
+	jQuery.when2( [ defer1, defer2 ] )
+	.done(function( a, b ) {
+		deepEqual( [ a, b ], [ 1, 2 ], "resolve/resolve => resolve" );
+		strictEqual( this[ 0 ], defer1.promise(), "resolve/resolve 1st context OK" );
+		strictEqual( this[ 1 ], defer2.promise(), "resolve/resolve 2nd context OK" );
+	});
+
+	defer1.resolve( 1 );
+	defer2.resolve( 2 );
+});
+
+test( "jQuery.when2 - done (resolveOnFirstSuccess)", function() {
+
+	expect( 2 );
+
+	var defer1 = jQuery.Deferred(),
+		defer2 = jQuery.Deferred();
+
+	jQuery.when2( [ defer1, defer2 ],
+		      { resolveOnFirstSuccess: true } )
+	.done(function( index, value ) {
+		deepEqual( [ index, value ], [ 0, 1 ], "resolve/resolve => resolve" );
+		strictEqual( this, defer1.promise(), "resolve/resolve context OK" );
+	});
+
+	defer1.resolve( 1 );
+	defer2.resolve( 2 );
+});
+
+test( "jQuery.when2 - done (resolveOnFirstSuccess) other order", function() {
+
+	expect( 2 );
+
+	var defer1 = jQuery.Deferred(),
+		defer2 = jQuery.Deferred();
+
+	jQuery.when2( [ defer1, defer2 ],
+		      { resolveOnFirstSuccess: true } )
+	.done(function( index, value ) {
+		deepEqual( [ index, value ], [ 1, 2 ], "resolve/resolve => resolve" );
+		strictEqual( this, defer2.promise(), "resolve/resolve context OK" );
+	});
+
+	defer2.resolve( 2 );
+	defer1.resolve( 1 );
+});
+
+test( "jQuery.when2 - done scalar/resolve (resolveOnFirstSuccess)", function() {
+
+	expect( 2 );
+
+	var defer = jQuery.Deferred().resolve( 1 );
+
+	jQuery.when2( [ 3, defer ],
+		      { resolveOnFirstSuccess: true } )
+	.done(function( index, value ) {
+		deepEqual( [ index, value ], [ 0, 3 ], "scalar/resolve => resolve" );
+		strictEqual( this, window, "resolve/resolve context OK" );
+	});
+});
+
+test( "jQuery.when2 - done scalar/resolve later (resolveOnFirstSuccess)", function() {
+
+	expect( 2 );
+
+	var defer = jQuery.Deferred();
+
+	jQuery.when2( [ defer, 3 ],
+		      { resolveOnFirstSuccess: true } )
+	.done(function( index, value ) {
+		deepEqual( [ index, value ], [ 1, 3 ], "scalar/resolve => resolve" );
+		strictEqual( this, window, "resolve/resolve context OK" );
+	});
+
+	defer.resolve( 1 );
+});
+
+test( "jQuery.when2 - fail pending/reject", function() {
+
+	expect( 2 );
+
+	var defer1 = jQuery.Deferred(),
+		defer2 = jQuery.Deferred();
+
+	jQuery.when2( [ defer1, defer2 ] )
+	.fail(function( index, value ) {
+		deepEqual( [ index, value ], [ 0, 1 ], "pending/reject => fail" );
+		strictEqual( this, defer1.promise(), "pending/reject context" );
+	});
+
+	defer1.reject( 1 );
+});
+
+test( "jQuery.when2 - fail pending/reject (failOnFirstError true)", function() {
+
+	expect( 2 );
+
+	var defer1 = jQuery.Deferred(),
+		defer2 = jQuery.Deferred();
+
+	jQuery.when2( [ defer1, defer2 ],
+		      { failOnFirstError: true } )
+	.fail(function( index, value ) {
+		deepEqual( [ index, value ], [ 0, 1 ], "pending/reject => fail" );
+		strictEqual( this, defer1.promise(), "pending/reject context" );
+	});
+
+	defer1.reject( 1 );
+});
+
+test( "jQuery.when2 - fail resolve/reject", function() {
+
+	expect( 2 );
+
+	var defer1 = jQuery.Deferred(),
+		defer2 = jQuery.Deferred();
+
+	jQuery.when2( [ defer1, defer2 ] )
+	.fail(function( index, value ) {
+		deepEqual( [ index, value ], [ 1, 2 ], "resolve/reject => fail" );
+		strictEqual( this, defer2.promise(), "resolve/reject context" );
+	});
+
+	defer1.resolve( 1 );
+	defer2.reject( 2 );
+});
+
+test( "jQuery.when2 - fail resolve/reject (failOnFirstError true)", function() {
+
+	expect( 2 );
+
+	var defer1 = jQuery.Deferred(),
+		defer2 = jQuery.Deferred();
+
+	jQuery.when2( [ defer1, defer2 ],
+		      { failOnFirstError: true } )
+	.fail(function( index, value ) {
+		deepEqual( [ index, value ], [ 1, 2 ], "resolve/reject => fail" );
+		strictEqual( this, defer2.promise(), "resolve/reject context" );
+	});
+
+	defer1.resolve( 1 );
+	defer2.reject( 2 );
+});
+
+test( "jQuery.when2 - fail resolve/reject (failOnFirstError true, resolveOnFirstSuccess true)", function() {
+
+	expect( 2 );
+
+	var defer1 = jQuery.Deferred(),
+		defer2 = jQuery.Deferred();
+
+	jQuery.when2( [ defer1, defer2 ],
+		      { failOnFirstError: true, resolveOnFirstSuccess: true } )
+	.done(function( index, value ) {
+		deepEqual( [ index, value ], [ 0, 1 ], "resolve/reject => done" );
+		strictEqual( this, defer1.promise(), "resolve/reject context" );
+	})
+	.fail(function() {
+		ok( false, "Fail called when it shouldn't have been.");
+	});
+
+	defer1.resolve( 1 );
+	defer2.reject( 2 );
+});
+
+test( "jQuery.when2 - fail reject/resolve (failOnFirstError true, resolveOnFirstSuccess true)", function() {
+
+	expect( 2 );
+
+	var defer1 = jQuery.Deferred(),
+		defer2 = jQuery.Deferred();
+
+	jQuery.when2( [ defer1, defer2 ],
+		      { failOnFirstError: true, resolveOnFirstSuccess: true } )
+	.fail(function( index, value ) {
+		deepEqual( [ index, value ], [ 0, 1 ], "reject/resolve => done" );
+		strictEqual( this, defer1.promise(), "reject/resolve context" );
+	})
+	.done(function() {
+		ok( false, "Done called when it shouldn't have been.");
+	});
+
+	defer1.reject( 1 );
+	defer2.resolve( 2 );
+});
+
+test( "jQuery.when2 - fail (failOnFirstError false) reject/resolve", function() {
+
+	expect( 3 );
+
+	var defer1 = jQuery.Deferred(),
+		defer2 = jQuery.Deferred();
+
+	jQuery.when2( [ defer1, defer2 ],
+		      { failOnFirstError: false } )
+	.done(function( a, b ) {
+		deepEqual( [ a, b ], [ 1, 2 ], "reject/resolve => done" );
+		strictEqual( this[0], defer1.promise(), "reject/resolve context 1" );
+		strictEqual( this[1], defer2.promise(), "reject/resolve context 2" );
+	});
+
+	defer1.reject( 1 );
+	defer2.resolve( 2 );
+});
+
+test( "jQuery.when2 - progress notify/notify", function() {
+
+	expect( 4 );
+
+	var defer1 = jQuery.Deferred(),
+		defer2 = jQuery.Deferred(),
+		count = 0;
+
+	jQuery.when2( [ defer1, defer2 ],
+		      { failOnFirstError: false } )
+	.progress(function( index, value ) {
+		if ( count === 0 ) {
+			deepEqual( [ index, value ], [ 0, 1 ], "notify 1 => progress" );
+			strictEqual( this, defer1.promise(), "notify context 1" );
+			count++;
+		} else if ( count === 1 ){
+			deepEqual( [ index, value ], [ 1, 2 ], "notify 2 => progress" );
+			strictEqual( this, defer2.promise(), "notify context 2" );
+			count++;
+		} else {
+			ok( false, "Progress called too many times" );
+		}
+	});
+
+	defer1.notify( 1 );
+	defer2.notify( 2 );
+});
+
+test( "jQuery.when2 - progress no notify after resolve", function() {
+
+	expect( 2 );
+
+	var defer1 = jQuery.Deferred(),
+		defer2 = jQuery.Deferred(),
+		count = 0;
+
+	jQuery.when2( [ defer1, defer2 ],
+		      { failOnFirstError: false } )
+	.progress(function( index, value ) {
+		if ( count === 0 ) {
+			deepEqual( [ index, value ], [ 0, 1 ], "notify 1 => progress" );
+			strictEqual( this, defer1.promise(), "notify context 1" );
+			count++;
+		} else {
+			ok( false, "Progress called too many times." );
+		}
+	});
+
+	defer1.notify( 1 );
+	defer1.resolve( 1 );
+	defer2.resolve( 2 );
+	defer2.notify( 2 );
+});


### PR DESCRIPTION
I'm not sure if this belongs in a pull request. I'm sending it out for discussion. Maybe it should just be a totally separate module.

The patch adds a `jQuery.when2` function. The code borrows heavily from `jQuery.when`. The main differences from `jQuery.when` are:
- when2 must be called with a list as its first argument.
- An options object may be passed as a second argument.
- If `options.resolveOnFirstSuccess` is `true`, the deferred returned by when2 will be resolved as soon as any of the passed deferreds resolves. In this case, done callbacks will be passed `index`, `value` args, where `index` is the index of the deferred that fired. If non-deferreds are in the arguments to `when2`, the first one seen will trigger the resolve (not very useful, but consistent).
- If `options.failOnFirstError` is `false`, the deferred returned by when2 will never fail. It will collect the results from all the deferreds and pass them all back. The caller gets to figure out which values (if any) are errors.
- If no options are given (or `options.failOnFirstError` is `true`), `fail` will be called on the master deferred on the first error, as with `jQuery.when`. The args passed to `fail` will be `index` and `value`, to indicate which deferred was rejected.
- Any `.progress` callbacks added to the `when2` returned deferred are also called with `index` and `value` so you can tell which deferred made progress.  Once the master deferred has fired, no further progress events are fired.
- `when2` always makes a new deferred (instead of trying to re-use the single deferred it is given if it only has one argument). This makes the code simpler and was in any case necessary due to needing to pass index and value args to the callbacks in the single-argument case when `resolveOnFirstSuccess` or `failOnFirstError` indicate that just one deferred should trigger the master.
- A slightly radical possible future thing to add would be to co-opt the `.progress` callback and use it to instead relay `resolve` info (each call having an index & a value to show which of the passed deferreds had resolved). A flag in `options` could request that behavior. It's a perversion but it's easy to think of ways in which that could be useful.
- It might be possible to implement `jQuery.when` in terms of `jQuery.when2`. I tried that originally, but ran into difficulty so decided to leave it for later (or never).
- It would be easy to add convenience functions like `jQuery.whenAnySuccess` or `jQuery.whenAllResolvedOrRejected` that just called `when2` with the correct option.

The aim here, obviously, is to provide more flexibility than `when` does. I don't like the name `when2` much, but I called it that for now (in the spirit of `dup2`). I'm sure my Javascript style wont match the jQuery style in some ways & am happy to fix that.  I copied some of the `jQuery.when` tests, but some were too complicated to get right for `when2` so I ended up adding a bunch of small tests as well.

Thanks for any help / discussion. I'm not expecting this to get merged anytime soon, or even at all. But I'd like to hear what people think.

BTW, the approach mirrors what you can do with Twisted's DeferredList (see http://twistedmatrix.com/documents/current/api/twisted.internet.defer.DeferredList.html), which gives you the same 3 behaviors: fire on first callback, fire on first errback, fire when everything is done (errors or not).
