### PR TITLE
Serialize: Ignore inherited properties

### DIFF
--- a/src/serialize.js
+++ b/src/serialize.js
@@ -36,7 +36,9 @@ function buildParams( prefix, obj, traditional, add ) {
 	} else if ( !traditional && jQuery.type( obj ) === "object" ) {
 		// Serialize object item.
 		for ( name in obj ) {
-			buildParams( prefix + "[" + name + "]", obj[ name ], traditional, add );
+			if ( obj.hasOwnProperty( name ) ) {
+				buildParams( prefix + "[" + name + "]", obj[ name ], traditional, add );
+			}
 		}
 
 	} else {
@@ -72,7 +74,9 @@ jQuery.param = function( a, traditional ) {
 		// If traditional, encode the "old" way (the way 1.3.2 or older
 		// did it), otherwise encode params recursively.
 		for ( prefix in a ) {
-			buildParams( prefix, a[ prefix ], traditional, add );
+			if ( a.hasOwnProperty( prefix ) ) {
+				buildParams( prefix, a[ prefix ], traditional, add );
+			}
 		}
 	}
 

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -85,7 +85,7 @@ test("jQuery.param()", function() {
 });
 
 test("jQuery.param() Constructed prop values", function() {
-	expect( 4 );
+	expect( 5 );
 
 	/** @constructor */
 	function Record() {
@@ -107,6 +107,12 @@ test("jQuery.param() Constructed prop values", function() {
 	// should allow non-native constructed objects
 	params = { "test": new Record() };
 	equal( jQuery.param( params, false ), jQuery.param({ "test": { "prop": "val" } }), "Allow non-native constructed objects" );
+
+	Record.prototype.inheritedProp = "inheritedVal";
+	params = { "test": new Record() };
+	params.test.nestedRecord = new Record();
+	equal( jQuery.param( params, false ), jQuery.param({ "test": { "prop": "val", "nestedRecord": { "prop": "val" } } }), "Ignore inherited properties");
+
 });
 
 test("serialize()", function() {


### PR DESCRIPTION
Hi,

I think that jQuery.param() should not encode an object's inherited enumerable properties.

If encoding inherithed enumerable properties along with own ones is the expected behavior instead, I would recommend to add a test for the serialize module that makes it explicit.

Thank you for your amazing work.
Francesco
