### PR TITLE
Add `keywords` to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,5 +18,10 @@
   "devDependencies": {
     "requirejs": "~2.1.8",
     "qunit": "~1.12.0"
-  }
+  },
+  "keywords": [
+    "jquery",
+    "javascript",
+    "library"
+  ]
 }


### PR DESCRIPTION
See: https://docs.google.com/document/d/1APq7oA9tNao1UYWyOm8dKqlRP2blVkROYLZ2fLIjtWc/edit#heading=h.gexwkmadfy56

http://sindresorhus.com/bower-components/ makes use of the keywords for search.

Not very useful here, but sets a good example for people looking at the jQuery bower.json.
