### PR TITLE
Ajax: 15160 - Fix for request aborted in ajaxSend

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -631,6 +631,12 @@ jQuery.extend({
 			if ( fireGlobals ) {
 				globalEventContext.trigger( "ajaxSend", [ jqXHR, s ] );
 			}
+
+			// If request was aborted inside ajaxSend, stop there
+			if ( state === 2 ) {
+				return jqXHR;
+			}
+
 			// Timeout
 			if ( s.async && s.timeout > 0 ) {
 				timeoutTimer = setTimeout(function() {

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -440,6 +440,23 @@ module( "ajax", {
 		};
 	});
 
+	ajaxTest( "#15160 - jQuery.ajax() - request manually aborted in ajaxSend", 3, {
+		setup: function() {
+			jQuery( document ).on( "ajaxSend", function( e, jqXHR ) {
+				jqXHR.abort();
+			});
+
+			jQuery( document ).on( "ajaxError ajaxComplete", function( e, jqXHR ) {
+				equal( jqXHR.statusText, "abort", "jqXHR.statusText equals abort on global ajaxComplete and ajaxError events" );
+			});
+		},
+		url: url("data/name.html"),
+		error: true,
+		complete: function() {
+			ok( true, "complete" );
+		}
+	});
+
 	ajaxTest( "jQuery.ajax() - context modification", 1, {
 		url: url("data/name.html"),
 		context: {},


### PR DESCRIPTION
Bug ticket: http://bugs.jquery.com/ticket/15160

The same approach to a very similar problem was used on [line 533](https://github.com/jquery/jquery/pull/1619/files#diff-c3749d3acba09ca9ec16bb56e496408bL533)

Simply: If `done` has already been invoked for the request then we don't want to call it again.
