### PR TITLE
Simplification of manipulation wrappers

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -47,9 +47,10 @@ var nodeNames = "abbr|article|aside|audio|bdi|canvas|data|datalist|" +
 	// We have to close these tags to support XHTML (#13200)
 	wrapMap = {
 		option: [ 1, "<select multiple='multiple'>", "</select>" ],
-		legend: [ 1, "<fieldset>", "</fieldset>" ],
-		area: [ 1, "<map>", "</map>" ],
+
+		// Support: IE8
 		param: [ 1, "<object>", "</object>" ],
+
 		thead: [ 1, "<table>", "</table>" ],
 		tr: [ 2, "<table><tbody>", "</tbody></table>" ],
 		col: [ 2, "<table><tbody></tbody><colgroup>", "</colgroup></table>" ],


### PR DESCRIPTION
Since support for IE6-7 was dropped these wrappers no longer required
Ref 90d7cc1d8b2ea7ac75f0eacb42439349c9c73278
Fixes gh-2002

Note: if this would be merged, it would not auto-close #2002.
Should we mention "Fixes ..." for compat only commits?