### PR TITLE
window.getDefaultComputedStyle may return null

### DIFF
--- a/src/css/defaultDisplay.js
+++ b/src/css/defaultDisplay.js
@@ -13,14 +13,14 @@ var iframe,
  */
 // Called only from within defaultDisplay
 function actualDisplay( name, doc ) {
-	var elem = jQuery( doc.createElement( name ) ).appendTo( doc.body ),
+	var elem = jQuery( doc.createElement( name ) ).appendTo( doc.body ), style,
 
 		// getDefaultComputedStyle might be reliably used only on attached element
-		display = window.getDefaultComputedStyle ?
+		display = window.getDefaultComputedStyle && ( style = window.getDefaultComputedStyle( elem[ 0 ] ) ) ?
 
 			// Use of this method is a temporary fix (more like optmization) until something better comes along,
 			// since it was removed from specification and supported only in FF
-			window.getDefaultComputedStyle( elem[ 0 ] ).display : jQuery.css( elem[ 0 ], "display" );
+			style.display : jQuery.css( elem[ 0 ], "display" );
 
 	// We don't have any data stored on the element,
 	// so use "detach" method as fast way to get rid of the element


### PR DESCRIPTION
In Iceweasel 24.2.0 it happens here when I call layout from jQuery layout plugin in an iframe from an invisible tab (from jQuery UI tabs).

I know it's not in the API specification but believe me: it may return null. Here's the message I get in the console of Iceweasel 24.2.0:

"TypeError: window.getDefaultComputedStyle(...) is null"
