### PR TITLE
Data: shave off a couple of bytes.

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -1,10 +1,9 @@
 define([
 	"./core",
-	"./var/rnotwhite",
 	"./core/access",
 	"./data/var/dataPriv",
 	"./data/var/dataUser"
-], function( jQuery, rnotwhite, access, dataPriv, dataUser ) {
+], function( jQuery, access, dataPriv, dataUser ) {
 
 //	Implementation Summary
 //
@@ -17,7 +16,7 @@ define([
 //	6. Provide a clear path for implementation upgrade to WeakMap in 2014
 
 var rbrace = /^(?:\{[\w\W]*\}|\[[\w\W]*\])$/,
-	rmultiDash = /([A-Z])/g;
+	rmultiDash = /[A-Z]/g;
 
 function dataAttr( elem, key, data ) {
 	var name;
@@ -25,7 +24,7 @@ function dataAttr( elem, key, data ) {
 	// If nothing was found internally, try to fetch any
 	// data from the HTML5 data-* attribute
 	if ( data === undefined && elem.nodeType === 1 ) {
-		name = "data-" + key.replace( rmultiDash, "-$1" ).toLowerCase();
+		name = "data-" + key.replace( rmultiDash, "-$&" ).toLowerCase();
 		data = elem.getAttribute( name );
 
 		if ( typeof data === "string" ) {


### PR DESCRIPTION
Just a primitive changeset to drop a couple of bytes:
1. Remove unused varialbe `rnotwhite` in `src/data.js` — doesn't change the size but clarifies the code;
2. Change the RegExp used to convert camelCase to dash.

Tested in all modern desktop browsers + iOS 7 + Android 4. I think it will also work in iOS 6 and Android 2.3
Just in case, performance test: http://jsperf.com/camelcase-to-dash

```
   raw     gz Sizes                                                            
245620  72741 dist/jquery.js                                                   
 84039  29325 dist/jquery.min.js                                               

   raw     gz Compared to master @ ce308e25e57a0a040cd1ea05f00bf1cc23c1bd8a    
    -2     -2 dist/jquery.js                                                   
    -2     -1 dist/jquery.min.js         
```
