### PR TITLE
Data: Drop the tests relying on applets

### DIFF
--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -159,10 +159,6 @@ test("jQuery.data(<embed>)", 25, function() {
 	dataTests( document.createElement("embed") );
 });
 
-test("jQuery.data(<applet>)", 25, function() {
-	dataTests( document.createElement("applet") );
-});
-
 test("jQuery.data(object/flash)", 25, function() {
 	var flash = document.createElement("object");
 	flash.setAttribute( "classid", "clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" );
@@ -766,14 +762,15 @@ test(".data doesn't throw when calling selection is empty. #13551", function() {
 	}
 });
 
-test("jQuery.acceptData", 11, function() {
+test("jQuery.acceptData", function() {
+	expect( 10 );
+
 	var flash, pdf;
 
 	ok( jQuery.acceptData( document ), "document" );
 	ok( jQuery.acceptData( document.documentElement ), "documentElement" );
 	ok( jQuery.acceptData( {} ), "object" );
 	ok( jQuery.acceptData( document.createElement( "embed" ) ), "embed" );
-	ok( jQuery.acceptData( document.createElement( "applet" ) ), "applet" );
 
 	flash = document.createElement( "object" );
 	flash.setAttribute( "classid", "clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" );


### PR DESCRIPTION
BrowserStack regularly has outdated Java in their IE instances causing our
data tests to hang & give no output. Skip the tests that create applets,
applets are treated in the same way as an embed elements which we're already
testing.

Fixes gh-1938

(note to myself: if accepted, remember to cherry-pick this to `2.1-stable` & `1.11-stable` together with #2028)

Original description:

BrowserStack regularly has outdated Java in their IE instances causing our
data tests to hang & give no output. Skip the assertion if the test is run
via TestSwarm.