### PR TITLE
Update getStyles.js to support when ownerDocument is a shadow dom element

### DIFF
--- a/src/css/var/getStyles.js
+++ b/src/css/var/getStyles.js
@@ -4,7 +4,7 @@ define(function() {
 		// IE throws on elements created in popups
 		// FF meanwhile throws on frame elements through "defaultView.getComputedStyle"
 		if ( elem.ownerDocument.defaultView.opener ) {
-			return elem.ownerDocument.defaultView.getComputedStyle( elem, null );
+			return (elem.ownerDocument.defaultView || document.defaultView).getComputedStyle( elem, null );
 		}
 
 		return window.getComputedStyle( elem, null );


### PR DESCRIPTION
Use case: http://jsbin.com/lirejo/edit
