### PR TITLE
Core: Make jQuery objects iterable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 
 /dist
 /node_modules
+
+/test/node_smoke_tests/lib/ensure_iterability.js

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,5 +1,6 @@
 {
 	"preset": "jquery",
 
-	"excludeFiles": [ "external", "src/intro.js", "src/outro.js" ]
+	"excludeFiles": [ "external", "src/intro.js", "src/outro.js",
+		"test/node_smoke_tests/lib/ensure_iterability.js" ]
 }

--- a/.jshintignore
+++ b/.jshintignore
@@ -9,3 +9,4 @@ test/data/readywaitasset.js
 test/data/readywaitloader.js
 test/data/support/csp.js
 test/data/support/getComputedSupport.js
+test/node_smoke_tests/lib/ensure_iterability.js

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,6 +30,18 @@ module.exports = function( grunt ) {
 				cache: "build/.sizecache.json"
 			}
 		},
+		babel: {
+			options: {
+				sourceMap: "inline",
+				retainLines: true
+			},
+			nodeSmokeTests: {
+				files: {
+					"test/node_smoke_tests/lib/ensure_iterability.js":
+						"test/node_smoke_tests/lib/ensure_iterability_es6.js"
+				}
+			}
+		},
 		build: {
 			all: {
 				dest: "dist/jquery.js",

--- a/build/tasks/node_smoke_tests.js
+++ b/build/tasks/node_smoke_tests.js
@@ -15,7 +15,8 @@ module.exports = function( grunt ) {
 
 	fs.readdirSync( testsDir )
 		.filter( function( testFilePath ) {
-			return fs.statSync( testsDir + testFilePath ).isFile();
+			return fs.statSync( testsDir + testFilePath ).isFile() &&
+				/\.js$/.test( testFilePath );
 		} )
 		.forEach( function( testFilePath ) {
 			var taskName = "node_" + testFilePath.replace( /\.js$/, "" );

--- a/build/tasks/node_smoke_tests.js
+++ b/build/tasks/node_smoke_tests.js
@@ -5,7 +5,7 @@ module.exports = function( grunt ) {
 	var fs = require( "fs" ),
 		spawnTest = require( "./lib/spawn_test.js" ),
 		testsDir = "./test/node_smoke_tests/",
-		nodeSmokeTests = [ "jsdom" ];
+		nodeSmokeTests = [ "jsdom", "babel:nodeSmokeTests" ];
 
 	// Fire up all tests defined in test/node_smoke_tests/*.js in spawned sub-processes.
 	// All the files under test/node_smoke_tests/*.js are supposed to exit with 0 code

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
   "dependencies": {},
   "devDependencies": {
     "commitplease": "2.0.0",
+    "core-js": "0.9.17",
     "grunt": "0.4.5",
+    "grunt-babel": "5.0.1",
     "grunt-cli": "0.1.13",
     "grunt-compare-size": "0.4.0",
     "grunt-contrib-jshint": "0.11.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",
     "grunt-compare-size": "0.4.0",
-    "grunt-contrib-jshint": "0.10.0",
+    "grunt-contrib-jshint": "0.11.2",
     "grunt-contrib-uglify": "0.7.0",
     "grunt-contrib-watch": "0.6.1",
     "grunt-git-authors": "2.0.1",

--- a/src/core.js
+++ b/src/core.js
@@ -425,6 +425,16 @@ jQuery.extend({
 	support: support
 });
 
+// JSHint would error on this code due to the Symbol not being defined in ES5.
+// Defining this global in .jshintrc would create a danger of using the global
+// unguarded in another place, it seems safer to just disable JSHint for these
+// three lines.
+/* jshint ignore: start */
+if ( typeof Symbol === "function" ) {
+	jQuery.fn[ Symbol.iterator ] = arr[ Symbol.iterator ];
+}
+/* jshint ignore: end */
+
 // Populate the class2type map
 jQuery.each("Boolean Number String Function Array Date RegExp Object Error".split(" "),
 function(i, name) {

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -22,6 +22,7 @@
 		"define": false,
 		"DOMParser": false,
 		"Promise": false,
+		"Symbol": false,
 		"QUnit": false,
 		"ok": false,
 		"equal": false,

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -21,6 +21,7 @@
 		"require": false,
 		"define": false,
 		"DOMParser": false,
+		"Promise": false,
 		"QUnit": false,
 		"ok": false,
 		"equal": false,

--- a/test/node_smoke_tests/.jshintrc
+++ b/test/node_smoke_tests/.jshintrc
@@ -1,0 +1,14 @@
+{
+	"boss": true,
+	"curly": true,
+	"eqeqeq": true,
+	"eqnull": true,
+	"expr": true,
+	"immed": true,
+	"noarg": true,
+	"quotmark": "double",
+	"undef": true,
+	"unused": true,
+
+	"node": true
+}

--- a/test/node_smoke_tests/document_missing.js
+++ b/test/node_smoke_tests/document_missing.js
@@ -1,19 +1,11 @@
-/* jshint node: true */
-
 "use strict";
 
-var ensureGlobalNotCreated = require( "./lib/ensure_global_not_created" ),
+var assert = require( "assert" ),
+	ensureGlobalNotCreated = require( "./lib/ensure_global_not_created" ),
 	jQueryFactory = require( "../../dist/jquery.js" );
 
-try {
+assert.throws( function () {
 	jQueryFactory( {} );
-	console.error( "The jQuery factory should reject window without a document" );
-	process.exit( 1 );
-} catch ( e ) {
-	if ( e.message ===  "jQuery requires a window with a document" ) {
-		ensureGlobalNotCreated( module.exports );
-		process.exit( 0 );
-	}
-	console.error( "An unexpected error thrown; message: ", e.message );
-	process.exit( 1 );
-}
+}, /jQuery requires a window with a document/ );
+
+ensureGlobalNotCreated( module.exports );

--- a/test/node_smoke_tests/document_passed.js
+++ b/test/node_smoke_tests/document_passed.js
@@ -1,12 +1,9 @@
-/* jshint node: true */
-
 "use strict";
 
+var assert = require( "assert" );
+
 require( "jsdom" ).env( "", function( errors, window ) {
-	if ( errors ) {
-		console.error( errors );
-		process.exit( 1 );
-	}
+	assert.ifError( errors );
 
 	var ensureJQuery = require( "./lib/ensure_jquery" ),
 		ensureGlobalNotCreated = require( "./lib/ensure_global_not_created" ),

--- a/test/node_smoke_tests/document_present_originally.js
+++ b/test/node_smoke_tests/document_present_originally.js
@@ -1,12 +1,9 @@
-/* jshint node: true */
-
 "use strict";
 
+var assert = require( "assert" );
+
 require( "jsdom" ).env( "", function( errors, window ) {
-	if ( errors ) {
-		console.error( errors );
-		process.exit( 1 );
-	}
+	assert.ifError( errors );
 
 	// Pretend the window is a global.
 	global.window = window;

--- a/test/node_smoke_tests/iterable_with_native_symbol.js
+++ b/test/node_smoke_tests/iterable_with_native_symbol.js
@@ -1,0 +1,8 @@
+"use strict";
+
+if ( typeof Symbol === "undefined" ) {
+	console.log( "Symbols not supported, skipping the test..." );
+	process.exit();
+}
+
+require( "./lib/ensure_iterability_es6" )();

--- a/test/node_smoke_tests/iterable_with_symbol_polyfill.js
+++ b/test/node_smoke_tests/iterable_with_symbol_polyfill.js
@@ -1,0 +1,13 @@
+/* jshint esnext: true */
+
+"use strict";
+
+var assert = require( "assert" );
+
+delete global.Symbol;
+require( "core-js" );
+
+assert.strictEqual( typeof Symbol, "function", "Expected Symbol to be a function" );
+assert.notEqual( typeof Symbol.iterator, "symbol", "Expected Symbol.iterator to be polyfilled" );
+
+require( "./lib/ensure_iterability" )();

--- a/test/node_smoke_tests/lib/ensure_global_not_created.js
+++ b/test/node_smoke_tests/lib/ensure_global_not_created.js
@@ -1,6 +1,6 @@
-/* jshint node: true */
-
 "use strict";
+
+var assert = require( "assert" );
 
 // Ensure the jQuery property on global/window/module.exports/etc. was not
 // created in a CommonJS environment.
@@ -9,9 +9,7 @@ module.exports = function ensureGlobalNotCreated() {
 	var args = [].slice.call( arguments ).concat( global );
 
 	args.forEach( function( object ) {
-		if ( object.jQuery ) {
-			console.error( "A jQuery global was created in a CommonJS environment." );
-			process.exit( 1 );
-		}
+		assert.strictEqual( object.jQuery, undefined,
+			"A jQuery global was created in a CommonJS environment." );
 	} );
 };

--- a/test/node_smoke_tests/lib/ensure_iterability_es6.js
+++ b/test/node_smoke_tests/lib/ensure_iterability_es6.js
@@ -1,0 +1,25 @@
+/* jshint esnext: true */
+
+"use strict";
+
+var assert = require( "assert" );
+
+module.exports = function ensureIterability() {
+	require( "jsdom" ).env( "", function( errors, window ) {
+		assert.ifError( errors );
+
+		var i,
+			ensureJQuery = require( "./ensure_jquery" ),
+			jQuery = require( "../../../dist/jquery.js" )( window ),
+			elem = jQuery( "<div></div><span></span><a></a>" ),
+			result = "";
+
+		ensureJQuery( jQuery );
+
+		for ( i of elem ) {
+			result += i.nodeName;
+		}
+
+		assert.strictEqual( result, "DIVSPANA", "for-of doesn't work on jQuery objects" );
+	} );
+};

--- a/test/node_smoke_tests/lib/ensure_jquery.js
+++ b/test/node_smoke_tests/lib/ensure_jquery.js
@@ -1,11 +1,9 @@
-/* jshint node: true */
-
 "use strict";
+
+var assert = require( "assert" );
 
 // Check if the object we got is the jQuery object by invoking a basic API.
 module.exports = function ensureJQuery( jQuery ) {
-	if ( !/^jQuery/.test( jQuery.expando ) ) {
-		console.error( "jQuery.expando was not detected, the jQuery bootstrap process has failed" );
-		process.exit( 1 );
-	}
+	assert( /^jQuery/.test( jQuery.expando ),
+		"jQuery.expando was not detected, the jQuery bootstrap process has failed" );
 };

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -1538,3 +1538,23 @@ testIframeWithCallback( "Don't call window.onready (#14802)", "core/onready.html
 			equal( error, false, "no call to user-defined onready" );
 	}
 );
+
+test( "Iterability of jQuery objects (gh-1693)", function() {
+	/* jshint unused: false */
+	expect( 1 );
+
+	var i, elem, result;
+
+	if ( typeof Symbol === "function" ) {
+
+		elem = jQuery( "<div></div><span></span><a></a>" );
+		result = "";
+
+		try {
+			eval( "for ( i of elem ) { result += i.nodeName; }" );
+		} catch ( e ) {}
+		equal( result, "DIVSPANA", "for-of works on jQuery objects" );
+	} else {
+		ok( true, "The browser doesn't support Symbols" );
+	}
+} );


### PR DESCRIPTION
Make iterating over jQuery objects possible using ES 2015 for-of:

    for ( node of $( "<div id=narwhal>" ) ) {
        console.log( node.id ); // "narwhal"
    }

Fixes gh-1693

TODO:
* [x] Add a Node.js test checking if the iterator is defined even for `core-js`-polyfilled `Symbol` & `Symbol.iterator`.
* [x] Add tests ensuring that the iterator works with babel + core-js polyfills.
* [x] Rename jsHint to JSHint in comments.
* [x] Drop the `Symbol.iterator` check, leave just the `typeof Symbol` one.
* [x] Switch `[][Symbol.iterator]` to `arr[Symbol.iterator]`.
* [x] ~~Use `QUnit.skip` to skip the test in non-ES6 browsers.~~ Just use the `ok` assertions in non-ES6 browsers.
* [ ] Split the JSHint upgrade to a separate commit (to do just before landing).

@rwaldron, could you have a look if it's safe to include this in 3.0.0?