### PR TITLE
Core: Allow more than 2 arrays for merge function.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -368,16 +368,22 @@ jQuery.extend({
 		return arr == null ? -1 : indexOf.call( arr, elem, i );
 	},
 
-	merge: function( first, second ) {
-		var len = +second.length,
-			j = 0,
-			i = first.length;
+	merge: function() {
+		var i = 1, j, array, len,
+			first = arguments[ 0 ],
+			firstLen = first.length;
 
-		for ( ; j < len; j++ ) {
-			first[ i++ ] = second[ j ];
+		for ( ; i < arguments.length ; i++ ) {
+			// Only deal with non-null/undefined values
+			if ( ( array = arguments[ i ] ) != null ) {
+				len = array.length;
+				for ( j = 0 ; j < len ; j++ ) {
+					first [ firstLen++ ] = array[ j ];
+				}
+			}
 		}
 
-		first.length = i;
+		first.length = firstLen;
 
 		return first;
 	},

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -904,7 +904,7 @@ test("jQuery.map", function() {
 });
 
 test("jQuery.merge()", function() {
-	expect( 10 );
+	expect( 11 );
 
 	deepEqual(
 		jQuery.merge( [], [] ),
@@ -962,6 +962,12 @@ test("jQuery.merge()", function() {
 		jQuery.merge( [], document.getElementById("lengthtest").getElementsByTagName("input") ),
 		[ document.getElementById("length"), document.getElementById("idTest") ],
 		"Second NodeList"
+	);
+
+	deepEqual(
+		jQuery.merge( [ 1, 2 ], [ 2, 3 ], [ 3, 4 ] ),
+		[ 1, 2, 2, 3, 3, 4 ],
+		"Multiple arrays"
 	);
 });
 


### PR DESCRIPTION
Function merge now allows only 2 arrays for merging. This patch allow to have more than 2 arrays for merging, same as function extend allows more then 2 plain objects for merge.

http://bugs.jquery.com/ticket/14982
