### PR TITLE
Component.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -2,7 +2,7 @@
   "name": "jquery",
   "repo": "jquery/jquery",
   "description": "JavaScript library for DOM operations",
-  "version": "2.1.0-rc1",
+  "version": "2.1.0pre",
   "keywords": [
     "jquery",
     "javascript",


### PR DESCRIPTION
This is the component.json for [Ticket 14644](http://bugs.jquery.com/ticket/14664).

This branch is branched from master, version is set at 2.1.0pre. I've tested this locally and other Component dependencies are able to locate jQuery.

Just having a component.json on master won't work tho. A tag must exist for the version contained in the "version" for Component to be able to fetch, much like Bower.

Let me know when you tag so I can test installing remotely with this.

BTW, can we also get this for the 1.x branch?
