### PR TITLE
Attr: remove unnecessary element null check

### DIFF
--- a/src/attributes/attr.js
+++ b/src/attributes/attr.js
@@ -27,7 +27,7 @@ jQuery.extend({
 			nType = elem.nodeType;
 
 		// don't get/set attributes on text, comment and attribute nodes
-		if ( !elem || nType === 3 || nType === 8 || nType === 2 ) {
+		if ( nType === 3 || nType === 8 || nType === 2 ) {
 			return;
 		}
 


### PR DESCRIPTION
because the `nodeType` property was already accessed and would have thrown an exception

Or should the elem null check go before reading the `nodeType` property?