### PR TITLE
IE XHR method polyfill

### DIFF
--- a/src/ajax/xhr.js
+++ b/src/ajax/xhr.js
@@ -27,6 +27,13 @@ if ( window.ActiveXObject ) {
 			xhrCallbacks[ key ]( undefined, true );
 		}
 	});
+	jQuery.ajaxPrefilter( function(options) {
+		if ( /^(head|options|patch)/i.test( options.type ) ) {
+			options.xhr = function() {
+				return new window.ActiveXObject("Microsoft.XMLHTTP");
+			};
+		}
+	});
 }
 
 // Determine support properties


### PR DESCRIPTION
At line 30 of /src/ajax/xhr.js I've added a prefilter which resolves bug #13240, since the issue only effects IE<9 therefore not required as part of 2.x and based on 1.x-master
