### PR TITLE
Declutter the file tree

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,7 @@
   "ignore": [
     "**/.*",
     "build",
+    "src",
     "speed",
     "test",
     "*.md",


### PR DESCRIPTION
Users installing Bower don't need the src, and just want the jquery.js or jquery.min.js file.
