### PR TITLE
note on AMD best practices

### DIFF
--- a/src/exports/amd.js
+++ b/src/exports/amd.js
@@ -12,7 +12,8 @@ define([
 
 // Note that for maximum portability, libraries that are not jQuery should
 // declare themselves as anonymous modules, and avoid setting a global if an
-// AMD loader is present. jQuery is a special case.
+// AMD loader is present. jQuery is a special case. For more information, see
+// https://github.com/jrburke/requirejs/wiki/Updating-existing-libraries#wiki-anon
 
 if ( typeof define === "function" && define.amd ) {
 	define( "jquery", [], function() {


### PR DESCRIPTION
Not surprisingly, jQuery has become the go-to example for developers looking to add an AMD definition to their library.  As we know, jQuery's near ubiquity means that certain AMD recommendations are not practical _for jQuery_.  Unfortunately, the jQuery named module registration is referenced with the (reasonable) assumption that it's representative of AMD best practices.  For example discussions, see https://github.com/Leaflet/Leaflet/issues/1364. https://github.com/Leaflet/Leaflet/pull/1778, https://github.com/janl/mustache.js/pull/333, https://github.com/janl/mustache.js/pull/345 and https://github.com/mbostock/d3/pull/1672.

I'm hoping an extra comment will make it clear that jQuery is a special case.
