### PR TITLE
Use JSHint for complexity metrics.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,9 +13,12 @@ module.exports = function( grunt ) {
 		path = require( "path" ),
 		srcHintOptions = readOptionalJSON( "src/.jshintrc" );
 
-	// The concatenated file won't pass onevar
+	// The concatenated file won't pass onevar or complexity metrics
 	// But our modules can
 	delete srcHintOptions.onevar;
+	delete srcHintOptions.maxdepth;
+	delete srcHintOptions.maxstatements;
+	delete srcHintOptions.maxcomplexity;
 
 	grunt.initConfig({
 		pkg: grunt.file.readJSON( "package.json" ),

--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -13,6 +13,10 @@
 	"undef": true,
 	"unused": true,
 
+	"maxdepth": 7,
+	"maxstatements": 50,
+	"maxcomplexity": 20,
+
 	"sub": true,
 
 	"browser": true,

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -211,6 +211,7 @@ function ajaxConvert( s, response, jqXHR, isSuccess ) {
 	current = dataTypes.shift();
 
 	// Convert to each sequential dataType
+	/*jshint -W073*/ // block nesting
 	while ( current ) {
 
 		if ( s.responseFields[ current ] ) {
@@ -282,6 +283,7 @@ function ajaxConvert( s, response, jqXHR, isSuccess ) {
 			}
 		}
 	}
+	/*jshint +W073*/
 
 	return { state: "success", data: response };
 }
@@ -379,6 +381,7 @@ jQuery.extend({
 	ajaxTransport: addToPrefiltersOrTransports( transports ),
 
 	// Main method
+	/*jshint -W071, -W074*/ // too many statements, cyclomatic complexity
 	ajax: function( url, options ) {
 
 		// If url is an object, simulate pre-1.5 signature
@@ -766,6 +769,7 @@ jQuery.extend({
 
 		return jqXHR;
 	},
+	/*jshint +W071, +W074*/
 
 	getJSON: function( url, data, callback ) {
 		return jQuery.get( url, data, callback, "json" );

--- a/src/core/init.js
+++ b/src/core/init.js
@@ -13,6 +13,7 @@ var rootjQuery,
 	// Strict HTML recognition (#11290: must start with <)
 	rquickExpr = /^(?:\s*(<[\w\W]+>)[^>]*|#([\w-]*))$/,
 
+	/* jshint -W074*/ // cyclomatic complexity
 	init = jQuery.fn.init = function( selector, context ) {
 		var match, elem;
 
@@ -111,6 +112,7 @@ var rootjQuery,
 
 		return jQuery.makeArray( selector, this );
 	};
+	/* jshint +W074*/ // cyclomatic complexity
 
 // Give the init function the jQuery prototype for later instantiation
 init.prototype = jQuery.fn;

--- a/src/effects.js
+++ b/src/effects.js
@@ -70,6 +70,7 @@ var
 			return tween;
 		} ]
 	};
+/*jshint -W074*/ // cyclomatic complexity
 
 // Animations created synchronously will run synchronously
 function createFxNow() {
@@ -115,7 +116,6 @@ function createTween( value, prop, animation ) {
 }
 
 function defaultPrefilter( elem, props, opts ) {
-	/* jshint validthis: true */
 	var prop, value, toggle, tween, hooks, oldfire, display,
 		anim = this,
 		orig = {},
@@ -381,6 +381,7 @@ function Animation( elem, properties, options ) {
 		.fail( animation.opts.fail )
 		.always( animation.opts.always );
 }
+/*jshint +W074*/
 
 jQuery.Animation = jQuery.extend( Animation, {
 

--- a/src/event.js
+++ b/src/event.js
@@ -40,6 +40,7 @@ jQuery.event = {
 
 	global: {},
 
+	/*jshint -W074*/ // cyclomatic complexity
 	add: function( elem, types, handler, data, selector ) {
 
 		var handleObjIn, eventHandle, tmp,
@@ -144,8 +145,10 @@ jQuery.event = {
 		}
 
 	},
+	/*jshint +W074*/
 
 	// Detach an event or set of events from an element
+	/*jshint -W074*/ // cyclomatic complexity
 	remove: function( elem, types, handler, selector, mappedTypes ) {
 
 		var j, origCount, tmp,
@@ -215,7 +218,9 @@ jQuery.event = {
 			data_priv.remove( elem, "events" );
 		}
 	},
+	/*jshint +W074*/
 
+	/*jshint -W074, -W071*/ // cyclomatic complexity, too many statements
 	trigger: function( event, data, elem, onlyHandlers ) {
 
 		var i, cur, tmp, bubbleType, ontype, handle, special,
@@ -347,6 +352,7 @@ jQuery.event = {
 
 		return event.result;
 	},
+	/*jshint +W074, +W071*/
 
 	dispatch: function( event ) {
 


### PR DESCRIPTION
This is really more of a proof-of-concept and conversation starter than something to land.

Following up on our discussion Monday, this uses the complexity measures from JSHint and sets default limits that just about all the code currently passes. For the exceptions I've wrapped them in jshint directives that turn off the warnings. There's also a max line length check, but when set to our style guide's recommended max of 100 it is quite noisy. :smile: 

Pros:
- The comments lay out where the hot spots are, so we can have a better idea of where to be careful and spend extra time in reviewing patches or refactoring.
- Only the people who read the code need to be concerned with these comments, so they're not drawing a bunch of attention from people who'd naively recommend we rewrite them just to get better metrics.

Cons:
- In jshint you can't restore a setting back to its original default or previous value. So if you want to avoid a warning you have to turn it off completely, then back on. That means subsequent editing in the complex areas may make things worse and nobody will notice it. What I want to do is bump the limit up around these just enough to avoid the warning.
- There's some bug in JSHint where the warning in effects has to be in a much larger block of code to be effectve, rather than being tightly around the offending function (`defaultPrefilter`).

I think the inability to push/pop temporary limits to specific metrics is a deal-killer for this idea. It might be worth looking into eslint, seems like it could potentially do the job of both JSHint and jscs.
