### PR TITLE
Fix #14683 - AJAX: Invalid url triggers networkerror in Chrome

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -499,7 +499,11 @@ jQuery.extend({
 					done( -1, e );
 				// Simply rethrow otherwise
 				} else {
-					throw e;
+					// Throw asynchronously to ensure deferred
+					// callbacks are called
+					setTimeout(function(){
+						throw e;
+					});
 				}
 			}
 		}


### PR DESCRIPTION
Fixed the issues mentioned in http://bugs.jquery.com/ticket/14683

When an invalid url is used in an ajax request no callback are called. You can see the issue here http://jsfiddle.net/4FxSt/.

`fail` and `always` callbacks will not be called in the example below

```
//pulled from ticket
$.get('//example.com:80q').then(function () {
    console.log('not called'); 
}).fail(function () {
    console.log('not called'); 
}).always(function () {
    console.log('not called');
});
```

This appears because of the added onerror listener to xhr at https://github.com/jquery/jquery/blob/master/src/ajax/xhr.js#L110

Because this successfully fires (in chrome and safari) when trying an invalid url the try catch at https://github.com/jquery/jquery/blob/master/src/ajax.js#L649 throws an error instead of calling done() when chrome triggers a networkerror. Unfortunately throwing this error prevents the deferred callback from being called.

This can be fixed by delaying throwing the error by adding a setTimeout around throw e.

The alternative fix for this issue would be to remove the `xhr.onerror` callback that is not consistently being called with all browsers or remove `throw e` line.
