### PR TITLE
Core: Remove deprecated context and selector properties

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -40,9 +40,6 @@ jQuery.fn = jQuery.prototype = {
 
 	constructor: jQuery,
 
-	// Start with an empty selector
-	selector: "",
-
 	// The default length of a jQuery object is 0
 	length: 0,
 
@@ -71,7 +68,6 @@ jQuery.fn = jQuery.prototype = {
 
 		// Add the old object onto the stack (as a reference)
 		ret.prevObject = this;
-		ret.context = this.context;
 
 		// Return the newly-formed element set
 		return ret;

--- a/src/core/init.js
+++ b/src/core/init.js
@@ -73,12 +73,9 @@ var rootjQuery,
 
 					if ( elem ) {
 						// Inject the element directly into the jQuery object
-						this.length = 1;
 						this[0] = elem;
+						this.length = 1;
 					}
-
-					this.context = document;
-					this.selector = selector;
 					return this;
 				}
 
@@ -94,7 +91,7 @@ var rootjQuery,
 
 		// HANDLE: $(DOMElement)
 		} else if ( selector.nodeType ) {
-			this.context = this[0] = selector;
+			this[0] = selector;
 			this.length = 1;
 			return this;
 
@@ -105,11 +102,6 @@ var rootjQuery,
 				rootjQuery.ready( selector ) :
 				// Execute immediately if ready is not present
 				selector( jQuery );
-		}
-
-		if ( selector.selector !== undefined ) {
-			this.selector = selector.selector;
-			this.context = selector.context;
 		}
 
 		return jQuery.makeArray( selector, this );

--- a/src/traversing/findFilter.js
+++ b/src/traversing/findFilter.js
@@ -72,10 +72,7 @@ jQuery.fn.extend({
 			jQuery.find( selector, self[ i ], ret );
 		}
 
-		// Needed because $( selector, context ) becomes $( context ).find( selector )
-		ret = this.pushStack( len > 1 ? jQuery.unique( ret ) : ret );
-		ret.selector = this.selector ? this.selector + " " + selector : selector;
-		return ret;
+		return this.pushStack( len > 1 ? jQuery.unique( ret ) : ret );
 	},
 	filter: function( selector ) {
 		return this.pushStack( winnow(this, selector || [], false) );

--- a/test/index.html
+++ b/test/index.html
@@ -25,7 +25,6 @@
 	<!-- iframes will not load AMD as loading needs to be synchronous for some tests -->
 	<!-- Also executes the function above to load tests -->
 	<script src="jquery.js"></script>
-	<script src="jquery-migrate.js"></script>
 
 	<script>
 		// Load tests if they have not been loaded

--- a/test/index.html
+++ b/test/index.html
@@ -25,6 +25,7 @@
 	<!-- iframes will not load AMD as loading needs to be synchronous for some tests -->
 	<!-- Also executes the function above to load tests -->
 	<script src="jquery.js"></script>
+	<script src="jquery-migrate.js"></script>
 
 	<script>
 		// Load tests if they have not been loaded

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -57,7 +57,7 @@ test("jQuery()", function() {
 	equal( jQuery(undefined).length, 0, "jQuery(undefined) === jQuery([])" );
 	equal( jQuery(null).length, 0, "jQuery(null) === jQuery([])" );
 	equal( jQuery("").length, 0, "jQuery('') === jQuery([])" );
-	equal( jQuery(obj).selector, "div", "jQuery(jQueryObj) == jQueryObj" );
+	deepEqual( jQuery(obj).get(), obj.get(), "jQuery(jQueryObj) == jQueryObj" );
 
 	// Invalid #id goes to Sizzle which will throw an error (gh-1682)
 	try {
@@ -154,49 +154,6 @@ test("jQuery(selector, context)", function() {
 	deepEqual( jQuery("div p", "#qunit-fixture").get(), q("sndp", "en", "sap"), "Basic selector with string as context" );
 	deepEqual( jQuery("div p", q("qunit-fixture")[0]).get(), q("sndp", "en", "sap"), "Basic selector with element as context" );
 	deepEqual( jQuery("div p", jQuery("#qunit-fixture")).get(), q("sndp", "en", "sap"), "Basic selector with jQuery object as context" );
-});
-
-test( "selector state", function() {
-	expect( 18 );
-
-	var test;
-
-	test = jQuery( undefined );
-	equal( test.selector, "", "Empty jQuery Selector" );
-	equal( test.context, undefined, "Empty jQuery Context" );
-
-	test = jQuery( document );
-	equal( test.selector, "", "Document Selector" );
-	equal( test.context, document, "Document Context" );
-
-	test = jQuery( document.body );
-	equal( test.selector, "", "Body Selector" );
-	equal( test.context, document.body, "Body Context" );
-
-	test = jQuery("#qunit-fixture");
-	equal( test.selector, "#qunit-fixture", "#qunit-fixture Selector" );
-	equal( test.context, document, "#qunit-fixture Context" );
-
-	test = jQuery("#notfoundnono");
-	equal( test.selector, "#notfoundnono", "#notfoundnono Selector" );
-	equal( test.context, document, "#notfoundnono Context" );
-
-	test = jQuery( "#qunit-fixture", document );
-	equal( test.selector, "#qunit-fixture", "#qunit-fixture Selector" );
-	equal( test.context, document, "#qunit-fixture Context" );
-
-	test = jQuery( "#qunit-fixture", document.body );
-	equal( test.selector, "#qunit-fixture", "#qunit-fixture Selector" );
-	equal( test.context, document.body, "#qunit-fixture Context" );
-
-	// Test cloning
-	test = jQuery( test );
-	equal( test.selector, "#qunit-fixture", "#qunit-fixture Selector" );
-	equal( test.context, document.body, "#qunit-fixture Context" );
-
-	test = jQuery( document.body ).find("#qunit-fixture");
-	equal( test.selector, "#qunit-fixture", "#qunit-fixture find Selector" );
-	equal( test.context, document.body, "#qunit-fixture find Context" );
 });
 
 test( "globalEval", function() {

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -462,9 +462,9 @@ testIframe("offset/body", "body", function( $ ) {
 test("chaining", function() {
 	expect(3);
 	var coords = { "top":  1, "left":  1 };
-	equal( jQuery("#absolute-1").offset(coords).selector, "#absolute-1", "offset(coords) returns jQuery object" );
-	equal( jQuery("#non-existent").offset(coords).selector, "#non-existent", "offset(coords) with empty jQuery set returns jQuery object" );
-	equal( jQuery("#absolute-1").offset(undefined).selector, "#absolute-1", "offset(undefined) returns jQuery object (#5571)" );
+	equal( jQuery("#absolute-1").offset(coords).jquery, jQuery.fn.jquery, "offset(coords) returns jQuery object" );
+	equal( jQuery("#non-existent").offset(coords).jquery, jQuery.fn.jquery, "offset(coords) with empty jQuery set returns jQuery object" );
+	equal( jQuery("#absolute-1").offset(undefined).jquery, jQuery.fn.jquery, "offset(undefined) returns jQuery object (#5571)" );
 });
 
 test("offsetParent", function(){


### PR DESCRIPTION
Fixes gh-1908

Ref https://github.com/jquery/jquery-migrate/issues/79