### PR TITLE
Fix #14036 - ajaxLocation Includes HTTP Basic Authentication Info

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -18,7 +18,7 @@ var
 	rlocalProtocol = /^(?:about|app|app-storage|.+-extension|file|res|widget):$/,
 	rnoContent = /^(?:GET|HEAD)$/,
 	rprotocol = /^\/\//,
-	rurl = /^([\w.+-]+:)(?:\/\/(?:[^/?#]*@|)([^\/?#:]*)(?::(\d+)|)|)/,
+	rurl = /^([\w.+-]+:)(?:\/\/(?:[^\/?#]*@|)([^\/?#:]*)(?::(\d+)|)|)/,
 
 	/* Prefilters
 	 * 1) They are useful to introduce custom dataTypes (see ajax/jsonp.js for an example)
@@ -44,7 +44,7 @@ var
 // #8138, IE may throw an exception when accessing
 // a field from window.location if document.domain has been set
 try {
-	ajaxLocation = location.protocol + "//" + location.host;
+	ajaxLocation = location.href;
 } catch( e ) {
 	// Use the href attribute of an A element
 	// since IE will modify it given document.location


### PR DESCRIPTION
Fixed the issues mentioned in http://bugs.jquery.com/ticket/14036

Issue occurs when using HTTP Basic Authentication in Chrome and checking for crossdomain. Because chrome includes username:password@ when using `location.href`, `s.crossDomain` is true.

You can see an example of this behavior by visiting http://username:password@example.com/ in Chrome and running `location.href`. Running  the following with this address

```
ajaxLocParts = rurl.exec( ajaxLocation.toLowerCase() ) || [];
```

will produce username as the domain instead of example.com

As mentioned by paulie4 in the ticket using `location.protocol + "//" + location.host` will alleviate the problem.
