### PR TITLE
grunt-update-submodules

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -141,6 +141,7 @@ module.exports = function( grunt ) {
 	grunt.loadNpmTasks( "grunt-contrib-jshint" );
 	grunt.loadNpmTasks( "grunt-contrib-uglify" );
 	grunt.loadNpmTasks( "grunt-jsonlint" );
+	grunt.loadNpmTasks( "grunt-update-submodules" );
 
 	// Integrate jQuery specific tasks
 	grunt.loadTasks( "build/tasks" );


### PR DESCRIPTION
```
>> Local Npm module "grunt-update-submodules" not found. Is it installed?
Warning: Task "update_submodules" not found. Used --force, continuing.

Done, but with warnings.
```
