### PR TITLE
Remove charAt() calls.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -66,7 +66,7 @@ jQuery.fn = jQuery.prototype = {
 
 		// Handle HTML strings
 		if ( typeof selector === "string" ) {
-			if ( selector.charAt(0) === "<" && selector.charAt( selector.length - 1 ) === ">" && selector.length >= 3 ) {
+			if ( selector[0] === "<" && selector[ selector.length - 1 ] === ">" && selector.length >= 3 ) {
 				// Assume that strings that start and end with <> are HTML and skip the regex check
 				match = [ null, selector, null ];
 

--- a/src/css.js
+++ b/src/css.js
@@ -38,7 +38,7 @@ function vendorPropName( style, name ) {
 	}
 
 	// check for vendor prefixed names
-	var capName = name.charAt(0).toUpperCase() + name.slice(1),
+	var capName = name[0].toUpperCase() + name.slice(1),
 		origName = name,
 		i = cssPrefixes.length;
 


### PR DESCRIPTION
No ticket. Remove all `charAt()` calls in favor of `[]` notation (as long as all modern browsers support it) for consistency and size.
Not losing anything in speed: http://jsperf.com/charat-vs-index/2

```
   raw     gz Compared to master @ 8791920183f9f13a7be1d513652b9c96d29648c7    
   -21    -13 dist/jquery.js                                                   
   -21    -18 dist/jquery.min.js   
```
