### PR TITLE
Make top of the HTML suite compliant with style guide

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -1,12 +1,10 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" dir="ltr" id="html">
+<!doctype html>
+<html lang="en" id="html">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+	<meta charset="utf-8">
 	<title>jQuery Test Suite</title>
-	<link rel="Stylesheet" media="screen" href="../external/qunit/qunit.css" />
-	<link rel="Stylesheet" media="screen" href="data/testsuite.css" />
-	<!-- Includes -->
+	<link rel="stylesheet" href="../external/qunit/qunit.css" />
+	<link rel="stylesheet" href="data/testsuite.css" />
 
 	<!--
 		We have to use previous jQuery as helper to ensure testability with


### PR DESCRIPTION
Make top of the html suite compliant with <a href="http://contribute.jquery.org/style-guide/html/">our</a> html code style.

@dmethvin xhtml doctype was chosen for specific reason or it's fine like that?