### PR TITLE
Fixex 15245: "text-decoration" wrong returns on Chrome31~36

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -448,6 +448,21 @@ jQuery.cssHooks.marginRight = addGetHookIf( support.reliableMarginRight,
 	}
 );
 
+jQuery.cssHooks.textDecoration = {
+	get: function(elem, computed) {
+		if (computed) {
+			//Chrome 31-36 return text-decoration-line and text-decoration-color
+			//which are not expected yet.
+			//see https://code.google.com/p/chromium/issues/detail?id=342126
+			var ret = curCSS(elem, "text-decoration");
+			//We cannot assume the first word as "text-decoration-style"
+			if (/\b(inherit|(?:und|ov)erline|blink|line\-through|none)\b/.test(ret)) {
+				return RegExp.$1;
+			}
+		}
+	}
+};
+
 // These hooks are used by animate to expand properties
 jQuery.each({
 	margin: "",

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -3,7 +3,7 @@ if ( jQuery.css ) {
 module("css", { teardown: moduleTeardown });
 
 test("css(String|Hash)", function() {
-	expect( 43 );
+	expect( 44 );
 
 	equal( jQuery("#qunit-fixture").css("display"), "block", "Check for css property \"display\"" );
 
@@ -64,6 +64,9 @@ test("css(String|Hash)", function() {
 	jQuery.support.opacity ?
 		ok(true, "Requires the same number of tests"):
 		ok( ~jQuery("#empty")[0].currentStyle.filter.indexOf("gradient"), "Assert setting opacity doesn't overwrite other filters of the stylesheet in IE" );
+
+	div.css( "text-decoration", "underline" );
+	equal( div.css( "text-decoration" ), "underline", "ssert text-decoration is taken without line&color");
 
 	div = jQuery("#nothiddendiv");
 	child = jQuery("#nothiddendivchild");


### PR DESCRIPTION
Chrome 31-36 return text-decoration-line and text-decoration-color which are not expected yet.

see https://code.google.com/p/chromium/issues/detail?id=342126
