### PR TITLE
Handle .html calls with numbers via the more efficient .innerHTML method

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -412,8 +412,9 @@ jQuery.fn.extend({
 				return elem.innerHTML;
 			}
 
-			if ( typeof value === "number" )
+			if ( typeof value === "number" ) {
 				value = value.toString();
+			}
 
 			// See if we can take a shortcut and just use innerHTML
 			if ( typeof value === "string" && !rnoInnerhtml.test( value ) &&


### PR DESCRIPTION
Without this `$el.html('3333')` is treated differently from `$el.html(3333)`.
