### PR TITLE
Remove deprecated JSHint options

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -6,10 +6,7 @@
 	"expr": true,
 	"immed": true,
 	"noarg": true,
-	"onevar": true,
 	"quotmark": "double",
-	"smarttabs": true,
-	"trailing": true,
 	"undef": true,
 	"unused": true,
 


### PR DESCRIPTION
JSHint no longer supports `onevar`, `smarttabs` or `trailing` options (JSHint source [here](https://github.com/jshint/jshint/blob/3d9c430259afbecd002ca65662ea3103cae512b8/src/options.js#L875))

> JSHint is moving away from purely stylistic warnings. You should use JSCS for that.

Bonus: Includes "final new line" based on `.editorconfig` rule :stuck_out_tongue_winking_eye: 