### PR TITLE
Enable JavaScript linting with Hound

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,4 @@
+java_script:
+  enabled: true
+  config_file: .jshintrc
+  ignore_file: .jshintignore


### PR DESCRIPTION
Hello, jQuery team!

thoughtbot recently released Javascript linting for Hound, and I think it would be a good tool for this project. I saw that jQuery has a [JS style guide] for its projects – if you have to point out a lot of [style violations in pull requests], I think it would be worth giving Hound a spin for a while. It's free for open source, and it's helped me out a lot in my projects.

If you haven't heard of Hound, it's a github integration that watches repos for pull requests and points out style guide violations in the PRs. There's some background on it here: http://robots.thoughtbot.com/hound-reviews-javascript-for-style-violations

[style violations in pull requests]: https://github.com/jquery/jquery/pull/885#discussion-diff-1308308
[JS style guide]: https://github.com/jquery/contribute.jquery.org/blob/master/pages/style-guide/js.md

This PR configures Hound to watch for violations based on your jsHint settings. To get Hound to watch this repo, an admin would also have to activate the repo at https://houndci.com/.


So you can get an idea of what Hound would look like, I've opened a pull request on my fork of jQuery with some style violations. You can check it out here: https://github.com/graysonwright/jquery/pull/1

For full disclosure, I work at thoughtbot, which makes Hound. We're trying to spread the word a bit by suggesting Hound to open-source projects where it would be a good fit. But you don't have to worry – we're big supporters of open source, and Hound will stay free for open source projects forever.

Either way, thanks so much for jQuery – it's a great library and we use it every day. I hope Hound can make your jobs a little bit easier!

Cheers,
-Grayson