### PR TITLE
Fixex 15245: "text-decoration" wrong returns on Chrome31~36

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -223,6 +223,22 @@ jQuery.extend({
 					return ret === "" ? "1" : ret;
 				}
 			}
+		},
+		textDecoration: {
+			get: function( elem, computed ) {
+				if ( computed ) {
+
+					//Chrome 31-36 return text-decoration-line and text-decoration-color
+					//which are not expected yet.
+					//see https://code.google.com/p/chromium/issues/detail?id=342126
+					var ret = curCSS( elem, "text-decoration" );
+					//We cannot assume the first word as "text-decoration-style"
+					if ( /\b(inherit|(?:und|ov)erline|blink|line\-through|none)\b/.test( ret ) )
+					{
+						return RegExp.$1;
+					}
+				}
+			}
 		}
 	},
 

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -3,7 +3,7 @@ if ( jQuery.css ) {
 module("css", { teardown: moduleTeardown });
 
 test("css(String|Hash)", function() {
-	expect( 42 );
+	expect( 43 );
 
 	equal( jQuery("#qunit-fixture").css("display"), "block", "Check for css property \"display\"" );
 
@@ -61,7 +61,10 @@ test("css(String|Hash)", function() {
 	equal( jQuery("#empty").css("opacity"), "0", "Assert opacity is accessible via filter property set in stylesheet in IE" );
 	jQuery("#empty").css({ "opacity": "1" });
 	equal( jQuery("#empty").css("opacity"), "1", "Assert opacity is taken from style attribute when set vs stylesheet in IE with filters" );
-
+	
+	div.css( "text-decoration", "underline" );
+	equal( div.css("text-decoration"), "underline", "Assert text-decoration is taken without line&color");
+	
 	div = jQuery("#nothiddendiv");
 	child = jQuery("#nothiddendivchild");
 


### PR DESCRIPTION
Chrome 31-36 return text-decoration-line and text-decoration-color which are not expected yet.

see https://code.google.com/p/chromium/issues/detail?id=342126
