### PR TITLE
Use absolute paths in .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/dist
 .project
 .settings
 *~
@@ -8,6 +7,7 @@
 .DS_Store
 .bower.json
 .sizecache.json
-dist/.destination.json
-bower_components
-node_modules
+
+/dist
+/bower_components
+/node_modules

--- a/.npmignore
+++ b/.npmignore
@@ -1,10 +1,12 @@
-.editorconfig
-.gitattributes
-.jscs.json
 .jshintignore
 .jshintrc
-.mailmap
-.travis.yml
+
+/.editorconfig
+/.gitattributes
+/.jscs.json
+/.mailmap
+/.travis.yml
+
 /build
 /speed
 /test


### PR DESCRIPTION
.gitignore treats all its paths as relative to _every_ directory
in the repository. In most cases that’s not what’s desired.
