### PR TITLE
Bugfix for #15247 DEFERRED.PROGRESS() IS STILL AVAILABLE AFTER THE DEFERRED OBJECT HAS BEEN RESOLVED OR REJECTED

### DIFF
--- a/src/deferred.js
+++ b/src/deferred.js
@@ -72,7 +72,7 @@ jQuery.extend({
 					state = stateString;
 
 				// [ reject_list | resolve_list ].disable; progress_list.lock
-				}, tuples[ i ^ 1 ][ 2 ].disable, tuples[ 2 ][ 2 ].lock );
+				}, tuples[ i ^ 1 ][ 2 ].disable, tuples[ 2 ][ 2 ].disable );
 			}
 
 			// deferred[ resolve | reject | notify ]


### PR DESCRIPTION
As the jQuery documentation say in  [deferred.notify()](http://api.jquery.com/deferred.notify/])

> Any calls to .notify() after a Deferred is resolved or rejected (or any progressCallbacks added after that) are ignored.

But the progressCallback is just locked when the deferred object is resolved or rejected. So if the .notify() was not called before we call .resolve() or .reject(), the progressCallback will be disabled, but if the .notify() was called before we call .resolve() or .reject(), the progressCallback was just locked.

This issue exist in version 1.8-edge version of jQuery.

You can check out the code example here:

 http://jsfiddle.net/yuuuuc/zez5dtpv/3/

The fix: change `tuples[ 2 ][ 2 ].lock` to `tuples[ 2 ][ 2 ].disable`
