### PR TITLE
Fixed rquickExpr to require 1 or more chars for ID

### DIFF
--- a/src/core/init.js
+++ b/src/core/init.js
@@ -11,7 +11,7 @@ var rootjQuery,
 	// A simple way to check for HTML strings
 	// Prioritize #id over <tag> to avoid XSS via location.hash (#9521)
 	// Strict HTML recognition (#11290: must start with <)
-	rquickExpr = /^(?:\s*(<[\w\W]+>)[^>]*|#([\w-]*))$/,
+	rquickExpr = /^(?:\s*(<[\w\W]+>)[^>]*|#([\w-]+))$/,
 
 	init = jQuery.fn.init = function( selector, context ) {
 		var match, elem;


### PR DESCRIPTION
jQuery's `rquickExpr` allows for an ID with zero or more characters. An ID with zero characters isn't useful for fetching an element from the DOM, and `getElementById` will throw an error in Firefox, but not in Chrome.

While a selector like `$("#")` is unlikely to be manually written, it's more likely to be encountered with generated selectors.

The `rquickExpr` in Sizzle does require at least one character after `#`, so this will bring uniformity to the optimization.

Sizzle line 135: https://github.com/jquery/sizzle/blob/709e1db5bcb42e9d761dd4a8467899dd36ce63bc/src/sizzle.js#L135
