### PR TITLE
Build: Fix typo in minimum build requirement error logging

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -177,7 +177,7 @@ module.exports = function( grunt ) {
 						// Check removeWith list
 						excludeList( removeWith[ module ] );
 					} else {
-						grunt.log.error( "Module \"" + module + "\" is a mimimum requirement.");
+						grunt.log.error( "Module \"" + module + "\" is a minimum requirement.");
 						if ( module === "selector" ) {
 							grunt.log.error(
 								"If you meant to replace Sizzle, use -sizzle instead."


### PR DESCRIPTION
When trying to do a custom build such as -
grunt custom:-core I came across a message where 'minimum' was misspelled as 'mimimum'. This pull request simply corrects that. No functional change hence should not impact rest of the code base in any way.
