### PR TITLE
Make $.when() support an array as the first argument.

### DIFF
--- a/src/deferred.js
+++ b/src/deferred.js
@@ -95,7 +95,7 @@ jQuery.extend({
 	// Deferred helper
 	when: function( subordinate /* , ..., subordinateN */ ) {
 		var i = 0,
-			resolveValues = $.isArray( subordinate ) ? subordinate : slice.call( arguments ),
+			resolveValues = jQuery.isArray( subordinate ) ? subordinate : slice.call( arguments ),
 			length = resolveValues.length,
 
 			// the count of uncompleted subordinates


### PR DESCRIPTION
I thing `$.when()` method can also support an array as it's first argument as `Promise.all()` does.

And then one can use this api like this:

``` javascript
$.when(q.map(getImg)).then(success);
```

here `q` is an array and `getImg()` method will return a `jQuery.Deferred` object.
