### PR TITLE
Add bower install before grunt to fix bug build error, because of missin...

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ bower -version
 Enter the jquery directory and install the Node and Bower dependencies, this time *without* specifying a global(-g) install:
 
 ```bash
-cd jquery && npm install
+cd jquery && npm install && bower install
 ```
 
 Then, to get a complete, minified (w/ Uglify.js), linted (w/ JSHint) version of jQuery, type the following:


### PR DESCRIPTION
...g bower sizzle

```
Running "build:all:*" (build) task
Warning: Error: ENOENT, no such file or directory '/var/jquery/src/../bower_components/sizzle/dist/sizzle.js'
In module tree:
    jquery
      selector
        selector-sizzle

    at Object.fs.openSync (fs.js:338:18)
 Use --force to continue.
```

Aborted due to warnings.
