### PR TITLE
Minor spelling/grammar corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ start();
 ```
 
 
-Note: QUnit's eventual addition of an argument to stop/start is ignored in this test suite so that start and stop can be passed as callbacks without worrying about their parameters
+*Note*: QUnit's eventual addition of an argument to stop/start is ignored in this test suite so that start and stop can be passed as callbacks without worrying about their parameters.
 
 ### Test assertions ###
 


### PR DESCRIPTION
- Format second note in README.md to match the formatting style of the first note.
- Add a "." at the end of the paragraph.
