### PR TITLE
No ticket. Remove the unnecessary guard in addGetHookIf.

### DIFF
--- a/src/css/addGetHookIf.js
+++ b/src/css/addGetHookIf.js
@@ -4,15 +4,7 @@ function addGetHookIf( conditionFn, hookFn ) {
 	// Define the hook, we'll check on the first run if it's really needed.
 	return {
 		get: function() {
-			var condition = conditionFn();
-
-			if ( condition == null ) {
-				// The test was not ready at this point; screw the hook this time
-				// but check again when needed next time.
-				return;
-			}
-
-			if ( condition ) {
+			if ( conditionFn() ) {
 				// Hook not needed (or it's not possible to use it due to missing dependency),
 				// remove it.
 				// Since there are no other hooks for marginRight, remove the whole object.


### PR DESCRIPTION
In 1.x if the support test executes before doc ready, it may not be able
to return a result yet. In such a case, we protect ourselves from future
breakages, allowing only for the ones before doc ready.

Since in 2.x lazy support tests attach test elements to docElem, not body,
such a guard is unnecessary.
