### PR TITLE
Pass window to intro if available

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -35,7 +35,7 @@
 	}
 
 // Pass this if window is not defined yet
-}(typeof window !== 'undefined' ? window : this, function( window, noGlobal ) {
+}(typeof window !== "undefined" ? window : this, function( window, noGlobal ) {
 
 // Can't do this because several apps including ASP.NET trace
 // the stack via arguments.caller.callee and Firefox dies if


### PR DESCRIPTION
This is needed so that `var jQuery = require('jquery')` returns jQuery and not the factory when used via browserify.
