### PR TITLE
CSS: Re-allow setting shorthand properties in IE<9

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -292,11 +292,14 @@ jQuery.extend({
 			// If a hook was provided, use that value, otherwise just set the specified value
 			if ( !hooks || !("set" in hooks) || (value = hooks.set( elem, value, extra )) !== undefined ) {
 
-				// Support: IE
+				// Support: IE<9
 				// Swallow errors from 'invalid' CSS values (#5509)
 				try {
 					// Support: Chrome, Safari
-					// Setting style to blank string required to delete "style: x !important;"
+					// Setting style to blank string is required to delete "style: x !important;"
+					// Support: IE<9
+					// Shorthand properties like "font" cannot be blanked (#14759)
+					style[ name ] = value;
 					style[ name ] = "";
 					style[ name ] = value;
 				} catch(e) {}

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -207,7 +207,7 @@ test( "css() explicit and relative values", 29, function() {
 });
 
 test("css(String, Object)", function() {
-	expect( 19 );
+	expect( 20 );
 	var j, div, display, ret, success;
 
 	jQuery("#nothiddendiv").css("top", "-1em");
@@ -242,15 +242,18 @@ test("css(String, Object)", function() {
 	equal( ret, div, "Make sure setting undefined returns the original set." );
 	equal( div.css("display"), display, "Make sure that the display wasn't changed." );
 
-	// Test for Bug #5509
 	success = true;
 	try {
-		jQuery("#foo").css("backgroundColor", "rgba(0, 0, 0, 0.1)");
+		jQuery( "#foo" ).css( "backgroundColor", "rgba(0, 0, 0, 0.1)" );
 	}
 	catch (e) {
 		success = false;
 	}
-	ok( success, "Setting RGBA values does not throw Error" );
+	ok( success, "Setting RGBA background-color does not throw (#5509)" );
+
+	jQuery( "#foo" ).css( "font", "7px/21px sans-serif" );
+	strictEqual( jQuery( "#foo" ).css( "line-height" ), "21px",
+		"Set font shorthand property (#14759)" );
 });
 
 test( "css(Array)", function() {


### PR DESCRIPTION
```
   raw     gz Sizes
284202  84383 dist/jquery.js
 96537  33455 dist/jquery.min.js

   raw     gz Compared to 1.x-master @ f361f0378b80f6141e79d906821f6964bcdfbfc4
  +123    +42 dist/jquery.js
    +7     +3 dist/jquery.min.js
```
