### PR TITLE
Event: remove guard for falsy handler argument of jQuery#on method

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -819,8 +819,6 @@ jQuery.fn.extend({
 		}
 		if ( fn === false ) {
 			fn = returnFalse;
-		} else if ( !fn ) {
-			return this;
 		}
 
 		if ( one === 1 ) {

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -5,20 +5,6 @@ module( "event", {
 	teardown: moduleTeardown
 });
 
-test("null or undefined handler", function() {
-	expect(2);
-	// Supports Fixes bug #7229
-	try {
-		jQuery("#firstp").on( "click", null );
-		ok(true, "Passing a null handler will not throw an exception");
-	} catch ( e ) {}
-
-	try {
-		jQuery("#firstp").on( "click", undefined );
-		ok(true, "Passing an undefined handler will not throw an exception");
-	} catch ( e ) {}
-});
-
 test("on() with non-null,defined data", function() {
 
 	expect(2);


### PR DESCRIPTION
Since we don't have this in `off` method and its a common perception that this is a rudiment code.
See #2248 