### PR TITLE
exit early of camelCase if no dash found

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -25,6 +25,7 @@ var
 	},
 
 	// Matches dashed string for camelizing
+	rdash = /-/,
 	rmsPrefix = /^-ms-/,
 	rdashAlpha = /-([\da-z])/gi,
 
@@ -279,7 +280,7 @@ jQuery.extend({
 	// Convert dashed to camelCase; used by the css and data modules
 	// Microsoft forgot to hump their vendor prefix (#9572)
 	camelCase: function( string ) {
-		return string.replace( rmsPrefix, "ms-" ).replace( rdashAlpha, fcamelCase );
+		return string.search( rdash ) === -1 ? string : string.replace( rmsPrefix, "ms-" ).replace( rdashAlpha, fcamelCase );
 	},
 
 	nodeName: function( elem, name ) {


### PR DESCRIPTION
$.camelCase is used for $.css calls. Profiling those showed that for calls like `el.css('display', 'none')` 2% of work was done in the $.camelCase function.

The additional check for a dash adds negligible more computation but a performance boost for a lot of functions which use this. In Firefox 30 the proposed version is 3.5 times faster when no dashes are found and the same if something is found which might be nice for often-used CSS attributes like display and position.

http://jsperf.com/jquerycamelcase
