### PR TITLE
Remove trailing comma in define array

### DIFF
--- a/src/effects/animated-selector.js
+++ b/src/effects/animated-selector.js
@@ -1,7 +1,7 @@
 define([
 	"../core",
 	"../selector",
-	"../effects",
+	"../effects"
 ], function( jQuery ) {
 	jQuery.expr.filters.animated = function( elem ) {
 		return jQuery.grep(jQuery.timers, function( fn ) {


### PR DESCRIPTION
Just noticed this minor syntax correction. Great work on the AMD support, this is amazing!
