### PR TITLE
Store the context of a proxy as an attribute on the proxy object.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -483,6 +483,9 @@ jQuery.extend({
 		// Set the guid of unique handler to the same of original handler, so it can be removed
 		proxy.guid = fn.guid = fn.guid || jQuery.guid++;
 
+		// Store the context as an attribute on the proxy so the context can be determined later
+		proxy.context = context;
+
 		return proxy;
 	},
 


### PR DESCRIPTION
This PR stores the `context` of a proxied function as an attribute on the resultant proxy.  The following shows why this is convinient:

``` javascript
a = $.proxy(myFunction, myContext)
```

The context cannot be determined from `a` in _master_.  With this PR the context can now be determined by

``` javascript
a.context
```

[Ticket #14552](http://bugs.jquery.com/ticket/14552)
