### PR TITLE
allow form inputs to have names of "className"

### DIFF
--- a/src/attributes/classes.js
+++ b/src/attributes/classes.js
@@ -16,7 +16,7 @@ jQuery.fn.extend({
 
 		if ( jQuery.isFunction( value ) ) {
 			return this.each(function( j ) {
-				jQuery( this ).addClass( value.call( this, j, this.className ) );
+				jQuery( this ).addClass( value.call( this, j, jQuery( this ).attr( "class" ) ) );
 			});
 		}
 
@@ -27,7 +27,7 @@ jQuery.fn.extend({
 			for ( ; i < len; i++ ) {
 				elem = this[ i ];
 				cur = elem.nodeType === 1 && ( elem.className ?
-					( " " + elem.className + " " ).replace( rclass, " " ) :
+					( " " + jQuery( elem ).attr( "class" ) + " " ).replace( rclass, " " ) :
 					" "
 				);
 
@@ -41,8 +41,8 @@ jQuery.fn.extend({
 
 					// only assign if different to avoid unneeded rendering.
 					finalValue = jQuery.trim( cur );
-					if ( elem.className !== finalValue ) {
-						elem.className = finalValue;
+					if ( jQuery( elem ).attr( "class" ) !== finalValue ) {
+						jQuery( elem ).attr( "class", finalValue );
 					}
 				}
 			}
@@ -59,7 +59,7 @@ jQuery.fn.extend({
 
 		if ( jQuery.isFunction( value ) ) {
 			return this.each(function( j ) {
-				jQuery( this ).removeClass( value.call( this, j, this.className ) );
+				jQuery( this ).removeClass( value.call( this, j, jQuery( this ).attr( "class" ) ) );
 			});
 		}
 		if ( proceed ) {
@@ -68,8 +68,8 @@ jQuery.fn.extend({
 			for ( ; i < len; i++ ) {
 				elem = this[ i ];
 				// This expression is here for better compressibility (see addClass)
-				cur = elem.nodeType === 1 && ( elem.className ?
-					( " " + elem.className + " " ).replace( rclass, " " ) :
+				cur = elem.nodeType === 1 && ( jQuery( elem ).attr( "class" ) ?
+					( " " + jQuery( elem ).attr( "class" ) + " " ).replace( rclass, " " ) :
 					""
 				);
 
@@ -84,8 +84,8 @@ jQuery.fn.extend({
 
 					// only assign if different to avoid unneeded rendering.
 					finalValue = value ? jQuery.trim( cur ) : "";
-					if ( elem.className !== finalValue ) {
-						elem.className = finalValue;
+					if ( jQuery( elem ).attr( "class" ) !== finalValue ) {
+						jQuery( elem ).attr( "class", finalValue );
 					}
 				}
 			}
@@ -103,7 +103,7 @@ jQuery.fn.extend({
 
 		if ( jQuery.isFunction( value ) ) {
 			return this.each(function( i ) {
-				jQuery( this ).toggleClass( value.call(this, i, this.className, stateVal), stateVal );
+				jQuery( this ).toggleClass( value.call(this, i, jQuery( this ).attr( "class" ), stateVal), stateVal );
 			});
 		}
 
@@ -126,16 +126,16 @@ jQuery.fn.extend({
 
 			// Toggle whole class name
 			} else if ( type === strundefined || type === "boolean" ) {
-				if ( this.className ) {
+				if ( jQuery( this ).attr( "class" ) ) {
 					// store className if set
-					data_priv.set( this, "__className__", this.className );
+					data_priv.set( this, "__className__", jQuery( this ).attr( "class" ) );
 				}
 
 				// If the element has a class name or if we're passed "false",
 				// then remove the whole classname (if there was one, the above saved it).
 				// Otherwise bring back whatever was previously saved (if anything),
 				// falling back to the empty string if nothing was stored.
-				this.className = this.className || value === false ? "" : data_priv.get( this, "__className__" ) || "";
+				jQuery( this ).attr( "class", jQuery( this ).attr( "class" ) || value === false ? "" : data_priv.get( this, "__className__" ) || "" );
 			}
 		});
 	},
@@ -145,7 +145,7 @@ jQuery.fn.extend({
 			i = 0,
 			l = this.length;
 		for ( ; i < l; i++ ) {
-			if ( this[i].nodeType === 1 && (" " + this[i].className + " ").replace(rclass, " ").indexOf( className ) >= 0 ) {
+			if ( this[i].nodeType === 1 && (" " + jQuery( this[i] ).attr( "class" ) + " ").replace(rclass, " ").indexOf( className ) >= 0 ) {
 				return true;
 			}
 		}

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -1047,6 +1047,7 @@ var testAddClass = function( valueObj ) {
 	expect( 9 );
 
 	var pass, j, i,
+	  form = jQuery("<form></form>"),
 		div = jQuery("#qunit-fixture div");
 	div.addClass( valueObj("test") );
 	pass = true;
@@ -1087,6 +1088,10 @@ var testAddClass = function( valueObj ) {
 	div.removeClass();
 	div.addClass( valueObj("bar bar") );
 	equal( div.attr("class"), "bar", "Do not add the same class twice in the same call." );
+
+	form.addClass("a");
+	form.append("<input name=\"className\">");
+	equal( form.attr("class"), "a", "Allow forms to have inputs with a name of \"className\"." );
 };
 
 test( "addClass(String)", function() {


### PR DESCRIPTION
The way browsers map inputs to form properties, it is impossible to access the class name of a `<form>` element containing an `<input>` with the attribute of `name="className"` as `form.className` maps to the `<input name="className">` rather than the `class` attribute of the `<form>`.

This causes undesired results when using the current `addClass()` implementation:

``` js
var form = jQuery('<form class="a">');
form.append('<input name="className">');
form.addClass('b');

assert(form.getAttribute('class') == 'a b');
// Error: Expected "[HTMLInputElement] b" to equal "a b".
```

Addresses angular/angular.js#3786 and angular/angular.js#3773
