### PR TITLE
Fix #14424. Use ActiveX in IE9+ for local files.

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -20,6 +20,7 @@
 	"globals": {
 		"jQuery": true,
 		"define": true,
-		"module": true
+		"module": true,
+		"ActiveXObject": true
 	}
 }

--- a/src/ajax/xhr.js
+++ b/src/ajax/xhr.js
@@ -5,6 +5,14 @@ define([
 ], function( jQuery, support ) {
 
 jQuery.ajaxSettings.xhr = function() {
+	// Support: IE9+
+	// IE can't get local files with standard XHR, only ActiveX
+	if ( this.isLocal ) {
+		try {
+			return new ActiveXObject( "Microsoft.XMLHTTP" );
+		} catch( e ) {}
+	}
+
 	try {
 		return new XMLHttpRequest();
 	} catch( e ) {}


### PR DESCRIPTION
For local accesses I'm letting non-IE run through the ActiveX case, seems harmless enough and a little smaller. Even at that, it's +28 gzip. Ugh.
