### PR TITLE
Allow build scripts to be downloaded when installing from Bower or NPM.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,7 +7,5 @@
 /.mailmap
 /.travis.yml
 
-/build
 /speed
 /test
-/Gruntfile.js

--- a/bower.json
+++ b/bower.json
@@ -5,12 +5,10 @@
   "license": "MIT",
   "ignore": [
     "**/.*",
-    "build",
     "speed",
     "test",
     "*.md",
     "AUTHORS.txt",
-    "Gruntfile.js",
     "package.json"
   ],
   "devDependencies": {


### PR DESCRIPTION
Allowing Bower and NPM to download build scripts will make it easier to
automate the upgrade / downgrade process of jquery when a project
requires a custom build of the library.
