### PR TITLE
Optimizing jQuery.merge for size (#14313)

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -560,10 +560,6 @@ jQuery.extend({
 			for ( ; j < l; j++ ) {
 				first[ i++ ] = second[ j ];
 			}
-		} else {
-			while ( second[j] !== undefined ) {
-				first[ i++ ] = second[ j++ ];
-			}
 		}
 
 		first.length = i;


### PR DESCRIPTION
- Using the `+` operator instead of `typeof l === "number"` would saves around 22 bytes 
- Eliminate oldIE specific `else` condition
