### PR TITLE
Gruntfile: Remove project prefix from TestSwarm job name

### DIFF
--- a/build/tasks/testswarm.js
+++ b/build/tasks/testswarm.js
@@ -12,10 +12,10 @@ module.exports = function( grunt ) {
 			tests = grunt.config([ this.name, "tests" ]);
 
 		if ( pull ) {
-			jobName = "jQuery pull <a href='https://github.com/jquery/jquery/pull/" +
+			jobName = "Pull <a href='https://github.com/jquery/jquery/pull/" +
 				pull[ 1 ] + "'>#" + pull[ 1 ] + "</a>";
 		} else {
-			jobName = "jQuery commit #<a href='https://github.com/jquery/jquery/commit/" +
+			jobName = "Commit <a href='https://github.com/jquery/jquery/commit/" +
 				commit + "'>" + commit.substr( 0, 10 ) + "</a>";
 		}
 


### PR DESCRIPTION
The interface already shows the project in various places. It also makes the tables more concise (they're already quite wide).

Kept the `#` inside the PR label (to be consistent with github syntax), removed the `#` from the regular commit builds since that's inconsistent with github syntax.
