### PR TITLE
CSS: save 7 bytes on the getStyles function

### DIFF
--- a/src/css/var/getStyles.js
+++ b/src/css/var/getStyles.js
@@ -6,6 +6,10 @@ define(function() {
 		// FF meanwhile throws on frame elements through "defaultView.getComputedStyle"
 		var view = elem.ownerDocument.defaultView;
 
-		return ( view.opener && view || window ).getComputedStyle( elem );
+		if ( !view.opener ) {
+			view = window;
+		}
+
+		return view.getComputedStyle( elem );
 	};
 });

--- a/src/css/var/getStyles.js
+++ b/src/css/var/getStyles.js
@@ -1,12 +1,11 @@
 define(function() {
 	return function( elem ) {
+
 		// Support: IE<=11+, Firefox<=30+ (#15098, #14150)
 		// IE throws on elements created in popups
 		// FF meanwhile throws on frame elements through "defaultView.getComputedStyle"
-		if ( elem.ownerDocument.defaultView.opener ) {
-			return elem.ownerDocument.defaultView.getComputedStyle( elem );
-		}
+		var view = elem.ownerDocument.defaultView;
 
-		return window.getComputedStyle( elem );
+		return ( view.opener && view || window ).getComputedStyle( elem );
 	};
 });


### PR DESCRIPTION
Hi,

I saw few bytes to save after reading #2341, but I didn't change the logic.