### PR TITLE
Add Node v0.12 and iojs to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 sudo: false
 node_js:
 - '0.10'
+- '0.12'
+- 'iojs'


### PR DESCRIPTION
I would like to upgrade .travis.yml.
node.js v0.12 and add io.js are released. 
