### PR TITLE
fix $.isPlainObject()

### DIFF
--- a/src/wrap.js
+++ b/src/wrap.js
@@ -2,7 +2,7 @@ define([
 	"./core",
 	"./core/init",
 	"./manipulation", // clone
-	"./traversing" // parent, contents;
+	"./traversing" // parent, contents
 ], function( jQuery ) {
 
 jQuery.fn.extend({


### PR DESCRIPTION
$.isPlainObject(param)  when param is Math .It should return false
