### PR TITLE
Traversing: Don't exempt .children and .contents from sorting

### DIFF
--- a/src/traversing.js
+++ b/src/traversing.js
@@ -7,14 +7,7 @@ define([
 	"./selector"
 ], function( jQuery, indexOf, rneedsContext ) {
 
-var rparentsprev = /^(?:parents|prev(?:Until|All))/,
-	// Methods guaranteed to produce a unique set when starting from a unique set
-	guaranteedUnique = {
-		children: true,
-		contents: true,
-		next: true,
-		prev: true
-	};
+var rparentsprev = /^(?:parents|prev(?:Until|All))/;
 
 jQuery.extend({
 	dir: function( elem, dir, until ) {
@@ -180,8 +173,8 @@ jQuery.each({
 		}
 
 		if ( this.length > 1 ) {
-			// Remove duplicates
-			if ( !guaranteedUnique[ name ] ) {
+			// Sorting (which implicitly de-dupes) is required for non-adjacent traversals
+			if ( name !== "prev" && name !== "next" ) {
 				jQuery.unique( matched );
 			}
 

--- a/src/traversing.js
+++ b/src/traversing.js
@@ -7,8 +7,6 @@ define([
 	"./selector"
 ], function( jQuery, indexOf, rneedsContext ) {
 
-var rparentsprev = /^(?:parents|prev(?:Until|All))/;
-
 jQuery.extend({
 	dir: function( elem, dir, until ) {
 		var matched = [],
@@ -161,10 +159,18 @@ jQuery.each({
 		return elem.contentDocument || jQuery.merge( [], elem.childNodes );
 	}
 }, function( name, fn ) {
+	var // Sorting (which implicitly de-dupes) is required for non-adjacent traversals
+		sort = name !== "prev" && name !== "next",
+
+		// Reverse order for prev-derivatives and parents*
+		reverse = name !== "prev" && name.slice( 0, 4 ) === "prev" ||
+			name.slice( 0, 7 ) === "parents";
+
 	jQuery.fn[ name ] = function( until, selector ) {
 		var matched = jQuery.map( this, fn, until );
 
-		if ( name.slice( -5 ) !== "Until" ) {
+		// Only *Until methods support two parameters
+		if ( fn.length !== 3 ) {
 			selector = until;
 		}
 
@@ -173,13 +179,10 @@ jQuery.each({
 		}
 
 		if ( this.length > 1 ) {
-			// Sorting (which implicitly de-dupes) is required for non-adjacent traversals
-			if ( name !== "prev" && name !== "next" ) {
+			if ( sort ) {
 				jQuery.unique( matched );
 			}
-
-			// Reverse order for parents* and prev-derivatives
-			if ( rparentsprev.test( name ) ) {
+			if ( reverse ) {
 				matched.reverse();
 			}
 		}

--- a/test/unit/traversing.js
+++ b/test/unit/traversing.js
@@ -508,9 +508,17 @@ test("siblings([String]) - jQuery only", function() {
 });
 
 test("children([String])", function() {
-	expect(2);
-	deepEqual( jQuery("#foo").children().get(), q("sndp", "en", "sap"), "Check for children" );
-	deepEqual( jQuery("#foo").children("#en, #sap").get(), q("en", "sap"), "Check for multiple filters" );
+	expect( 3 );
+
+	deepEqual( jQuery( "#foo" ).children().get(), q( "sndp", "en", "sap" ),
+		"Check for children" );
+	deepEqual( jQuery( "#foo" ).children( "#en, #sap" ).get(), q( "en", "sap" ),
+		"Check for multiple filters" );
+	deepEqual(
+		jQuery( "#foo, #en" ).children().get(),
+		q( "sndp", "en", "yahoo", "sap" ),
+		"children of a self-descendant collection are sorted in document order (gh-1766)"
+	);
 });
 
 test("children([String]) - jQuery only", function() {
@@ -642,7 +650,8 @@ test("prevUntil([String])", function() {
 });
 
 test("contents()", function() {
-	expect(12);
+	expect( 13 );
+
 	var ibody, c;
 
 	equal( jQuery("#ap").contents().length, 9, "Check element contents" );
@@ -673,6 +682,14 @@ test("contents()", function() {
 	c = jQuery("#nonnodes").contents().contents();
 	equal( c.length, 1, "Check node,textnode,comment contents is just one" );
 	equal( c[0].nodeValue, "hi", "Check node,textnode,comment contents is just the one from span" );
+
+	c = jQuery( "#nonnodes" ).contents().get();
+	c.splice( 1, 0, c[ 0 ].firstChild );
+	deepEqual(
+		jQuery( "#nonnodes, #nonnodesElement" ).contents().get(),
+		c,
+		"contents of a self-descendant collection are sorted in document order (gh-1766)"
+	);
 });
 
 test("sort direction", function() {


### PR DESCRIPTION
Fixes gh-1766

```
   raw     gz Compared to master @ 892625b3c36eda6bb6ac226d15e0a158ba35cf21    
   -20     -6 dist/jquery.js                                                   
   -23    -28 dist/jquery.min.js
```