### PR TITLE
Build: Remove dates from copyright notice

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -137,7 +137,7 @@ module.exports = function( grunt ) {
 						"ascii_only": true
 					},
 					banner: "/*! jQuery v<%= pkg.version %> | " +
-						"Copyright jQuery Foundation and other contributors " +
+						"(c) jQuery Foundation, Inc. | " +
 						"jquery.org/license */",
 					compress: {
 						"hoist_funs": false,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -137,7 +137,7 @@ module.exports = function( grunt ) {
 						"ascii_only": true
 					},
 					banner: "/*! jQuery v<%= pkg.version %> | " +
-						"(c) 2005, <%= grunt.template.today('yyyy') %> jQuery Foundation, Inc. | " +
+						"Copyright jQuery Foundation and other contributors " +
 						"jquery.org/license */",
 					compress: {
 						"hoist_funs": false,

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,4 @@
-Copyright 2005, 2014 jQuery Foundation and other contributors,
-https://jquery.org/
+Copyright jQuery Foundation and other contributors, https://jquery.org/
 
 This software consists of voluntary contributions made by many
 individuals. For exact contribution history, see the revision history

--- a/src/intro.js
+++ b/src/intro.js
@@ -5,7 +5,7 @@
  * Includes Sizzle.js
  * http://sizzlejs.com/
  *
- * Copyright 2005, 2014 jQuery Foundation, Inc. and other contributors
+ * Copyright jQuery Foundation and other contributors
  * Released under the MIT license
  * http://jquery.org/license
  *


### PR DESCRIPTION
I'm not too sure about the change in Gruntfile.js, so please let me know if you would like it to be different, e,g, whether the jquery.org/license should be on the same line as the Copyright notice, whether it should be https://jquery.org/ or https://jquery.org/license also, or anything else.