### PR TITLE
Optimize jQuery.grep on 1.x and add unit tests for the same (#14332)

### DIFF
--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -905,6 +905,26 @@ test("jQuery.map", function() {
 	equal( result.join(""), "00012223", "Array results flattened (#2616)" );
 });
 
+test("jQuery.grep()", function() {
+	expect(8);
+
+	var searchCriterion = function( value ) {
+		return value % 2 === 0;
+	};
+
+	deepEqual( jQuery.grep( [], searchCriterion ), [], "Empty array" );
+	deepEqual( jQuery.grep( new Array(4), searchCriterion ), [], "Sparse array" );
+
+	deepEqual( jQuery.grep( [ 1, 2, 3, 4, 5, 6 ], searchCriterion ), [ 2, 4, 6 ], "Satisfying elements present" );
+	deepEqual( jQuery.grep( [ 1, 3, 5, 7], searchCriterion ), [], "Satisfying elements absent" );
+
+	deepEqual( jQuery.grep( [ 1, 2, 3, 4, 5, 6 ], searchCriterion, true ), [ 1, 3, 5 ], "Satisfying elements present and grep inverted" );
+	deepEqual( jQuery.grep( [ 1, 3, 5, 7], searchCriterion, true ), [1, 3, 5, 7], "Satisfying elements absent and grep inverted" );
+
+	deepEqual( jQuery.grep( [ 1, 2, 3, 4, 5, 6 ], searchCriterion, false ), [ 2, 4, 6 ], "Satisfying elements present but grep explicitly uninverted" );
+	deepEqual( jQuery.grep( [ 1, 3, 5, 7 ], searchCriterion, false ), [], "Satisfying elements absent and grep explicitly uninverted" );
+});
+
 test("jQuery.merge()", function() {
 	expect( 10 );
 


### PR DESCRIPTION
On ES5 compiant browsers fallback on the native `Array.prototype.filter` method to take advantage of browser level optimizations
