### PR TITLE
core: Fix cut off comment in jQuery.map from c72371f714

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -428,7 +428,7 @@ jQuery.extend({
 			isArray = isArraylike( elems ),
 			ret = [];
 
-		// Go through the array, translating each of the items to their
+		// Go through the array, translating each of the items to their new values
 		if ( isArray ) {
 			for ( ; i < length; i++ ) {
 				value = callback( elems[ i ], i, arg );


### PR DESCRIPTION
Follows-up c72371f714 after 2 years and 5 months, first released in jQuery 1.6.
