### PR TITLE
Added bower as a dependancy in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
 		"grunt-jsonlint": "~1.0.0",
 		"gzip-js": "0.3.2",
 		"testswarm": "~1.1.0",
-		"requirejs": "~2.1.8"
+		"requirejs": "~2.1.8",
+		"bower": "~1.2.6"
 	},
 	"scripts": {
 		"install": "bower install",


### PR DESCRIPTION
Bower is a required dependency, yet it is not automatically installed via:

``` bash
npm install
```

I've added it as a required development dependancy.
