### PR TITLE
Build: Fix regex that removes empty definitions

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -20,7 +20,7 @@ module.exports = function( grunt ) {
 			// Include dependencies loaded with require
 			findNestedDependencies: true,
 			// Avoid inserting define() placeholder
-			skipModuleInsertion:true,
+			skipModuleInsertion: true,
 			// Avoid breaking semicolons inserted by r.js
 			skipSemiColonInsertion: true,
 			wrap: {


### PR DESCRIPTION
# Bug

The regex does not match the case `define([]);` , so it's not removed from the final output.
Reproduce the bug with this command:  `grunt build:*`  (Building an empty jQuery)
The output should be an empty jQuery build, with only the wrappers `"src/intro.js"`and `src/outro.js"`
but it outputs also these two lines: 

```
      define([]); 
      define("jquery", function(){}); 
```

When loading this jquery.js build in the browser, it will give you a "define" is not defined error.
See bug ticket: http://bugs.jquery.com/ticket/15061#comment:2
# Fix

This PR fixes the first "define", I'm working to fix the other "define" that shouldn't be there neither.
