### PR TITLE
fixed incorrectly referenced sizzle module

### DIFF
--- a/src/selector-sizzle.js
+++ b/src/selector-sizzle.js
@@ -1,6 +1,6 @@
 define([
 	"./core",
-	"sizzle"
+	"./sizzle/dist/sizzle"
 ], function( jQuery, Sizzle ) {
 
 jQuery.find = Sizzle;


### PR DESCRIPTION
there is no sizze.js where the dependency array indicates, it is instead in sizzle/dist
