### PR TITLE
core: Consistently use local reference to access()

### DIFF
--- a/src/core/access.js
+++ b/src/core/access.js
@@ -13,7 +13,7 @@ var access = jQuery.access = function( elems, fn, key, value, chainable, emptyGe
 	if ( jQuery.type( key ) === "object" ) {
 		chainable = true;
 		for ( i in key ) {
-			jQuery.access( elems, fn, i, key[i], true, emptyGet, raw );
+			access( elems, fn, i, key[i], true, emptyGet, raw );
 		}
 
 	// Sets one value


### PR DESCRIPTION
Follows-up 3b53b75160.

> Our internal code always calls the local `access` reference, not `jQuery.access`. Which means if someone were to override this method, jQuery core APIs would not be affected (I guess we kept it exposed for backwards compatibility, it's not a documented API though).
> Except that core APIs **are** affected when an object is passed, because the loop calls the public one instead of the private one.

Let's call the private reference there as well?
