### PR TITLE
Remove old workarounds and simplify use of the native API 

### DIFF
--- a/src/ajax/xhr.js
+++ b/src/ajax/xhr.js
@@ -10,9 +10,7 @@ jQuery.ajaxSettings.xhr = function() {
 	} catch ( e ) {}
 };
 
-var xhrId = 0,
-	xhrCallbacks = {},
-	xhrSuccessStatus = {
+var xhrSuccessStatus = {
 		// file protocol always yields status code 0, assume 200
 		0: 200,
 		// Support: IE9
@@ -20,17 +18,6 @@ var xhrId = 0,
 		1223: 204
 	},
 	xhrSupported = jQuery.ajaxSettings.xhr();
-
-// Support: IE9
-// Open requests must be manually aborted on unload (#5280)
-// See https://support.microsoft.com/kb/2856746 for more info
-if ( window.attachEvent ) {
-	window.attachEvent( "onunload", function() {
-		for ( var key in xhrCallbacks ) {
-			xhrCallbacks[ key ]();
-		}
-	});
-}
 
 support.cors = !!xhrSupported && ( "withCredentials" in xhrSupported );
 support.ajax = xhrSupported = !!xhrSupported;
@@ -43,8 +30,7 @@ jQuery.ajaxTransport(function( options ) {
 		return {
 			send: function( headers, complete ) {
 				var i,
-					xhr = options.xhr(),
-					id = ++xhrId;
+					xhr = options.xhr();
 
 				xhr.open(
 					options.type,
@@ -84,7 +70,6 @@ jQuery.ajaxTransport(function( options ) {
 				callback = function( type ) {
 					return function() {
 						if ( callback ) {
-							delete xhrCallbacks[ id ];
 							callback = xhr.onload = xhr.onerror = null;
 
 							if ( type === "abort" ) {
@@ -117,7 +102,7 @@ jQuery.ajaxTransport(function( options ) {
 				xhr.onerror = callback("error");
 
 				// Create the abort callback
-				callback = xhrCallbacks[ id ] = callback("abort");
+				callback = callback("abort");
 
 				try {
 					// Do send the request (this may raise an exception)

--- a/src/core/ready.js
+++ b/src/core/ready.js
@@ -63,8 +63,8 @@ jQuery.extend({
  * The ready event handler and self cleanup method
  */
 function completed() {
-	document.removeEventListener( "DOMContentLoaded", completed, false );
-	window.removeEventListener( "load", completed, false );
+	document.removeEventListener( "DOMContentLoaded", completed );
+	window.removeEventListener( "load", completed );
 	jQuery.ready();
 }
 
@@ -85,10 +85,10 @@ jQuery.ready.promise = function( obj ) {
 		} else {
 
 			// Use the handy event callback
-			document.addEventListener( "DOMContentLoaded", completed, false );
+			document.addEventListener( "DOMContentLoaded", completed );
 
 			// A fallback to window.onload, that will always work
-			window.addEventListener( "load", completed, false );
+			window.addEventListener( "load", completed );
 		}
 	}
 	return readyList.promise( obj );

--- a/src/css/support.js
+++ b/src/css/support.js
@@ -38,7 +38,7 @@ define([
 		div.innerHTML = "";
 		documentElement.appendChild( container );
 
-		var divStyle = window.getComputedStyle( div, null );
+		var divStyle = window.getComputedStyle( div );
 		pixelPositionVal = divStyle.top !== "1%";
 		boxSizingReliableVal = divStyle.height === "4px";
 		pixelMarginRightVal = divStyle.marginRight === "4px";
@@ -89,7 +89,7 @@ define([
 			div.style.width = "1px";
 			documentElement.appendChild( container );
 
-			ret = !parseFloat( window.getComputedStyle( marginDiv, null ).marginRight );
+			ret = !parseFloat( window.getComputedStyle( marginDiv ).marginRight );
 
 			documentElement.removeChild( container );
 			div.removeChild( marginDiv );

--- a/src/css/var/getStyles.js
+++ b/src/css/var/getStyles.js
@@ -4,9 +4,9 @@ define(function() {
 		// IE throws on elements created in popups
 		// FF meanwhile throws on frame elements through "defaultView.getComputedStyle"
 		if ( elem.ownerDocument.defaultView.opener ) {
-			return elem.ownerDocument.defaultView.getComputedStyle( elem, null );
+			return elem.ownerDocument.defaultView.getComputedStyle( elem );
 		}
 
-		return window.getComputedStyle( elem, null );
+		return window.getComputedStyle( elem );
 	};
 });

--- a/src/event.js
+++ b/src/event.js
@@ -688,7 +688,7 @@ jQuery.Event.prototype = {
 
 		this.isDefaultPrevented = returnTrue;
 
-		if ( e && e.preventDefault ) {
+		if ( e ) {
 			e.preventDefault();
 		}
 	},
@@ -697,7 +697,7 @@ jQuery.Event.prototype = {
 
 		this.isPropagationStopped = returnTrue;
 
-		if ( e && e.stopPropagation ) {
+		if ( e ) {
 			e.stopPropagation();
 		}
 	},
@@ -706,7 +706,7 @@ jQuery.Event.prototype = {
 
 		this.isImmediatePropagationStopped = returnTrue;
 
-		if ( e && e.stopImmediatePropagation ) {
+		if ( e ) {
 			e.stopImmediatePropagation();
 		}
 

--- a/src/event.js
+++ b/src/event.js
@@ -123,7 +123,7 @@ jQuery.event = {
 					special.setup.call( elem, data, namespaces, eventHandle ) === false ) {
 
 					if ( elem.addEventListener ) {
-						elem.addEventListener( type, eventHandle, false );
+						elem.addEventListener( type, eventHandle );
 					}
 				}
 			}
@@ -631,9 +631,10 @@ jQuery.event = {
 };
 
 jQuery.removeEvent = function( elem, type, handle ) {
+
 	// This "if" is needed for plain objects
 	if ( elem.removeEventListener ) {
-		elem.removeEventListener( type, handle, false );
+		elem.removeEventListener( type, handle );
 	}
 };
 

--- a/src/event.js
+++ b/src/event.js
@@ -26,6 +26,8 @@ function returnFalse() {
 	return false;
 }
 
+// Support: IE9
+// See #13393 for more info
 function safeActiveElement() {
 	try {
 		return document.activeElement;
@@ -424,8 +426,11 @@ jQuery.event = {
 			delegateCount = handlers.delegateCount,
 			cur = event.target;
 
+		// Support (at least): Chrome, IE9
 		// Find delegate handlers
 		// Black-hole SVG <use> instance trees (#13180)
+		//
+		// Support: Firefox
 		// Avoid non-left-click bubbling in Firefox (#3861)
 		if ( delegateCount && cur.nodeType && (!event.button || event.type !== "click") ) {
 
@@ -626,6 +631,7 @@ jQuery.event = {
 };
 
 jQuery.removeEvent = function( elem, type, handle ) {
+	// This "if" is needed for plain objects
 	if ( elem.removeEventListener ) {
 		elem.removeEventListener( type, handle, false );
 	}


### PR DESCRIPTION
Simplifications of the `stopImmediatePropagation`, `stopPropagation` and `preventDefault` look like risky changes, but tests are passing and support in browsers already exist. 

/cc @dmethvin