### PR TITLE
don't include src in bower bundle

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,7 @@
     "**/.*",
     "build",
     "speed",
+    "src",
     "test",
     "*.md",
     "AUTHORS.txt",


### PR DESCRIPTION
I think generally if someone is getting jquery via bower, they will just want the final jquery.js or jquery.min.js, so there's no reason to give them an extra meg of separate files.
