### PR TITLE
Core: Fix loop issue when jQuery object present

### DIFF
--- a/src/core/init.js
+++ b/src/core/init.js
@@ -16,8 +16,8 @@ var rootjQuery,
 	init = jQuery.fn.init = function( selector, context ) {
 		var match, elem;
 
-		// HANDLE: $(""), $(null), $(undefined), $(false)
-		if ( !selector ) {
+		// HANDLE: $(""), $(null), $(undefined), $(false), $($)
+		if ( !selector || selector === jQuery ) {
 			return this;
 		}
 


### PR DESCRIPTION
When I present jQuery object to jQuery initializer, jQuery happens to infinite loop problem.
for example:

``` js
$($)
```
