### PR TITLE
Callbacks: Update locking behavior

### DIFF
--- a/src/callbacks.js
+++ b/src/callbacks.js
@@ -190,7 +190,7 @@ jQuery.Callbacks = function( options ) {
 			lock: function() {
 				stack = undefined;
 				locked = true;
-				if ( !memory ) {
+				if ( !memory && !firing ) {
 					self.disable();
 				}
 				return this;

--- a/src/callbacks.js
+++ b/src/callbacks.js
@@ -51,6 +51,8 @@ jQuery.Callbacks = function( options ) {
 		memory,
 		// Flag to know if list was already fired
 		fired,
+		// Flag to prevent .fire/.fireWith
+		locked,
 		// End of the loop when firing
 		firingLength,
 		// Index of currently firing callback (modified by remove if needed)
@@ -63,6 +65,7 @@ jQuery.Callbacks = function( options ) {
 		stack = !options.once && [],
 		// Fire callbacks
 		fire = function( data ) {
+			locked = options.once;
 			memory = options.memory && data;
 			fired = true;
 			firingIndex = firingStart || 0;
@@ -78,13 +81,21 @@ jQuery.Callbacks = function( options ) {
 				}
 			}
 			firing = false;
+
+			// If not disabled,
 			if ( list ) {
+
+				// If repeatable, check for pending execution
 				if ( stack ) {
 					if ( stack.length ) {
 						fire( stack.shift() );
 					}
+
+				// If not repeatable but with memory, clear out spent callbacks
 				} else if ( memory ) {
 					list = [];
+
+				// Else, disable
 				} else {
 					self.disable();
 				}
@@ -123,6 +134,7 @@ jQuery.Callbacks = function( options ) {
 				}
 				return this;
 			},
+
 			// Remove a callback from the list
 			remove: function() {
 				if ( list ) {
@@ -144,11 +156,13 @@ jQuery.Callbacks = function( options ) {
 				}
 				return this;
 			},
+
 			// Check if a given callback is in the list.
 			// If no argument is given, return whether or not list has callbacks attached.
 			has: function( fn ) {
 				return fn ? jQuery.inArray( fn, list ) > -1 : !!( list && list.length );
 			},
+
 			// Remove all callbacks from the list
 			empty: function() {
 				if ( list ) {
@@ -157,30 +171,37 @@ jQuery.Callbacks = function( options ) {
 				}
 				return this;
 			},
-			// Have the list do nothing anymore
+
+			// Disable .fire and .add
+			// Abort any current/pending executions
+			// Clear all callbacks and values
 			disable: function() {
 				list = stack = memory = undefined;
+				locked = true;
 				return this;
 			},
-			// Is it disabled?
 			disabled: function() {
 				return !list;
 			},
-			// Lock the list in its current state
+
+			// Disable .fire
+			// Also disable .add unless we have memory (since it would have no effect)
+			// Abort any pending executions
 			lock: function() {
 				stack = undefined;
+				locked = true;
 				if ( !memory ) {
 					self.disable();
 				}
 				return this;
 			},
-			// Is it locked?
 			locked: function() {
-				return !stack;
+				return !!locked;
 			},
+
 			// Call all callbacks with the given context and arguments
 			fireWith: function( context, args ) {
-				if ( list && ( !fired || stack ) ) {
+				if ( !locked ) {
 					args = args || [];
 					args = [ context, args.slice ? args.slice() : args ];
 					if ( firing ) {
@@ -191,11 +212,13 @@ jQuery.Callbacks = function( options ) {
 				}
 				return this;
 			},
+
 			// Call all the callbacks with the given arguments
 			fire: function() {
 				self.fireWith( this, arguments );
 				return this;
 			},
+
 			// To know if the callbacks have already been called at least once
 			fired: function() {
 				return !!fired;

--- a/test/unit/callbacks.js
+++ b/test/unit/callbacks.js
@@ -65,11 +65,7 @@ jQuery.each( tests, function( strFlags, resultString ) {
 
 				test( "jQuery.Callbacks( " + showFlags( flags ) + " ) - " + filterLabel, function() {
 
-					expect( 21 );
-
-					// Give qunit a little breathing room
-					stop();
-					setTimeout( start, 0 );
+					expect( 28 );
 
 					var cblist,
 						results = resultString.split( /\s+/ );
@@ -77,10 +73,14 @@ jQuery.each( tests, function( strFlags, resultString ) {
 					// Basic binding and firing
 					output = "X";
 					cblist = jQuery.Callbacks( flags );
+					strictEqual( cblist.locked(), false, ".locked() initially false" );
+					strictEqual( cblist.disabled(), false, ".disabled() initially false" );
+					strictEqual( cblist.fired(), false, ".fired() initially false" );
 					cblist.add(function( str ) {
 						output += str;
 					});
-					cblist.fire("A");
+					strictEqual( cblist.fired(), false, ".fired() still false after .add" );
+					cblist.fire( "A" );
 					strictEqual( output, "XA", "Basic binding and firing" );
 					strictEqual( cblist.fired(), true, ".fired() detects firing" );
 					output = "X";
@@ -91,6 +91,8 @@ jQuery.each( tests, function( strFlags, resultString ) {
 					strictEqual( output, "X", "Adding a callback after disabling" );
 					cblist.fire("A");
 					strictEqual( output, "X", "Firing after disabling" );
+					strictEqual( cblist.disabled(), true, ".disabled() becomes true" );
+					strictEqual( cblist.locked(), true, "disabling locks" );
 
 					// #13517 - Emptying while firing
 					cblist = jQuery.Callbacks( flags );
@@ -160,6 +162,7 @@ jQuery.each( tests, function( strFlags, resultString ) {
 						output += str;
 					});
 					strictEqual( output, "X", "Lock early" );
+					strictEqual( cblist.locked(), true, "Locking reflected in accessor" );
 
 					// Ordering
 					output = "X";

--- a/test/unit/callbacks.js
+++ b/test/unit/callbacks.js
@@ -65,7 +65,7 @@ jQuery.each( tests, function( strFlags, resultString ) {
 
 				test( "jQuery.Callbacks( " + showFlags( flags ) + " ) - " + filterLabel, function() {
 
-					expect( 28 );
+					expect( 29 );
 
 					var cblist,
 						results = resultString.split( /\s+/ );
@@ -94,7 +94,7 @@ jQuery.each( tests, function( strFlags, resultString ) {
 					strictEqual( cblist.disabled(), true, ".disabled() becomes true" );
 					strictEqual( cblist.locked(), true, "disabling locks" );
 
-					// #13517 - Emptying while firing
+					// Emptying while firing (#13517)
 					cblist = jQuery.Callbacks( flags );
 					cblist.add( cblist.empty );
 					cblist.add( function() {
@@ -163,6 +163,16 @@ jQuery.each( tests, function( strFlags, resultString ) {
 					});
 					strictEqual( output, "X", "Lock early" );
 					strictEqual( cblist.locked(), true, "Locking reflected in accessor" );
+
+					// Locking while firing (gh-1990)
+					output = "X";
+					cblist = jQuery.Callbacks( flags );
+					cblist.add( cblist.lock );
+					cblist.add(function( str ) {
+						output += str;
+					});
+					cblist.fire( "A" );
+					strictEqual( output, "XA", "Locking doesn't abort execution (gh-1990)" );
 
 					// Ordering
 					output = "X";
@@ -331,8 +341,6 @@ test( "jQuery.Callbacks.has", function() {
 	strictEqual( cb.has(), true, "Check if unique list has callback function(s) attached" );
 	cb.lock();
 	strictEqual( cb.has(), false, "locked() list is empty and returns false" );
-
-
 });
 
 test( "jQuery.Callbacks() - adding a string doesn't cause a stack overflow", function() {


### PR DESCRIPTION
Fixes gh-1989
Fixes gh-1990

```
   raw     gz Compared to compat @ 2866da9e12b7cf339667ae894ffe072f4eb673de    
  +398   +108 dist/jquery.js                                                   
   +18    +17 dist/jquery.min.js
```

I isolated size reduction into a [followup branch](https://github.com/gibson042/jquery/tree/2015-01-callbacks-reduce) this time. [Applying it](https://github.com/gibson042/jquery/compare/2015-01-callbacks...2015-01-callbacks-reduce) (which should happen together with landing this PR) changes the above as follows:
```
   raw     gz Compared to compat @ 2866da9e12b7cf339667ae894ffe072f4eb673de    
   -85     -8 dist/jquery.js                                                   
   -83    -52 dist/jquery.min.js
```