### PR TITLE
Why replace '%20' with '+'?

### DIFF
--- a/src/serialize.js
+++ b/src/serialize.js
@@ -77,7 +77,7 @@ jQuery.param = function( a, traditional ) {
 	}
 
 	// Return the resulting serialization
-	return s.join( "&" ).replace( r20, "+" );
+	return s.join( "&" );
 };
 
 jQuery.fn.extend({


### PR DESCRIPTION
It causes issues if you later try to parse the serialized string with decodeURIComponent and %20 should be just as compatible as +
