### PR TITLE
Core: add workaround for iOS JIT error in isArrayLike

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -478,7 +478,12 @@ jQuery.each("Boolean Number String Function Array Date RegExp Object Error".spli
 });
 
 function isArraylike( obj ) {
-	var length = obj.length,
+
+	// Support: iOS 8.2 (not reproducible in simulator)
+	// `in` check used to prevent JIT error (gh-2145)
+	// hasOwn isn't used here due to false negatives
+	// regarding Nodelist length in IE
+	var length = "length" in obj && obj.length,
 		type = jQuery.type( obj );
 
 	if ( type === "function" || jQuery.isWindow( obj ) ) {

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -1217,6 +1217,27 @@ test("jQuery.each(Object,Function)", function() {
 	equal( i, 2, "Iteration over document.styleSheets" );
 });
 
+test( "JIT compilation does not interfere with length retrieval (gh-2145)", function() {
+	expect( 4 );
+
+	var i;
+
+	// Trigger JIT compilation of jQuery.each – and therefore isArraylike – in iOS.
+	// Convince JSC to use one of its optimizing compilers
+	// by providing code which can be LICM'd into nothing.
+	for ( i = 0; i < 1000; i++ ) {
+		jQuery.each( [] );
+	}
+
+	i = 0;
+	jQuery.each( { 1: "1", 2: "2", 3: "3" }, function( index ) {
+		equal( ++i, index, "Iteration over object with solely " +
+			"numeric indices (gh-2145 JIT iOS 8 bug)" );
+	});
+	equal( i, 3, "Iteration over object with solely " +
+		"numeric indices (gh-2145 JIT iOS 8 bug)" );
+});
+
 test("jQuery.makeArray", function(){
 	expect(15);
 


### PR DESCRIPTION
I was able to reproduce on an iPhone 5s and iPhone 6 plus in iOS 8.2. Additionally, I tested AMD and minified versions for posterity. Let me know if I missed something.

Perf difference seems to be [negligible](http://jsperf.com/jquery-each-vs-no-jit-error).

Fixes gh-2145