### PR TITLE
Effects: Remove a workaround for a crash bug on some Android 2.3 phones

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -309,10 +309,7 @@ function Animation( elem, properties, options ) {
 			}
 			var currentTime = fxNow || createFxNow(),
 				remaining = Math.max( 0, animation.startTime + animation.duration - currentTime ),
-				// Support: Android 2.3
-				// Archaic crash bug won't allow us to use `1 - ( 0.5 || 0 )` (#12497)
-				temp = remaining / animation.duration || 0,
-				percent = 1 - temp,
+				percent = 1 - (remaining / animation.duration || 0),
 				index = 0,
 				length = animation.tweens.length;
 


### PR DESCRIPTION
This reverts the change introduced in:
https://github.com/jquery/jquery/commit/877306738f931a711c41d907e69fc8930f985830

cc @dmethvin, refs https://github.com/jquery/jquery/pull/1837#discussion_r20020781
