### PR TITLE
Fix #14340. Remove remnants of oldIE from unit tests.

### DIFF
--- a/test/data/testsuite.css
+++ b/test/data/testsuite.css
@@ -1,4 +1,3 @@
-/* for testing opacity set in styles in IE */
 ol#empty {
 	opacity: 0;
 }

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -565,33 +565,44 @@ test( "removeAttr(String)", function() {
 	expect( 12 );
 	var $first;
 
-	equal( jQuery("#mark").removeAttr("class").attr("class"), undefined, "remove class" );
-	equal( jQuery("#form").removeAttr("id").attr("id"), undefined, "Remove id" );
-	equal( jQuery("#foo").attr( "style", "position:absolute;" ).removeAttr("style").attr("style"), undefined, "Check removing style attribute" );
-	equal( jQuery("#form").attr( "style", "position:absolute;" ).removeAttr("style").attr("style"), undefined, "Check removing style attribute on a form" );
-	equal( jQuery("<div style='position: absolute'></div>").appendTo("#foo").removeAttr("style").prop("style").cssText, "", "Check removing style attribute (#9699 Webkit)" );
-	equal( jQuery("#fx-test-group").attr( "height", "3px" ).removeAttr("height").get( 0 ).style.height, "1px", "Removing height attribute has no effect on height set with style attribute" );
+	equal( jQuery( "#mark" ).removeAttr( "class" ).attr( "class" ), undefined, "remove class" );
+	equal( jQuery( "#form" ).removeAttr( "id" ).attr( "id" ), undefined, "Remove id" );
+	equal( jQuery( "#foo" ).attr( "style", "position:absolute;" )
+		.removeAttr( "style" ).attr( "style" ), undefined, "Check removing style attribute" );
+	equal( jQuery( "#form" ).attr( "style", "position:absolute;" )
+		.removeAttr( "style" ).attr( "style" ), undefined,
+		"Check removing style attribute on a form" );
+	equal( jQuery( "<div style='position: absolute'></div>" ).appendTo( "#foo" )
+		.removeAttr( "style" ).prop( "style" ).cssText, "",
+		"Check removing style attribute (#9699 Webkit)" );
+	equal( jQuery( "#fx-test-group" ).attr( "height", "3px" )
+		.removeAttr( "height" ).get( 0 ).style.height, "1px",
+		"Removing height attribute has no effect on height set with style attribute" );
 
-	jQuery("#check1").removeAttr("checked").prop( "checked", true ).removeAttr("checked");
-	equal( document.getElementById("check1").checked, false, "removeAttr sets boolean properties to false" );
-	jQuery("#text1").prop( "readOnly", true ).removeAttr("readonly");
-	equal( document.getElementById("text1").readOnly, false, "removeAttr sets boolean properties to false" );
+	jQuery( "#check1" ).removeAttr( "checked" ).prop( "checked", true ).removeAttr( "checked" );
+	equal( document.getElementById( "check1" ).checked, false,
+		"removeAttr sets boolean properties to false" );
+	jQuery("#text1").prop( "readOnly", true ).removeAttr( "readonly" );
+	equal( document.getElementById( "text1" ).readOnly, false,
+		"removeAttr sets boolean properties to false" );
 
-	jQuery("#option2c").removeAttr("selected");
-	equal( jQuery("#option2d").attr("selected"), "selected", "Removing `selected` from an option that is not selected does not remove selected from the currently selected option (#10870)" );
+	jQuery( "#option2c" ).removeAttr( "selected" );
+	equal( jQuery( "#option2d" ).attr( "selected" ), "selected",
+		"Removing `selected` from an option that is not selected does not remove selected from " +
+			"the currently selected option (#10870)" );
 
 	try {
-		$first = jQuery("#first").attr( "contenteditable", "true" ).removeAttr("contenteditable");
+		$first = jQuery( "#first" )
+			.attr( "contenteditable", "true" ).removeAttr( "contenteditable" );
 		equal( $first.attr("contenteditable"), undefined, "Remove the contenteditable attribute" );
 	} catch( e ) {
 		ok( false, "Removing contenteditable threw an error (#10429)" );
 	}
 
-	$first = jQuery("<div Case='mixed'></div>");
-	equal( $first.attr("Case"), "mixed", "case of attribute doesn't matter" );
-	$first.removeAttr("Case");
-	// IE 6/7 return empty string here, not undefined
-	ok( !$first.attr("Case"), "mixed-case attribute was removed" );
+	$first = jQuery( "<div Case='mixed'></div>" );
+	equal( $first.attr( "Case" ), "mixed", "case of attribute doesn't matter" );
+	$first.removeAttr( "Case" );
+	equal( $first.attr( "Case" ), undefined, "mixed-case attribute was removed" );
 });
 
 test( "removeAttr(String) in XML", function() {
@@ -1387,12 +1398,12 @@ test( "hasClass correctly interprets non-space separators (#13835)", function() 
 	});
 });
 
