### PR TITLE
Ensure callback firing flag goes back to false if any handler throws

### DIFF
--- a/src/callbacks.js
+++ b/src/callbacks.js
@@ -64,13 +64,16 @@ jQuery.Callbacks = function( options ) {
 			firingStart = 0;
 			firingLength = list.length;
 			firing = true;
-			for ( ; list && firingIndex < firingLength; firingIndex++ ) {
-				if ( list[ firingIndex ].apply( data[ 0 ], data[ 1 ] ) === false && options.stopOnFalse ) {
-					memory = false; // To prevent further calls using add
-					break;
+			try {
+				for ( ; list && firingIndex < firingLength; firingIndex++ ) {
+					if ( list[ firingIndex ].apply( data[ 0 ], data[ 1 ] ) === false && options.stopOnFalse ) {
+						memory = false; // To prevent further calls using add
+						break;
+					}
 				}
+			} finally {
+				firing = false;
 			}
-			firing = false;
 			if ( list ) {
 				if ( stack ) {
 					if ( stack.length ) {


### PR DESCRIPTION
Using try finally to ensure `firing` is always set back to false, otherwise if any callback throws subsequent calls won't fire.

The issue can be easily reproduced this way:

``` js

$(function(){

   $(function(){ console.log("I get called"); });

   $(function(){ throw "something bad"; });

   $(function(){ console.log("I never get called"); });

});

```

The problem with is many jQuery plugins rely on jQuery ready function, and any error on a 3rd party handler function makes subsequent ones to never work again.
