### PR TITLE
Data: avoid non-alphanumeric chars in expando properties

### DIFF
--- a/src/data/Data.js
+++ b/src/data/Data.js
@@ -14,7 +14,7 @@ function Data() {
 		}
 	});
 
-	this.expando = jQuery.expando + Math.random();
+	this.expando = jQuery.expando + Data.uid++;
 }
 
 Data.uid = 1;


### PR DESCRIPTION
Ref chromium issue 378607
Ref jQuery issue 14839

As discussed a bit in the original commit (https://github.com/jbedard/jquery/commit/ed3a9887d16b098a7c784cc4920185d9e5c53e2a#commitcomment-7857752) and bug (http://bugs.jquery.com/ticket/14839) this avoids the use of non-alphanumeric characters in the expando property used by the `Data` objects.

This avoids https://code.google.com/p/chromium/issues/detail?id=378607 when creating data on an element for the first time. It seems like jq2 doesn't cleanup the expando property on cleanData so the delete case doesn't occur.
