### PR TITLE
Manipulation: improve test for data-URI

### DIFF
--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -2462,15 +2462,28 @@ test( "Make sure jQuery.fn.remove can work on elements in documentFragment", 1, 
 	equal( fragment.childNodes.length, 0, "div element was removed from documentFragment" );
 });
 
-// IE8 doesn't support data-URI in src attribute of script element
-// Relevant - http://msdn.microsoft.com/en-us/library/cc848897(v=vs.85).aspx
-if ( !/msie 8\.0/i.test( navigator.userAgent ) ) {
-	asyncTest( "Insert script with data-URI (gh-1887)", 1, function() {
-		Globals.register( "testFoo" );
-		jQuery( "#qunit-fixture" ).append( "<script src=\"data:text/javascript,testFoo = 'foo';\"></script>" );
-		setTimeout(function (){
-			strictEqual( window[ "testFoo" ], "foo", "data-URI script executed" );
-			start();
-		}, 100 );
+asyncTest( "Insert script with data-URI (gh-1887)", 1, function() {
+	Globals.register( "testFoo" );
+	Globals.register( "testSrcFoo" );
+
+	var script = document.createElement( "script" ),
+		fixture = document.getElementById( "qunit-fixture" );
+
+	script.src = "data:text/javascript,testSrcFoo = 'foo';";
+
+	fixture.appendChild( script );
+
+	jQuery( fixture ).append( "<script src=\"data:text/javascript,testFoo = 'foo';\"></script>" );
+
+	setTimeout(function() {
+		if ( window[ "testSrcFoo" ] === "foo" ) {
+			strictEqual( window[ "testFoo" ], window[ "testSrcFoo" ], "data-URI script executed" );
+
+		} else {
+			ok( true, "data-URI script is not supported by this environment" );
+		}
+
+		start();
 	});
-}
+});
+


### PR DESCRIPTION
Some environments do not support data-uri in "src" attribute of script element.
Mitigate it with equality assertion.

/cc @mzgol 
