### PR TITLE
Manipulation: buildFragment always uses document of the context

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -203,7 +203,8 @@ jQuery.extend({
 
 	buildFragment: function( elems, context, scripts, selection ) {
 		var elem, tmp, tag, wrap, contains, j,
-			fragment = context.createDocumentFragment(),
+			doc = context.ownerDocument || context,
+			fragment = doc.createDocumentFragment(),
 			nodes = [],
 			i = 0,
 			l = elems.length;
@@ -221,11 +222,11 @@ jQuery.extend({
 
 				// Convert non-html into a text node
 				} else if ( !rhtml.test( elem ) ) {
-					nodes.push( context.createTextNode( elem ) );
+					nodes.push( doc.createTextNode( elem ) );
 
 				// Convert html into DOM nodes
 				} else {
-					tmp = tmp || fragment.appendChild( context.createElement("div") );
+					tmp = tmp || fragment.appendChild( doc.createElement("div") );
 
 					// Deserialize a standard representation
 					tag = ( rtagName.exec( elem ) || [ "", "" ] )[ 1 ].toLowerCase();


### PR DESCRIPTION
buildFragment methods such as createDocumentFragment or createElement.
It called it on context, but the context could have been some random
node, not necesarilly document node. This commit fixes that method so it
always takes the ownerDocument of the context (or the context if it's
document itself) and callse the mentioned methods on that