### PR TITLE
Data: remove the expando when there's no more data; minor cleanup

### DIFF
--- a/src/data/Data.js
+++ b/src/data/Data.js
@@ -120,10 +120,7 @@ Data.prototype = {
 			return;
 		}
 
-		if ( key === undefined ) {
-			this.register( owner );
-
-		} else {
+		if ( key !== undefined ) {
 
 			// Support array or space separated string of keys
 			if ( jQuery.isArray( key ) ) {
@@ -146,6 +143,11 @@ Data.prototype = {
 			while ( i-- ) {
 				delete cache[ key[ i ] ];
 			}
+		}
+
+		// Remove the expando if there's no more data
+		if ( key === undefined || jQuery.isEmptyObject( cache ) ) {
+			delete owner[ this.expando ];
 		}
 	},
 	hasData: function( owner ) {

--- a/src/data/Data.js
+++ b/src/data/Data.js
@@ -13,8 +13,8 @@ Data.accepts = jQuery.acceptData;
 
 Data.prototype = {
 
-	register: function( owner, initial ) {
-		var value = initial || {};
+	register: function( owner ) {
+		var value = {};
 
 		// If it is a node unlikely to be stringify-ed or looped over
 		// use plain assignment
@@ -33,7 +33,7 @@ Data.prototype = {
 		}
 		return owner[ this.expando ];
 	},
-	cache: function( owner, initial ) {
+	cache: function( owner ) {
 
 		// We can accept data for non-element nodes in modern browsers,
 		// but we should not, see #8335.
@@ -51,7 +51,7 @@ Data.prototype = {
 		}
 
 		// If not, register one
-		return this.register( owner, initial );
+		return this.register( owner );
 	},
 	set: function( owner, data, value ) {
 		var prop,
@@ -151,11 +151,6 @@ Data.prototype = {
 	hasData: function( owner ) {
 		var cache = owner[ this.expando ];
 		return cache !== undefined && !jQuery.isEmptyObject( cache );
-	},
-	discard: function( owner ) {
-		if ( owner[ this.expando ] ) {
-			delete owner[ this.expando ];
-		}
 	}
 };
 

--- a/src/event.js
+++ b/src/event.js
@@ -216,14 +216,9 @@ jQuery.event = {
 			}
 		}
 
-		// Remove the expando if it's no longer used
+		// Remove data and the expando if it's no longer used
 		if ( jQuery.isEmptyObject( events ) ) {
-			// Normally this should go through the data api
-			// but since event.js owns these properties,
-			// this exception is made for the sake of optimizing
-			// the operation.
-			delete elemData.handle;
-			delete elemData.events;
+			dataPriv.remove( elem, "handle events" );
 		}
 	},
 

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -837,7 +837,24 @@ test("Check proper data removal of non-element descendants nodes (#8335)", 1, fu
 });
 
 testIframeWithCallback( "enumerate data attrs on body (#14894)", "data/dataAttrs.html", function( result ) {
-	expect(1);
+	expect( 1 );
 
-	equal(result, "ok", "enumeration of data- attrs on body" );
+	equal( result, "ok", "enumeration of data- attrs on body" );
+});
+
+test( "Check that the expando is removed when there's no more data", function() {
+	expect( 1 );
+
+	var key,
+		div = jQuery( "<div/>" );
+	div.data( "some", "data" );
+	equal( div.data( "some" ), "data", "Data is added" );
+	div.removeData( "some" );
+
+	// Make sure the expando is gone
+	for ( key in div[ 0 ] ) {
+		if ( /^jQuery/.test( key ) ) {
+			ok( false, "Expando was not removed when there was no more data" );
+		}
+	}
 });

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -2657,6 +2657,27 @@ test( "Inline event result is returned (#13993)", function() {
 	equal( result, 42, "inline handler returned value" );
 });
 
+test( ".off() removes the expando when there's no more data", function() {
+	expect( 1 );
+
+	var key,
+		div = jQuery( "<div/>" ).appendTo( "#qunit-fixture" );
+
+	div.on( "click", false );
+	div.on( "custom", function() {
+		ok( true, "Custom event triggered" );
+	} );
+	div.trigger( "custom" );
+	div.off( "click custom" );
+
+	// Make sure the expando is gone
+	for ( key in div[ 0 ] ) {
+		if ( /^jQuery/.test( key ) ) {
+			ok( false, "Expando was not removed when there was no more data" );
+		}
+	}
+});
+
 // This tests are unreliable in Firefox
 if ( !(/firefox/i.test( window.navigator.userAgent )) ) {
 	test( "Check order of focusin/focusout events", 2, function() {


### PR DESCRIPTION
- This also removes the `Data#discard()` method, which we never used, and the `initial` paramater in `Data#register()` – also never used.

Fixes gh-1760