### PR TITLE
Attributes: Use the option val hook in select val hook and simplify it

### DIFF
--- a/src/attributes/val.js
+++ b/src/attributes/val.js
@@ -74,12 +74,9 @@ jQuery.extend({
 	valHooks: {
 		option: {
 			get: function( elem ) {
-				var val = jQuery.find.attr( elem, "value" );
-				return val != null ?
-					val :
-					// Support: IE10-11+
-					// option.text throws exceptions (#14686, #14858)
-					jQuery.trim( jQuery.text( elem ) );
+				// Support: IE<11
+				// option.value not trimmed (#14858)
+				return jQuery.trim( elem.value );
 			}
 		},
 		select: {
@@ -130,7 +127,8 @@ jQuery.extend({
 
 				while ( i-- ) {
 					option = options[ i ];
-					if ( (option.selected = jQuery.inArray( option.value, values ) >= 0) ) {
+					if ( (option.selected =
+							jQuery.inArray( jQuery.valHooks.option.get( option ), values ) >= 0) ) {
 						optionSet = true;
 					}
 				}

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -1461,6 +1461,11 @@ test( "should not throw at $(option).val() (#14686)", 1, function() {
 	}
 });
 
+test( "option value not trimmed when setting via parent select", function() {
+	expect( 1 );
+	equal( jQuery( "<select><option> 2</option></select>" ).val( "2" ).val(), "2" );
+});
+
 test( "Insignificant white space returned for $(option).val() (#14858)", function() {
 	expect ( 3 );
 


### PR DESCRIPTION
The hook is still defined; not using it could cause issues in IE<11.
Also, IE10 no longer throws when value not set but it still doesn't trim the
value. IE11 has all those issues fixed; support comments are updated.

Fixes gh-1902
Closes gh-1901

Most of this PR will need to be cherry-picked to `compat` as well.

Funny what things you find when you remove support for older browsers. ;)
