### PR TITLE
Fix #14290. Don't throw if text node is appended to table.

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -52,7 +52,7 @@ require( "./event" );
 // Manipulating tables requires a tbody
 function manipulationTarget( elem, content ) {
 	return jQuery.nodeName( elem, "table" ) &&
-		jQuery.nodeName( content.nodeType === 1 ? content : content.firstChild, "tr" ) ?
+		jQuery.nodeName( content.nodeType !== 11 ? content : content.firstChild, "tr" ) ?
 
 		elem.getElementsByTagName("tbody")[0] ||
 			elem.appendChild( elem.ownerDocument.createElement("tbody") ) :

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -179,7 +179,7 @@ function testAppendForObject( valueObj, isFragment ) {
 
 function testAppend( valueObj ) {
 
-	expect( 78 );
+	expect( 79 );
 
 	testAppendForObject( valueObj, false );
 	testAppendForObject( valueObj, true );
@@ -286,6 +286,13 @@ function testAppend( valueObj ) {
 	equal( $radioUnchecked[ 0 ].checked, false, "Reappending radios uphold not being checked" );
 
 	equal( jQuery("<div/>").append( valueObj("option<area/>") )[ 0 ].childNodes.length, 2, "HTML-string with leading text should be processed correctly" );
+
+	try {
+		jQuery("<table></table>").append( valueObj("text value") );
+		ok( true, "Appending text to table" );
+	} catch ( e ) {
+		ok( false, "Appending text threw an exception" );
+	}
 }
 
 test( "append(String|Element|Array<Element>|jQuery)", function() {


### PR DESCRIPTION
Alternative to gh-1347. I still wonder if we should be trying to suppress exceptions on bad markup. I tried to keep the assertion as vague and general as possible here, we are only saying it won't throw but don't care about what it generates. Thoughts?
