### PR TITLE
#10568 - Animation does not work for inline elements while showing them

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -292,7 +292,7 @@ function defaultPrefilter( elem, props, opts ) {
 
 		// Set display property to inline-block for height/width
 		// animations on inline elements that are having width/height animated
-		if ( jQuery.css( elem, "display" ) === "inline" &&
+		if ( jQuery.isPlainObject(elemdisplay) && elemdisplay[elem.tagName] === "inline" &&
 				jQuery.css( elem, "float" ) === "none" ) {
 
 			style.display = "inline-block";

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -308,6 +308,19 @@ test("animate native inline width/height", function() {
 			});
 });
 
+test("animate native inline element width while showing it", function() {
+	expect(3);
+
+	stop();
+	jQuery("#foo").css({ display: "", width: "", height: "" })
+		.append("<span>text</span>")
+		.children("span")
+			.animate({ width: "show" }, 100, function() {
+				equal( jQuery(this).css("display"), "inline-block", "inline-block was set on non-floated inline element when animating width on showing it" );
+				start();
+			});
+});
+
 test( "animate block width/height", function() {
 	expect( 3 );
 	stop();


### PR DESCRIPTION
Solves the animation issue mentioned in http://bugs.jquery.com/ticket/10568

Issue: We make inline elements to inline-block before animations but in this case, since display was none, inline elements were not able to get convert to inline-block and hence animation was not working as shown in the jsfiddle in above issue.

Issue can also be seen at: http://jsbin.com/izuyat/1/edit
Click on show span and hide span and notice the difference.
