### PR TITLE
Ajax: Use the native XHR for all non-local requests in IE9+

### DIFF
--- a/src/ajax/xhr.js
+++ b/src/ajax/xhr.js
@@ -11,17 +11,31 @@ jQuery.ajaxSettings.xhr = window.ActiveXObject !== undefined ?
 	function() {
 
 		// XHR cannot access local files, always use ActiveX for that case
-		return !this.isLocal &&
+		if ( this.isLocal ) {
+			return createActiveXHR();
+		}
 
-			// Support: IE<9
-			// oldIE XHR does not support non-RFC2616 methods (#13240)
-			// See http://msdn.microsoft.com/en-us/library/ie/ms536648(v=vs.85).aspx
-			// and http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9
-			// Although this check for six methods instead of eight
-			// since IE also does not support "trace" and "connect"
-			/^(get|post|head|put|delete|options)$/i.test( this.type ) &&
+		// Support: IE 10-11
+		// IE seems to error on cross-domain PATCH requests when ActiveX XHR
+		// is used. In IE 9+ always use the native XHR.
+		// Note: this condition won't catch Spartan as it doesn't define
+		// document.documentMode but it also doesn't have ActiveX so it won't
+		// reach this code.
+		if ( document.documentMode > 8 ) {
+			return createStandardXHR();
+		}
 
-			createStandardXHR() || createActiveXHR();
+		// Support: IE<9
+		// oldIE XHR does not support non-RFC2616 methods (#13240)
+		// See http://msdn.microsoft.com/en-us/library/ie/ms536648(v=vs.85).aspx
+		// and http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9
+		// Although this check for six methods instead of eight
+		// since IE also does not support "trace" and "connect"
+		if ( /^(get|post|head|put|delete|options)$/i.test( this.type ) ) {
+			return createActiveXHR();
+		}
+
+		return createStandardXHR();
 	} :
 	// For all other browsers, use the standard XMLHttpRequest object
 	createStandardXHR;

--- a/test/integration/gh-1684-ajax.html
+++ b/test/integration/gh-1684-ajax.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+	<meta charset="UTF-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<title>Test for gh-1684</title>
+	<style>
+		#result {
+			font-size: 24px;
+			margin: 0.5em 0;
+		}
+		#response {
+			white-space: pre;
+		}
+		.error {
+			background-color: red;
+		}
+		.warn {
+			background-color: yellow;
+		}
+		.success {
+			background-color: lightgreen;
+		}
+	</style>
+</head>
+
+<body>
+	<div id="result"></div>
+	<div id="response"></div>
+	<script src="../../dist/jquery.js"></script>
+	<script>
+		if ( !jQuery.support.cors ) {
+			jQuery( "#result" )
+				.addClass( "success" )
+				.text( "CORS not supported in this browser. Test not run." );
+		} else {
+			jQuery.ajax( {
+				url: "http://httpbin.org/patch",
+				method: "PATCH",
+				success: function( data ) {
+					jQuery( "#result" ).addClass( "success" ).text( "Test passed." );
+					jQuery( "#response" ).text( "Response:\n" + JSON.stringify( data, null, 4 ) );
+				},
+				error: function( error ) {
+					jQuery( "#result" ).addClass( "error" ).text( "Test failed." );
+					jQuery( "#response" ).text( "Error:\n" + JSON.stringify( error, null, 4 ) );
+				}
+			} );
+		}
+	</script>
+</body>
+</html>

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -1578,8 +1578,10 @@ module( "ajax", {
 		}
 	} );
 
-	// BrowserStack PATCH support sometimes breaks so on TestSwarm run the test in IE8 only.
-	if ( location.search.indexOf( "swarmURL=" ) === -1 || document.documentMode < 9 ) {
+	// BrowserStack PATCH support sometimes breaks so on TestSwarm run the test in IE only.
+	// Unfortunately, all IE versions gets special treatment in request object creation
+	// so we need to test in all supported IE versions to be sure.
+	if ( location.search.indexOf( "swarmURL=" ) === -1 || document.documentMode ) {
 		ajaxTest( "#13240 - jQuery.ajax() - support non-RFC2616 methods", 1, {
 			url: "data/echoQuery.php",
 			method: "PATCH",


### PR DESCRIPTION
IE throws an error on cross-domain PATCH requests if issued via the ActiveX
interface. This commit switches the logic to use the native XHR in all
non-local requests.

Fixes gh-1684

I'd like to test it but we'd need a *real* cross-domain request that has `Access-Control-Allow-Origin` set to `*` and will respond to `PATCH` requests. Can we have a page like that? cc @gnarf @ryanneufeld @aulvi