### PR TITLE
Removed oldIE support from Sizzle - saves 238 gz bytes

### DIFF
--- a/src/sizzle/dist/sizzle.js
+++ b/src/sizzle/dist/sizzle.js
@@ -345,20 +345,6 @@ function assert( fn ) {
 }
 
 /**
- * Adds the same handler for all of the specified attrs
- * @param {String} attrs Pipe-separated list of attributes
- * @param {Function} handler The method that will be applied
- */
-function addHandle( attrs, handler ) {
-	var arr = attrs.split("|"),
-		i = attrs.length;
-
-	while ( i-- ) {
-		Expr.attrHandle[ arr[i] ] = handler;
-	}
-}
-
-/**
  * Checks document order of two siblings
  * @param {Element} a
  * @param {Element} b
@@ -493,16 +479,6 @@ setDocument = Sizzle.setDocument = function( node ) {
 			});
 		}
 	}
-
-	/* Attributes
-	---------------------------------------------------------------------- */
-
-	// Support: IE<8
-	// Verify that getAttribute really returns attributes and not properties (excepting IE8 booleans)
-	support.attributes = assert(function( div ) {
-		div.className = "i";
-		return !div.getAttribute("className");
-	});
 
 	/* getElement(s)By*
 	---------------------------------------------------------------------- */
@@ -877,7 +853,7 @@ Sizzle.attr = function( elem, name ) {
 
 	return val !== undefined ?
 		val :
-		support.attributes || !documentIsHTML ?
+		!documentIsHTML ?
 			elem.getAttribute( name ) :
 			(val = elem.getAttributeNode(name)) && val.specified ?
 				val.value :
@@ -1366,13 +1342,8 @@ Expr = Sizzle.selectors = {
 		},
 
 		"text": function( elem ) {
-			var attr;
 			return elem.nodeName.toLowerCase() === "input" &&
-				elem.type === "text" &&
-
-				// Support: IE<8
-				// New HTML5 attribute values (e.g., "search") appear with elem.type === "text"
-				( (attr = elem.getAttribute("type")) == null || attr.toLowerCase() === "text" );
+				elem.type === "text";
 		},
 
 		// Position-in-collection
@@ -1985,50 +1956,6 @@ support.sortDetached = assert(function( div1 ) {
 	// Should return 1, but returns 4 (following)
 	return div1.compareDocumentPosition( document.createElement("div") ) & 1;
 });
-
-// Support: IE<8
-// Prevent attribute/property "interpolation"
-// http://msdn.microsoft.com/en-us/library/ms536429%28VS.85%29.aspx
-if ( !assert(function( div ) {
-	div.innerHTML = "<a href='#'></a>";
-	return div.firstChild.getAttribute("href") === "#" ;
-}) ) {
-	addHandle( "type|href|height|width", function( elem, name, isXML ) {
-		if ( !isXML ) {
-			return elem.getAttribute( name, name.toLowerCase() === "type" ? 1 : 2 );
-		}
-	});
-}
-
-// Support: IE<9
-// Use defaultValue in place of getAttribute("value")
-if ( !support.attributes || !assert(function( div ) {
-	div.innerHTML = "<input/>";
-	div.firstChild.setAttribute( "value", "" );
-	return div.firstChild.getAttribute( "value" ) === "";
-}) ) {
-	addHandle( "value", function( elem, name, isXML ) {
-		if ( !isXML && elem.nodeName.toLowerCase() === "input" ) {
-			return elem.defaultValue;
-		}
-	});
-}
-
-// Support: IE<9
-// Use getAttributeNode to fetch booleans when getAttribute lies
-if ( !assert(function( div ) {
-	return div.getAttribute("disabled") == null;
-}) ) {
-	addHandle( booleans, function( elem, name, isXML ) {
-		var val;
-		if ( !isXML ) {
-			return elem[ name ] === true ? name.toLowerCase() :
-					(val = elem.getAttributeNode( name )) && val.specified ?
-					val.value :
-				null;
-		}
-	});
-}
 
 // EXPOSE
 if ( typeof define === "function" && define.amd ) {


### PR DESCRIPTION
By removing oldIE support from 2.1+'s Sizzle, the code becomes more readable, and the filesize is reduced.

```
Running "compare_size:files" (compare_size) task
   raw     gz Sizes
244350  72434 dist/jquery.js
 83434  29244 dist/jquery.min.js

   raw     gz Compared to master @ d837f119c3729565103005d5d7fa89e1dd8110cb
 -2145   -618 dist/jquery.js
  -865   -238 dist/jquery.min.js
```

Cheers,
Chris
