### PR TITLE
Remove optimization to make jQuery compatible with Google's Polymer project

### DIFF
--- a/src/css/defaultDisplay.js
+++ b/src/css/defaultDisplay.js
@@ -13,8 +13,7 @@ var iframe,
  */
 // Called only from within defaultDisplay
 function actualDisplay( name, doc ) {
-	var style,
-		elem = jQuery( doc.createElement( name ) ).appendTo( doc.body ),
+	var elem = jQuery( doc.createElement( name ) ).appendTo( doc.body ),
 
 		display = jQuery.css( elem[ 0 ], "display" );
 


### PR DESCRIPTION
When Polymer platform is used together with jQuery, removed lines cause error:

> TypeError: Argument 1 of Window.getDefaultComputedStyle does not implement interface Element.

Since removal of this method doesn't break anything, and method was removed from specification, I think it is possible to merge this pull request without problems.
