### PR TITLE
Offset: `$.fn.offset()` on element inside shadowRoot

### DIFF
--- a/src/offset.js
+++ b/src/offset.js
@@ -96,10 +96,6 @@ jQuery.fn.extend({
 
 		// We have element in ShadowDOM, need recursive traversal from element to its parent
 		if ( elem.matches && elem.matches( ":host *" ) ) {
-			if ( !elem.getBoundingClientRect ) {
-				return box;
-			}
-
 			// Make sure it's not a disconnected DOM node
 			while ( true ) {
 				elemParent = elemParent.parentNode || elemParent.host;

--- a/src/offset.js
+++ b/src/offset.js
@@ -97,7 +97,7 @@ jQuery.fn.extend({
 		// We have element in ShadowDOM, need recursive traversal from element to its parent
 		// First checking for shadowRoot creation support
 		// If that is present - we have non-prefixed element.matches() support
-		if ( Element.prototype.createShadowRoot && elem.matches( ":host *" ) ) {
+		if ( elem.createShadowRoot && elem.matches( ":host *" ) ) {
 			// Make sure it's not a disconnected DOM node
 			while ( true ) {
 				elemParent = elemParent.parentNode || elemParent.host;

--- a/src/offset.js
+++ b/src/offset.js
@@ -92,21 +92,29 @@ jQuery.fn.extend({
 			return;
 		}
 
-		if ( !elem.getBoundingClientRect ) {
-			return box;
-		}
+		docElem = doc.documentElement;
 
-		// Make sure it's not a disconnected DOM node
-		while ( true ) {
-			elemParent = elemParent.parentNode || elemParent.host;
-			if ( elemParent === doc ) {
-				break;
-			} else if ( !elemParent ) {
+		// We have element in ShadowDOM, need recursive traversal from element to its parent
+		if ( elem.matches && elem.matches( ":host *" ) ) {
+			if ( !elem.getBoundingClientRect ) {
+				return box;
+			}
+
+			// Make sure it's not a disconnected DOM node
+			while ( true ) {
+				elemParent = elemParent.parentNode || elemParent.host;
+				if ( elemParent === doc ) {
+					break;
+				} else if ( !elemParent ) {
+					return box;
+				}
+			}
+		} else {
+			// Make sure it's not a disconnected DOM node
+			if ( !jQuery.contains( docElem, elem ) ) {
 				return box;
 			}
 		}
-
-		docElem = doc.documentElement;
 
 		box = elem.getBoundingClientRect();
 		win = getWindow( doc );

--- a/src/offset.js
+++ b/src/offset.js
@@ -85,18 +85,28 @@ jQuery.fn.extend({
 		var docElem, win,
 			elem = this[ 0 ],
 			box = { top: 0, left: 0 },
-			doc = elem && elem.ownerDocument;
+			doc = elem && elem.ownerDocument,
+			elemParent = elem;
 
 		if ( !doc ) {
 			return;
 		}
 
-		docElem = doc.documentElement;
-
-		// Make sure it's not a disconnected DOM node
-		if ( !jQuery.contains( docElem, elem ) ) {
+		if ( !elem.getBoundingClientRect ) {
 			return box;
 		}
+
+		// Make sure it's not a disconnected DOM node
+		while ( true ) {
+			elemParent = elemParent.parentNode || elemParent.host;
+			if ( elemParent === doc ) {
+				break;
+			} else if ( !elemParent ) {
+				return box;
+			}
+		}
+
+		docElem = doc.documentElement;
 
 		box = elem.getBoundingClientRect();
 		win = getWindow( doc );

--- a/src/offset.js
+++ b/src/offset.js
@@ -95,7 +95,9 @@ jQuery.fn.extend({
 		docElem = doc.documentElement;
 
 		// We have element in ShadowDOM, need recursive traversal from element to its parent
-		if ( elem.matches && elem.matches( ":host *" ) ) {
+		// First checking for shadowRoot creation support
+		// If that is present - we have non-prefixed element.matches() support
+		if ( Element.prototype.createShadowRoot && elem.matches( ":host *" ) ) {
 			// Make sure it's not a disconnected DOM node
 			while ( true ) {
 				elemParent = elemParent.parentNode || elemParent.host;

--- a/test/data/offset/shadowdom.html
+++ b/test/data/offset/shadowdom.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<title>shadowdom</title>
+		<style type="text/css" media="screen">
+			body::shadow div {
+				left     : 30px;
+				position : absolute;
+				top      : 20px;
+			}
+		</style>
+		<script src="../../jquery.js"></script>
+		<script>
+			jQuery(function() {
+				var body = document.body;
+				body.createShadowRoot();
+				body.shadowRoot.appendChild(
+					document.createElement('div')
+				);
+			});
+		</script>
+	</head>
+	<body></body>
+</html>

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -65,7 +65,7 @@ test("disconnected node", function() {
 	equal( result.left, 0, "Check left" );
 });
 
-(!document.body.createShadowRoot ? QUnit.skip : testIframe)("offset/shadowdom", "working inside shadowDOM", function($, iframe) {
+( !Element.prototype.createShadowRoot ? QUnit.skip : testIframe )("offset/shadowdom", "working inside shadowDOM", function($, iframe) {
 	expect(2);
 
 	var result = $(iframe.document.body.shadowRoot.querySelector("div")).offset();

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -68,7 +68,7 @@ test("disconnected node", function() {
 (!document.body.createShadowRoot ? QUnit.skip : testIframe)("offset/shadowdom", "working inside shadowDOM", function($, iframe) {
 	expect(2);
 
-	var result = $(iframe.document.body.shadowRoot.querySelector('div')).offset();
+	var result = $(iframe.document.body.shadowRoot.querySelector("div")).offset();
 
 	equal( result.top, 20, "Check top" );
 	equal( result.left, 30, "Check left" );

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -65,6 +65,15 @@ test("disconnected node", function() {
 	equal( result.left, 0, "Check left" );
 });
 
+(!document.body.createShadowRoot ? QUnit.skip : testIframe)("offset/shadowdom", "working inside shadowDOM", function($, iframe) {
+	expect(2);
+
+	var result = $(iframe.document.body.shadowRoot.querySelector('div')).offset();
+
+	equal( result.top, 20, "Check top" );
+	equal( result.left, 30, "Check left" );
+});
+
 testIframe("offset/absolute", "absolute", function($, iframe) {
 	expect(4);
 


### PR DESCRIPTION
`$.fn.offset()` didn't worked on `html>...>shadowRoot>...>target_element`, while `target_element.getBoundingClientRect` worked fine with correct result.
The reason was that check for disconnected node made by checking whether `document` contains `target_element` fails, which is correct, element inside shadowDOM, not in main DOM.

That is why I've added recursive traversal from element to its parent until it reaches `document` or until `parent_element.parentNode` is `falsy` (for disconnected nodes it will be `null`, if pass some badly composed object - it may be `undefined`, so, just `falsy`, in this case we just return).
If we encounter `DocumentFragment` (`shadowRoot`), we take `parent_element.host` property instead of `parent_element.parentNode` in order to get parent element of that `shadowRoot`.
Also it was necessary to add explicit check for `target_element.getBoundingClientRect` property.

This is modern, Web Components-aware version of ea507b3e998126ae1f94f4fd1618994d645c9cc8