### PR TITLE
Cleanup of doc (into docblock) in /data/accepts.js

### DIFF
--- a/src/data/accepts.js
+++ b/src/data/accepts.js
@@ -6,12 +6,15 @@ define([
  * Determines whether an object can have data
  */
 jQuery.acceptData = function( owner ) {
-	// Accepts only:
-	//  - Node
-	//    - Node.ELEMENT_NODE
-	//    - Node.DOCUMENT_NODE
-	//  - Object
-	//    - Any
+	/** 
+	 * Accepts only:
+	 *  - Node
+	 *    - Node.ELEMENT_NODE
+	 *    - Node.DOCUMENT_NODE
+	 *  - Object
+	 *    - Any
+	 */
+	 
 	/* jshint -W018 */
 	return owner.nodeType === 1 || owner.nodeType === 9 || !( +owner.nodeType );
 };


### PR DESCRIPTION
I think to better keep up with doc standard, we should turn the long comment doc into a better docblock.