### PR TITLE
Readme grammar improved on lines 24, 25, 27 and 61

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Environments in which to use jQuery
 What you need to build your own jQuery
 --------------------------------------
 
-In order to build jQuery, you need to have the latest Node.js/npm and git 1.7 or later. Earlier versions might work OK, but are not supported with tests.
+In order to build jQuery, you need to have the latest Node.js/npm and git 1.7 or later. Earlier versions might work, but are not supported.
 
 For Windows, you have to download and install [git](http://git-scm.com/downloads) and [Node.js](http://nodejs.org/download/).
 


### PR DESCRIPTION
line 24 and 25:
In order to build jQuery, you need to have Node.js/npm latest and git 1.7 or later. 
(Earlier versions might work OK, but are not tested.)
--> added missing article, changed word order, moved full sentence parenthetical to a sentence -->
In order to build jQuery, you need to have the latest Node.js/npm and git 1.7 or later. Earlier versions might work OK, but are not supported with tests.

line 27:
For Windows you have to download and install [git](http://git-scm.com/downloads) and [Node.js](http://nodejs.org/download/).
--> inserted comma for opening parenthetical -->
For Windows, you have to download and install [git](http://git-scm.com/downloads) and [Node.js](http://nodejs.org/download/).

line 61:
Now by running `grunt` command, in the jquery directory, you could build full version of jQuery, just like with `npm run build` command:
--> inserted missing articles; verb conjugation -->
Now by running the `grunt` command, in the jquery directory, you can build a full version of jQuery, just like with a `npm run build` command:
