### PR TITLE
Misc: allow forcing jQuery to return a factory in commonjs environments

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -22,7 +22,10 @@
 		// This accentuates the need for the creation of a real `window`.
 		// e.g. var jQuery = require("jquery")(window);
 		// See ticket #14549 for more info.
-		module.exports = global.document ?
+
+		// if global.JQUERY_FACTORY is true, you can still get a factory with which you can then make additional jQueries bound to different windows.
+
+		module.exports = (global.document && !global.JQUERY_FACTORY) ?
 			factory( global, true ) :
 			function( w ) {
 				if ( !w.document ) {


### PR DESCRIPTION
Currently jQuery only returns a factory if global.document is not set. For a project I am working on I need jQuery to return a factory even if global.document is set. Here is a patch that will return the factory if global.document is set and global.JQUERY_FACTORY is also set.  In all other cases it will behave identically to before.
