### PR TITLE
jQuery.parseHTML: Disable inline event handlers when removing scripts

### DIFF
--- a/src/core/parseHTML.js
+++ b/src/core/parseHTML.js
@@ -17,6 +17,11 @@ jQuery.parseHTML = function( data, context, keepScripts ) {
 	}
 	context = context || document;
 
+	// Disable event handlers like onload, onerror, etc. when scripts are removed
+	if ( !keepScripts ) {
+		data = data.replace( /\b(on[a-z]+)/gi, "data-$1" );
+	}
+
 	var parsed = rsingleTag.exec( data ),
 		scripts = !keepScripts && [];
 

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -1319,7 +1319,7 @@ test("jQuery.proxy", function(){
 });
 
 test("jQuery.parseHTML", function() {
-	expect( 18 );
+	expect( 21 );
 
 	var html, nodes;
 
@@ -1333,6 +1333,12 @@ test("jQuery.parseHTML", function() {
 	nodes = jQuery.parseHTML( jQuery("body")[0].innerHTML );
 	ok( nodes.length > 4, "Parse a large html string" );
 	equal( jQuery.type( nodes ), "array", "parseHTML returns an array rather than a nodelist" );
+
+	html = "<div onclick=alert(1)><img src='x' ONERROR></div>";
+	console.log ( jQuery.parseHTML( html ), jQuery.parseHTML( html )[0], jQuery.parseHTML( html )[0].hasAttribute("onload") );
+	equal( jQuery.parseHTML( html )[0].hasAttribute("onclick"), false, "Remove event handlers by default" );
+	equal( jQuery.parseHTML( html )[0].hasAttribute("data-onclick"), true, "Replace event handlers with data attributes by default" );
+	equal( jQuery.parseHTML( html, true )[0].hasAttribute("onclick"), true, "Preserve event handlers when requested" );
 
 	html = "<script>undefined()</script>";
 	equal( jQuery.parseHTML( html ).length, 0, "Ignore scripts by default" );


### PR DESCRIPTION
When removing script tags from the parsed result, inline event handlers should
be removed as well. It would be very insecure to create a blacklist of
event handler attributes, in case of one being forgotten or new handlers
being added in the future.

Therefore, all attributes starting with `on*` should be replaced by a data
attribute of the same name. All code which might exist can still be accessed,
but is not executed after being injected into the DOM to avoid possible XSS
attacks.

See also PR #1505.
