### PR TITLE
Warn on npm install if Bower isn't installed.

### DIFF
--- a/build/bower-install.js
+++ b/build/bower-install.js
@@ -1,0 +1,23 @@
+var installer,
+	which = require( "which" ),
+	spawn = require( "child_process" ).spawn;
+
+try {
+	which.sync( "bower" );
+} catch( error ) {
+	console.error( "Bower must be installed to build jQuery." );
+	console.error( "Please install Bower by running the following command:" );
+	console.error( "npm install -g bower" );
+	process.exit( 1 );
+}
+
+installer = spawn( "bower", [ "install" ] );
+installer.stdout.on( "data", function( data ) {
+	console.log( data );
+});
+installer.stderr.on( "data", function( data ) {
+	console.error( data );
+});
+installer.on( "close", function( code ) {
+	process.exit( code );
+});

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
 		"grunt-jsonlint": "~1.0.0",
 		"gzip-js": "0.3.2",
 		"testswarm": "~1.1.0",
-		"requirejs": "~2.1.8"
+		"requirejs": "~2.1.8",
+		"which": "~1.0.5"
 	},
 	"scripts": {
 		"install": "bower install",


### PR DESCRIPTION
This is mostly to get some discussion started.

Instead of just running `bower install` during `npm install`, we now check if bower is installed. If it's not, we fail with a useful error message telling the user how to proceed.

The problem is that the npm output is so verbose that the message gets lost:

```
Bower must be installed to build jQuery.
Please install Bower by running the following command:
npm install -g bower
npm ERR! jquery@2.1.0-pre install: `node build/bower-install.js`
npm ERR! `sh "-c" "node build/bower-install.js"` failed with 1
npm ERR! 
npm ERR! Failed at the jquery@2.1.0-pre install script.
npm ERR! This is most likely a problem with the jquery package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node build/bower-install.js
npm ERR! You can get their info via:
npm ERR!     npm owner ls jquery
npm ERR! There is likely additional logging output above.

npm ERR! System Darwin 11.4.2
npm ERR! command "/usr/local/bin/node" "/usr/local/bin/npm" "install"
npm ERR! cwd /Users/scottgonzalez/Projects/jquery
npm ERR! node -v v0.8.23
npm ERR! npm -v 1.2.18
npm ERR! code ELIFECYCLE
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /Users/scottgonzalez/Projects/jquery/npm-debug.log
npm ERR! not ok code 0
```

Thoughts on what we should do here?
