### PR TITLE
Adding a simple symbol to separate the description ':'

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,5 +367,5 @@ testIframeWithCallback( testName, fileName, callback );
 Questions?
 ----------
 
-If you have any questions, please feel free to ask on the
+If you have any questions, please feel free to ask on the:
 [Developing jQuery Core forum](http://forum.jquery.com/developing-jquery-core) or in #jquery on irc.freenode.net.


### PR DESCRIPTION
Adding the symbol ":" to separate the description on the README file. 
Well, I've never contributed to github, I would start somewhere. Thank.
Best regards!! :)