### PR TITLE
bower.json should have a main parameter pointing to the distribution

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "jquery",
   "version": "2.1.1pre",
+  "main": "dist/jquery.js",
   "ignore": [
     "**/.*",
     "build",


### PR DESCRIPTION
The main parameter in bower.json:

https://github.com/bower/bower.json-spec#main
https://github.com/bower/bower/issues/393

Can be used by package managers or build tools to work with the jQuery project automatically.

For example, debowerify used with browserify will allow you to require "jquery" as a dependency in browserify. However this does not work currently without the main parameter above.
