### PR TITLE
Effects: Reintroduce use of requestAnimationFrame

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -16,6 +16,7 @@ define([
 
 var
 	fxNow, timerId,
+	hasRaf = !!window.requestAnimationFrame,
 	rfxtypes = /^(?:toggle|show|hide)$/,
 	rfxnum = new RegExp( "^(?:([+-])=|)(" + pnum + ")([a-z%]*)$", "i" ),
 	rrun = /queueHooks$/,
@@ -76,11 +77,6 @@ function raf() {
 		window.requestAnimationFrame( raf );
 		jQuery.fx.tick();
 	}
-}
-
-// Will get false negative for old browsers which is okay
-function isDocumentHidden() {
-	return "hidden" in document && document.hidden;
 }
 
 // Animations created synchronously will run synchronously
@@ -439,8 +435,15 @@ jQuery.speed = function( speed, easing, fn ) {
 		easing: fn && easing || easing && !jQuery.isFunction( easing ) && easing
 	};
 
-	opt.duration = jQuery.fx.off ? 0 : typeof opt.duration === "number" ? opt.duration :
-		opt.duration in jQuery.fx.speeds ? jQuery.fx.speeds[ opt.duration ] : jQuery.fx.speeds._default;
+	// Go to the end state if fx are off or if document is hidden
+	if ( jQuery.fx.off || document.hidden ) {
+		opt.duration = 0;
+
+	} else {
+		opt.duration = typeof opt.duration === "number" ?
+			opt.duration : opt.duration in jQuery.fx.speeds ?
+				jQuery.fx.speeds[ opt.duration ] : jQuery.fx.speeds._default;
+	}
 
 	// normalize opt.queue - true/undefined/null -> "fx"
 	if ( opt.queue == null || opt.queue === true ) {
@@ -465,9 +468,6 @@ jQuery.speed = function( speed, easing, fn ) {
 
 jQuery.fn.extend({
 	fadeTo: function( speed, to, easing, callback ) {
-		if ( isDocumentHidden() ) {
-			return this;
-		}
 
 		// show any hidden elements after setting opacity to 0
 		return this.filter( isHidden ).css( "opacity", 0 ).show()
@@ -476,10 +476,6 @@ jQuery.fn.extend({
 			.end().animate({ opacity: to }, speed, easing, callback );
 	},
 	animate: function( prop, speed, easing, callback ) {
-		if ( isDocumentHidden() ) {
-			return this;
-		}
-
 		var empty = jQuery.isEmptyObject( prop ),
 			optall = jQuery.speed( speed, easing, callback ),
 			doAnimation = function() {
@@ -647,17 +643,19 @@ jQuery.fx.timer = function( timer ) {
 jQuery.fx.interval = 13;
 jQuery.fx.start = function() {
 	if ( !timerId ) {
-		if ( window.requestAnimationFrame ) {
-			timerId = true;
-			window.requestAnimationFrame( raf );
-		} else {
-			timerId = setInterval( jQuery.fx.tick, jQuery.fx.interval );
-		}
+		timerId = hasRaf ?
+			window.requestAnimationFrame( raf ) :
+			setInterval( jQuery.fx.tick, jQuery.fx.interval );
 	}
 };
 
 jQuery.fx.stop = function() {
-	clearInterval( timerId );
+	if ( hasRaf ) {
+		window.cancelAnimationFrame( timerId );
+	} else {
+		clearInterval( timerId );
+	}
+
 	timerId = null;
 };
 

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -2183,4 +2183,28 @@ test( "Respect display value on inline elements (#14824)", 2, function() {
 	clock.tick( 800 );
 });
 
+test( "Animation should go to its end state if document.hidden = true", 1, function() {
+	var height;
+
+	if ( Object.defineProperty ) {
+
+		// Can't rewrite document.hidden property if its host property
+		Object.defineProperty( document, "hidden", {
+			get: function() {
+				return true;
+			}
+		});
+	} else {
+		document.hidden = true;
+	}
+
+	if ( document.hidden ) {
+		height = jQuery( "#qunit-fixture" ).animate({ height: 500 } ).height();
+
+		equal( height, 500, "Animation should happen immediately if document.hidden = true" );
+		jQuery( document ).removeProp( "hidden" );
+	}
+});
+
+
 })();


### PR DESCRIPTION
Pretty easy, takes advantage of Page Visibility API (PVAPI), provides incompatible change – animations in background tabs get paused, but obviously, in older browsers it would work as it works right now

In environment where PVAPI has not exist but `raf` has it could create issues described in <a href="http://bugs.jquery.com/ticket/9381">#9381</a> but such environments live only in the past.

It worth to note that Opera 12.16 has not `requestAnimationFrame` but has PVAPI – in there, last animation will finish all it's frames but new animations would not be accepted, iOS < 7 has `requestAnimationFrame` and hasn't PVAPI (we could workaround that with `pagehide/pageshow` events but i don't think it's worth it), but in there `requestAnimationFrame` is prefixed, in iOS 7 `raf` is unprefixed but it also has PVAPI. Android 4.4 version has both API's and none in previous ones.

Why do i get a feeling that i'm miss something?
