### PR TITLE
CONTRIBUTING: fix(parseJSON): do not fail if data is null

### DIFF
--- a/src/ajax/parseJSON.js
+++ b/src/ajax/parseJSON.js
@@ -5,6 +5,9 @@ define([
 // Support: Android 2.3
 // Workaround failure to string-cast null input
 jQuery.parseJSON = function( data ) {
+	if (!data) {
+		return null;
+	}
 	return JSON.parse( data + "" );
 };
 


### PR DESCRIPTION
Hello there,

this failed in `ajaxConvert` when for example a server response was null, which is often the case for POST or PUT requests.

Cheers !
