### PR TITLE
Build: Use jsHint extends option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .bower.json
 .sizecache.json
 
-/dist
+/dist/*
+!/dist/.jshintrc
 /bower_components
 /node_modules

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,17 +1,5 @@
 {
-	"boss": true,
-	"curly": true,
-	"eqeqeq": true,
-	"eqnull": true,
-	"expr": true,
-	"immed": true,
-	"noarg": true,
-	"onevar": true,
-	"quotmark": "double",
-	"smarttabs": true,
-	"trailing": true,
-	"undef": true,
-	"unused": true,
+	"extends": ".jshintrc-common",
 
 	"node": true
 }

--- a/.jshintrc-common
+++ b/.jshintrc-common
@@ -1,0 +1,15 @@
+{
+	"boss": true,
+	"curly": true,
+	"eqeqeq": true,
+	"eqnull": true,
+	"expr": true,
+	"immed": true,
+	"noarg": true,
+	"onevar": true,
+	"quotmark": "double",
+	"smarttabs": true,
+	"trailing": true,
+	"undef": true,
+	"unused": true
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,12 +9,7 @@ module.exports = function( grunt ) {
 		return data;
 	}
 
-	var gzip = require( "gzip-js" ),
-		srcHintOptions = readOptionalJSON( "src/.jshintrc" );
-
-	// The concatenated file won't pass onevar
-	// But our modules can
-	delete srcHintOptions.onevar;
+	var gzip = require( "gzip-js" );
 
 	grunt.initConfig({
 		pkg: grunt.file.readJSON( "package.json" ),
@@ -86,16 +81,12 @@ module.exports = function( grunt ) {
 		jshint: {
 			all: {
 				src: [
-					"src/**/*.js", "Gruntfile.js", "test/**/*.js", "build/tasks/*",
-					"build/{bower-install,release-notes,release}.js"
+					"src/**/*.js", "dist/jquery.js", "test/**/*.js", "Gruntfile.js",
+					"build/tasks/*", "build/{bower-install,release-notes,release}.js"
 				],
 				options: {
 					jshintrc: true
 				}
-			},
-			dist: {
-				src: "dist/jquery.js",
-				options: srcHintOptions
 			}
 		},
 		jscs: {

--- a/dist/.jshintrc
+++ b/dist/.jshintrc
@@ -1,0 +1,5 @@
+{
+	"extends": "../src/.jshintrc",
+
+	"onevar": false
+}

--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -1,17 +1,5 @@
 {
-	"boss": true,
-	"curly": true,
-	"eqeqeq": true,
-	"eqnull": true,
-	"expr": true,
-	"immed": true,
-	"noarg": true,
-	"onevar": true,
-	"quotmark": "double",
-	"smarttabs": true,
-	"trailing": true,
-	"undef": true,
-	"unused": true,
+	"extends": "../.jshintrc-common",
 
 	"sub": true,
 

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -1,17 +1,5 @@
 {
-	"boss": true,
-	"curly": true,
-	"eqeqeq": true,
-	"eqnull": true,
-	"expr": true,
-	"immed": true,
-	"noarg": true,
-	"onevar": true,
-	"quotmark": "double",
-	"smarttabs": true,
-	"trailing": true,
-	"undef": true,
-	"unused": true,
+	"extends": "../.jshintrc-common",
 
 	"evil": true,
 	"sub": true,


### PR DESCRIPTION
jsHint 2.4.0 adds an option to extend another configuration file,
making it possible to extract common configuration to a separate file.

Note: I'm not happy with the `assign` hack so it might be better to wait until https://github.com/jshint/jshint/issues/1439 is fixed. Nonetheless, I wanted to get some feedback so I'm putting it here.

Fixing https://github.com/jshint/jshint/issues/1439 will let us not only not add the hack I had to add here but also remove the one with deleting the `onevar` option - it's better to just overwrite it in `dist/.jshintrc`. All our jsHint configuration can then be merged to one target instead of two we have now.
