### PR TITLE
Fixes to resolve unsafe warnings in WWAs

### DIFF
--- a/src/sizzle/dist/sizzle.js
+++ b/src/sizzle/dist/sizzle.js
@@ -614,16 +614,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 			// setting a boolean content attribute,
 			// since its presence should be enough
 			// http://bugs.jquery.com/ticket/12359
-			// Support: Windows Web Apps (WWA)
-			// unknown attribute `t` set with setAttribute for WWA security compliance
-			var select = document.createElement("select"),
-				option = document.createElement("option");
-
-			select.setAttribute("t", "");
-			option.setAttribute("selected", "");
-
-			select.appendChild(option);
-			div.appendChild(select);
+			div.innerHTML = "<select t=''><option selected=''></option></select>";
 
 			// Support: IE8, Opera 10-12
 			// Nothing should be selected when empty strings follow ^= or $= or *=


### PR DESCRIPTION
Setting the innerHTML property in an unsafe manner raises issues in
Windows Web Applications. Strings being passed into innerHTML cannot
include name the attribute. Creating elements, and settings attributes,
has far better cross-environment compliance.

Historical context:
- https://github.com/jquery/sizzle/pull/190
- https://github.com/jquery/sizzle/pull/193
