### PR TITLE
Add recommended `main` field to bower.json to help build tools find the source.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "jquery",
   "version": "2.1.1pre",
+  "main": "dist/jquery.js",
   "ignore": [
     "**/.*",
     "build",
@@ -9,8 +10,7 @@
     "*.md",
     "AUTHORS.txt",
     "Gruntfile.js",
-    "package.json",
-    "bower.json"
+    "package.json"
   ],
   "dependencies": {
     "sizzle": "1.10.18"


### PR DESCRIPTION
This makes it possible for build tools such as [Webpack](https://github.com/webpack/webpack) to [resolve the package using bower.json.](https://github.com/webpack/webpack/issues/143#issuecomment-32866443)

[bower.json specification](https://github.com/bower/bower.json-spec#main) recommends adding this field.

Also removed `bower.json` from the ignore list in bower.json,
to prevent it from being removed when the package is installed,
so it can be used for this purpose.
