### PR TITLE
Remove elem property from event handle

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -72,12 +72,9 @@ jQuery.event = {
 			eventHandle = elemData.handle = function( e ) {
 				// Discard the second event of a jQuery.event.trigger() and
 				// when an event is called after a page has unloaded
-				return typeof jQuery !== strundefined && (!e || jQuery.event.triggered !== e.type) ?
-					jQuery.event.dispatch.apply( eventHandle.elem, arguments ) :
-					undefined;
+				return typeof jQuery !== strundefined && jQuery.event.triggered !== e.type ?
+					jQuery.event.dispatch.apply( elem, arguments ) : undefined;
 			};
-			// Add elem as a property of the handle fn to prevent a memory leak with IE non-native events
-			eventHandle.elem = elem;
 		}
 
 		// Handle multiple events separated by a space
@@ -146,8 +143,6 @@ jQuery.event = {
 			jQuery.event.global[ type ] = true;
 		}
 
-		// Nullify elem to prevent memory leaks in IE
-		elem = null;
 	},
 
 	// Detach an event or set of events from an element


### PR DESCRIPTION
As discussed with @dmethvin on jQuery Russia, elem is removed from the event handle stored in data_priv.

1) This property helped to fix memory leaks in IE<9. Not needed in 2.0 => removal is good.

2) If an element with bound events is removed without cleanData (e.g with native DOM ops), then it will remain in memory with the whole DOM subtree because elemData references it. 
After the patch which removes the reference, the memory can be freed. This will help to shrink memory leaks in such cases making them barely noticeable.
