### PR TITLE
Fix #14503: Cast to string before setting XHR header

### DIFF
--- a/src/ajax/xhr.js
+++ b/src/ajax/xhr.js
@@ -78,7 +78,15 @@ if ( xhrSupported ) {
 
 					// Set headers
 					for ( i in headers ) {
-						xhr.setRequestHeader( i, headers[ i ] );
+						// Support: IE<9
+						// IE's ActiveXObject throws a 'Type Mismatch' exception when setting
+						// request header to a null-value.
+						//
+						// To keep consistent with other XHR implementations, cast the value
+						// to string and ignore `undefined`.
+						if ( headers[ i ] !== undefined ) {
+							xhr.setRequestHeader( i, headers[ i ] + "" );
+						}
 					}
 
 					// Do send the request

--- a/test/data/headers.php
+++ b/test/data/headers.php
@@ -14,5 +14,10 @@ foreach( $_SERVER as $key => $value ) {
 }
 
 foreach( explode( "_" , $_GET[ "keys" ] ) as $key ) {
-	echo "$key: " . @$headers[ strtoupper( $key ) ] . "\n";
+
+	// Only echo if key exists in the header
+	if ( isset( $headers[ strtoupper( $key ) ] ) ) {
+		echo "$key: " . @$headers[ strtoupper( $key ) ] . "\n";
+	}
+
 }

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -177,17 +177,22 @@ module( "ajax", {
 		});
 	});
 
-	ajaxTest( "jQuery.ajax() - headers", 4, {
+	ajaxTest( "jQuery.ajax() - headers", 5, {
 		setup: function() {
 			jQuery( document ).ajaxSend(function( evt, xhr ) {
 				xhr.setRequestHeader( "ajax-send", "test" );
 			});
 		},
-		url: url("data/headers.php?keys=siMPle_SometHing-elsE_OthEr_ajax-send"),
+		url: url("data/headers.php?keys=siMPle_SometHing-elsE_OthEr_Nullable_undefined_Empty_ajax-send"),
 		headers: {
 			"siMPle": "value",
 			"SometHing-elsE": "other value",
-			"OthEr": "something else"
+			"OthEr": "something else",
+			"Nullable": null,
+			"undefined": undefined,
+			// Not all browsers allow empty-string headers
+			// Firefox in particular: https://bugzilla.mozilla.org/show_bug.cgi?id=815299
+			//"Empty": ""
 		},
 		success: function( data, _, xhr ) {
 			var i, emptyHeader,
@@ -196,12 +201,13 @@ module( "ajax", {
 				}),
 				tmp = [];
 			for ( i in requestHeaders ) {
-				tmp.push( i, ": ", requestHeaders[ i ], "\n" );
+				tmp.push( i, ": ", requestHeaders[ i ] + "", "\n" );
 			}
 			tmp = tmp.join("");
 
 			strictEqual( data, tmp, "Headers were sent" );
 			strictEqual( xhr.getResponseHeader("Sample-Header"), "Hello World", "Sample header received" );
+			ok( data.indexOf( "undefined" ) < 0 , "Undefined header value was not sent" );
 
 			emptyHeader = xhr.getResponseHeader("Empty-Header");
 			if ( emptyHeader === null ) {
@@ -238,7 +244,7 @@ module( "ajax", {
 			url: url("data/headers.php?keys=content-type"),
 			contentType: false,
 			success: function( data ) {
-				strictEqual( data, "content-type: \n", "Test content-type is not sent when options.contentType===false" );
+				strictEqual( data, "", "Test content-type is not sent when options.contentType===false" );
 			}
 		}
 	]);


### PR DESCRIPTION
When setting request header to a `null` value, **Microsoft.XMLHTTP** throws a `Type Mismatch` exception. This means that in IE6+ passing a `null` value in the `headers` property causes `$.ajax` to fail. (IE7 and above require users to uncheck _"Enable native XMLHTTP support"_ in settings).

After a discussion the proposed solution was to skip `undefined` and cast to string in other cases.

Relevant tests have been extended and existing tests modified to fit new changes. [See the discussion on jQuery Bug Tracker](http://bugs.jquery.com/ticket/14503).

Changes to existing tests:
- `headers.php` now echo headers that have non-empty values
