### PR TITLE
removed incorrect test

### DIFF
--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -204,11 +204,8 @@ test( "css() explicit and relative values", 29, function() {
 });
 
 test("css(String, Object)", function() {
-	expect( 19 );
+	expect( 18 );
 	var j, div, display, ret, success;
-
-	jQuery("#nothiddendiv").css("top", "-1em");
-	ok( jQuery("#nothiddendiv").css("top"), -16, "Check negative number in EMs." );
 
 	jQuery("#floatTest").css("float", "left");
 	equal( jQuery("#floatTest").css("float"), "left", "Modified CSS float using \"float\": Assert float is left");


### PR DESCRIPTION
this test could be valid, but it uses the `ok(result, msg)` signature incorrectly. I did notice a discrepancy with this test though.

Safari 7 returns "auto", while Chrome 31 returns "-16px".
