### PR TITLE
Event: Remove redundant fallback to getPreventDefault()

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -684,11 +684,9 @@ jQuery.Event = function( src, props ) {
 		// Events bubbling up the document may have been marked as prevented
 		// by a handler lower down the tree; reflect the correct value.
 		this.isDefaultPrevented = src.defaultPrevented ||
-				src.defaultPrevented === undefined && (
-				// Support: IE < 9
-				src.returnValue === false ||
-				// Support: Android < 4.0
-				src.getPreventDefault && src.getPreventDefault() ) ?
+				src.defaultPrevented === undefined &&
+				// Support: IE < 9, Android < 4.0
+				src.returnValue === false ?
 			returnTrue :
 			returnFalse;
 


### PR DESCRIPTION
Android 2.3 is happy with returnValue already used for oldIE;
the getPreventDefault() fallback is not needed.

See #1545
