### PR TITLE
Build: Set npmTags and use exec properly

### DIFF
--- a/build/release.js
+++ b/build/release.js
@@ -113,6 +113,9 @@ module.exports = function( Release ) {
 
 	Release.define({
 		npmPublish: true,
+		npmTags: function() {
+			return [ "1.x" ];
+		},
 		issueTracker: "trac",
 		contributorReportId: 508,
 		/**


### PR DESCRIPTION
To make use of the changes in https://github.com/jquery/jquery-release/pull/48

I've tested this locally and the npm command ends up as this:

``` sh
npm publish --tag 1.x
```

Feel free to change the tag name to whatever you want. Also I haven't actually tested this with npm.
