### PR TITLE
Bugfix for #15213: calling .empty() on disabled callbacks object kind of re-enables it

### DIFF
--- a/src/callbacks.js
+++ b/src/callbacks.js
@@ -151,8 +151,10 @@ jQuery.Callbacks = function( options ) {
 			},
 			// Remove all callbacks from the list
 			empty: function() {
-				list = [];
-				firingLength = 0;
+				if ( list ) {
+					list = [];
+					firingLength = 0;
+				}
 				return this;
 			},
 			// Have the list do nothing anymore


### PR DESCRIPTION
Copying description from jQuery bug tracker:

---

Earlier today I answered  this StackOverflow question, wherein this behavior is shown:

var c = $.Callbacks();
var f = /\* some function */;
c.disable();
c.empty();
c.add(f);
c.disabled(); // of course true
c.fire(); // invokes f!

This behavior occurs in all versions of jQuery I tested (latest 1.9, 1.10, 1.11, 2.0, 2.1) -- here's a  fiddle to easily reproduce it.

The problem is that .disable() relies on setting internal variables of the callbacks object to undefined, and while most other methods such as .add() test and this condition and abort if true, .empty() itself does not. Instead it resets some of those variables, which causes the abort test in the other methods to erroneously pass and ultimately for callbacks to be added to and invoked by a disabled object.
