### PR TITLE
Build: Update release script for new jquery-release API

### DIFF
--- a/build/release.js
+++ b/build/release.js
@@ -4,10 +4,6 @@ module.exports = function( Release ) {
 		fs = require( "fs" ),
 		shell = require( "shelljs" ),
 
-		// Windows needs the .cmd version but will find the non-.cmd
-		// On Windows, ensure the HOME environment variable is set
-		gruntCmd = process.platform === "win32" ? "grunt.cmd" : "grunt",
-
 		devFile = "dist/jquery.js",
 		minFile = "dist/jquery.min.js",
 		mapFile = "dist/jquery.min.map",
@@ -127,9 +123,7 @@ module.exports = function( Release ) {
 		 * @param {Function} callback
 		 */
 		generateArtifacts: function( callback ) {
-			if ( Release.exec( gruntCmd ).code !== 0 ) {
-				Release.abort("Grunt command failed");
-			}
+			Release.exec( "grunt", "Grunt command failed" );
 			makeReleaseCopies();
 			callback([ "dist/jquery.js", "dist/jquery.min.js", "dist/jquery.min.map" ]);
 		},
@@ -170,3 +164,8 @@ module.exports = function( Release ) {
 		}
 	});
 };
+
+module.exports.dependencies = [
+	"archiver@0.5.2",
+	"shelljs@0.2.6"
+];

--- a/package.json
+++ b/package.json
@@ -29,12 +29,10 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "archiver": "0.5.2",
     "gzip-js": "0.3.2",
     "testswarm": "1.1.0",
     "load-grunt-tasks": "0.3.0",
     "requirejs": "2.1.10",
-    "shelljs": "0.2.6",
     "grunt": "0.4.2",
     "grunt-cli": "0.1.13",
     "grunt-contrib-jshint": "0.8.0",


### PR DESCRIPTION
See https://github.com/jquery/jquery-release/pull/39 for the `Release.exec()` change and https://github.com/jquery/jquery-release/issues/34 for the dependency definition.

_Note: I did not test this._
