### PR TITLE
Avoid use of Object.keys() [corrected]

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -276,7 +276,7 @@ jQuery.extend({
 	},
 
 	cleanData: function( elems ) {
-		var data, elem, events, type, key, j,
+		var data, elem, events, type, key,
 			special = jQuery.event.special,
 			i = 0;
 
@@ -285,9 +285,8 @@ jQuery.extend({
 				key = elem[ data_priv.expando ];
 
 				if ( key && (data = data_priv.cache[ key ]) ) {
-					events = Object.keys( data.events || {} );
-					if ( events.length ) {
-						for ( j = 0; (type = events[j]) !== undefined; j++ ) {
+					if ( (events = data.events) ) {
+						for (type in events) {
 							if ( special[ type ] ) {
 								jQuery.event.remove( elem, type );
 


### PR DESCRIPTION
Avoid use of Object.create() to keep code consistency for iteration of object properties.
