### PR TITLE
No ticket: Fix XHTML regression

### DIFF
--- a/src/manipulation/support.js
+++ b/src/manipulation/support.js
@@ -8,7 +8,7 @@ define([
 		div = fragment.appendChild( document.createElement( "div" ) );
 
 	// #11217 - WebKit loses check when the name is after the checked attribute
-	div.innerHTML = "<input type='radio' checked name='t'/>";
+	div.innerHTML = "<input type='radio' checked='checked' name='t'/>";
 
 	// Support: Safari 5.1, iOS 5.1, Android 4.x, Android 2.3
 	// old WebKit doesn't clone checked state correctly in fragments


### PR DESCRIPTION
Attached is a very simple patch for the regression which made jQuery fail to initialize due to invalid syntax when in XHTML mode.

I have already signed the CLA.
