### PR TITLE
Fix default load behaviour

### DIFF
--- a/src/ajax/load.js
+++ b/src/ajax/load.js
@@ -20,8 +20,9 @@ jQuery.fn.load = function( url, params, callback ) {
 		return _load.apply( this, arguments );
 	}
 
-	var selector, type, response,
+	var selector, response,
 		self = this,
+		type = "GET",
 		off = url.indexOf(" ");
 
 	if ( off >= 0 ) {
@@ -45,8 +46,6 @@ jQuery.fn.load = function( url, params, callback ) {
 	if ( self.length > 0 ) {
 		jQuery.ajax({
 			url: url,
-
-			// if "type" variable is undefined, then "GET" method will be used
 			type: type,
 			dataType: "html",
 			data: params


### PR DESCRIPTION
If $.ajaxSetup is used with {"type":"POST"}, $.load will use POST, even if params is not set.

This differs from the documented behaviour: "The POST method is used if data is provided as an object; otherwise, GET is assumed.".

In case POST was used intentionally: providing an empty params object will use POST without changing the request data.
