### PR TITLE
Fix #14282. Don't fondle getPreventDefault if preventDefault exists.

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -635,13 +635,12 @@ jQuery.Event = function( src, props ) {
 
 		// Events bubbling up the document may have been marked as prevented
 		// by a handler lower down the tree; reflect the correct value.
-		this.isDefaultPrevented =
-			( "defaultPrevented" in src ) ?
-				( src.defaultPrevented ? returnTrue : returnFalse ) :
-			// Support: Android < 4.0
-			src.getPreventDefault && src.getPreventDefault() ?
-				returnTrue :
-				returnFalse;
+		this.isDefaultPrevented = src.defaultPrevented ||
+				src.defaultPrevented === undefined &&
+				// Support: Android < 4.0
+				src.getPreventDefault && src.getPreventDefault() ?
+			returnTrue :
+			returnFalse;
 
 	// Event type
 	} else {


### PR DESCRIPTION
A couple of items here. 

What about the formatting? It's kind of a complex conditional expression but the more straightforward `if` is pretty ugly, big and duplicated.

This passes our current defaultPrevented tests but it's kind of hard to test otherwise, so I haven't added any unit test for it.
