### PR TITLE
Core: jQuery.grep throws exception when elem passed is undefined

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -338,7 +338,7 @@ jQuery.extend({
 		var callbackInverse,
 			matches = [],
 			i = 0,
-			length = elems.length,
+			length = !!elems ? elems.length : 0,
 			callbackExpect = !invert;
 
 		// Go through the array, only saving the items

--- a/src/core.js
+++ b/src/core.js
@@ -338,7 +338,7 @@ jQuery.extend({
 		var callbackInverse,
 			matches = [],
 			i = 0,
-			length = !!elems ? elems.length : 0,
+			length = (!!elems) ? elems.length : 0,
 			callbackExpect = !invert;
 
 		// Go through the array, only saving the items


### PR DESCRIPTION
.length access to undefined throws exception. Instead made length as zero so loops skips automatically.
