### PR TITLE
Tests: cache window.clearTimeout so that it’s not mocked

### DIFF
--- a/test/libs/qunit/qunit.js
+++ b/test/libs/qunit/qunit.js
@@ -21,6 +21,7 @@ var QUnit,
 	// Keep a local reference to Date (GH-283)
 	Date = window.Date,
 	setTimeout = window.setTimeout,
+	clearTimeout = window.clearTimeout,
 	defined = {
 		setTimeout: typeof window.setTimeout !== "undefined",
 		sessionStorage: (function() {


### PR DESCRIPTION
window.setTimeout is already cached; doing the same for clearTimeout
may reduce race conditions causing TestSwarm to sometimes stop executing
tests in the middle.
