### PR TITLE
Manipulation: Make cross-document buildFragment work on Android 2.3

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -254,7 +254,9 @@ jQuery.extend({
 			contains = jQuery.contains( elem.ownerDocument, elem );
 
 			// Append to fragment
-			tmp = getAll( fragment.appendChild( elem ), "script" );
+			// Support: Android<4.0
+			// appendChild doesn't work cross-document on old Android.
+			tmp = getAll( fragment.appendChild( context.adoptNode( elem ) ), "script" );
 
 			// Preserve script evaluation history
 			if ( contains ) {


### PR DESCRIPTION
Fixes http://bugs.jquery.com/ticket/14796

cc @gibson042
