### PR TITLE
toggle: renamed argument 'state' to 'doShow'

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -447,9 +447,9 @@ jQuery.fn.extend({
 	hide: function() {
 		return showHide( this );
 	},
-	toggle: function( state ) {
-		if ( typeof state === "boolean" ) {
-			return state ? this.show() : this.hide();
+	toggle: function( doShow ) {
+		if ( typeof doShow === "boolean" ) {
+			return doShow ? this.show() : this.hide();
 		}
 
 		return this.each(function() {


### PR DESCRIPTION
To make it clear that passing true shows and passing false hides. Otherwise if you take the documentation with showOrHide at its word, it would do nothing if you pass false and would call the regular toggle() if you pass true. 
I created a pull request for the api.jquery.change as well.
https://github.com/jquery/api.jquery.com/pull/654