### PR TITLE
No ticket. Abstract conditional hook definition.

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -14,6 +14,7 @@ var
 	curCSS = require( "./css/curCSS" ),
 	support = require( "./css/support" ),
 	defaultDisplay = require( "./css/defaultDisplay" ),
+	addGetHookIf = require( "./css/addGetHookIf" ),
 	data_priv = require( "./data/var/data_priv" ),
 
 	// swappable if display is none or starts with table except "table", "table-cell", or "table-caption"
@@ -369,28 +370,16 @@ jQuery.each([ "height", "width" ], function( i, name ) {
 });
 
 // Support: Android 2.3
-jQuery.cssHooks.marginRight = {
-	get: function( elem, computed ) {
-		if ( support.reliableMarginRight() ) {
-			// Hook not needed, remove it.
-			// Since there are no other hooks for marginRight, remove the whole object.
-			delete jQuery.cssHooks.marginRight;
-			return;
+addGetHookIf( jQuery.cssHooks.marginRight, support.reliableMarginRight,
+	function ( elem, computed ) {
+		if ( computed ) {
+			// WebKit Bug 13343 - getComputedStyle returns wrong value for margin-right
+			// Work around by temporarily setting element display to inline-block
+			return jQuery.swap( elem, { "display": "inline-block" },
+				curCSS, [ elem, "marginRight" ] );
 		}
-
-		jQuery.cssHooks.marginRight.get = function( elem, computed ) {
-			if ( computed ) {
-				// Support: Android 2.3
-				// WebKit Bug 13343 - getComputedStyle returns wrong value for margin-right
-				// Work around by temporarily setting element display to inline-block
-				return jQuery.swap( elem, { "display": "inline-block" },
-					curCSS, [ elem, "marginRight" ] );
-			}
-		};
-
-		return jQuery.cssHooks.marginRight.get( elem, computed );
 	}
-};
+);
 
 // These hooks are used by animate to expand properties
 jQuery.each({

--- a/src/css/addGetHookIf.js
+++ b/src/css/addGetHookIf.js
@@ -1,0 +1,33 @@
+define( function() {
+
+function addGetHookIf( hookVar, conditionFn, hookFn ) {
+	// Define the hook, we'll check on the first run if it's really needed.
+	hookVar = {
+		get: function() {
+			var condition = conditionFn();
+
+			if ( condition == null ) {
+				// The test was not ready at this point; screw the hook this time
+				// but check again when needed next time.
+				return;
+			}
+
+			if ( condition ) {
+				// Hook not needed (or it's not possible to use it due to missing dependency),
+				// remove it.
+				// Since there are no other hooks for marginRight, remove the whole object.
+				delete hookVar.get;
+				return;
+			}
+
+			// Hook needed; redefine it so that the support test is not executed again.
+			hookVar.get = hookFn;
+
+			return hookVar.get.apply( hookVar, arguments );
+		}
+	};
+}
+
+return addGetHookIf;
+
+});

--- a/src/offset.js
+++ b/src/offset.js
@@ -6,6 +6,7 @@ var
 	access = require( "./core/access" ),
 	rnumnonpx = require( "./css/var/rnumnonpx" ),
 	curCSS = require( "./css/curCSS" ),
+	addGetHookIf = require( "./css/addGetHookIf" ),
 	support = require( "./css/support" ),
 	docElem = window.document.documentElement;
 
@@ -186,28 +187,17 @@ jQuery.each( {scrollLeft: "pageXOffset", scrollTop: "pageYOffset"}, function( me
 // getComputedStyle returns percent when specified for top/left/bottom/right
 // rather than make the css module depend on the offset module, we just check for it here
 jQuery.each( [ "top", "left" ], function( i, prop ) {
-	jQuery.cssHooks[ prop ] = {
-		get: function( elem, computed ) {
-			if ( support.pixelPosition() ) {
-				// Hook not needed, remove it.
-				// Since there are no other hooks for prop, remove the whole object.
-				delete jQuery.cssHooks[ prop ];
-				return;
+	addGetHookIf( jQuery.cssHooks[ prop ], support.pixelPosition,
+		function ( elem, computed ) {
+			if ( computed ) {
+				computed = curCSS( elem, prop );
+				// if curCSS returns percentage, fallback to offset
+				return rnumnonpx.test( computed ) ?
+					jQuery( elem ).position()[ prop ] + "px" :
+					computed;
 			}
-
-			jQuery.cssHooks[ prop ].get = function ( i, prop ) {
-				if ( computed ) {
-					computed = curCSS( elem, prop );
-					// if curCSS returns percentage, fallback to offset
-					return rnumnonpx.test( computed ) ?
-						jQuery( elem ).position()[ prop ] + "px" :
-						computed;
-				}
-			};
-
-			return jQuery.cssHooks[ prop ].get( i, prop );
 		}
-	};
+	);
 });
 
 return jQuery;


### PR DESCRIPTION
Shaves off 14 bytes minified gzipped.

The mechanism used to define hooks requiring lazy supports is repeated: first define the hook unconditionally as a function first executing the support test and later either removing itself or redefining to just execute the hook function without repeating executing support tests.

Analogous PR for `1.x-master`: #1356.
