### PR TITLE
Event: Restore the `constructor` property on jQuery.Event prototype

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -660,6 +660,7 @@ jQuery.Event = function( src, props ) {
 // jQuery.Event is based on DOM3 Events as specified by the ECMAScript Language Binding
 // http://www.w3.org/TR/2003/WD-DOM-Level-3-Events-20030331/ecma-script-binding.html
 jQuery.Event.prototype = {
+	constructor: jQuery.Event,
 	isDefaultPrevented: returnFalse,
 	isPropagationStopped: returnFalse,
 	isImmediatePropagationStopped: returnFalse,

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -1442,7 +1442,7 @@ if ( window.onbeforeunload === null &&
 
 test("jQuery.Event( type, props )", function() {
 
-	expect(5);
+	expect(6);
 
 	var event = jQuery.Event( "keydown", { keyCode: 64 }),
 			handler = function( event ) {
@@ -1457,6 +1457,8 @@ test("jQuery.Event( type, props )", function() {
 	equal( jQuery.inArray("type", jQuery.event.props), -1, "'type' property not in props (#10375)" );
 
 	ok( "keyCode" in event, "Special 'keyCode' property exists" );
+
+	strictEqual( jQuery.isPlainObject( event ), false, "Instances of $.Event should not be identified as a plain object." );
 
 	jQuery("body").on( "keydown", handler ).trigger( event );
 


### PR DESCRIPTION
The original definition of the jQuery.Event prototype was paving over the
`constructor` property which was causing jQuery.isPlainObject to
improperly report that an instance of jQuery.Event was a plain object.

Fixes #15090
