### PR TITLE
Init: check for jQuery instance as selector

### DIFF
--- a/src/core/init.js
+++ b/src/core/init.js
@@ -16,8 +16,8 @@ var rootjQuery,
 	init = jQuery.fn.init = function( selector, context ) {
 		var match, elem;
 
-		// HANDLE: $(""), $(null), $(undefined), $(false)
-		if ( !selector ) {
+		// HANDLE: $(""), $(null), $(undefined), $(false), $($)
+		if ( !selector || selector === jQuery ) {
 			return this;
 		}
 


### PR DESCRIPTION
This issue was originally brought up on Reddit: http://www.reddit.com/r/javascript/comments/2affb3/jquery_magic/

When `$` is passed in to `init`, it's read as a function, which is then passed through `init` again. I haven't touched the jQuery source before, so if this is a terrible place or way to solve the problem, let me know and I'll happily try again elsewhere/elsehow (?).
