### PR TITLE
bower: Define main section in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "jquery",
   "version": "2.0.4-pre",
+  "main": "dist/jquery.min.js",
   "ignore": [
     "**/.*",
     "build",


### PR DESCRIPTION
The main section defines what files to use in Bower packages that are consuming the component: https://github.com/bower/bower

Referencing a non-minified version would be even better but grunt didn't build one in dist/
