### PR TITLE
Event: off() should delete all handlers from queue

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -388,7 +388,8 @@ jQuery.event = {
 
 			j = 0;
 			while ( (handleObj = matched.handlers[ j++ ]) &&
-				!event.isImmediatePropagationStopped() ) {
+				handlers.indexOf(handleObj) > -1 &&
+				!event.isImmediatePropagationStopped()) {
 
 				// Triggered event must either 1) have no namespace, or 2) have namespace(s)
 				// a subset or equal to those in the bound event (both can have no namespace).

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -822,6 +822,24 @@ test("off(eventObject)", function() {
 	assert( 0 );
 });
 
+test("off() should delete all handlers from queue", function() {
+	expect(1);
+
+	var counter = 0,
+		handler1 = function() { counter++; },
+		handler2 = function() { counter++; };
+
+	jQuery("#foo").on("foo", handler1);
+	jQuery("#foo").on("foo", function() {
+		jQuery("#foo").off();
+	});
+	jQuery("#foo").on("foo", handler2);
+
+	jQuery("#foo").trigger("foo");
+
+	equal( counter, 1, "Make sure that the event handler is not called after handler removal" );
+});
+
 if ( jQuery.fn.hover ) {
 	test("hover() mouseenter mouseleave", function() {
 		expect(1);


### PR DESCRIPTION
jQuery call deleted event handlers after handler removal. You can check native and jQuery behaviour in this example: http://jsfiddle.net/wwbne37b/.