### PR TITLE
Replacing jquery returnTrue and returnFalse functions with one line variables

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -16,15 +16,9 @@ var
 	rkeyEvent = /^key/,
 	rmouseEvent = /^(?:mouse|contextmenu)|click/,
 	rfocusMorph = /^(?:focusinfocus|focusoutblur)$/,
-	rtypenamespace = /^([^.]*)(?:\.(.+)|)$/;
-
-function returnTrue() {
-	return true;
-}
-
-function returnFalse() {
-	return false;
-}
+	rtypenamespace = /^([^.]*)(?:\.(.+)|)$/,
+	returnTrue = Function("return true"),
+	returnFalse = Function("return false");
 
 function safeActiveElement() {
 	try {


### PR DESCRIPTION
It is possible to replace these functions with one liners. The functions the variables return are anonymous. 
