### PR TITLE
Empty 'data-attr' value represents HTML5 Boolean attribute, not just emp...

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -31,7 +31,7 @@ function dataAttr( elem, key, data ) {
 
 		if ( typeof data === "string" ) {
 			try {
-				data = data === "true" ? true :
+				data = ( data === "true" || data === "" ) ? true :
 					data === "false" ? false :
 					data === "null" ? null :
 					// Only convert to a number if it doesn't change the string

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -366,7 +366,7 @@ test("data-* attributes", function() {
 		"JSON object with leading non-JSON read from attribute as string");
 	strictEqual( child.data("notjson2"), "[] ",
 		"JSON array with trailing non-JSON read from attribute as string");
-	strictEqual( child.data("empty"), "", "Empty string read from attribute");
+	strictEqual( child.data("empty"), true, "Empty string read from attribute represents true (HTML5 Boolean attributes)");
 	strictEqual( child.data("space"), " ", "Whitespace string read from attribute");
 	strictEqual( child.data("null"), null, "Primitive null read from attribute");
 	strictEqual( child.data("string"), "test", "Typical string read from attribute");


### PR DESCRIPTION
According to [w3c](http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#boolean-attribute) empty attribute represents `true`, not just empty string. And if attribute is omitted, it represents `false`. The latter is not a big deal as currently it returns `undefined` which becomes `false` afterwards explicit conversion to boolean. The former still fails in that sense and this pull request is supposed to fix that.

Current status:

``` javascript
element = jQuery("<div data-somewhat></div>");
should_be_true = element.data("somewhat"); // ""
should_be_false = element.data("omitted"); // undefined

!!should_be_true; // false, incorrect; fixed in the pull request
!!should_be_false; // false, correct
```
