### PR TITLE
Ajax: Allow setTimeout to return 0 as a valid timeoutId

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -666,7 +666,7 @@ jQuery.extend({
 			state = 2;
 
 			// Clear timeout if it exists
-			if ( timeoutTimer ) {
+			if ( timeoutTimer != null ) {
 				clearTimeout( timeoutTimer );
 			}
 


### PR DESCRIPTION
When handling ajax timeouts, the code should allow 0 as a valid timeoutId.  Currently, the use of if (timeoutId) means that 0 is treated as false, when it should not be.  One browser that uses a 0 timeoutId is zombie.js, but the spec for setTimeout allows 0 for any browser.
