### PR TITLE
CSS: Do not throw on frame elements in FF

### DIFF
--- a/src/css/var/getStyles.js
+++ b/src/css/var/getStyles.js
@@ -1,5 +1,12 @@
 define(function() {
 	return function( elem ) {
-		return elem.ownerDocument.defaultView.getComputedStyle( elem, null );
+		// Support: IE<=11+, Firefox<=30+ (#15098, #14150)
+		// IE throws on elements created in popups
+		// FF meanwhile throws on frame elements through "defaultView.getComputedStyle"
+		if ( elem.ownerDocument.defaultView.opener ) {
+			return elem.ownerDocument.defaultView.getComputedStyle( elem, null );
+		}
+
+		return window.getComputedStyle( elem, null );
 	};
 });

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -1068,4 +1068,27 @@ test( "show() after hide() should always set display to initial value (#14750)",
 		});
 	}
 })();
+
+test( "Do not throw on frame elements from css method (#15098)", 1, function() {
+	var frameWin, frameDoc,
+		frameElement = document.createElement( "iframe" ),
+		frameWrapDiv = document.createElement( "div" );
+
+	frameWrapDiv.appendChild( frameElement );
+	document.body.appendChild( frameWrapDiv );
+	frameWin = frameElement.contentWindow;
+	frameDoc = frameWin.document;
+	frameDoc.open();
+	frameDoc.write( "<!doctype html><html><body><div>Hi</div></body></html>" );
+	frameDoc.close();
+
+	frameWrapDiv.style.display = "none";
+
+	try {
+		jQuery( frameDoc.body ).css( "direction" );
+		ok( true, "It didn't throw" );
+	} catch ( _ ) {
+		ok( false, "It did throw" );
+	}
+});
 }


### PR DESCRIPTION
IE9-10 throws on elements created in popups (see <a href="http://bugs.jquery.com/ticket/14150">#14150</a>), FF meanwhile throws on frame elements through "defaultView.getComputedStyle" (see <a href="http://bugs.jquery.com/ticket/15098">#15098</a>)

Use "defaultView" if in the popup which would fix IE issue, use "window.getComputedStyle" which would fix FF issue.

And everybody wins, except performance, but who cares right?

Fixes #15098
