### PR TITLE
Core: Follow the AMD specification for define

### DIFF
--- a/src/selector.js
+++ b/src/selector.js
@@ -1,1 +1,1 @@
-define([ "./selector-sizzle" ]);
+define([ "./selector-sizzle" ], function() {});


### PR DESCRIPTION
AMD specification requires the factory argument to define.

According to [the AMD specification for the `define` function](https://github.com/amdjs/amdjs-api/wiki/AMD#define-function-) the `factory` argument is not optional. The RequireJS implementation apparently deviates from the spec by including modules when no factory is specified. In one instance jQuery relies on this non-standard feature which breaks compatibility with spec-compliant AMD loaders. Adding an empty factory function fixes this problem.