### PR TITLE
remove npm from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "jsdom": "3.1.2",
     "load-grunt-tasks": "1.0.0",
     "native-promise-only": "0.7.8-a",
-    "npm": "2.1.12",
     "promises-aplus-tests": "2.1.0",
     "q": "1.1.2",
     "qunitjs": "1.17.1",


### PR DESCRIPTION
it is unclear why npm was included in the dependencies, it looks like it was accidentally included in this commit 2d5c5d213f09fa0205d07a2d60a36581058cc40a.  I think we can be fairly sure that they will already have npm at this point due to that list being used by npm :smile: 