### PR TITLE
tests - use weak ETag header

### DIFF
--- a/test/data/etag.php
+++ b/test/data/etag.php
@@ -4,13 +4,16 @@ error_reporting(0);
 $ts = $_REQUEST['ts'];
 $etag = md5($ts);
 
-$ifNoneMatch = isset($_SERVER['HTTP_IF_NONE_MATCH']) ? stripslashes($_SERVER['HTTP_IF_NONE_MATCH']) : false;
+$ifNoneMatch = isset($_SERVER['HTTP_IF_NONE_MATCH']) ? stripslashes($_SERVER['HTTP_IF_NONE_MATCH']) : "";
+preg_match('/"([^"]+)"/', $ifNoneMatch, $matches);
+$ifNoneMatch = isset($matches[1]) ? $matches[1] : false;
+
 if ($ifNoneMatch == $etag) {
 	header('HTTP/1.0 304 Not Modified');
 	die; // stop processing
 }
 
-header("Etag: " . $etag);
+header("Etag: W/\"" . $etag . "\"");
 
 if ( $ifNoneMatch ) {
 	echo "OK: " . $etag;


### PR DESCRIPTION
Two things here:

1) ETag header should put quotes around the ETag
2) The type of ETag we are using is technically a "weak" ETag

http://en.wikipedia.org/wiki/HTTP_ETag#Strong_and_weak_validation

I'm hoping to get nginx to support not stripping weak ETag from gzipped resources
