### PR TITLE
Use grunt-jscs over deprecated grunt-jscs-checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "grunt-contrib-uglify": "0.6.0",
     "grunt-contrib-watch": "0.6.1",
     "grunt-git-authors": "2.0.1",
-    "grunt-jscs-checker": "0.8.1",
+    "grunt-jscs": "1.2.0",
     "grunt-jsonlint": "1.0.4",
     "grunt-npmcopy": "0.1.0",
     "gzip-js": "0.3.2",


### PR DESCRIPTION
The NPM package `grunt-jscs-checker` was renamed `grunt-jscs`, thus `grunt-jscs-checker` is now deprecated.

See https://github.com/jscs-dev/grunt-jscs/issues/53

Switching to `grunt-jscs` v1.2.0 over `grunt-jscs-checker` v0.8.1 results in ~126 errors, all the errors are for spaces around square brackets e.g.

```
Missing space after opening bracket at src/queue.js :
    94 |    jQuery._queueHooks( this, type );
    95 |
    96 |    if ( type === "fx" && queue[0] !== "inprogress" ) {
----------------------------------------^
    97 |     jQuery.dequeue( this, type );
    98 |    }
Missing space before closing bracket at src/queue.js :
    94 |    jQuery._queueHooks( this, type );
    95 |
    96 |    if ( type === "fx" && queue[0] !== "inprogress" ) {
-----------------------------------------^
```

Rather than patching each of these files at this stage (happy to if this is in fact the desired coding standard) though I thought I should check if the current rules based in the jQuery presets are preseumed to be accurate in JSCS's jQuery presets file https://github.com/jscs-dev/node-jscs/blob/master/presets/jquery.json, in particular both of these settings:

* `"requireSpacesInsideObjectBrackets": "all",` - JSCS Docs [disallowSpacesInsideObjectBrackets](http://jscs.info/rules.html#disallowspacesinsideobjectbrackets) / [requireSpacesInsideObjectBrackets](http://jscs.info/rules.html#requirespacesinsideobjectbrackets)
* `"requireSpacesInsideArrayBrackets": "all",` - JSCS Docs [disallowSpacesInsideArrayBrackets](http://jscs.info/rules.html#disallowspacesinsidearraybrackets) / [requireSpacesInsideArrayBrackets](http://jscs.info/rules.html#requirespacesinsidearraybrackets)