### PR TITLE
add addCssProp function to css.js

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -248,6 +248,17 @@ jQuery.extend({
 		"float": "cssFloat"
 	},
 
+	// Add a CSS property to JQuery.cssProps, but only
+	// if that property is not defined already.
+	addCssProp: function (name, value) {
+		// Check if the property already exists
+		if (!JQuery.cssProps[name]) {
+			// If it does not, set it to the new value.
+			JQuery.cssProps[name] = value;
+		}
+		return this;
+	},
+
 	// Get and set the style property on a DOM Node
 	style: function( elem, name, value, extra ) {
 


### PR DESCRIPTION
Adds a function that allows people to easily add short-forms for CSS properties to the JQuery.cssProps array.  This function checks if the property name already exists in the array. If so, it simply returns `this`. Otherwise, it assigns the new property and then returns `this`.
