### PR TITLE
Ignore source folder in Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,7 @@
   "ignore": [
     "**/.*",
     "build",
+    "src",
     "speed",
     "test",
     "*.md",


### PR DESCRIPTION
You should only need the `/dist` folder in Bower, not the source files.
