### PR TITLE
Data: Fix to .data update if key was added as-is

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -123,7 +123,12 @@ function internalData( elem, name, data, pvt /* Internal Use Only */ ) {
 	}
 
 	if ( data !== undefined ) {
-		thisCache[ jQuery.camelCase( name ) ] = data;
+		thisCache[ 
+			//check if key exist as-is and update
+			thisCache[ name ] ? name :
+			//convert to camelCase and update
+			jQuery.camelCase( name ) 
+		] = data;
 	}
 
 	// Check for both converted-to-camel and non-converted data property names

--- a/src/data.js
+++ b/src/data.js
@@ -123,12 +123,8 @@ function internalData( elem, name, data, pvt /* Internal Use Only */ ) {
 	}
 
 	if ( data !== undefined ) {
-		thisCache[ 
-			//check if key exist as-is and update
-			thisCache[ name ] ? name :
-			//convert to camelCase and update
-			jQuery.camelCase( name ) 
-		] = data;
+		//check if key exist as-is else convert to camelCase and update
+		thisCache[ thisCache[ name ] ? name : jQuery.camelCase( name ) ] = data;
 	}
 
 	// Check for both converted-to-camel and non-converted data property names

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -678,18 +678,18 @@ test( "JSON data- attributes can have newlines", function() {
 	x.remove();
 });
 
-/*testIframeWithCallback( "enumerate data attrs on body (#14894)", "data/dataAttrs.html", function( result ) {
+testIframeWithCallback( "enumerate data attrs on body (#14894)", "data/dataAttrs.html", function( result ) {
 	expect(1);
 
 	equal(result, "ok", "enumeration of data- attrs on body" );
-});*/
+});
 
 test(".data should update as-is if added without camel casing (PR 1.x-master #1905)", function() {
 	expect(5);
 	var div = jQuery("<div></div>").prependTo("body");
 	div.data({
 		"data-test-1": "data1",
-		"data-test-2": "data2",
+		"data-test-2": "data2"
 	});
 	equal( div.data()["data-test-1"], "data1", "Verifing data update succesful with object" );
 	
@@ -698,11 +698,11 @@ test(".data should update as-is if added without camel casing (PR 1.x-master #19
 	equal( div.data()["dataTest1"], undefined, "Verifying it is not camel cased when adding as object" );
 	
 	//update data-test-1
-	div.data('data-test-1', 'data1_updated');
-	equal( div.data()["data-test-1"], 'data1_updated', "Verifying .update() updating the right data" );
+	div.data("data-test-1", "data1_updated");
+	equal( div.data()["data-test-1"], "data1_updated", "Verifying .update() updating the right data" );
 	
 	//remove data-test-1 and data-test-2
-	div.removeData(['data-test-1', 'data-test-2']);
+	div.removeData(["data-test-1", "data-test-2"]);
 	equal( div.data()["data-test-1"], undefined, "Verifying remove of data-test-1 deleting the right data" );
 	equal( div.data()["data-test-2"], undefined, "Verifying remove of data-test-2 deleting the right data" );
 	div.remove();

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -678,8 +678,32 @@ test( "JSON data- attributes can have newlines", function() {
 	x.remove();
 });
 
-testIframeWithCallback( "enumerate data attrs on body (#14894)", "data/dataAttrs.html", function( result ) {
+/*testIframeWithCallback( "enumerate data attrs on body (#14894)", "data/dataAttrs.html", function( result ) {
 	expect(1);
 
 	equal(result, "ok", "enumeration of data- attrs on body" );
+});*/
+
+test(".data should update as-is if added without camel casing (PR 1.x-master #1905)", function() {
+	expect(5);
+	var div = jQuery("<div></div>").prependTo("body");
+	div.data({
+		"data-test-1": "data1",
+		"data-test-2": "data2",
+	});
+	equal( div.data()["data-test-1"], "data1", "Verifing data update succesful with object" );
+	
+	//the purpose of the below test is to remove this patch once we stop using $.extend to create data 
+	//when using object notation. This is expected to fail if jQuery decides to camelCase always.
+	equal( div.data()["dataTest1"], undefined, "Verifying it is not camel cased when adding as object" );
+	
+	//update data-test-1
+	div.data('data-test-1', 'data1_updated');
+	equal( div.data()["data-test-1"], 'data1_updated', "Verifying .update() updating the right data" );
+	
+	//remove data-test-1 and data-test-2
+	div.removeData(['data-test-1', 'data-test-2']);
+	equal( div.data()["data-test-1"], undefined, "Verifying remove of data-test-1 deleting the right data" );
+	equal( div.data()["data-test-2"], undefined, "Verifying remove of data-test-2 deleting the right data" );
+	div.remove();
 });


### PR DESCRIPTION
When adding data using object argument, the keys are not camel cased as internally it uses `.extend` to create data cache. This fails when trying to update the value currently as the update is always camel cased. 

Test Scenario: Creating a data using [object argument](http://api.jquery.com/data/#data-obj) with keys in object has dash(es).

````
//creates a data for the element with keys data-test-1 and data-test-2 
$('#data-test').data({'data-test-1': 1, 'data-test-2': 2}); 
//logs 1
console.log($('#data-test').data('data-test-1'));
//creates a new data dataTest1 and updates the value 4
$('#data-test').data('data-test-1', 4);
//still logs 1 as the update didn't actually update the value
console.log($('#data-test').data('data-test-1'));
````

Test Case: http://jsfiddle.net/c0k0owkq/

![jq](https://cloud.githubusercontent.com/assets/1577203/5320813/6fdb0344-7c83-11e4-992c-0a04b93e0834.png)

The fix is to either use a different method instead of `.extend` to add data from an object or check if the key exist as-is when updating. The later was an easy change.