-test( "coords returns correct values in IE6/IE7, see #10828", function() {
+test( "coords returns correct values, see #10828", function() {
 	expect( 1 );
 
 	var area,
 		map = jQuery("<map />");
 
-	area = map.html("<area shape='rect' coords='0,0,0,0' href='#' alt='a' />").find("area");
-	equal( area.attr("coords"), "0,0,0,0", "did not retrieve coords correctly" );
+	area = map.html( "<area shape='rect' coords='0,0,0,0' href='#' alt='a' />" ).find( "area" );
+	equal( area.attr( "coords" ), "0,0,0,0", "did not retrieve coords correctly" );
 });

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -585,7 +585,7 @@ test("isWindow", function() {
 });
 
 test("jQuery('html')", function() {
-	expect( 15 );
+	expect( 18 );
 
 	var s, div, j;
 
@@ -620,10 +620,13 @@ test("jQuery('html')", function() {
 	ok( jQuery("<div></div>")[0], "Create a div with closing tag." );
 	ok( jQuery("<table></table>")[0], "Create a table with closing tag." );
 
-	// equal( jQuery("element[attribute='<div></div>']").length, 0, "When html is within brackets, do not recognize as html." );
-	// equal( jQuery("element[attribute=<div></div>]").length, 0, "When html is within brackets, do not recognize as html." );
-	// equal( jQuery("element:not(<div></div>)").length, 0, "When html is within parens, do not recognize as html." );
-	// equal( jQuery("\\<div\\>").length, 0, "Ignore escaped html characters" );
+	equal( jQuery( "element[attribute='<div></div>']" ).length, 0,
+		"When html is within brackets, do not recognize as html." );
+	//equal( jQuery( "element[attribute=<div></div>]" ).length, 0,
+	//	"When html is within brackets, do not recognize as html." );
+	equal( jQuery( "element:not(<div></div>)" ).length, 0,
+		"When html is within parens, do not recognize as html." );
+	equal( jQuery( "\\<div\\>" ).length, 0, "Ignore escaped html characters" );
 });
 
 test("jQuery('massive html #7990')", function() {

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -751,12 +751,6 @@ test("can't get background-position in IE<9, see #10796", function() {
 	}
 });
 
-test("percentage properties for bottom and right in IE<9 should not be incorrectly transformed to pixels, see #11311", function() {
-	expect( 1 );
-	var div = jQuery("<div style='position: absolute; width: 1px; height: 20px; bottom:50%;'></div>").appendTo( "#qunit-fixture" );
-	ok( window.getComputedStyle || div.css( "bottom" ) === "50%", "position properties get incorrectly transformed in IE<8, see #11311" );
-});
-
 if ( jQuery.fn.offset ) {
 	test("percentage properties for left and top should be transformed to pixels, see #9505", function() {
 		expect( 2 );

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -348,40 +348,32 @@ test("animate table width/height", function() {
 	});
 });
 
-test("animate table-row width/height", function() {
+test( "animate table-row width/height", function() {
 	expect(3);
 	stop();
-	var displayMode,
-		tr = jQuery("#table")
+	var tr = jQuery( "#table" )
 			.attr({ "cellspacing": 0, "cellpadding": 0, "border": 0 })
-			.html("<tr style='height:42px;'><td style='padding:0;'><div style='width:20px;height:20px;'></div></td></tr>")
-			.find("tr");
-
-	// IE<8 uses "block" instead of the correct display type
-	displayMode = tr.css("display") !== "table-row" ? "block" : "table-row";
+			.html( "<tr style='height:42px;'><td style='padding:0;'><div style='width:20px;height:20px;'></div></td></tr>" )
+			.find( "tr" );
 
 	tr.animate({ width: 10, height: 10 }, 100, function() {
-		equal( jQuery(this).css("display"), displayMode, "display mode is correct" );
+		equal( jQuery(this).css( "display" ), "table-row", "display mode is correct" );
 		equal( this.offsetWidth, 20, "width animated to shrink wrap point" );
 		equal( this.offsetHeight, 20, "height animated to shrink wrap point" );
 		start();
 	});
 });
 
-test("animate table-cell width/height", function() {
+test( "animate table-cell width/height", function() {
 	expect(3);
 	stop();
-	var displayMode,
-		td = jQuery("#table")
+	var td = jQuery( "#table" )
 			.attr({ "cellspacing": 0, "cellpadding": 0, "border": 0 })
-			.html("<tr><td style='width:42px;height:42px;padding:0;'><div style='width:20px;height:20px;'></div></td></tr>")
-			.find("td");
-
-	// IE<8 uses "block" instead of the correct display type
-	displayMode = td.css("display") !== "table-cell" ? "block" : "table-cell";
+			.html( "<tr><td style='width:42px;height:42px;padding:0;'><div style='width:20px;height:20px;'></div></td></tr>" )
+			.find( "td" );
 
 	td.animate({ width: 10, height: 10 }, 100, function() {
-		equal( jQuery(this).css("display"), displayMode, "display mode is correct" );
+		equal( jQuery(this).css( "display" ), "table-cell", "display mode is correct" );
 		equal( this.offsetWidth, 20, "width animated to shrink wrap point" );
 		equal( this.offsetHeight, 20, "height animated to shrink wrap point" );
 		start();

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -381,34 +381,21 @@ test("on immediate propagation", function() {
 	$p.off( "click", "**" );
 });
 
-test("on bubbling, isDefaultPrevented", function() {
-	expect(2);
+test( "on bubbling, isDefaultPrevented", function() {
+	expect( 2 );
 	var $anchor2 = jQuery( "#anchor2" ),
 		$main = jQuery( "#qunit-fixture" ),
-		fakeClick = function($jq) {
+		fakeClick = function( $jq ) {
 			// Use a native click so we don't get jQuery simulated bubbling
-			if ( document.createEvent ) {
-				var e = document.createEvent( "MouseEvents" );
-				e.initEvent( "click", true, true );
-				$jq[0].dispatchEvent(e);
-			}
-			else if ( $jq[0].click ) {
-				$jq[0].click();	// IE
-			}
+			var e = document.createEvent( "MouseEvents" );
+			e.initEvent( "click", true, true );
+			$jq[0].dispatchEvent( e );
 		};
-	$anchor2.on( "click", function(e) {
+	$anchor2.on( "click", function( e ) {
 		e.preventDefault();
 	});
-	$main.on("click", "#foo", function(e) {
-		var orig = e.originalEvent;
-
-		if ( typeof(orig.defaultPrevented) === "boolean" || typeof(orig.returnValue) === "boolean" || orig["getPreventDefault"] ) {
-			equal( e.isDefaultPrevented(), true, "isDefaultPrevented true passed to bubbled event" );
-
-		} else {
-			// Opera < 11 doesn't implement any interface we can use, so give it a pass
-			ok( true, "isDefaultPrevented not supported by this browser, test skipped" );
-		}
+	$main.on( "click", "#foo", function( e ) {
+		equal( e.isDefaultPrevented(), true, "isDefaultPrevented true passed to bubbled event" );
 	});
 	fakeClick( $anchor2 );
 	$anchor2.off( "click" );
@@ -1219,8 +1206,6 @@ test("trigger(eventObject, [data], [fn])", function() {
 	equal( event.isDefaultPrevented(), false, "default not prevented" );
 });
 
-// Explicitly introduce global variable for oldIE so QUnit doesn't complain if checking globals
-window.onclick = undefined;
 test(".trigger() bubbling on disconnected elements (#10489)", function() {
 	expect(2);
 

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -77,8 +77,7 @@ function testText( valueObj ) {
 	equal( jQuery( j[ 0 ] ).text(), "hi!", "Check node,textnode,comment with text()" );
 	equal( j[ 1 ].nodeValue, " there ", "Check node,textnode,comment with text()" );
 
-	// Blackberry 4.6 doesn't maintain comments in the DOM
-	equal( jQuery("#nonnodes")[ 0 ].childNodes.length < 3 ? 8 : j[ 2 ].nodeType, 8, "Check node,textnode,comment with text()" );
+	equal( j[ 2 ].nodeType, 8, "Check node,textnode,comment with text()" );
 }
 
 test( "text(String)", function() {
@@ -473,26 +472,8 @@ test( "append(xml)", function() {
 	var xmlDoc, xml1, xml2;
 
 	function createXMLDoc() {
-		// Initialize DOM based upon latest installed MSXML or Netscape
-		var elem, n, len,
-			aActiveX =
-				[ "MSXML6.DomDocument",
-				"MSXML3.DomDocument",
-				"MSXML2.DomDocument",
-				"MSXML.DomDocument",
-				"Microsoft.XmlDom" ];
-
-		if ( document.implementation && "createDocument" in document.implementation ) {
-			return document.implementation.createDocument( "", "", null );
-		} else {
-			// IE
-			for ( n = 0, len = aActiveX.length; n < len; n++ ) {
-				try {
-					elem = new ActiveXObject( aActiveX[ n ] );
-					return elem;
-				} catch(_) {}
-			}
-		}
+		// Initialize DOM
+		return document.implementation.createDocument( "", "", null );
 	}
 
 	xmlDoc = createXMLDoc();
@@ -1169,7 +1150,7 @@ test( "clone()", function() {
 	equal( clone[ 0 ].nodeName.toUpperCase(), "DIV", "DIV element cloned" );
 	div = div.find("object");
 	clone = clone.find("object");
-	// oldIE adds extra attributes and <param> elements, so just test for existence of the defined set
+
 	jQuery.each( [ "height", "width", "classid" ], function( i, attr ) {
 		equal( clone.attr( attr ), div.attr( attr ), "<object> attribute cloned: " + attr );
 	} );
@@ -1866,7 +1847,7 @@ test( "Guard against exceptions when clearing safeChildNodes", function() {
 	ok( div && div.jquery, "Created nodes safely, guarded against exceptions on safeChildNodes[ -1 ]" );
 });
 
-test( "Ensure oldIE creates a new set on appendTo (#8894)", function() {
+test( "Ensure a new set is created on appendTo (#8894)", function() {
 
 	expect( 5 );
 

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -178,35 +178,34 @@ testIframe("offset/absolute", "absolute", function( $ ) {
 	});
 });
 
-testIframe("offset/relative", "relative", function( $ ) {
+testIframe( "offset/relative", "relative", function( $ ) {
 	expect(60);
 
-	var ie, tests;
-
-	// IE is collapsing the top margin of 1px; detect and adjust accordingly
-	ie = $("#relative-1").offset().top === 6;
-
 	// get offset
-	tests = [
-		{ "id": "#relative-1",   "top": ie ?   6 :   7, "left":  7 },
-		{ "id": "#relative-1-1", "top": ie ?  13 :  15, "left": 15 },
-		{ "id": "#relative-2",   "top": ie ? 141 : 142, "left": 27 }
+	var tests = [
+		{ "id": "#relative-1",   "top":   7, "left":  7 },
+		{ "id": "#relative-1-1", "top":  15, "left": 15 },
+		{ "id": "#relative-2",   "top": 142, "left": 27 }
 	];
 	jQuery.each( tests, function() {
-		equal( $( this["id"] ).offset().top,  this["top"],  "jQuery('" + this["id"] + "').offset().top" );
-		equal( $( this["id"] ).offset().left, this["left"], "jQuery('" + this["id"] + "').offset().left" );
+		equal( $( this[ "id" ] ).offset().top,  this[ "top" ],
+			"jQuery('" + this[ "id" ] + "').offset().top" );
+		equal( $( this[ "id" ] ).offset().left, this[ "left" ],
+			"jQuery('" + this[ "id" ] + "').offset().left" );
 	});
 
 
 	// get position
 	tests = [
-		{ "id": "#relative-1",   "top": ie ?   5 :   6, "left":  6 },
-		{ "id": "#relative-1-1", "top": ie ?   4 :   5, "left":  5 },
-		{ "id": "#relative-2",   "top": ie ? 140 : 141, "left": 26 }
+		{ "id": "#relative-1",   "top":   6, "left":  6 },
+		{ "id": "#relative-1-1", "top":   5, "left":  5 },
+		{ "id": "#relative-2",   "top": 141, "left": 26 }
 	];
 	jQuery.each( tests, function() {
-		equal( $( this["id"] ).position().top,  this["top"],  "jQuery('" + this["id"] + "').position().top" );
-		equal( $( this["id"] ).position().left, this["left"], "jQuery('" + this["id"] + "').position().left" );
+		equal( $( this[ "id" ] ).position().top,  this[ "top" ],
+			"jQuery('" + this[ "id" ] + "').position().top" );
+		equal( $( this[ "id" ] ).position().left, this[ "left" ],
+			"jQuery('" + this[ "id" ] + "').position().left" );
 	});
 
 
@@ -244,17 +243,12 @@ testIframe("offset/relative", "relative", function( $ ) {
 testIframe("offset/static", "static", function( $ ) {
 	expect( 80 );
 
-	var ie, tests;
-
-	// IE is collapsing the top margin of 1px; detect and adjust accordingly
-	ie = $("#static-1").offset().top === 6;
-
 	// get offset
-	tests = [
-		{ "id": "#static-1",     "top": ie ?   6 :   7, "left":  7 },
-		{ "id": "#static-1-1",   "top": ie ?  13 :  15, "left": 15 },
-		{ "id": "#static-1-1-1", "top": ie ?  20 :  23, "left": 23 },
-		{ "id": "#static-2", "top": ie ? 121 : 122, left: 7 }
+	var tests = [
+		{ "id": "#static-1",     "top":   7, "left":  7 },
+		{ "id": "#static-1-1",   "top":  15, "left": 15 },
+		{ "id": "#static-1-1-1", "top":  23, "left": 23 },
+		{ "id": "#static-2",     "top": 122, left: 7 }
 	];
 	jQuery.each( tests, function() {
 		equal( $( this["id"] ).offset().top,  this["top"],  "jQuery('" + this["id"] + "').offset().top" );
@@ -264,10 +258,10 @@ testIframe("offset/static", "static", function( $ ) {
 
 	// get position
 	tests = [
-		{ "id": "#static-1",     "top": ie ?   5 :   6, "left":  6 },
-		{ "id": "#static-1-1",   "top": ie ?  12 :  14, "left": 14 },
-		{ "id": "#static-1-1-1", "top": ie ?  19 :  22, "left": 22 },
-		{ "id": "#static-2", "top": ie ? 120 : 121, "left": 6 }
+		{ "id": "#static-1",     "top":   6, "left":  6 },
+		{ "id": "#static-1-1",   "top":  14, "left": 14 },
+		{ "id": "#static-1-1-1", "top":  22, "left": 22 },
+		{ "id": "#static-2",     "top": 121, "left": 6 }
 	];
 	jQuery.each( tests, function() {
 		equal( $( this["id"] ).position().top,  this["top"],  "jQuery('" + this["top"]  + "').position().top" );
@@ -313,25 +307,22 @@ testIframe("offset/static", "static", function( $ ) {
 testIframe("offset/fixed", "fixed", function( $ ) {
 	expect(34);
 
-	var ie, tests, $noTopLeft;
-
-	// IE is collapsing the top margin of 1px; detect and adjust accordingly
-	ie = $("#fixed-1").position().top === 2;
+	var tests, $noTopLeft;
 
 	tests = [
 		{
 			"id": "#fixed-1",
 			"offsetTop": 1001,
 			"offsetLeft": 1001,
-			"positionTop": ie ? 2 : 0,
-			"positionLeft": ie ? 2 : 0
+			"positionTop": 0,
+			"positionLeft": 0
 		},
 		{
 			"id": "#fixed-2",
 			"offsetTop": 1021,
 			"offsetLeft": 1021,
-			"positionTop": ie ? 22 : 20,
-			"positionLeft": ie ? 22 : 20
+			"positionTop": 20,
+			"positionLeft": 20
 		}
 	];
 
@@ -413,21 +404,10 @@ testIframe("offset/table", "table", function( $ ) {
 testIframe("offset/scroll", "scroll", function( $, win ) {
 	expect(24);
 
-	// If we're going to bastardize the tests, let's just DO it
-	var ie = /msie [678]/i.test( navigator.userAgent );
-
-	if ( ie ) {
-		ok( true, "TestSwarm's iframe has hosed this test in oldIE, we surrender" );
-	} else {
-		equal( $("#scroll-1").offset().top, 7, "jQuery('#scroll-1').offset().top" );
-	}
+	equal( $("#scroll-1").offset().top, 7, "jQuery('#scroll-1').offset().top" );
 	equal( $("#scroll-1").offset().left, 7, "jQuery('#scroll-1').offset().left" );
 
-	if ( ie ) {
-		ok( true, "TestSwarm's iframe has hosed this test in oldIE, we surrender" );
-	} else {
-		equal( $("#scroll-1-1").offset().top, 11, "jQuery('#scroll-1-1').offset().top" );
-	}
+	equal( $("#scroll-1-1").offset().top, 11, "jQuery('#scroll-1-1').offset().top" );
 	equal( $("#scroll-1-1").offset().left, 11, "jQuery('#scroll-1-1').offset().left" );
 
 	// scroll offset tests .scrollTop/Left

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -74,7 +74,7 @@ test("disconnected nodes - jQuery only", function() {
 });
 
 testIframe("selector/html5_selector", "attributes - jQuery.attr", function( jQuery, window, document ) {
-	expect( 35 );
+	expect( 38 );
 
 	/**
 	 * Returns an array of elements with the given IDs
@@ -132,10 +132,10 @@ testIframe("selector/html5_selector", "attributes - jQuery.attr", function( jQue
 	t( "Attribute Exists", "[indeterminate]",  []);
 	t( "Attribute Exists", "[ismap]",          ["img1"]);
 	t( "Attribute Exists", "[itemscope]",      ["div1"]);
-	// t( "Attribute Exists", "[loop]",           ["video1"]); // IE 6/7 cannot differentiate here. loop is also used on img, input, and marquee tags as well as video/audio. getAttributeNode unfortunately also retrieves the property value.
+	t( "Attribute Exists", "[loop]",           ["video1"]);
 	t( "Attribute Exists", "[multiple]",       ["select1"]);
 	t( "Attribute Exists", "[muted]",          ["audio1"]);
-	// t( "Attribute Exists", "[nohref]",         ["area1"]); // IE 6/7 keep this set to false regardless of presence. The attribute node is not retrievable.
+	t( "Attribute Exists", "[nohref]",         ["area1"]);
 	t( "Attribute Exists", "[noresize]",       ["textarea1"]);
 	t( "Attribute Exists", "[noshade]",        ["hr1"]);
 	t( "Attribute Exists", "[nowrap]",         ["td1", "div1"]);
@@ -157,7 +157,8 @@ testIframe("selector/html5_selector", "attributes - jQuery.attr", function( jQue
 	});
 	t( "Enumerated attribute", "[spellcheck]", ["span1"]);
 
-	// t( "tabindex selector does not retrieve all elements in IE6/7(#8473)", "form, [tabindex]", ["form1", "text1"] ); // sigh, FF12 QSA mistakenly includes video elements even though they have no tabindex attribute (see https://bugzilla.mozilla.org/show_bug.cgi?id=618737)
+	t( "tabindex selector does not retrieve all elements in IE6/7 (#8473)",
+		"form, [tabindex]", [ "form1", "text1" ] );
 	t( "Improperly named form elements do not interfere with form selections (#9570)", "form[name='formName']", ["form1"] );
 });
 

--- a/test/unit/traversing.js
+++ b/test/unit/traversing.js
@@ -715,7 +715,7 @@ test("add(String|Element|Array|undefined)", function() {
 
 	// For the time being, we're discontinuing support for jQuery(form.elements) since it's ambiguous in IE
 	// use jQuery([]).add(form.elements) instead.
-	//equal( jQuery([]).add(jQuery("#form")[0].elements).length, jQuery(jQuery("#form")[0].elements).length, "Array in constructor must equals array in add()" );
+	// equal( jQuery([]).add(jQuery("#form")[0].elements).length, jQuery(jQuery("#form")[0].elements).length, "Array in constructor must equals array in add()" );
 
 	divs = jQuery("<div/>").add("#sndp");
 	ok( divs[0].parentNode, "Sort with the disconnected node last (started with disconnected first)." );

--- a/test/unit/wrap.js
+++ b/test/unit/wrap.js
@@ -49,7 +49,6 @@ function testWrap( val ) {
 	j = jQuery("#nonnodes").contents();
 	j.wrap( val("<i></i>") );
 
-	// Blackberry 4.6 doesn't maintain comments in the DOM
 	equal( jQuery("#nonnodes > i").length, jQuery("#nonnodes")[ 0 ].childNodes.length, "Check node,textnode,comment wraps ok" );
 	equal( jQuery("#nonnodes > i").text(), j.text(), "Check node,textnode,comment wraps doesn't hurt text" );
 


### PR DESCRIPTION
Ticket: http://bugs.jquery.com/ticket/14340

There's lots of code with specific checks for oldIE in our support tests on current master, sometimes for really old Opera etc.

When I was refactoring support tests and dealing with temporary errors in the test, I encountered this fact and I made changes in the process.
