### PR TITLE
Support non-standardized methods for oldIE (#13240)

### DIFF
--- a/src/ajax/xhr.js
+++ b/src/ajax/xhr.js
@@ -8,9 +8,20 @@ define([
 // (This is still attached to ajaxSettings for backward compatibility)
 jQuery.ajaxSettings.xhr = window.ActiveXObject !== undefined ?
 	// Support: IE6+
-	// XHR cannot access local files, always use ActiveX for that case
 	function() {
-		return !this.isLocal && createStandardXHR() || createActiveXHR();
+
+		// XHR cannot access local files, always use ActiveX for that case
+		return !this.isLocal &&
+
+			// Support: IE7-8
+			// XHR does not support non-RFC2616 methods (#13240)
+			// See http://msdn.microsoft.com/en-us/library/ie/ms536648(v=vs.85).aspx
+			// and http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9
+			// Although this check for six methods instead of eight
+			// since IE also does not support "trace" and "connect"
+			/^(get|post|head|put|delete|options)$/i.test( this.type ) &&
+
+			createStandardXHR() || createActiveXHR();
 	} :
 	// For all other browsers, use the standard XMLHttpRequest object
 	createStandardXHR;

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -1575,6 +1575,17 @@ module( "ajax", {
 		}
 	} );
 
+	ajaxTest( "#13240 - jQuery.ajax() - support non-RFC2616 methods", 1, {
+		url: "data/echoQuery.php",
+		method: "PATCH",
+		success: function() {
+			ok( true, "success" );
+		},
+		error: function() {
+			ok( false, "error" );
+		}
+	});
+
 	// Support: Chrome 31.
 	// Chrome 31 doesn't fire Ajax requests in beforeunload event handler.
 	// There is no way for us to workaround it and it's been fixed in Chrome 32


### PR DESCRIPTION
As i promised, alternative to <a href="https://github.com/jquery/jquery/pull/1460">this</a> PR. Weighs 30 bytes of damage.

/cc @dmethvin, @jaubourg
