### PR TITLE
Tests: Blacklist beforeunload test in iOS

### DIFF
--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -1385,7 +1385,10 @@ test("Submit event can be stopped (#11049)", function() {
 });
 
 // Test beforeunload event only if it supported (i.e. not Opera)
-if ( window.onbeforeunload === null ) {
+// Support: iOS 7+
+// iOS has the window.onbeforeunload field but doesn't support the beforeunload
+// handler making it impossible to feature-detect the support.
+if ( window.onbeforeunload === null && !/(ipad|iphone|ipod)/i.test( navigator.userAgent ) ) {
 	asyncTest("on(beforeunload)", 1, function() {
 		var iframe = jQuery(jQuery.parseHTML("<iframe src='data/event/onbeforeunload.html'><iframe>"));
 


### PR DESCRIPTION
iOS has the `window.onbeforeunload` field but doesn't support the `beforeunload` handler making it impossible to feature-detect the support.

I'd love to get a proper feature detect here but it would require to actually trigger the unload event and canceling it in `beforeunload` handler won't help in a browser that doesn't fire the event. :(

Why they exposed the field is beyond me.
