### PR TITLE
Tests: Increase QUnit timeout

### DIFF
--- a/test/data/testrunner.js
+++ b/test/data/testrunner.js
@@ -15,7 +15,7 @@ var oldCacheLength = 0,
 
 // Max time for stop() and asyncTest() until it aborts test
 // and start()'s the next test.
-QUnit.config.testTimeout = 2e4; // 20 seconds
+QUnit.config.testTimeout = 12e4; // 2 minutes
 
 // Enforce an "expect" argument or expect() call in all test bodies.
 QUnit.config.requireExpects = true;


### PR DESCRIPTION
Android 2.3 is very slow & times out a lot in async tests, they have to be
restarted multiple times to settle. Long test execution is not a huge problem
as Android 2.3 is tested only periodically during the night, unstable tests
are a bigger problem. This might mitigate that.

In a regular scenario almost all tests should pass so increasing the timeout
for all browsers shouldn't have a huge impact on overall test time.