### PR TITLE
IE8 Bugfix - JavaScript Error "Object doesn't support this property or method"

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -335,7 +335,7 @@ jQuery.event = {
 				// Call a native DOM method on the target with the same name name as the event.
 				// Can't use an .isFunction() check here because IE6/7 fails that test.
 				// Don't do default actions on window, that's where global variables be (#6170)
-				if ( ontype && elem[ type ] && !jQuery.isWindow( elem ) ) {
+				if ( ontype  && (typeof elem[ type ] !== 'unknown') && elem[ type ] && !jQuery.isWindow( elem ) ) {
 
 					// Don't re-trigger an onFOO event when we call its FOO() method
 					tmp = elem[ ontype ];


### PR DESCRIPTION
Fixed a bug when IE8 elem[ type ] triggers "Object doesn't support this
property or method" by checking typeof elem[ type ] against "unknown".
