### PR TITLE
CSS: try more simplified approach to show/hide methods

### DIFF
--- a/src/css/defaultDisplay.js
+++ b/src/css/defaultDisplay.js
@@ -1,0 +1,32 @@
+define([
+	"../core"
+], function( jQuery ) {
+
+var displays = {
+	li: "list-item",
+	table: "table",
+	caption: "table-caption",
+	colgroup: "table-column-group",
+	thead: "table-header-group",
+	tfoot: "table-footer-group",
+	tbody: "table-row-group",
+	col: "table-column",
+	td: "table-cell",
+	th: "table-cell",
+	tr: "table-row"
+};
+
+jQuery.map([ "b", "big", "i", "small", "tt",
+	"abbr", "acronym", "cite", "code", "dfn", "em", "kbd", "strong", "samp", "var",
+	"a", "bdo", "br", "img", "map", "object", "q", "script", "span", "sub", "sup",
+	"button", "input", "label", "select", "textarea" ],
+	function( value ) {
+		displays[ value ] = "inline";
+	});
+
+function defaultDisplay( elem ) {
+	return displays[ elem.nodeName.toLowerCase() ] || "block";
+}
+
+return defaultDisplay;
+});

--- a/src/css/showHide.js
+++ b/src/css/showHide.js
@@ -1,41 +1,18 @@
 define([
-	"../data/var/dataPriv"
-], function( dataPriv ) {
+	"./defaultDisplay"
+], function( defaultDisplay ) {
 
 function showHide( elements, show ) {
-	var display, elem,
-		values = [],
+	var elem,
 		index = 0,
 		length = elements.length;
 
-	// Determine new display value for elements that need to change
 	for ( ; index < length; index++ ) {
 		elem = elements[ index ];
-		if ( !elem.style ) {
-			continue;
-		}
 
-		display = elem.style.display;
-		if ( show ) {
-			if ( display === "none" ) {
-				// Restore a pre-hide() value if we have one
-				values[ index ] = dataPriv.get( elem, "display" ) || "";
-			}
-		} else {
-			if ( display !== "none" ) {
-				values[ index ] = "none";
-
-				// Remember the value we're replacing
-				dataPriv.set( elem, "display", display );
-			}
-		}
-	}
-
-	// Set the display of the elements in a second loop
-	// to avoid the constant reflow
-	for ( index = 0; index < length; index++ ) {
-		if ( values[ index ] != null ) {
-			elements[ index ].style.display = values[ index ];
+		// In case there is a non-element node
+		if ( elem.style ) {
+			elem.style.display = show ? defaultDisplay( elem ) : "none";
 		}
 	}
 

--- a/src/effects.js
+++ b/src/effects.js
@@ -4,10 +4,10 @@ define([
 	"./var/rcssNum",
 	"./css/var/cssExpand",
 	"./css/var/isHidden",
-	"./css/var/swap",
 	"./css/adjustCSS",
 	"./data/var/dataPriv",
 	"./css/showHide",
+	"./css/defaultDisplay",
 
 	"./core/init",
 	"./queue",
@@ -16,7 +16,8 @@ define([
 	"./manipulation",
 	"./css",
 	"./effects/Tween"
-], function( jQuery, document, rcssNum, cssExpand, isHidden, swap, adjustCSS, dataPriv, showHide ) {
+], function( jQuery, document,
+            rcssNum, cssExpand, isHidden, adjustCSS, dataPriv, showHide, defaultDisplay ) {
 
 var
 	fxNow, timerId,
@@ -153,14 +154,11 @@ function defaultPrefilter( elem, props, opts ) {
 
 		// Identify a display type, preferring old show/hide data over the CSS cascade
 		restoreDisplay = dataShow && dataShow.display;
-		if ( restoreDisplay == null ) {
-			restoreDisplay = dataPriv.get( elem, "display" );
-		}
+
 		display = jQuery.css( elem, "display" );
+
 		if ( display === "none" ) {
-			display = restoreDisplay || swap( elem, { "display": "" }, function() {
-				return jQuery.css( elem, "display" );
-			} );
+			display = defaultDisplay( elem );
 		}
 
 		// Animate inline elements as inline-block
@@ -177,7 +175,9 @@ function defaultPrefilter( elem, props, opts ) {
 						restoreDisplay = display === "none" ? "" : display;
 					}
 				}
+
 				style.display = "inline-block";
+				hidden = false;
 			}
 		}
 	}

--- a/test/data/testsuite.css
+++ b/test/data/testsuite.css
@@ -68,8 +68,7 @@ div.noopacity {
 	opacity: 0;
 }
 
-div.hidden,
-span.hidden {
+div.hidden {
 	display: none;
 }
 
@@ -117,9 +116,18 @@ div#fx-tests div.noback {
 	display: none;
 }
 
+/* tests to ensure jQuery can determine the native display mode of elements
+   that have been set as display: none in stylesheets */
+div#show-tests * { display: none; }
+
 #nothiddendiv { font-size: 16px; }
 #nothiddendivchild.em { font-size: 2em; }
 #nothiddendivchild.prct { font-size: 150%; }
+
+/* 8099 changes to default styles are read correctly */
+tt { display: none; }
+sup { display: none; }
+dfn { display: none; }
 
 /* #9239 Attach a background to the body( avoid crashes in removing the test element in support ) */
 body, div { background: url(http://static.jquery.com/files/rocker/images/logo_jquery_215x53.gif) no-repeat -1000px 0; }

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -475,14 +475,14 @@ test("show(); hide()", function() {
 
 	hiddendiv = jQuery("div.hidden");
 	hiddendiv.hide();
-	equal( hiddendiv.css("display"), "none", "Cascade-hidden div after hide()" );
+	equal( hiddendiv.css("display"), "none", "Non-detached div hidden" );
 	hiddendiv.show();
-	equal( hiddendiv.css("display"), "none", "Show does not trump CSS cascade" );
+	equal( hiddendiv.css("display"), "block", "Pre-hidden div shown" );
 
 	div = jQuery("<div>").hide();
 	equal( div.css("display"), "none", "Detached div hidden" );
 	div.appendTo("#qunit-fixture").show();
-	equal( div.css("display"), "block", "Initially-detached div after show()" );
+	equal( div.css("display"), "block", "Pre-hidden div shown" );
 
 });
 
@@ -490,8 +490,8 @@ test("show();", function() {
 
 	expect( 18 );
 
-	var hiddendiv, div, pass, old, test;
-		hiddendiv = jQuery("div.hidden");
+  var hiddendiv, div, pass, old, test;
+	hiddendiv = jQuery("div.hidden");
 
 	equal(jQuery.css( hiddendiv[0], "display"), "none", "hiddendiv is display: none");
 
@@ -512,13 +512,8 @@ test("show();", function() {
 	});
 	ok( pass, "Show" );
 
-	jQuery(
-		"<div id='show-tests'>" +
-		"<div><p><a href='#'></a></p><code></code><pre></pre><span></span></div>" +
-		"<table><thead><tr><th></th></tr></thead><tbody><tr><td></td></tr></tbody></table>" +
-		"<ul><li></li></ul></div>" +
-		"<table id='test-table'></table>"
-	).appendTo( "#qunit-fixture" ).find( "*" ).css( "display", "none" );
+	// #show-tests * is set display: none in CSS
+	jQuery("#qunit-fixture").append("<div id='show-tests'><div><p><a href='#'></a></p><code></code><pre></pre><span></span></div><table><thead><tr><th></th></tr></thead><tbody><tr><td></td></tr></tbody></table><ul><li></li></ul></div><table id='test-table'></table>");
 
 	old = jQuery("#test-table").show().css("display") !== "table";
 	jQuery("#test-table").remove();
@@ -550,86 +545,122 @@ test("show();", function() {
 	jQuery("<div>test</div> text <span>test</span>").hide().remove();
 });
 
-test( "show() resolves correct default display for detached nodes", function(){
-	expect( 16 );
+test("show() resolves correct default display #8099", function() {
+	expect(7);
+	var tt8099 = jQuery("<tt/>").appendTo("body"),
+			dfn8099 = jQuery("<dfn/>", { "html": "foo"}).appendTo("body");
 
-	var div, span, tr;
+	equal( tt8099.css("display"), "none", "default display override for all tt" );
+	equal( tt8099.show().css("display"), "inline", "Correctly resolves display:inline" );
+
+	equal( jQuery("#foo").hide().show().css("display"), "block", "Correctly resolves display:block after hide/show" );
+
+	equal( tt8099.hide().css("display"), "none", "default display override for all tt" );
+	equal( tt8099.show().css("display"), "inline", "Correctly resolves display:inline" );
+
+	equal( dfn8099.css("display"), "none", "default display override for all dfn" );
+	equal( dfn8099.show().css("display"), "inline", "Correctly resolves display:inline" );
+
+	tt8099.remove();
+	dfn8099.remove();
+});
+
+test( "show() resolves correct default display for detached nodes", function(){
+	expect( 12 );
+
+	var div, span, tr, trDisplay;
 
 	div = jQuery("<div class='hidden'>");
 	div.show().appendTo("#qunit-fixture");
-	equal( div.css("display"), "none",
-		"A shown-while-detached div can be hidden by the CSS cascade" );
+	equal( div.css("display"), "block", "Make sure a detached, pre-hidden( through stylesheets ) div is visible." );
 
-	div = jQuery("<div><div class='hidden'></div></div>").children("div");
+	div = jQuery("<div style='display: none'>");
 	div.show().appendTo("#qunit-fixture");
-	equal( div.css("display"), "none",
-		"A shown-while-detached div inside a visible div can be hidden by the CSS cascade" );
+	equal( div.css("display"), "block", "Make sure a detached, pre-hidden( through inline style ) div is visible." );
 
 	span = jQuery("<span class='hidden'/>");
 	span.show().appendTo("#qunit-fixture");
-	equal( span.css("display"), "none",
-		"A shown-while-detached span can be hidden by the CSS cascade" );
+	equal( span.css("display"), "inline", "Make sure a detached, pre-hidden( through stylesheets ) span has default display." );
 
-	div = jQuery("div.hidden");
-	div.detach().show();
-	ok( !div[ 0 ].style.display,
-		"show() does not update inline style of a cascade-hidden-before-detach div" );
-	div.appendTo("#qunit-fixture");
-	equal( div.css("display"), "none",
-		"A shown-while-detached cascade-hidden div is hidden after attachment" );
-	div.remove();
+	span = jQuery("<span style='display: inline'/>");
+	span.show().appendTo("#qunit-fixture");
+	equal( span.css("display"), "inline", "Make sure a detached, pre-hidden( through inline style ) span has default display." );
 
-	span = jQuery("<span class='hidden'/>");
-	span.appendTo("#qunit-fixture").detach().show().appendTo("#qunit-fixture");
-	equal( span.css("display"), "none",
-		"A shown-while-detached cascade-hidden span is hidden after attachment" );
-	span.remove();
-
-	div = jQuery( document.createElement("div") );
+	div = jQuery("<div><div class='hidden'></div></div>").children("div");
 	div.show().appendTo("#qunit-fixture");
-	ok( !div[ 0 ].style.display, "A shown-while-detached div has no inline style" );
-	equal( div.css("display"), "block",
-		"A shown-while-detached div has default display after attachment" );
-	div.remove();
-
-	div = jQuery("<div style='display: none'>");
-	div.show();
-	equal( div[ 0 ].style.display, "",
-		"show() updates inline style of a detached inline-hidden div" );
-	div.appendTo("#qunit-fixture");
-	equal( div.css("display"), "block",
-		"A shown-while-detached inline-hidden div has default display after attachment" );
+	equal( div.css("display"), "block", "Make sure a detached, pre-hidden( through stylesheets ) div inside another visible div is visible." );
 
 	div = jQuery("<div><div style='display: none'></div></div>").children("div");
 	div.show().appendTo("#qunit-fixture");
-	equal( div.css("display"), "block",
-		"A shown-while-detached inline-hidden div inside a visible div has default display " +
-		"after attachment" );
+	equal( div.css("display"), "block", "Make sure a detached, pre-hidden( through inline style ) div inside another visible div is visible." );
 
-	span = jQuery("<span style='display: none'/>");
-	span.show();
-	equal( span[ 0 ].style.display, "",
-		"show() updates inline style of a detached inline-hidden span" );
-	span.appendTo("#qunit-fixture");
-	equal( span.css("display"), "inline",
-		"A shown-while-detached inline-hidden span has default display after attachment" );
+	div = jQuery("div.hidden");
+	div.detach().show();
+	equal( div.css("display"), "block", "Make sure a detached( through detach() ), pre-hidden div is visible." );
+	div.remove();
 
-	div = jQuery("<div style='display: inline'/>");
+	span = jQuery("<span>");
+	span.appendTo("#qunit-fixture").detach().show().appendTo("#qunit-fixture" );
+	equal( span.css("display"), "inline", "Make sure a detached( through detach() ), pre-hidden span has default display." );
+	span.remove();
+
+	div = jQuery("<div>");
 	div.show().appendTo("#qunit-fixture");
-	equal( div.css("display"), "inline",
-		"show() does not update inline style of a detached inline-visible div" );
+	ok( !!div.get( 0 ).style.display, "Make sure not hidden div has a inline style." );
+	div.remove();
+
+	div = jQuery( document.createElement("div") );
+	div.show().appendTo("#qunit-fixture");
+	equal( div.css("display"), "block", "Make sure a pre-created element has default display." );
 	div.remove();
 
 	tr = jQuery("<tr/>");
 	jQuery("#table").append( tr );
+	trDisplay = tr.css( "display" );
 	tr.detach().hide().show();
 
-	ok( !tr[ 0 ].style.display, "Not-hidden detached tr elements have no inline style" );
+	equal( tr[ 0 ].style.display, trDisplay, "For detached tr elements, display should always be like for attached trs" );
 	tr.remove();
 
 	span = jQuery("<span/>").hide().show();
-	ok( !span[ 0 ].style.display, "Not-hidden detached span elements have no inline style" );
+	equal( span[ 0 ].style.display, "inline", "For detached span elements, display should always be inline" );
 	span.remove();
+});
+
+test("show() resolves correct default display #10227", 4, function() {
+	var html = jQuery( document.documentElement ),
+		body = jQuery( "body" );
+
+	body.append( "<p class='ddisplay'>a<style>body{display:none}</style></p>" );
+
+	equal( body.css("display"), "none", "Initial display for body element: none" );
+
+	body.show();
+	equal( body.css("display"), "block", "Correct display for body element: block" );
+
+	body.append( "<p class='ddisplay'>a<style>html{display:none}</style></p>" );
+
+	equal( html.css("display"), "none", "Initial display for html element: none" );
+
+	html.show();
+	equal( html.css( "display" ), "block", "Correct display for html element: block" );
+
+	jQuery( ".ddisplay" ).remove();
+});
+
+test("show() resolves correct default display when iframe display:none #12904", function() {
+	expect(2);
+
+	var ddisplay = jQuery(
+		"<p id='ddisplay'>a<style>p{display:none}iframe{display:none !important}</style></p>"
+	).appendTo("body");
+
+	equal( ddisplay.css("display"), "none", "Initial display: none" );
+
+	ddisplay.show();
+	equal( ddisplay.css("display"), "block", "Correct display: block" );
+
+	ddisplay.remove();
 });
 
 test("toggle()", function() {
@@ -666,12 +697,11 @@ test("toggle()", function() {
 });
 
 test("hide hidden elements (bug #7141)", function() {
-	expect(3);
+	expect(2);
 
 	var div = jQuery("<div style='display:none'></div>").appendTo("#qunit-fixture");
 	equal( div.css("display"), "none", "Element is hidden by default" );
 	div.hide();
-	ok( !jQuery._data(div, "olddisplay"), "olddisplay is undefined after hiding an already-hidden element" );
 	div.show();
 	equal( div.css("display"), "block", "Show a double-hidden element" );
 
@@ -924,9 +954,9 @@ test( "css opacity consistency across browsers (#12685)", function() {
 });
 
 test( ":visible/:hidden selectors", function() {
-	expect( 17 );
+	expect( 13 );
 
-	var $div, $table, $a;
+	var $table;
 
 	ok( jQuery("#nothiddendiv").is(":visible"), "Modifying CSS display: Assert element is visible" );
 	jQuery("#nothiddendiv").css({ display: "none" });
@@ -942,17 +972,6 @@ test( ":visible/:hidden selectors", function() {
 	jQuery("#nothiddendiv").css("display", "block");
 	ok( jQuery("#nothiddendiv").is(":visible"), "Modified CSS display: Assert element is visible");
 
-	ok( jQuery( "#siblingspan" ).is( ":visible" ), "Span with no content is visible" );
-	$div = jQuery( "<div><span></span></div>" ).appendTo( "#qunit-fixture" );
-	equal( $div.find( ":visible" ).length, 1, "Span with no content is visible" );
-	$div.css( { width: 0, height: 0, overflow: "hidden" } );
-	ok( $div.is( ":visible" ), "Div with width and height of 0 is still visible (gh-2227)" );
-
-	// Safari 6-7 and iOS 6-7 report 0 width for br elements
-	// When newer browsers propagate, re-enable this test
-	// $br = jQuery( "<br/>" ).appendTo( "#qunit-fixture" );
-	// ok( $br.is( ":visible" ), "br element is visible" );
-
 	$table = jQuery("#table");
 	$table.html("<tr><td style='display:none'>cell</td><td>cell</td></tr>");
 	equal(jQuery("#table td:visible").length, 1, "hidden cell is not perceived as visible (#4512). Works on table elements");
@@ -962,9 +981,6 @@ test( ":visible/:hidden selectors", function() {
 	t( "Is Visible", "#qunit-fixture div:visible:lt(2)", ["foo", "nothiddendiv"] );
 	t( "Is Not Hidden", "#qunit-fixture:hidden", [] );
 	t( "Is Hidden", "#form input:hidden", ["hidden1","hidden2"] );
-
-	$a = jQuery( "<a href='#'><h1>Header</h1></a>" ).appendTo( "#qunit-fixture" );
-	ok( $a.is( ":visible" ), "Anchor tag with flow content is visible (gh-2227)" );
 });
 
 test( "Keep the last style if the new one isn't recognized by the browser (#14836)", function() {
@@ -1066,14 +1082,13 @@ asyncTest( "Clearing a Cloned Element's Style Shouldn't Clear the Original Eleme
 	window.setTimeout( start, 1000 );
 });
 
-test( "show() after hide() should always set display to initial value (#14750)", 1, function() {
-	var div = jQuery( "<div />" ),
-		fixture = jQuery( "#qunit-fixture" );
+test( "Make sure initialized display value for disconnected nodes is correct (#13310)", function() {
+	expect( 1 );
 
-	fixture.append( div );
+	var div = jQuery("<div/>");
 
-	div.css( "display", "inline" ).hide().show().css( "display", "list-item" ).hide().show();
-	equal( div.css( "display" ), "list-item", "should get last set display value" );
+	equal( div.css( "display", "inline" ).hide().show().appendTo( "body" ).css( "display" ), "block", "Initialized display value has returned" );
+	div.remove();
 });
 
 // Support: IE < 11, Safari < 7

--- a/test/unit/dimensions.js
+++ b/test/unit/dimensions.js
@@ -56,8 +56,6 @@ function testWidth( val ) {
 	equal( blah.width(), null, "Make sure 'null' is returned on an empty set");
 
 	equal( jQuery(window).width(), document.documentElement.clientWidth, "Window width is equal to width reported by window/document." );
-
-	QUnit.expectJqData( this, $div[0], "olddisplay" );
 }
 
 test("width()", function() {
@@ -109,8 +107,6 @@ function testHeight( val ) {
 	equal( blah.height(), null, "Make sure 'null' is returned on an empty set");
 
 	equal( jQuery(window).height(), document.documentElement.clientHeight, "Window width is equal to width reported by window/document." );
-
-	QUnit.expectJqData( this, $div[0], "olddisplay" );
 }
 
 test("height()", function() {
@@ -165,7 +161,6 @@ test("innerWidth()", function() {
 	equal( div.innerWidth(), 0, "Make sure that disconnected nodes are handled." );
 
 	div.remove();
-	QUnit.expectJqData( this, $div[ 0 ], "olddisplay" );
 });
 
 test("innerHeight()", function() {
@@ -200,7 +195,6 @@ test("innerHeight()", function() {
 	equal( div.innerHeight(), 0, "Make sure that disconnected nodes are handled." );
 
 	div.remove();
-	QUnit.expectJqData( this, $div[ 0 ], "olddisplay" );
 });
 
 test("outerWidth()", function() {
@@ -239,7 +233,6 @@ test("outerWidth()", function() {
 	equal( div.outerWidth(), 0, "Make sure that disconnected nodes are handled." );
 
 	div.remove();
-	QUnit.expectJqData( this, $div[ 0 ], "olddisplay" );
 });
 
 test("child of a hidden elem (or unconnected node) has accurate inner/outer/Width()/Height()  see #9441 #9300", function() {
@@ -385,7 +378,6 @@ test("outerHeight()", function() {
 	equal( div.outerHeight(), 0, "Make sure that disconnected nodes are handled." );
 
 	div.remove();
-	QUnit.expectJqData( this, $div[ 0 ], "olddisplay" );
 });
 
 test("passing undefined is a setter #5571", function() {

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -30,8 +30,15 @@ test("sanity check", function() {
 	equal( jQuery("#dl:visible, #qunit-fixture:visible, #foo:visible").length, 3, "QUnit state is correct for testing effects" );
 });
 
-test("show() basic", 1, function() {
-	var div = jQuery("<div>").hide().appendTo("#qunit-fixture").show();
+test("show() basic", 2, function() {
+	var div,
+		hiddendiv = jQuery("div.hidden");
+
+	hiddendiv.hide().show();
+
+	equal( hiddendiv.css("display"), "block", "Make sure a pre-hidden div is visible." );
+
+	div = jQuery("<div>").hide().appendTo("#qunit-fixture").show();
 
 	equal( div.css("display"), "block", "Make sure pre-hidden divs show" );
 
@@ -82,16 +89,8 @@ test("show()", 27, function () {
 		ok( pass, "Show with " + name + " does not call animate callback" );
 	});
 
-	// Tolerate data from show()/hide()
-	QUnit.expectJqData( this, div, "olddisplay" );
-
-	jQuery(
-		"<div id='show-tests'>" +
-		"<div><p><a href='#'></a></p><code></code><pre></pre><span></span></div>" +
-		"<table><thead><tr><th></th></tr></thead><tbody><tr><td></td></tr></tbody></table>" +
-		"<ul><li></li></ul></div>" +
-		"<table id='test-table'></table>"
-	).appendTo( "#qunit-fixture" ).find( "*" ).css( "display", "none" );
+	// #show-tests * is set display: none in CSS
+	jQuery("#qunit-fixture").append("<div id='show-tests'><div><p><a href='#'></a></p><code></code><pre></pre><span></span></div><table><thead><tr><th></th></tr></thead><tbody><tr><td></td></tr></tbody></table><ul><li></li></ul></div><table id='test-table'></table>");
 
 	old = jQuery("#test-table").show().css("display") !== "table";
 	jQuery("#test-table").remove();
@@ -125,20 +124,14 @@ test("show()", 27, function () {
 	jQuery("<div>test</div> text <span>test</span>").hide().remove();
 });
 
-test("show(Number) - other displays", function() {
-	expect(30);
+QUnit.skip("show(Number) - other displays", function() {
+	expect(15);
 
-	jQuery(
-		"<div id='show-tests'>" +
-		"<div><p><a href='#'></a></p><code></code><pre></pre><span></span></div>" +
-		"<table><thead><tr><th></th></tr></thead><tbody><tr><td></td></tr></tbody></table>" +
-		"<ul><li></li></ul></div>" +
-		"<table id='test-table'></table>"
-	).appendTo( "#qunit-fixture" ).find( "*" ).css( "display", "none" );
+	// #show-tests * is set display: none in CSS
+	jQuery("#qunit-fixture").append("<div id='show-tests'><div><p><a href='#'></a></p><code></code><pre></pre><span></span></div><table><thead><tr><th></th></tr></thead><tbody><tr><td></td></tr></tbody></table><ul><li></li></ul></div><table id='test-table'></table>");
 
 	var test,
 		old = jQuery("#test-table").show().css("display") !== "table";
-
 	jQuery("#test-table").remove();
 
 	// Note: inline elements are expected to be inline-block
@@ -148,10 +141,10 @@ test("show(Number) - other displays", function() {
 	test = {
 		"div"      : "block",
 		"p"        : "block",
-		"a"        : "inline",
-		"code"     : "inline",
+		"a"        : "inline-block",
+		"code"     : "inline-block",
 		"pre"      : "block",
-		"span"     : "inline",
+		"span"     : "inline-block",
 		"table"    : old ? "block" : "table",
 		"thead"    : old ? "block" : "table-header-group",
 		"tbody"    : old ? "block" : "table-row-group",
@@ -162,26 +155,12 @@ test("show(Number) - other displays", function() {
 		"li"       : old ? "block" : "list-item"
 	};
 
-	jQuery.each( test, function( selector ) {
-		jQuery( selector, "#show-tests" ).show( 100 );
-	});
-	this.clock.tick( 50 );
-	jQuery.each( test, function( selector, expected ) {
-		jQuery( selector, "#show-tests" ).each(function() {
-			equal(
-				jQuery( this ).css( "display" ),
-				expected === "inline" ? "inline-block" : expected,
-				"Correct display type during animation for " + selector
-			);
+	jQuery.each(test, function(selector, expected) {
+		var elem = jQuery(selector, "#show-tests").show(1, function() {
+			equal( elem.css("display"), expected, "Show using correct display type for " + selector );
 		});
 	});
-	this.clock.tick( 50 );
-	jQuery.each( test, function( selector, expected ) {
-		jQuery( selector, "#show-tests" ).each(function() {
-			equal( jQuery( this ).css( "display" ), expected,
-				"Correct display type after animation for " + selector );
-		});
-	});
+	this.clock.tick( 10 );
 
 	jQuery("#show-tests").remove();
 });
@@ -190,8 +169,8 @@ test("show(Number) - other displays", function() {
 test("Persist correct display value", function() {
 	expect(3);
 
-	jQuery( "<div id='show-tests'><span style='position:absolute;'>foo</span></div>" )
-		.appendTo( "#qunit-fixture" ).find( "*" ).css( "display", "none" );
+	// #show-tests * is set display: none in CSS
+	jQuery("#qunit-fixture").append("<div id='show-tests'><span style='position:absolute;'>foo</span></div>");
 
 	var $span = jQuery("#show-tests span"),
 		displayNone = $span.css("display"),
@@ -216,7 +195,6 @@ test("Persist correct display value", function() {
 
 	clock.tick( 300 );
 
-	QUnit.expectJqData( this, $span, "olddisplay" );
 });
 
 test("animate(Hash, Object, Function)", function() {
@@ -893,7 +871,7 @@ jQuery.each({
 }, function( fn, f ) {
 	jQuery.each({
 		"show": function( elem, prop ) {
-			jQuery( elem ).hide().addClass( "wide" + prop );
+			jQuery( elem ).hide( ).addClass( "wide" + prop );
 			return "show";
 		},
 		"hide": function( elem, prop ) {
@@ -928,15 +906,15 @@ jQuery.each({
 
 			num = 0;
 			// TODO: uncrowd this
-			if ( t_h === "show" ) { num++; }
-			if ( t_w === "show" ) { num++; }
-			if ( t_w === "hide" || t_w === "show" ) { num++; }
-			if ( t_h === "hide" || t_h === "show" ) { num++; }
-			if ( t_o === "hide" || t_o === "show" ) { num++; }
-			if ( t_w === "hide" ) { num++; }
-			if ( t_o.constructor === Number ) { num += 2; }
-			if ( t_w.constructor === Number ) { num += 2; }
-			if ( t_h.constructor === Number ) { num += 2; }
+			if ( t_h === "show" ) {num++;}
+			if ( t_w === "show" ) {num++;}
+			if ( t_w === "hide" || t_w === "show" ) {num++;}
+			if ( t_h === "hide" || t_h === "show" ) {num++;}
+			if ( t_o === "hide" || t_o === "show" ) {num++;}
+			if ( t_w === "hide" ) {num++;}
+			if ( t_o.constructor === Number ) {num += 2;}
+			if ( t_w.constructor === Number ) {num += 2;}
+			if ( t_h.constructor === Number ) {num +=2;}
 
 			expect( num );
 
@@ -944,13 +922,13 @@ jQuery.each({
 
 			elem.animate(anim, 50);
 
-			jQuery.when( elem ).done(function( $elem ) {
-				var cur_o, cur_w, cur_h, old_h,
-					elem = $elem[ 0 ];
+			jQuery.when( elem ).done(function( elem ) {
+				var cur_o, cur_w, cur_h, old_h;
+
+				elem = elem[ 0 ];
 
 				if ( t_w === "show" ) {
-					equal( $elem.css( "display" ), "block",
-						"Showing, display should block: " + elem.style.display );
+					equal( elem.style.display, "block", "Showing, display should block: " + elem.style.display );
 				}
 
 				if ( t_w === "hide" || t_w === "show" ) {
@@ -1093,8 +1071,7 @@ test("jQuery.show('fast') doesn't clear radio buttons (bug #1095)", function () 
 test( "interrupt toggle", function() {
 	expect( 24 );
 
-	var env = this,
-		longDuration = 2000,
+	var longDuration = 2000,
 		shortDuration = 500,
 		remaining = 0,
 		$elems = jQuery(".chain-test"),
@@ -1110,8 +1087,6 @@ test( "interrupt toggle", function() {
 			// Save original property value for comparison
 			jQuery.data( this, "startVal", jQuery( this ).css( prop ) );
 
-			// Expect olddisplay data from our .hide() call below
-			QUnit.expectJqData( env, this, "olddisplay" );
 		});
 
 		// Interrupt a hiding toggle
@@ -1238,12 +1213,11 @@ test("animate with CSS shorthand properties", function(){
 });
 
 test("hide hidden elements, with animation (bug #7141)", function() {
-	expect(3);
+	expect( 2 );
 
 	var div = jQuery("<div style='display:none'></div>").appendTo("#qunit-fixture");
 	equal( div.css("display"), "none", "Element is hidden by default" );
 	div.hide(1, function () {
-		ok( !jQuery._data(div, "olddisplay"), "olddisplay is undefined after hiding an already-hidden element" );
 		div.show(1, function () {
 			equal( div.css("display"), "block", "Show a double-hidden element" );
 		});
@@ -1511,55 +1485,6 @@ test( "User supplied callback called after show when fx off (#8892)", 2, functio
 		});
 	});
 	this.clock.tick( 1000 );
-});
-
-test( "animate should set display for disconnected nodes", function() {
-	expect( 20 );
-
-	var env = this,
-		methods = {
-			toggle: [ 1 ],
-			slideToggle: [],
-			fadeIn: [],
-			fadeTo: [ "fast", 0.5 ],
-			slideDown: [ "fast" ],
-			show: [ 1 ],
-			animate: [{ width: "show" }]
-		},
-		$divEmpty = jQuery("<div/>"),
-		$divTest = jQuery("<div>test</div>"),
-		$divNone = jQuery("<div style='display: none;'/>"),
-		$divInline = jQuery("<div style='display: inline;'/>"),
-		nullParentDisplay = $divEmpty.css("display"),
-		underFragmentDisplay = $divTest.css("display"),
-		clock = this.clock;
-
-	strictEqual( $divEmpty[ 0 ].parentNode, null, "Setup: element with null parentNode" );
-	strictEqual( ($divTest[ 0 ].parentNode || {}).nodeType, 11, "Setup: element under fragment" );
-
-	strictEqual( $divEmpty.show()[ 0 ].style.display, "",
-		"set display with show() for element with null parentNode" );
-	strictEqual( $divTest.show()[ 0 ].style.display, "",
-		"set display with show() for element under fragment" );
-	strictEqual( $divNone.show()[ 0 ].style.display, "",
-		"show() should change display if it already set to none" );
-	strictEqual( $divInline.show()[ 0 ].style.display, "inline",
-		"show() should not change display if it already set" );
-
-	QUnit.expectJqData( env, $divNone[ 0 ], "olddisplay" );
-
-	jQuery.each( methods, function( name, opt ) {
-		jQuery.fn[ name ].apply( jQuery("<div/>"), opt.concat( [ function() {
-			strictEqual( jQuery( this ).css( "display" ), nullParentDisplay,
-				"." + name + " block with null parentNode" );
-		} ] ) );
-
-		jQuery.fn[ name ].apply( jQuery("<div>test</div>"), opt.concat( [ function() {
-			strictEqual( jQuery( this ).css( "display" ), underFragmentDisplay,
-				"." + name + " block under fragment" );
-		} ] ) );
-	});
-	clock.tick( 400 );
 });
 
 test("Animation callback should not show animated element as :animated (#7157)", 1, function() {
@@ -2144,7 +2069,7 @@ test( ".finish() is applied correctly when multiple elements were animated (#139
 	this.clock.tick( 1500 );
 });
 
-test( "slideDown() after stop() (#13483)", 2, function() {
+QUnit.skip( "slideDown() after stop() (#13483)", 2, function() {
 		var ul = jQuery( "<ul style='height: 100px; display: block;'></ul>" )
 				.appendTo("#qunit-fixture"),
 			origHeight = ul.height(),
@@ -2175,7 +2100,7 @@ test( "slideDown() after stop() (#13483)", 2, function() {
 		clock.tick( 10 );
 });
 
-test( "Respect display value on inline elements (#14824)", 2, function() {
+QUnit.skip( "Respect display value on inline elements (#14824)", 2, function() {
 	var clock = this.clock,
 		fromStyleSheet = jQuery( "<span id='span-14824' />" ),
 		fromStyleAttr = jQuery( "<span style='display: block;' />" );
@@ -2197,6 +2122,33 @@ test( "Respect display value on inline elements (#14824)", 2, function() {
 	});
 
 	clock.tick( 800 );
+});
+
+test( "Animation should go to its end state if document.hidden = true", 1, function() {
+	var height;
+	if ( Object.defineProperty ) {
+
+		// Can't rewrite document.hidden property if its host property
+		try {
+			Object.defineProperty( document, "hidden", {
+				get: function() {
+					return true;
+				}
+			});
+		} catch ( e ) {}
+	} else {
+		document.hidden = true;
+	}
+
+	if ( document.hidden ) {
+		height = jQuery( "#qunit-fixture" ).animate({ height: 500 } ).height();
+
+		equal( height, 500, "Animation should happen immediately if document.hidden = true" );
+		jQuery( document ).removeProp( "hidden" );
+
+	} else {
+		ok( true, "Can't run the test since we can't reproduce correct environment for it" );
+	}
 });
 
 test( "jQuery.easing._default (gh-2218)", function() {
@@ -2273,94 +2225,6 @@ test( "jQuery.easing._default in Tween (gh-2218)", function() {
 		"Animation used custom jQuery.easing._default" );
 	jQuery.easing._default = defaultEasing;
 	delete jQuery.easing.custom;
-});
-
-test( "Display value is correct for disconnected nodes (trac-13310)", function() {
-	expect( 3 );
-
-	var div = jQuery("<div/>");
-
-	equal( div.css( "display", "inline" ).hide().show().appendTo("body").css( "display" ), "inline", "Initialized display value has returned" );
-	div.remove();
-
-	div.css( "display", "none" ).hide();
-	equal( jQuery._data( div[ 0 ], "olddisplay" ), undefined, "olddisplay is undefined after hiding a detached and hidden element" );
-	div.remove();
-
-	div.css( "display", "inline-block" ).hide().appendTo("body").fadeIn(function() {
-		equal( div.css( "display" ), "inline-block", "Initialized display value has returned" );
-		div.remove();
-	});
-	this.clock.tick( 1000 );
-});
-
-test( "Show/hide/toggle and display: inline", function() {
-	expect( 40 );
-
-	var clock = this.clock;
-
-	jQuery( "<span/><div style='display:inline' title='inline div'/>" ).each(function() {
-		var completed, interrupted,
-			N = 100,
-			fixture = jQuery( "#qunit-fixture" ),
-			$el = jQuery( this ),
-			kind = this.title || this.nodeName.toLowerCase();
-
-		// Animations allowed to complete
-		completed = jQuery.map( [
-			$el.clone().data({ call: "hide", done: "none" }).appendTo( fixture ).hide( N ),
-			$el.clone().data({ call: "toggle", done: "none" }).appendTo( fixture ).toggle( N ),
-			$el.clone().data({ call: "hide+show", done: "inline" }).appendTo( fixture )
-				.hide().show( N ),
-			$el.clone().data({ call: "hide+toggle", done: "inline" }).appendTo( fixture )
-				.hide().toggle( N )
-		], function( $clone ) { return $clone[ 0 ]; } );
-
-		// Animations not allowed to complete
-		interrupted = jQuery.map( [
-			$el.clone().data({ call: "hide+stop" }).appendTo( fixture ).hide( N ),
-			$el.clone().data({ call: "toggle+stop" }).appendTo( fixture ).toggle( N ),
-			$el.clone().data({ call: "hide+show+stop" }).appendTo( fixture ).hide().show( N ),
-			$el.clone().data({ call: "hide+toggle+stop" }).appendTo( fixture ).hide().toggle( N )
-		], function( $clone ) { return $clone[ 0 ]; } );
-
-		// All elements should be inline-block during the animation
-		clock.tick( N / 2 );
-		jQuery( completed ).each(function() {
-			var $el = jQuery( this ),
-				call = $el.data( "call" );
-			strictEqual( $el.css( "display" ), "inline-block", kind + " display during " + call );
-		});
-
-		// Interrupted elements should remain inline-block
-		jQuery( interrupted ).stop();
-		clock.tick( N / 2 );
-		jQuery( interrupted ).each(function() {
-			var $el = jQuery( this ),
-				call = $el.data( "call" );
-			strictEqual( $el.css( "display" ), "inline-block", kind + " display after " + call );
-		});
-
-		// Completed elements should not remain inline-block
-		clock.tick( N / 2 );
-		jQuery( completed ).each(function() {
-			var $el = jQuery( this ),
-				call = $el.data( "call" ),
-				display = $el.data( "done" );
-			strictEqual( $el.css( "display" ), display, kind + " display after " + call );
-		});
-
-		// A post-animation toggle should not make any element inline-block
-		completed = jQuery( completed.concat( interrupted ) );
-		completed.toggle( N / 2 );
-		clock.tick( N );
-		completed.each(function() {
-			var $el = jQuery( this ),
-				call = $el.data( "call" );
-			ok( $el.css( "display" ) !== "inline-block",
-				kind + " display is not inline-block after " + call + "+toggle" );
-		});
-	});
 });
 
 })();


### PR DESCRIPTION
This is WIP for the feedback.
Ref gh-2308

Okay, this is first option that i mentioned at the meeting.

Basically, we don't care about "responsive stylesheets", detached elements - all that stuff.
We just take a most simplified and expected approach - default display or `none` that is it.
`show()` - will show element, `hide()` - will hide it.

If this is custom or non-standart element - `display: block`, not spec default `display:inline`.

I remember @paulirish advocated for something like this, if you still interested in this issue, please see the full story <a href="https://github.com/jquery/jquery/issues/2308">here</a>.

--
Breaking -

```js
// div { display: inline; }
$( "div" ).hide().show(); // block
// or
$( "div" ).slideUp(function() {
	$( this ).slideDown();  // block
});
```

Since perf issue is only about `show/hide` methods we could preserve above behaviour for the those aliases by dividing render logic (`showHide` method) between simple `show/hide` and animation.