### PR TITLE
iframe remove after callback

### DIFF
--- a/test/data/testinit.js
+++ b/test/data/testinit.js
@@ -242,10 +242,11 @@ this.testIframeWithCallback = function( title, fileName, func ) {
 			setTimeout(function() {
 				this.iframeCallback = undefined;
 
-				iframe.remove();
+				
 				func.apply( this, args );
 				func = function() {};
-
+				iframe.remove();
+				
 				start();
 			});
 		};


### PR DESCRIPTION
some  outer variable in callback function can't access if remove the 'iframe' before callback function execution in ie6/7 sometimes