### PR TITLE
Effects: Don't overwrite display:none when .hide()ing hidden elements

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -160,11 +160,8 @@ function defaultPrefilter( elem, props, opts ) {
 		// Set display property to inline-block for height/width
 		// animations on inline elements that are having width/height animated
 		display = jQuery.css( elem, "display" );
-		// Get default display if display is currently "none"
-		if ( display === "none" ) {
-			display = defaultDisplay( elem.nodeName );
-		}
-		if ( display === "inline" &&
+		// Test default display if display is currently "none"
+		if ( (display === "none" ? defaultDisplay( elem.nodeName ) : display) === "inline" &&
 				jQuery.css( elem, "float" ) === "none" ) {
 
 			style.display = "inline-block";
@@ -196,6 +193,10 @@ function defaultPrefilter( elem, props, opts ) {
 				}
 			}
 			orig[ prop ] = dataShow && dataShow[ prop ] || jQuery.style( elem, prop );
+
+		// Any non-fx value stops us from restoring the original display value
+		} else {
+			display = undefined;
 		}
 	}
 
@@ -238,6 +239,10 @@ function defaultPrefilter( elem, props, opts ) {
 				}
 			}
 		}
+
+	// If this is a noop like .hide().hide(), restore an overwritten display value
+	} else if ( (display === "none" ? defaultDisplay( elem.nodeName ) : display) === "inline" ) {
+		style.display = display;
 	}
 }
 

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -1620,6 +1620,19 @@ test( "hide, fadeOut and slideUp called on element width height and width = 0 sh
 	this.clock.tick( 400 );
 });
 
+test( "hide should not leave hidden inline elements visible (#14848)", 2, function() {
+	var el = jQuery("#simon1");
+
+	el.hide( 1, function() {
+		equal( el.css( "display" ), "none", "hidden" );
+		el.hide( 1, function() {
+			equal( el.css( "display" ), "none", "still hidden" );
+		});
+	});
+
+	this.clock.tick( 100 );
+});
+
 test( "Handle queue:false promises", 10, function() {
 	var foo = jQuery( "#foo" ).clone().addBack(),
 		step = 1;


### PR DESCRIPTION
Fixes [#14848](http://bugs.jquery.com/ticket/14848)

```
   raw     gz Sizes
246357  72980 dist/jquery.js
 84041  29395 dist/jquery.min.js

   raw     gz Compared to master @ a10aa3aac5223c250327d00c500ceb9c7a18b7f9
  +290    +87 dist/jquery.js
   +70    +18 dist/jquery.min.js
```
