### PR TITLE
build: Optimise uglifyjs compression options

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -111,10 +111,17 @@ module.exports = function( grunt ) {
 						ascii_only: true
 					},
 					compress: {
-						hoist_funs: false,
-						join_vars: false,
+						properties: true,
+						dead_code: true,
+						unsafe: false,
+						booleans: true,
 						loops: false,
-						unused: false
+						unused: false,
+						hoist_funs: false,
+						hoist_vars: false,
+						if_return: true,
+						join_vars: true,
+						warnings: true
 					}
 				}
 			}


### PR DESCRIPTION
- Hardcode certain sensible defaults.
- Flip `join_vars` on.

As of 217cbb7, lots of variable declarations changed in style from

``` js
var arr = [], slice = arr.slice;
```

to

``` js
var arr = []; var slice = arr.slice;
```

This because this code is now auto-generated from the var files by the build script into separate var statement, and since aae7abf the `join_vars` was disabled (which made them stay that way in the minified version).

This saves about 110 bytes in the minified version (consistently).
The gzipped version varies between saving 13 bytes or gaining 1 byte depending on 1.x-master or master. Either way, it seems sensible to enable.
