### PR TITLE
use innerHTML for numbers additionally to strings with .html()

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -415,13 +415,10 @@ jQuery.fn.extend({
 			}
 
 			// See if we can take a shortcut and just use innerHTML
-			if ( typeof value === "string" && ( !rnoInnerhtml.test( value ) &&
-				!wrapMap[ ( rtagName.exec( value ) || [ "", "" ] )[ 1 ].toLowerCase() ] ) ||
-				typeof value === "number" ) {
+			if ( typeof value === "string" && !rnoInnerhtml.test( value ) &&
+				!wrapMap[ ( rtagName.exec( value ) || [ "", "" ] )[ 1 ].toLowerCase() ] ) {
 
-				if ( typeof value === "string") {
-					value = value.replace( rxhtmlTag, "<$1></$2>" );
-				}
+				value = value.replace( rxhtmlTag, "<$1></$2>" );
 
 				try {
 					for ( ; i < l; i++ ) {


### PR DESCRIPTION
Hi, today I saw that doing something like `$('body').html(42)` would not take the `.innerHTML()` shortcut but goes the `.empty().append()` route instead. I do not see a reason why this is the case and added some test cases to make sure the behaviour stays the same like before. Performance-wise this should be much better.
