### PR TITLE
npm ignore src directory

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,7 @@
 /.mailmap
 /.travis.yml
 
+/src
 /build
 /speed
 /test


### PR DESCRIPTION
The src directory is full of AMD modules that are clearly not intended to be used in common js environments. Including it in the npm install doubles the size of the install from aproximately 1MB to 2MB. These files should be npm ignored and the world will have a little less waste.

(On this same token, the `dist/cdn` directory also appears to be unnecessary in the npm install, and again effectively doubles the npm module's footprint, but I probably best to take this one step at a time.)