### PR TITLE
Data: avoid using delete on DOM nodes

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -230,9 +230,9 @@ function internalRemoveData( elem, name, pvt ) {
 		/* jshint eqeqeq: true */
 		delete cache[ id ];
 
-	// When all else fails, null
+	// When all else fails, undefined
 	} else {
-		cache[ id ] = null;
+		cache[ id ] = undefined;
 	}
 }
 

--- a/src/data/support.js
+++ b/src/data/support.js
@@ -5,15 +5,12 @@ define([
 (function() {
 	var div = document.createElement( "div" );
 
-	// Execute the test only if not already executed in another module.
-	if (support.deleteExpando == null) {
-		// Support: IE<9
-		support.deleteExpando = true;
-		try {
-			delete div.test;
-		} catch ( e ) {
-			support.deleteExpando = false;
-		}
+	// Support: IE<9
+	support.deleteExpando = true;
+	try {
+		delete div.test;
+	} catch ( e ) {
+		support.deleteExpando = false;
 	}
 
 	// Null elements to avoid leaks in IE.

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -424,7 +424,7 @@ jQuery.extend({
 			i = 0,
 			internalKey = jQuery.expando,
 			cache = jQuery.cache,
-			deleteExpando = support.deleteExpando,
+			attrProps = support.attrProps,
 			special = jQuery.event.special;
 
 		for ( ; (elem = elems[i]) != null; i++ ) {
@@ -451,17 +451,18 @@ jQuery.extend({
 
 						delete cache[ id ];
 
-						// IE does not allow us to delete expando properties from nodes,
-						// nor does it have a removeAttribute function on Document nodes;
-						// we must handle all of these cases
-						if ( deleteExpando ) {
-							delete elem[ internalKey ];
-
-						} else if ( typeof elem.removeAttribute !== "undefined" ) {
+						// Support: IE<9
+						// IE does not allow us to delete expando properties from nodes
+						// IE creates expando attributes along with the property
+						// IE does not have a removeAttribute function on Document nodes
+						if ( attrProps && typeof elem.removeAttribute !== "undefined" ) {
 							elem.removeAttribute( internalKey );
 
+						// Webkit & Blink performance suffers when deleting properties
+						// from DOM nodes, so set to undefined instead
+						// https://code.google.com/p/chromium/issues/detail?id=378607
 						} else {
-							elem[ internalKey ] = null;
+							elem[ internalKey ] = undefined;
 						}
 
 						deletedIds.push( id );

--- a/src/manipulation/support.js
+++ b/src/manipulation/support.js
@@ -59,16 +59,8 @@ define([
 		div.cloneNode( true ).click();
 	}
 
-	// Execute the test only if not already executed in another module.
-	if (support.deleteExpando == null) {
-		// Support: IE<9
-		support.deleteExpando = true;
-		try {
-			delete div.test;
-		} catch ( e ) {
-			support.deleteExpando = false;
-		}
-	}
+	div[ jQuery.expando ] = 1;
+	support.attrProps = !!div.getAttribute( jQuery.expando );
 })();
 
 return support;

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -100,18 +100,10 @@ test("jQuery.data(document)", 25, function() {
 });
 
 test("Expando cleanup", 4, function() {
-	var expected, actual,
-		div = document.createElement("div");
+	var div = document.createElement("div");
 
 	function assertExpandoAbsent(message) {
-		if (jQuery.support.deleteExpando) {
-			expected = false;
-			actual = jQuery.expando in div;
-		} else {
-			expected = null;
-			actual = div[ jQuery.expando ];
-		}
-		equal( actual, expected, message );
+		strictEqual( div[ jQuery.expando ], undefined, message );
 	}
 
 	assertExpandoAbsent("There is no expando on new elements");

--- a/test/unit/support.js
+++ b/test/unit/support.js
@@ -81,6 +81,7 @@ testIframeWithCallback( "Check CSP (https://developer.mozilla.org/en-US/docs/Sec
 		expected = {
 			"ajax": true,
 			"appendChecked": true,
+			"attrProps": false,
 			"boxSizing": true,
 			"boxSizingReliable": true,
 			"changeBubbles": true,
@@ -118,6 +119,7 @@ testIframeWithCallback( "Check CSP (https://developer.mozilla.org/en-US/docs/Sec
 		expected = {
 			"ajax": true,
 			"appendChecked": true,
+			"attrProps": false,
 			"boxSizing": true,
 			"boxSizingReliable": true,
 			"changeBubbles": true,
@@ -155,6 +157,7 @@ testIframeWithCallback( "Check CSP (https://developer.mozilla.org/en-US/docs/Sec
 		expected = {
 			"ajax": true,
 			"appendChecked": true,
+			"attrProps": false,
 			"boxSizing": true,
 			"boxSizingReliable": false,
 			"changeBubbles": true,
@@ -192,6 +195,7 @@ testIframeWithCallback( "Check CSP (https://developer.mozilla.org/en-US/docs/Sec
 		expected = {
 			"ajax": true,
 			"appendChecked": true,
+			"attrProps": false,
 			"boxSizing": true,
 			"boxSizingReliable": false,
 			"changeBubbles": true,
@@ -229,6 +233,7 @@ testIframeWithCallback( "Check CSP (https://developer.mozilla.org/en-US/docs/Sec
 		expected = {
 			"ajax": true,
 			"appendChecked": true,
+			"attrProps": false,
 			"boxSizing": true,
 			"boxSizingReliable": false,
 			"changeBubbles": true,
@@ -266,6 +271,7 @@ testIframeWithCallback( "Check CSP (https://developer.mozilla.org/en-US/docs/Sec
 		expected = {
 			"ajax": true,
 			"appendChecked": true,
+			"attrProps": true,
 			"boxSizing": true,
 			"boxSizingReliable": false,
 			"changeBubbles": false,
@@ -303,6 +309,7 @@ testIframeWithCallback( "Check CSP (https://developer.mozilla.org/en-US/docs/Sec
 		expected = {
 			"ajax": true,
 			"appendChecked": false,
+			"attrProps": true,
 			"boxSizing": false,
 			"boxSizingReliable": false,
 			"changeBubbles": false,
@@ -340,6 +347,7 @@ testIframeWithCallback( "Check CSP (https://developer.mozilla.org/en-US/docs/Sec
 		expected = {
 			"ajax": true,
 			"appendChecked": false,
+			"attrProps": true,
 			"boxSizing": false,
 			"boxSizingReliable": false,
 			"changeBubbles": false,
@@ -377,6 +385,7 @@ testIframeWithCallback( "Check CSP (https://developer.mozilla.org/en-US/docs/Sec
 		expected = {
 			"ajax": true,
 			"appendChecked": true,
+			"attrProps": false,
 			"boxSizing": true,
 			"boxSizingReliable": true,
 			"changeBubbles": true,
@@ -414,6 +423,7 @@ testIframeWithCallback( "Check CSP (https://developer.mozilla.org/en-US/docs/Sec
 		expected = {
 			"ajax": true,
 			"appendChecked": true,
+			"attrProps": false,
 			"boxSizing": true,
 			"boxSizingReliable": true,
 			"changeBubbles": true,
@@ -451,6 +461,7 @@ testIframeWithCallback( "Check CSP (https://developer.mozilla.org/en-US/docs/Sec
 		expected = {
 			"ajax": true,
 			"appendChecked": true,
+			"attrProps": false,
 			"boxSizing": true,
 			"boxSizingReliable": true,
 			"changeBubbles": true,
@@ -488,6 +499,7 @@ testIframeWithCallback( "Check CSP (https://developer.mozilla.org/en-US/docs/Sec
 		expected = {
 			"ajax": true,
 			"appendChecked": true,
+			"attrProps": false,
 			"boxSizing": true,
 			"boxSizingReliable": true,
 			"changeBubbles": true,
@@ -525,6 +537,7 @@ testIframeWithCallback( "Check CSP (https://developer.mozilla.org/en-US/docs/Sec
 		expected = {
 			"ajax": true,
 			"appendChecked": true,
+			"attrProps": false,
 			"boxSizing": true,
 			"boxSizingReliable": true,
 			"changeBubbles": true,
@@ -562,6 +575,7 @@ testIframeWithCallback( "Check CSP (https://developer.mozilla.org/en-US/docs/Sec
 		expected = {
 			"ajax": true,
 			"appendChecked": true,
+			"attrProps": false,
 			"boxSizing": true,
 			"boxSizingReliable": true,
 			"changeBubbles": true,
@@ -599,6 +613,7 @@ testIframeWithCallback( "Check CSP (https://developer.mozilla.org/en-US/docs/Sec
 		expected = {
 			"ajax": true,
 			"appendChecked": true,
+			"attrProps": false,
 			"boxSizing": true,
 			"boxSizingReliable": true,
 			"changeBubbles": true,


### PR DESCRIPTION
This is similar to https://github.com/jquery/jquery/pull/1662 but for jQuery 1.x which reproduces https://code.google.com/p/chromium/issues/detail?id=378607 in `cleanData` by using `delete` on DOM nodes. I have found this issue worse then the jQuery2 version because cleanData often runs on large groups of nodes at once (such as when changing pages in a SPA).  If every node (with data) reproduces the chrome issue it can cause memory usage to spike very high and cause significant performance issues. I have seen pages spike from 15m to 150m while transitioning pages in a SPA, combined with https://code.google.com/p/v8/issues/detail?id=2073 that use case often crashes the browser.

The easiest way to reproduce it, in the chrome console (on any page, a blank one makes the memory snapshot easier to read):

```
var div = document.createElement("div");
div.jQuery123 = 1;
*heap snapshot #1*
delete div.jQuery123;
*heap snapshot #2*
```

If you find the detached div element in the heap snapshot it is about 150 bytes in snapshot 1, in snapshot 2 I'm normally seeing it around 6300 bytes.

I'm having trouble testing this properly in oldIE so I'm not 100% sure if the current commit covers oldIE correctly. I think setting `elem[ $.expando ] = undefined` will just change the expando attribute to `jQuery###="undefined"` in the DOM, so maybe we need a support test for that and an extra `.removeAttribute( internalKey )`?
