### PR TITLE
Event: Add reference to data module ...

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -6,7 +6,7 @@ define([
 	"./event/support",
 
 	"./core/init",
-	"./data/accepts",
+	"./data",
 	"./selector"
 ], function( jQuery, rnotwhite, hasOwn, slice, support ) {
 


### PR DESCRIPTION
Since we are using _data() quite a lot in event.js, it deserves a ref.
(It is actually broken if we reference unpacked jquery.js using AMD loader, an exception will be thrown at line:314 of event.js)

ps: on master branch, the "event.js" already correctly referenced prvtData which is the equivalent of _data(), so no fix needed for that.
