### PR TITLE
Fix #15073 Infinite loop on empty namespace

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -159,6 +159,9 @@ jQuery.event = {
 			return;
 		}
 
+                // Remove empty namespace (ie trailing dots)
+                types = types.replace(/\.+\s/, " ").replace(/\.+$/, "");
+
 		// Once for each type.namespace in types; type may be omitted
 		types = ( types || "" ).match( rnotwhite ) || [ "" ];
 		t = types.length;


### PR DESCRIPTION
The issue tracker name is a bit misleading, the actual problem is in .remove() not .off() - I'm happy to rename the tracker if needed.

Get an infinite loop if types parameter of .remove() has any trailing dots. Fix this by removing any trailing dots and removing the empty namespace

jsFiddle of the issue here http://jsfiddle.net/EJTyW/5/

--- Edit ---

I think it would be nice to add a unit test to this, but I'm unsure of a reliable way to test for an infinite loop (I'm not a huge fan of the "if it takes longer than XXXms then it's an infinite loop" - but I'm open to writing that if it's considered worth it?)
