### PR TITLE
Build: Speed up the Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
+sudo: false
 node_js:
 - '0.10'


### PR DESCRIPTION
Run Travis tests on a container infrastructure to make it start faster.

See http://docs.travis-ci.com/user/workers/container-based-infrastructure/