### PR TITLE
Data: Avoid ES5 defineProperty for speed

### DIFF
--- a/src/data/Data.js
+++ b/src/data/Data.js
@@ -29,24 +29,20 @@ Data.prototype = {
 			return 0;
 		}
 
-		var descriptor = {},
-			// Check if the owner object already has a cache key
-			unlock = owner[ this.expando ];
+		// Check if the owner object already has a cache key
+		var unlock = owner[ this.expando ];
 
 		// If not, create one
 		if ( !unlock ) {
 			unlock = Data.uid++;
 
-			// Secure it in a non-enumerable, non-writable property
-			try {
-				descriptor[ this.expando ] = { value: unlock };
-				Object.defineProperties( owner, descriptor );
-
-			// Support: Android<4
-			// Fallback to a less secure definition
-			} catch ( e ) {
-				descriptor[ this.expando ] = unlock;
-				jQuery.extend( owner, descriptor );
+			// If it is a node unlikely to be stringify-ed or looped over
+			// use plain assignment
+			if ( owner.nodeType ) {
+				owner[ this.expando ] = unlock;
+			// Otherwise secure it in a non-enumerable, non-writable property
+			} else {
+				Object.defineProperty( owner, this.expando, { value: unlock } );
 			}
 		}
 


### PR DESCRIPTION
As discussed in http://bugs.jquery.com/ticket/14839, removing the use of definePropert(y|ies) brings the jQuery2 data initialization up to speed with jQuery1 for DOM nodes. For non nodes this also switches from defineProperties to defineProperty which is a bit faster, saves an object and saves some bytes.

@gibson042 this has the changed you suggested in https://github.com/jbedard/jquery/commit/d44885b3603dd41ebc47ac889bc55a9a0da0fd4f