### PR TITLE
CSS: jQuery#hide should always save display value

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -177,13 +177,10 @@ function showHide( elements, show ) {
 				values[ index ] = data_priv.access( elem, "olddisplay", defaultDisplay(elem.nodeName) );
 			}
 		} else {
+			hidden = isHidden( elem );
 
-			if ( !values[ index ] ) {
-				hidden = isHidden( elem );
-
-				if ( display && display !== "none" || !hidden ) {
-					data_priv.set( elem, "olddisplay", hidden ? display : jQuery.css(elem, "display") );
-				}
+			if ( display !== "none" || !hidden ) {
+				data_priv.set( elem, "olddisplay", hidden ? display : jQuery.css( elem, "display" ) );
 			}
 		}
 	}

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -1026,6 +1026,16 @@ asyncTest( "Make sure initialized display value for disconnected nodes is correc
 	jQuery._removeData( jQuery("#display")[ 0 ] );
 });
 
+test( "show() after hide() should always set display to initial value (#14750)", 1, function() {
+	var div = jQuery( "<div />" ),
+		fixture = jQuery( "#qunit-fixture" );
+
+	fixture.append( div );
+
+	div.css( "display", "inline" ).hide().show().css( "display", "list-item" ).hide().show();
+	equal( div.css( "display" ), "list-item", "should get last setted display value" );
+});
+
 // Support: IE < 11, Safari < 7
 // We have to jump through the hoops here in order to test work with "order" CSS property,
 // that some browsers do not support. This test is not, strictly speaking, correct,


### PR DESCRIPTION
See <a href="http://bugs.jquery.com/ticket/14750">14750</a>. It saves some bytes and it would slow it down a bit.
