### PR TITLE
Fix #13353; #13428; #14359: Better treatment of native-backed events (focus/blur/checkbox-click)

### DIFF
--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -2461,6 +2461,40 @@ test("trigger native-backed events with arguments (#13353; #13428)", function() 
 	}, 50 );
 });
 
+test("trigger namespaced native-backed events (#14359)", function() {
+	expect( 4 );
+
+	var $el = jQuery( "#text1" )
+		.on( "focus.foo.bar.baz", function() {
+			ok( true, "Matching-namespace handler called" );
+		})
+		.on( "focus.foo.bar.baz.qux", function() {
+			ok( true, "Super-namespace handler called" );
+		})
+		.on( "focus", function() {
+			ok( false, "No-namespace handler called" );
+		})
+		.on( "focus.foo", function() {
+			ok( false, "Partial-namespace handler called" );
+		})
+		.on( "focus.quux", function() {
+			ok( false, "Other-namespace handler called" );
+		});
+
+	notEqual( document.activeElement, $el[0], "Not focused before .trigger" );
+
+	// Support: IE
+	// Address asynchronous focus/blur methods with setTimeout
+	// Browser window must be topmost for this to work properly!!
+	stop();
+	$el.trigger( "focus.baz.bar.foo" );
+	setTimeout(function() {
+		strictEqual( document.activeElement, $el[0], "Focused after .trigger (default action)" );
+
+		start();
+	}, 50 );
+});
+
 test("focus-blur order (#12868)", function() {
 	expect( 5 );
 


### PR DESCRIPTION
It's big, but much better than https://github.com/gibson042/jquery/commit/80789b1ced9ffd45b497e971978d81f847600bec... and this brings the count of fixed bugs up to 3, further reducing the added size per fix! :wink:

At any rate, I also found some possible optimizations in event.js that I'll be exploring once this PR closes either way.

   raw     gz Compared to 1.x-master @ fd2964237f07d8b6985df2145a4990f96eddba87

```
 +2073   +586 dist/jquery.js
  +484   +103 dist/jquery.min.js
```
