### PR TITLE
use getBoundingClientRect() for the hidden filter

### DIFF
--- a/src/css/hiddenVisibleSelectors.js
+++ b/src/css/hiddenVisibleSelectors.js
@@ -6,7 +6,8 @@ define([
 jQuery.expr.filters.hidden = function( elem ) {
 	// Use OR instead of AND as the element is not visible if either is true
 	// See tickets #10406 and #13132
-	return !elem.offsetWidth || !elem.offsetHeight;
+	var rect = elem.getBoundingClientRect();
+	return !rect.height || !rect.width;
 };
 jQuery.expr.filters.visible = function( elem ) {
 	return !jQuery.expr.filters.hidden( elem );


### PR DESCRIPTION
In my testing with Chrome (I didn't test other browsers) I found that all SVG elements seem to have an offsetWidth and offsetHeight of 0, so they are all considered to be hidden.