### PR TITLE
Css: Restore the previous style if the new one is rejected

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -247,7 +247,7 @@ jQuery.extend({
 		}
 
 		// Make sure that we're working with the right name
-		var ret, type, hooks,
+		var ret, type, hooks, oldValue,
 			origName = jQuery.camelCase( name ),
 			style = elem.style;
 
@@ -286,10 +286,19 @@ jQuery.extend({
 
 			// If a hook was provided, use that value, otherwise just set the specified value
 			if ( !hooks || !("set" in hooks) || (value = hooks.set( elem, value, extra )) !== undefined ) {
-				// Support: Chrome, Safari
+				oldValue = style[ name ];
+
+				// Support: Chrome, Safari, IE
 				// Setting style to blank string required to delete "style: x !important;"
 				style[ name ] = "";
 				style[ name ] = value;
+
+				// Revert to the old value if the browser didn't accept the new rule to
+				// not break the cascade.
+				// Fixes #14836
+				if ( value && !style[ name ] ) {
+					style[ name ] = oldValue;
+				}
 			}
 
 		} else {

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -929,6 +929,22 @@ test( "Override !important when changing styles (#14394)", function() {
 	equal( el.css( "display" ), "none", "New style replaced !important" );
 });
 
+test( "Keep the last style if the new one isn't recognized by the browser (#14836)", function() {
+	expect( 2 );
+
+	var el;
+	el = jQuery( "<div></div>" ).css( "color", "black" ).css( "color", "fake value" );
+	equal( el.css( "color" ), "black", "The old style is kept when setting an unrecognized value" );
+	el = jQuery( "<div></div>" ).css( "color", "black" ).css( "color", " " );
+	equal( el.css( "color" ), "black", "The old style is kept when setting to a space" );
+});
+
+test( "Reset the style if set to an empty string", function() {
+	expect( 1 );
+	var el = jQuery( "<div></div>" ).css( "color", "black" ).css( "color", "" );
+	equal( el.css( "color" ), "", "The style can be reset by setting to an empty string" );
+});
+
 asyncTest( "Clearing a Cloned Element's Style Shouldn't Clear the Original Element's Style (#8908)", 24, function() {
 	var baseUrl = document.location.href.replace( /([^\/]*)$/, "" ),
 	styles = [{


### PR DESCRIPTION
The workaround to be able to change !important styles broke the browser
keeping the old CSS value if the new one was rejected. Revert to the old
value explicitly in such a case.

Bug report: http://bugs.jquery.com/ticket/14836

+29 bytes
