### PR TITLE
use getBoundingClientRect() for the hidden filter.

### DIFF
--- a/src/css/hiddenVisibleSelectors.js
+++ b/src/css/hiddenVisibleSelectors.js
@@ -1,9 +1,17 @@
 define([
 	"../core",
+	"../var/strundefined",
 	"../selector"
-], function( jQuery ) {
+], function( jQuery, strundefined ) {
 
 jQuery.expr.filters.hidden = function( elem ) {
+	// Support: BlackBerry 5, iOS 3 (original iPhone)
+	// If we don't have gBCR, just use 0,0 rather than error
+	if ( typeof elem.getBoundingClientRect !== strundefined ) {
+		var rect = elem.getBoundingClientRect();
+		return rect.height === 0 || rect.width === 0;
+	}
+
 	// Support: Opera <= 12.12
 	// Opera reports offsetWidths and offsetHeights less than zero on some elements
 	return elem.offsetWidth <= 0 && elem.offsetHeight <= 0;


### PR DESCRIPTION
In my testing with Chrome (I didn't test other browsers) I found that all SVG elements seem to have an `offsetWidth` and `offsetHeight` of `0`, so they are all considered to be hidden. This solution isn't going to fix any browsers that don't support `getBoundingClientRect`.

In my project I've been able to monkey-patch my way around this:

```javascript
$.expr.filters.hidden = function(elem) {
	var rect = elem.getBoundingClientRect();
	return rect.height === 0 || rect.width === 0;
};
```