### PR TITLE
when appending a text node to a <table> element, jquery crashes.

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -100,7 +100,7 @@ function fixDefaultChecked( elem ) {
 // Manipulating tables requires a tbody
 function manipulationTarget( elem, content ) {
 	return jQuery.nodeName( elem, "table" ) &&
-		jQuery.nodeName( content.nodeType !== 11 ? content : content.firstChild, "tr" ) ?
+		jQuery.nodeName( content.nodeType !== 11 || !content.firstChild ? content : content.firstChild, "tr" ) ?
 
 		elem.getElementsByTagName("tbody")[0] ||
 			elem.appendChild( elem.ownerDocument.createElement("tbody") ) :


### PR DESCRIPTION
This is the sister pull request to https://github.com/jquery/jquery/pull/1442

When appending a text node to a `<table>`, jquery crashes during the call to manipulationTarget(). This change fixes the issue and averts the crash.

manipulationTarget() is trying to determine if the content being appended to the table is a `<tr>` tag. When doing this, it checks the nodeName of the appended content. Since the textnode doesn't contain any children, the nodeName() call crashes.

This commit ensures a firstChild property exists before sending it to nodeName().
