### PR TITLE
Package.json: Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,12 +22,7 @@
   "bugs": {
     "url": "https://github.com/jquery/jquery/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/jquery/jquery/blob/master/LICENSE.txt"
-    }
-  ],
+  "license": "MIT",
   "dependencies": {},
   "devDependencies": {
     "commitplease": "2.0.0",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/