### PR TITLE
Allow plugins to directly extend promises

### DIFF
--- a/src/deferred.js
+++ b/src/deferred.js
@@ -5,7 +5,7 @@ define([
 ], function( jQuery, slice ) {
 
 jQuery.extend({
-
+	_promise: {},
 	Deferred: function( func ) {
 		var tuples = [
 				// action, add listener, listener list, final state
@@ -53,6 +53,9 @@ jQuery.extend({
 
 		// Keep pipe for back-compat
 		promise.pipe = promise.then;
+
+		// Allow plugins to modify deferreds and promises by extending jQuery._promise.
+		jQuery.extend(promise, jQuery._promise);
 
 		// Add list-specific methods
 		jQuery.each( tuples, function( i, tuple ) {


### PR DESCRIPTION
Because a deferred is a function and a promise is a local variable in that function, it's hard to mess with. I had to do a double hook on promise and Deferred without this fix. I guess that's reasonable but not very inviting to extend.

This is my use-case: http://stackoverflow.com/questions/20693659/releasing-the-ui-to-update-with-deferreds/20710046#20710046 I wrote a `.thenst` method for all deferreds.

With this fix, a function that extends _promise can access the original promise with `this.promise()`.
