### PR TITLE
css: $.fn.removeСss method

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -441,6 +441,12 @@ jQuery.fn.extend({
 				jQuery.css( elem, name );
 		}, name, value, arguments.length > 1 );
 	},
+	removeCss: function( name ) {
+		return this.each(function() {
+			jQuery.style( this, name, '' );
+		});
+	}
+	,
 	show: function() {
 		return showHide( this, true );
 	},


### PR DESCRIPTION
Cause $.fn.css(attr, '') not obvious.
Inspired with http://stackoverflow.com/questions/9398870/remove-css-attribute-with-jquery

I know that this well documented here http://api.jquery.com/css/ but we have $.fn.removeAttr so. You decide.
