### PR TITLE
Offset: Round offset value for the sake of floating errors

### DIFF
--- a/test/unit/dimensions.js
+++ b/test/unit/dimensions.js
@@ -453,7 +453,8 @@ testIframe( "dimensions/documentLarge", "window vs. large document", function( j
 });
 
 test( "allow modification of coordinates argument (gh-1848)", 1, function() {
-	var element = jQuery( "<div/>" ).appendTo( "#qunit-fixture" );
+	var offsetTop,
+		element = jQuery( "<div/>" ).appendTo( "#qunit-fixture" );
 
 	element.offset(function( index, coords ) {
 		coords.top = 100;
@@ -461,7 +462,9 @@ test( "allow modification of coordinates argument (gh-1848)", 1, function() {
 		return coords;
 	});
 
-	equal( element.offset().top, 100, "coordinates are modified" );
+	offsetTop = element.offset().top;
+	ok( Math.abs(offsetTop - 100) < 0.02,
+		"coordinates are modified (got offset.top: " +  offsetTop + ")");
 });
 
 })();


### PR DESCRIPTION
IE10+ may return not exactly the offset.top value set in an offset callback
if parent has fractional top offset itself. Checking for being close to the
desired result fixes the test error.

Fixes gh-2147

@markelog why is this test in `unit/dimensions.js`, not `unit/offset.js`?

BTW, this behavior may be surprising to a lot of people; maybe we should mention that in the API docs that setting an offset & getting it later may result in a slightly different value.