### PR TITLE
Remove grunt and bower global dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,35 +29,16 @@ if you swing that way. Easy-peasy.
 How to build your own jQuery
 ----------------------------
 
-First, clone a copy of the main jQuery git repo by running:
+Clone a copy of the main jQuery git repo by running:
 
 ```bash
 git clone git://github.com/jquery/jquery.git
 ```
 
-Install the [grunt-cli](http://gruntjs.com/getting-started#installing-the-cli) and [bower](http://bower.io/) packages if you haven't before. These should be done as global installs:
-
-```bash
-npm install -g grunt-cli bower
-```
-
-Make sure you have `grunt` and `bower` installed by testing:
-
-```bash
-grunt -version
-bower -version
-```
-
-Enter the jquery directory and install the Node and Bower dependencies, this time *without* specifying a global(-g) install:
+Enter the jquery directory and build jQuery
 
 ```bash
 cd jquery && npm install
-```
-
-Then, to get a complete, minified (w/ Uglify.js), linted (w/ JSHint) version of jQuery, type the following:
-
-```bash
-grunt
 ```
 
 The built version of jQuery will be put in the `dist/` subdirectory, along with the minified copy and associated map file.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
 	"dependencies": {},
 	"devDependencies": {
 		"archiver": "~0.4.9",
+		"bower": "~1.2.7",
 		"grunt": "~0.4.1",
+		"grunt-cli": "~0.1.9",
 		"grunt-compare-size": "~0.4.0",
 		"grunt-contrib-jshint": "~0.6.4",
 		"grunt-contrib-uglify": "~0.2.4",
@@ -41,7 +43,12 @@
 		"requirejs": "~2.1.8"
 	},
 	"scripts": {
-		"install": "bower install",
-		"test": "grunt"
+		"install": "./node_modules/bower/bin/bower install",
+		"postinstall": "./node_modules/grunt-cli/bin/grunt",
+
+		"prestart": "./node_modules/grunt-cli/bin/grunt dev",
+		"start": "./node_modules/grunt-cli/bin/grunt watch",
+
+		"test": "./node_modules/grunt-cli/bin/grunt"
 	}
 }


### PR DESCRIPTION
We keep having problems with people choosing to intuitively build jQuery instead of following instructions – 
https://github.com/jquery/jquery/pull/1364, https://github.com/jquery/jquery/pull/1391.

Easy solution for it is to remove <code>grunt-cli</code> and <code>bower</code> packages from global dependencies and use them as local ones. Both readme of these packages recommend to install them globally, but it does not mean they would not work if installed locally (actually, it would be strange if they would not work this way). 

As jQuery developer you would still have an option to build jQuery with <code>bower</code> and <code>grunt</code> commands, but with this commit, you would not require to do so. It also simplifies build instructions and might help with dilemma of whether or not put bower components in the repository. 
