### PR TITLE
`.jshintrc`: remove deprecated options

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -8,8 +8,6 @@
 	"noarg": true,
 	"onevar": true,
 	"quotmark": "double",
-	"smarttabs": true,
-	"trailing": true,
 	"undef": true,
 	"unused": true,
 


### PR DESCRIPTION
The `smarttabs` and `trailing` jshint options are deprecated since [jshint version 2.5.0](https://github.com/jshint/jshint/releases/tag/2.5.0)
