### PR TITLE
Core: add location global for non-browsers, fix #1788

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -14,6 +14,9 @@ var
 	// Use the correct document accordingly with window argument (sandbox)
 	document = window.document,
 
+	// Add a location global for non-browser environments
+	location = window.location, // jshint ignore:line
+
 	version = "@VERSION",
 
 	// Define a local copy of jQuery


### PR DESCRIPTION
This is a simple fix that will also prevent future problems with this.
Of course, it would be nice to add a test, but I think it's a bit beyond the scope at the moment.
Poke #1788.
