### PR TITLE
Solve bug "??" json post

### DIFF
--- a/src/ajax/jsonp.js
+++ b/src/ajax/jsonp.js
@@ -5,9 +5,9 @@ define([
 	"../ajax"
 ], function( jQuery, nonce, rquery ) {
 
+//change #1639
 var oldCallbacks = [],
-	rjsonp = /(=)\?(?=&|$)|\?\?/;
-	//change #1639
+	rjsonp = /(=)\?(?=&|$)|\?\?/,
 	rjsonContent = /(=)\?(?=&|$)/;
 
 // Default jsonp settings


### PR DESCRIPTION
In many cases I need to send a text or a paragraph in Portuguese and Spanish containing the following characters: "??". However the same rule of URL is tested in json content. I believe this can be changed. http://bugs.jquery.com/ticket/12326
