### PR TITLE
Keep copyright year up-to-date

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -93,7 +93,7 @@ module.exports = function( grunt ) {
 				options: {
 					banner: "\n\n\n\n\n\n\n\n\n\n\n\n" + // banner line size must be preserved
 						"/*! jQuery v<%= pkg.version %> | " +
-						"(c) 2005, 2013 jQuery Foundation, Inc. | " +
+						"(c) 2005, <%= grunt.template.today('yyyy') %> jQuery Foundation, Inc. | " +
 						"jquery.org/license */\n"
 				}
 			}


### PR DESCRIPTION
Get ready for 2014 (and every year after that) ! :tada: 
Auto update copyright year directly through the Grunt script. :calendar: 
