### PR TITLE
Build: Specify valid components for commit messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,30 @@
     "build": "npm install && grunt",
     "start": "grunt watch",
     "test": "grunt"
+  },
+  "commitplease": {
+    "components": [
+      "Docs",
+      "Tests",
+      "Build",
+      "Release",
+
+      "Core",
+      "Ajax",
+      "Attributes",
+      "Callbacks",
+      "CSS",
+      "Data",
+      "Deferred",
+      "Dimensions",
+      "Effects",
+      "Event",
+      "Manipulation",
+      "Offset",
+      "Queue",
+      "Selector",
+      "Serialize",
+      "Traversing"
+    ]
   }
 }


### PR DESCRIPTION
I didn't see a sane place to reference the bypass prefixes (cf. https://github.com/jzaefferer/commitplease#usage ), but they really should be publicized to contributors to prevent unnecessary frustration.

Ref https://github.com/jzaefferer/commitplease/issues/23