### PR TITLE
Fix jQuery.noConflict

### DIFF
--- a/src/exports/global.js
+++ b/src/exports/global.js
@@ -19,6 +19,14 @@ jQuery.noConflict = function( deep ) {
 		window.jQuery = _jQuery;
 	}
 
+	// Do not pollute window object with undefined properties
+	if ( window.jQuery === undefined ) {
+		delete window.jQuery;
+	}
+	if ( window.$ === undefined ) {
+		delete window.$;
+	}
+
 	return jQuery;
 };
 


### PR DESCRIPTION
If there was no jQuery defined at all in the window, using `jQuery.noConflict` properly remove the `jQuery` and `$` references, but let them as `undefined` properties.

This fix, completely remove the keys. In the chrome console for example, the `$` reference, is then properly reset to the chrome console `$` utility.
