### PR TITLE
Core: simplify "each" stylesheet iteration test

### DIFF
--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -1199,7 +1199,7 @@ test("jQuery.each(Object,Function)", function() {
 	jQuery.each( document.styleSheets, function() {
 		i++;
 	});
-	equal( i, 2, "Iteration over document.styleSheets" );
+	equal( i, document.styleSheets.length, "Iteration over document.styleSheets" );
 });
 
 test("jQuery.makeArray", function(){


### PR DESCRIPTION
This assertion always fail on me, in chrome, because of the extension that i enable even in incognito mode.  

This change would make this check generic and eliminate the possible problem in usual mode too.