### PR TITLE
Test against the current version of node as well as iojs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 sudo: false
 node_js:
 - '0.10'
+- '0.12'
+- 'iojs'


### PR DESCRIPTION
Currently travis only tests using node 0.10, so this adds 0.12 and iojs to the travis config.