### PR TITLE
Replaced jQuery.each with forEach to iterate arrays.

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -763,7 +763,7 @@ jQuery.extend({
 	}
 });
 
-jQuery.each( [ "get", "post" ], function( i, method ) {
+[ "get", "post" ].forEach(function( method ) {
 	jQuery[ method ] = function( url, data, callback, type ) {
 		// Shift arguments if data argument was omitted
 		if ( jQuery.isFunction( data ) ) {

--- a/src/attributes/prop.js
+++ b/src/attributes/prop.js
@@ -76,7 +76,7 @@ if ( !support.optSelected ) {
 	};
 }
 
-jQuery.each([
+[
 	"tabIndex",
 	"readOnly",
 	"maxLength",
@@ -87,8 +87,8 @@ jQuery.each([
 	"useMap",
 	"frameBorder",
 	"contentEditable"
-], function() {
-	jQuery.propFix[ this.toLowerCase() ] = this;
+].forEach(function(prop) {
+	jQuery.propFix[ prop.toLowerCase() ] = prop;
 });
 
 });

--- a/src/attributes/val.js
+++ b/src/attributes/val.js
@@ -143,8 +143,8 @@ jQuery.extend({
 });
 
 // Radios and checkboxes getter/setter
-jQuery.each([ "radio", "checkbox" ], function() {
-	jQuery.valHooks[ this ] = {
+[ "radio", "checkbox" ].forEach(function(type) {
+	jQuery.valHooks[ type ] = {
 		set: function( elem, value ) {
 			if ( jQuery.isArray( value ) ) {
 				return ( elem.checked = jQuery.inArray( jQuery(elem).val(), value ) >= 0 );
@@ -152,7 +152,7 @@ jQuery.each([ "radio", "checkbox" ], function() {
 		}
 	};
 	if ( !support.checkOn ) {
-		jQuery.valHooks[ this ].get = function( elem ) {
+		jQuery.valHooks[ type ].get = function( elem ) {
 			return elem.getAttribute("value") === null ? "on" : elem.value;
 		};
 	}

--- a/src/core.js
+++ b/src/core.js
@@ -473,7 +473,7 @@ jQuery.extend({
 });
 
 // Populate the class2type map
-jQuery.each("Boolean Number String Function Array Date RegExp Object Error".split(" "), function(i, name) {
+"Boolean Number String Function Array Date RegExp Object Error".split(" ").forEach(function( name ) {
 	class2type[ "[object " + name + "]" ] = name.toLowerCase();
 });
 

--- a/src/css.js
+++ b/src/css.js
@@ -334,7 +334,7 @@ jQuery.extend({
 	}
 });
 
-jQuery.each([ "height", "width" ], function( i, name ) {
+[ "height", "width" ].forEach(function( name ) {
 	jQuery.cssHooks[ name ] = {
 		get: function( elem, computed, extra ) {
 			if ( computed ) {

--- a/src/effects.js
+++ b/src/effects.js
@@ -570,7 +570,7 @@ jQuery.fn.extend({
 	}
 });
 
-jQuery.each([ "toggle", "show", "hide" ], function( i, name ) {
+[ "toggle", "show", "hide" ].forEach(function( name ) {
 	var cssFn = jQuery.fn[ name ];
 	jQuery.fn[ name ] = function( speed, easing, callback ) {
 		return speed == null || typeof speed === "boolean" ?

--- a/src/event/ajax.js
+++ b/src/event/ajax.js
@@ -4,7 +4,7 @@ define([
 ], function( jQuery ) {
 
 // Attach a bunch of functions for handling common AJAX events
-jQuery.each( [ "ajaxStart", "ajaxStop", "ajaxComplete", "ajaxError", "ajaxSuccess", "ajaxSend" ], function( i, type ) {
+[ "ajaxStart", "ajaxStop", "ajaxComplete", "ajaxError", "ajaxSuccess", "ajaxSend" ].forEach( function( type ) {
 	jQuery.fn[ type ] = function( fn ) {
 		return this.on( type, fn );
 	};

--- a/src/event/alias.js
+++ b/src/event/alias.js
@@ -3,9 +3,10 @@ define([
 	"../event"
 ], function( jQuery ) {
 
-jQuery.each( ("blur focus focusin focusout load resize scroll unload click dblclick " +
+("blur focus focusin focusout load resize scroll unload click dblclick " +
 	"mousedown mouseup mousemove mouseover mouseout mouseenter mouseleave " +
-	"change select submit keydown keypress keyup error contextmenu").split(" "), function( i, name ) {
+	"change select submit keydown keypress keyup error contextmenu").split(" ").forEach(
+	function( name ) {
 
 	// Handle event binding
 	jQuery.fn[ name ] = function( data, fn ) {

--- a/src/offset.js
+++ b/src/offset.js
@@ -189,7 +189,7 @@ jQuery.each( { scrollLeft: "pageXOffset", scrollTop: "pageYOffset" }, function( 
 // Blink bug: https://code.google.com/p/chromium/issues/detail?id=229280
 // getComputedStyle returns percent when specified for top/left/bottom/right;
 // rather than make the css module depend on the offset module, just check for it here
-jQuery.each( [ "top", "left" ], function( i, prop ) {
+[ "top", "left" ].forEach(function( prop ) {
 	jQuery.cssHooks[ prop ] = addGetHookIf( support.pixelPosition,
 		function( elem, computed ) {
 			if ( computed ) {


### PR DESCRIPTION
All of the browsers supported by jQuery 2.x should support ES5 array iteration, so I don't see any benefit to using jQuery.each.  Just my preference for using native moving forward, feel free to close as the perf and file size differences would be insignificant.