### PR TITLE
Add time-grunt and load-grunt-tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,10 @@
 module.exports = function( grunt ) {
-
 	"use strict";
+
+	// Load all grunt tasks
+	require( "load-grunt-tasks" )( grunt );
+	// Show elapsed time at the end
+	require( "time-grunt" )( grunt );
 
 	var gzip = require( "gzip-js" ),
 		readOptionalJSON = function( filepath ) {
@@ -129,14 +133,6 @@ module.exports = function( grunt ) {
 			}
 		}
 	});
-
-	// Load grunt tasks from NPM packages
-	grunt.loadNpmTasks( "grunt-compare-size" );
-	grunt.loadNpmTasks( "grunt-git-authors" );
-	grunt.loadNpmTasks( "grunt-contrib-watch" );
-	grunt.loadNpmTasks( "grunt-contrib-jshint" );
-	grunt.loadNpmTasks( "grunt-contrib-uglify" );
-	grunt.loadNpmTasks( "grunt-jsonlint" );
 
 	// Integrate jQuery specific tasks
 	grunt.loadTasks( "build/tasks" );

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "gzip-js": "0.3.2",
     "testswarm": "~1.1.0",
     "requirejs": "~2.1.9",
-    "which": "~1.0.5"
+    "which": "~1.0.5",
+    "load-grunt-tasks": "~0.2.0",
+    "time-grunt": "~0.1.1"
   },
   "scripts": {
     "install": "node build/bower-install",


### PR DESCRIPTION
You might find these useful. Feel free to close if not.

![screen shot 2013-10-25 at 20 00 45](https://f.cloud.github.com/assets/170270/1410154/c2760870-3d9f-11e3-8c86-8d72a2d8fd96.png)

[time-grunt](https://github.com/sindresorhus/time-grunt) displays the elapsed execution time of grunt tasks and [load-grunt-tasks](https://github.com/sindresorhus/load-grunt-tasks) loads all the grunt tasks for you so you don't have to load each one manually.
