### PR TITLE
fix missed off(), which is not recorded in $.cache

### DIFF
--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -992,6 +992,7 @@ test("trigger() bubbling", function() {
 	equal( win, 4, "doc bubble" );
 
 	// manually clean up events from elements outside the fixture
+	jQuery(window).off("click");
 	jQuery(document).off("click");
 	jQuery("html, body, #qunit-fixture").off("click");
 });
@@ -2036,7 +2037,7 @@ test("Non DOM element events", function() {
 		ok( true, "Event on non-DOM object triggered" );
 	});
 
-	jQuery(o).trigger("nonelementobj");
+	jQuery(o).trigger("nonelementobj").off("nonelementobj");
 });
 
 test("inline handler returning false stops default", function() {


### PR DESCRIPTION
Some events are not disabled, and check in teardown does not find them
