### PR TITLE
[2.x] Deferred.pipe has been deprecated since 1.8 and can be removed (FIxes #14358 )

### DIFF
--- a/src/deferred.js
+++ b/src/deferred.js
@@ -51,9 +51,6 @@ jQuery.extend({
 			},
 			deferred = {};
 
-		// Keep pipe for back-compat
-		promise.pipe = promise.then;
-
 		// Add list-specific methods
 		jQuery.each( tuples, function( i, tuple ) {
 			var list = tuple[ 2 ],

--- a/test/unit/deferred.js
+++ b/test/unit/deferred.js
@@ -10,11 +10,7 @@ jQuery.each( [ "", " - new operator" ], function( _, withNew ) {
 
 	test( "jQuery.Deferred" + withNew, function() {
 
-		expect( 23 );
-
-		var defer = createDeferred();
-
-		strictEqual( defer.pipe, defer.then, "pipe is an alias of then" );
+		expect( 22 );
 
 		createDeferred().resolve().done(function() {
 			ok( true, "Success on resolve" );


### PR DESCRIPTION
Perhaps a candidate for removal in 2.1?
