### PR TITLE
Fix #14343. Remove jQuery.fn.size & jQuery.fn.andSelf.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Some example modules that can be excluded are:
 - **ajax/script**: The `<script>` AJAX transport only; used to retrieve scripts.
 - **ajax/jsonp**: The JSONP AJAX transport only; depends on the ajax/script transport.
 - **css**: The `.css()` method plus non-animated `.show()`, `.hide()` and `.toggle()`. Also removes **all** modules depending on css (including **effects**, **dimensions**, and **offset**).
-- **deprecated**: Methods documented as deprecated but not yet removed; currently only `.andSelf()`.
+- **deprecated**: Methods documented as deprecated but not yet removed.
 - **dimensions**: The `.width()` and `.height()` methods, including `inner-` and `outer-` variations.
 - **effects**: The `.animate()` method and its shorthands such as `.slideUp()` or `.hide("slow")`.
 - **event**: The `.on()` and `.off()` methods and all event functionality. Also removes `event/alias`.

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -1,11 +1,2 @@
-define([
-	"./core",
-	"./traversing"
-], function( jQuery ) {
-// The number of elements contained in the matched element set
-jQuery.fn.size = function() {
-	return this.length;
-};
-
-jQuery.fn.andSelf = jQuery.fn.addBack;
+define(function() {
 });

--- a/test/unit/deprecated.js
+++ b/test/unit/deprecated.js
@@ -1,8 +1,1 @@
 module("deprecated", { teardown: moduleTeardown });
-
-if ( jQuery.fn.size ) {
-	test("size()", function() {
-		expect(1);
-		equal( jQuery("#qunit-fixture p").size(), 6, "Get Number of Elements Found" );
-	});
-}


### PR DESCRIPTION
Ticket: http://bugs.jquery.com/ticket/14343

These have been deprecated since jQuery 1.8, it's high time to remove them for 2.1/1.11.
