### PR TITLE
Fix .offset() to work in ShadowDOM

### DIFF
--- a/src/offset.js
+++ b/src/offset.js
@@ -32,7 +32,7 @@ jQuery.offset = {
 			elem.style.position = "relative";
 		}
 
-		curOffset = curElem.offset();
+		curOffset = curElem.offset() || { top: 0, left: 0 };
 		curCSSTop = jQuery.css( elem, "top" );
 		curCSSLeft = jQuery.css( elem, "left" );
 		calculatePosition = ( position === "absolute" || position === "fixed" ) &&
@@ -57,10 +57,10 @@ jQuery.offset = {
 		}
 
 		if ( options.top != null ) {
-			props.top = ( options.top - ( curOffset ? curOffset.top : 0 ) ) + curTop;
+			props.top = ( options.top - curOffset.top ) + curTop;
 		}
 		if ( options.left != null ) {
-			props.left = ( options.left - ( curOffset ? curOffset.left : 0 ) ) + curLeft;
+			props.left = ( options.left - curOffset.left ) + curLeft;
 		}
 
 		if ( "using" in options ) {
@@ -93,18 +93,15 @@ jQuery.fn.extend({
 		rect = elem.getBoundingClientRect();
 
 		// Make sure element is not hidden (display: none) or disconnected
-		if ( !rect.width && !rect.height && !rect.left &&
-			!rect.top && !rect.right && !rect.bottom ) {
-			return;
+		if ( rect.width || rect.height || elem.getClientRects().length ) {
+			win = getWindow( doc );
+			docElem = doc.documentElement;
+
+			return {
+				top: rect.top + win.pageYOffset - docElem.clientTop,
+				left: rect.left + win.pageXOffset - docElem.clientLeft
+			};
 		}
-
-		win = getWindow( doc );
-		docElem = doc.documentElement;
-
-		return {
-			top: rect.top + win.pageYOffset - docElem.clientTop,
-			left: rect.left + win.pageXOffset - docElem.clientLeft
-		};
 	},
 
 	position: function() {

--- a/src/offset.js
+++ b/src/offset.js
@@ -92,7 +92,7 @@ jQuery.fn.extend({
 
 		rect = elem.getBoundingClientRect();
 
-		// Make sure element is not hidden or disconnected
+		// Make sure element is not hidden (display: none) or disconnected
 		if ( !rect.width && !rect.height && !rect.left &&
 			!rect.top && !rect.right && !rect.bottom ) {
 			return;

--- a/src/offset.js
+++ b/src/offset.js
@@ -82,7 +82,7 @@ jQuery.fn.extend({
 				});
 		}
 
-		var docElem, win,
+		var docElem, win, rect,
 			elem = this[ 0 ],
 			box = { top: 0, left: 0 },
 			doc = elem && elem.ownerDocument;
@@ -91,18 +91,19 @@ jQuery.fn.extend({
 			return;
 		}
 
-		docElem = doc.documentElement;
+		rect = elem.getBoundingClientRect();
 
-		// Make sure it's not a disconnected DOM node
-		if ( !jQuery.contains( docElem, elem ) ) {
+		// Make sure element is not hidden or disconnected
+		if ( !rect.width && !rect.height ) {
 			return box;
 		}
 
-		box = elem.getBoundingClientRect();
+		docElem = doc.documentElement;
 		win = getWindow( doc );
+
 		return {
-			top: box.top + win.pageYOffset - docElem.clientTop,
-			left: box.left + win.pageXOffset - docElem.clientLeft
+			top: rect.top + win.pageYOffset - docElem.clientTop,
+			left: rect.left + win.pageXOffset - docElem.clientLeft
 		};
 	},
 

--- a/src/offset.js
+++ b/src/offset.js
@@ -57,10 +57,10 @@ jQuery.offset = {
 		}
 
 		if ( options.top != null ) {
-			props.top = ( options.top - curOffset.top ) + curTop;
+			props.top = ( options.top - ( curOffset ? curOffset.top : 0 ) ) + curTop;
 		}
 		if ( options.left != null ) {
-			props.left = ( options.left - curOffset.left ) + curLeft;
+			props.left = ( options.left - ( curOffset ? curOffset.left : 0 ) ) + curLeft;
 		}
 
 		if ( "using" in options ) {
@@ -93,8 +93,9 @@ jQuery.fn.extend({
 		rect = elem.getBoundingClientRect();
 
 		// Make sure element is not hidden or disconnected
-		if ( !rect.width && !rect.height ) {
-			return { top: 0, left: 0 };
+		if ( !rect.width && !rect.height && !rect.left &&
+			!rect.top && !rect.right && !rect.bottom ) {
+			return;
 		}
 
 		win = getWindow( doc );

--- a/src/offset.js
+++ b/src/offset.js
@@ -91,6 +91,8 @@ jQuery.fn.extend({
 			return;
 		}
 
+		docElem = doc.documentElement;
+
 		// Make sure it's not a disconnected DOM node,
 		// which is enough only if user-agent does not support ShadowDOM
 		if ( !elem.createShadowRoot && !jQuery.contains( docElem, elem ) ) {
@@ -104,7 +106,6 @@ jQuery.fn.extend({
 			return box;
 		}
 
-		docElem = doc.documentElement;
 		win = getWindow( doc );
 
 		return {

--- a/src/offset.js
+++ b/src/offset.js
@@ -91,6 +91,12 @@ jQuery.fn.extend({
 			return;
 		}
 
+		// Make sure it's not a disconnected DOM node,
+		// which is enough only if user-agent does not support ShadowDOM
+		if ( !elem.createShadowRoot && !jQuery.contains( docElem, elem ) ) {
+			return box;
+		}
+
 		rect = elem.getBoundingClientRect();
 
 		// Make sure element is not hidden or disconnected

--- a/src/offset.js
+++ b/src/offset.js
@@ -84,29 +84,21 @@ jQuery.fn.extend({
 
 		var docElem, win, rect,
 			elem = this[ 0 ],
-			box = { top: 0, left: 0 },
 			doc = elem && elem.ownerDocument;
 
 		if ( !doc ) {
 			return;
 		}
 
-		docElem = doc.documentElement;
-
-		// Make sure it's not a disconnected DOM node,
-		// which is enough only if user-agent does not support ShadowDOM
-		if ( !elem.createShadowRoot && !jQuery.contains( docElem, elem ) ) {
-			return box;
-		}
-
 		rect = elem.getBoundingClientRect();
 
 		// Make sure element is not hidden or disconnected
 		if ( !rect.width && !rect.height ) {
-			return box;
+			return { top: 0, left: 0 };
 		}
 
 		win = getWindow( doc );
+		docElem = doc.documentElement;
 
 		return {
 			top: rect.top + win.pageYOffset - docElem.clientTop,

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -61,7 +61,7 @@ test("disconnected node", function() {
 
 	var result = jQuery( document.createElement("div") ).offset();
 
-	equal(typeof result, "undefined", "Check result typeof" );
+	equal( typeof result, "undefined", "Check result typeof" );
 });
 
 testIframe("offset/absolute", "absolute", function($, iframe) {

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -57,12 +57,11 @@ test("object without getBoundingClientRect", function() {
 });
 
 test("disconnected node", function() {
-	expect(2);
+	expect(1);
 
 	var result = jQuery( document.createElement("div") ).offset();
 
-	equal( result.top, 0, "Check top" );
-	equal( result.left, 0, "Check left" );
+	equal(typeof result, "undefined", "Check result typeof" );
 });
 
 testIframe("offset/absolute", "absolute", function($, iframe) {

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -72,7 +72,7 @@ test("hidden (display: none) element", function() {
 	expect(1);
 
 	var result,
-		node = jQuery("<div style='display: none' />").appendTo(document.body);
+		node = jQuery("<div style='display: none' />").appendTo("#qunit-fixture");
 
 	try {
 		result = node.offset();

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -56,12 +56,31 @@ test("object without getBoundingClientRect", function() {
 	equal( result.left, 0, "Check left" );
 });
 
-test("disconnected node", function() {
+test("disconnected element", function() {
 	expect(1);
 
-	var result = jQuery( document.createElement("div") ).offset();
+	var result;
 
-	equal( typeof result, "undefined", "Check result typeof" );
+	try {
+		result = jQuery( document.createElement("div") ).offset();
+	} catch ( e ) {}
+
+	ok( !result, "no position for disconnected element" );
+});
+
+test("hidden (display: none) element", function() {
+	expect(1);
+
+	var result,
+		node = jQuery("<div style='display: none' />").appendTo(document.body);
+
+	try {
+		result = node.offset();
+	} catch ( e ) {}
+
+	node.remove();
+
+	ok( !result, "no position for hidden (display: none) element" );
 });
 
 testIframe("offset/absolute", "absolute", function($, iframe) {


### PR DESCRIPTION
This pull request fixes #1784 issue.

Quick summary:
* ```element.contains()``` and ```element.compareDocumentPosition()``` does not work with ShadowDOM and always treated as disconnected even if it in the tree
* ```element.getBoundingClientRect()``` work fine with elements in ShadowDOM, returns correct values when element is in the tree and zeroes when not

Behavior of ```getBoundingClientRect```:
* For hidden elements returns all zeros
* For disconnected elements return all zeros
* In IE8 throws error when uses with disconnected element

What was made:
* Added guard which returns dummy block when rect has only zeroes (disconnected or hidden)
* ```jQuery.contains()``` check was not removed since without it IE8 will throw error and hence we need to return early for IE8 if element is disconnected
* But because ```jQuery.contains()``` has no effect with ShadowDOM (does not work as expected) I added check for existence of ShadowDOM before calling ```jQuery.contains()``` so we do not rely on it when it does not work.

Questions:
* Maybe it's better to move check of ShadowDOM existence to ```jQuery.supports.ShadowDOM``` and then use it?
* @nazar-pc mentioned in #1784 what he already made tests for ```.offset()``` in ShadowDOM. I can made my own test or we can use his since they are already made. If you decide to use his test, then probable it's better what he will commint them by himself.


Also @gibson042 said in #1784
> I don't like this conflation of unrelated behaviors.

About this line of code: ```if ( !elem.createShadowRoot && !jQuery.contains( docElem, elem ) ) {```
I agree with it, but this check is more performant than tree traversal or ```try..catch``` block. Also it's not so much unrelated, it's used to prevent use ```jQuery.contains()``` in situation when it does not work _and_, by the way, prevents IE8 to fail.