### PR TITLE
prevent parsing guid strings to json

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -17,7 +17,7 @@ define([
 	5. Avoid exposing implementation details on user objects (eg. expando properties)
 	6. Provide a clear path for implementation upgrade to WeakMap in 2014
 */
-var rbrace = /(?:\{[\w\W]*\}|\[[\w\W]*\])$/,
+var rbrace = /(?:\{.*:.*\}|\[.*:.*\])$/,
 	rmultiDash = /([A-Z])/g;
 
 function dataAttr( elem, key, data ) {


### PR DESCRIPTION
I use data-attribute at html with guid strings (Globally Unique Identifier) and I run into parse json error by using .data() methode. 

<code>&lt;div data-field-guid="{c2ef0eb8-f120-40e4-8a81-41be82d87729}"&gt; ... &lt;/div&gt;</code>

At first I changed .data('') to .attr('data-...') as a workaround. But the real problem is rbrace expression at data.js. So, I update this one to search for any single character in between a colon (one and more). (simple test cases: http://www.rubular.com/r/wdV4vvylCq)

Please review my code change.
