### PR TITLE
Offset: 'Make sure it's not a disconnected DOM node' performance enhanced

### DIFF
--- a/src/offset.js
+++ b/src/offset.js
@@ -93,7 +93,7 @@ jQuery.fn.extend({
 
 		// Make sure it's not a disconnected DOM node
 		parents = this.parents();
-		if ( parents[ parents.length-1 ] !== docElem ) {
+		if ( parents[ parents.length - 1 ] !== docElem ) {
 			return box;
 		}
 


### PR DESCRIPTION
'Make sure it's not a disconnected DOM node' performance enhanced.
Reason: In a document tree,finding a parent is often faster than finding a child.
