### PR TITLE
Event: Memory Leak bugfix

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -73,7 +73,7 @@ jQuery.event = {
 				// Discard the second event of a jQuery.event.trigger() and
 				// when an event is called after a page has unloaded
 				return typeof jQuery !== strundefined && jQuery.event.triggered !== e.type ?
-					jQuery.event.dispatch.apply( elem, arguments ) : undefined;
+					jQuery.event.dispatch.apply( this, arguments ) : undefined;
 			};
 		}
 


### PR DESCRIPTION
I found that Elements with events on them are not being garbage collected after being removed from the DOM, which can create a memory leak (more noticeable on larger applications). I wasn't able to write a unit test to show this, but I did create a new HTML file in the test directory that will walk you through how to test it manually. The existing unit tests still all pass.

Since the handle function is called with the element passed into it as `this`, I believe it's safe to again use `this` in place of `elem`.
