### PR TITLE
Manipulation: Use textarea for missing IE defaultValue check (#14716)

### DIFF
--- a/src/manipulation/support.js
+++ b/src/manipulation/support.js
@@ -3,8 +3,7 @@ define([
 ], function( support ) {
 
 (function() {
-	var input,
-		fragment = document.createDocumentFragment(),
+	var fragment = document.createDocumentFragment(),
 		div = fragment.appendChild( document.createElement( "div" ) );
 
 	// #11217 - WebKit loses check when the name is after the checked attribute
@@ -14,12 +13,10 @@ define([
 	// old WebKit doesn't clone checked state correctly in fragments
 	support.checkClone = div.cloneNode( true ).cloneNode( true ).lastChild.checked;
 
-	// Make sure checked status is properly cloned
-	// Support: IE9, IE10
-	input = document.createElement("input");
-	input.type = "checkbox";
-	input.checked = true;
-	support.noCloneChecked = input.cloneNode( true ).checked;
+	// Make sure textarea (and checkbox) defaultValue is properly cloned
+	// Support: IE9-IE11+
+	div.innerHTML = "<textarea>x</textarea>";
+	support.noCloneChecked = !!div.cloneNode( true ).lastChild.defaultValue;
 })();
 
 return support;


### PR DESCRIPTION
IE11 fixed the checkbox defaultValue issue but not textarea. Rather than
creating a new detect name I'm reusing the old one to protect anyone who
is unwisely using this externally. Re-fixing the defaultValue of when it
doesn't need to be done is not a problem, so leave that code for IE11.

Fixes #14716
