### PR TITLE
Build: reduce .jshintrc duplication using JSHint's "extends" option

### DIFF
--- a/.jshintrc.dist
+++ b/.jshintrc.dist
@@ -1,0 +1,5 @@
+{
+	"extends": "src/.jshintrc",
+
+	"onevar": false
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,12 +9,7 @@ module.exports = function( grunt ) {
 		return data;
 	}
 
-	var gzip = require( "gzip-js" ),
-		srcHintOptions = readOptionalJSON( "src/.jshintrc" );
-
-	// The concatenated file won't pass onevar
-	// But our modules can
-	delete srcHintOptions.onevar;
+	var gzip = require( "gzip-js" );
 
 	grunt.initConfig({
 		pkg: grunt.file.readJSON( "package.json" ),
@@ -95,7 +90,9 @@ module.exports = function( grunt ) {
 			},
 			dist: {
 				src: "dist/jquery.js",
-				options: srcHintOptions
+				options: {
+					jshintrc: ".jshintrc.dist"
+				}
 			}
 		},
 		jscs: {

--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -1,22 +1,11 @@
 {
-	"boss": true,
-	"curly": true,
-	"eqeqeq": true,
-	"eqnull": true,
-	"expr": true,
-	"immed": true,
-	"noarg": true,
-	"onevar": true,
-	"quotmark": "double",
-	"smarttabs": true,
-	"trailing": true,
-	"undef": true,
-	"unused": true,
+	"extends": "../.jshintrc",
 
 	"sub": true,
 
 	"browser": true,
-
+	"node": false,
+	
 	"globals": {
 		"jQuery": true,
 		"define": true,

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -1,24 +1,13 @@
 {
-	"boss": true,
-	"curly": true,
-	"eqeqeq": true,
-	"eqnull": true,
-	"expr": true,
-	"immed": true,
-	"noarg": true,
-	"onevar": true,
-	"quotmark": "double",
-	"smarttabs": true,
-	"trailing": true,
-	"undef": true,
-	"unused": true,
-
+	"extends": "../.jshintrc",
+	
 	"evil": true,
 	"sub": true,
 
 	"browser": true,
 	"devel": true,
 	"wsh": true,
+	"node": false,
 
 	"globals": {
 		"require": false,


### PR DESCRIPTION
JSHint has supported an "extends" option in .jshintrc files since 2.4.0:

https://github.com/jshint/jshint/commit/7f90f150de8862b68065c6796868662a83b74413#diff-d9d9214113dea1c364abd4ba3c70be11R324

I started using it in my own projects to remove duplicated rules between .jshintrc and test/.jshintrc, and noticed that jQuery could similarly benefit.

It does introduce a slightly confusing .jshintrc.dist → src/.jshintrc → .jshintrc dependency, however.

Running `grunt`:

``` bash
± % grunt                                                                                                                                                                                      !8671
Running "jsonlint:pkg" (jsonlint) task
>> 1 file lint free.

Running "jsonlint:jscs" (jsonlint) task
>> 0 files lint free.

Running "jsonlint:bower" (jsonlint) task
>> 1 file lint free.

Running "build:all:*" (build) task
>> File 'dist/jquery.js' created.

Running "jshint:all" (jshint) task
>> 108 files lint free.

Running "jshint:dist" (jshint) task
>> 1 file lint free.

Running "jscs:src" (jscs) task
>> 78 files without code style errors.

Running "jscs:gruntfile" (jscs) task
>> 1 files without code style errors.

Running "jscs:test" (jscs) task
>> 2 files without code style errors.

Running "jscs:tasks" (jscs) task
>> 3 files without code style errors.

Running "uglify:all" (uglify) task
File dist/jquery.min.map created (source map).
File dist/jquery.min.js created.
Original: 247165 bytes.
Minified: 84253 bytes.

Running "dist:*" (dist) task

Running "compare_size:files" (compare_size) task
   raw     gz Sizes
247165  73260 dist/jquery.js
 84253  29461 dist/jquery.min.js

   raw     gz Compared to master @ 90b43de21296cf59af7dd37c49c1a9a4f8483f68
     =      = dist/jquery.js
     =      = dist/jquery.min.js

   raw     gz Compared to last run
     =      = dist/jquery.js
     =      = dist/jquery.min.js

Saved as: jshintrc-extends

Done, without errors.
```
