### PR TITLE
Error fix that occurs in $.fn.contents when elem is iframe.

### DIFF
--- a/src/traversing.js
+++ b/src/traversing.js
@@ -165,7 +165,7 @@ jQuery.each({
 		return jQuery.sibling( elem.firstChild );
 	},
 	contents: function( elem ) {
-		return elem.nodeName.toLowerCase() !=='iframe' && elem.contentDocument || jQuery.merge( [], elem.childNodes );
+		return elem.nodeName.toLowerCase() !== "iframe" && elem.contentDocument || jQuery.merge( [], elem.childNodes );
 	}
 }, function( name, fn ) {
 	jQuery.fn[ name ] = function( until, selector ) {


### PR DESCRIPTION
Error fix that occurs in $.fn.contents when elem is iframe.
Exception: "DOMException". Exception name: "SecurityError".
