### PR TITLE
on now supports jQuery object passed as selector

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -763,7 +763,7 @@ jQuery.fn.extend({
 			if ( typeof selector !== "string" ) {
 				// ( types-Object, data )
 				data = data || selector;
-				selector = undefined;
+				selector = selector.selector || undefined;
 			}
 			for ( type in types ) {
 				this.on( type, selector, data, types[ type ], one );


### PR DESCRIPTION
The $.on function does not support a jQuery object being passed in as the selector argument as reported in http://bugs.jquery.com/ticket/14877.

I've made a very slight change, which will allow jQuery objects to be passed in optionally, instead of a string selector.
