### PR TITLE
Core: Align branches: remove an unused variable, add comments

### DIFF
--- a/src/ajax/script.js
+++ b/src/ajax/script.js
@@ -51,6 +51,8 @@ jQuery.ajaxTransport( "script", function( s ) {
 						}
 					}
 				);
+
+				// Use native DOM manipulation to avoid our domManip AJAX trickery
 				document.head.appendChild( script[ 0 ] );
 			},
 			abort: function() {

--- a/src/attributes/attr.js
+++ b/src/attributes/attr.js
@@ -6,7 +6,7 @@ define([
 	"../selector"
 ], function( jQuery, rnotwhite, access, support ) {
 
-var nodeHook, boolHook,
+var boolHook,
 	attrHandle = jQuery.expr.attrHandle;
 
 jQuery.fn.extend({
@@ -41,7 +41,7 @@ jQuery.extend({
 		if ( nType !== 1 || !jQuery.isXMLDoc( elem ) ) {
 			name = name.toLowerCase();
 			hooks = jQuery.attrHooks[ name ] ||
-				( jQuery.expr.match.bool.test( name ) ? boolHook : nodeHook );
+				( jQuery.expr.match.bool.test( name ) ? boolHook : undefined );
 		}
 
 		if ( value !== undefined ) {

--- a/src/css/support.js
+++ b/src/css/support.js
@@ -10,6 +10,7 @@ define([
 		container = document.createElement( "div" ),
 		div = document.createElement( "div" );
 
+	// Finish early in limited (non-browser) environments
 	if ( !div.style ) {
 		return;
 	}


### PR DESCRIPTION
These are a couple of things I found when I was comparing `compat` with `master` while writing a patch to drop IE6-7 & some other browsers from `compat` that I forgot to submit to `master` afterwards.