### PR TITLE
Event: fixing pageX/pageY mouse information in drag events

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -14,7 +14,7 @@ define([
 
 var
 	rkeyEvent = /^key/,
-	rmouseEvent = /^(?:mouse|pointer|contextmenu)|click/,
+	rmouseEvent = /^(?:mouse|pointer|contextmenu|drag)|click/,
 	rfocusMorph = /^(?:focusinfocus|focusoutblur)$/,
 	rtypenamespace = /^([^.]*)(?:\.(.+)|)/;
 

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -2444,6 +2444,20 @@ test("fixHooks extensions", function() {
 	jQuery.event.fixHooks.click = saved;
 });
 
+test( "drag events copy over mouse related event properties (#1925)", function() {
+	expect( 2 );
+
+	var $fixture = jQuery( "<div id='drag-fixture'></div>" ).appendTo( "body" );
+
+	$fixture.bind( "dragmove", function( evt ) {
+		ok( "pageX" in evt, "checking for pageX property" );
+		ok( "pageY" in evt, "checking for pageY property" );
+	});
+
+	fireNative( $fixture[ 0 ], "dragmove" );
+	$fixture.unbind( "dragmove" ).remove();
+});
+
 test( "focusin using non-element targets", function() {
 	expect( 2 );
 


### PR DESCRIPTION
Copy over drag event properties from mouse events, fixes #1925.
See [here](https://github.com/jquery/jquery/blob/master/src/event.js#L524-L538) for where the actual copying happens.
