### PR TITLE
Core: Use window.setTimeout & friends instead of global equivalents

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -14,10 +14,6 @@
 
 	"globals": {
 		"window": true,
-		"setTimeout": true,
-		"clearTimeout": true,
-		"setInterval": true,
-		"clearInterval": true,
 
 		"jQuery": true,
 		"define": true,

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -2,6 +2,8 @@ define([
 	"./core",
 	"./var/document",
 	"./var/rnotwhite",
+	"./var/setTimeout",
+	"./var/clearTimeout",
 	"./ajax/var/location",
 	"./ajax/var/nonce",
 	"./ajax/var/rquery",
@@ -9,7 +11,8 @@ define([
 	"./ajax/parseJSON",
 	"./ajax/parseXML",
 	"./deferred"
-], function( jQuery, document, rnotwhite, location, nonce, rquery ) {
+], function( jQuery, document, rnotwhite, setTimeout, clearTimeout,
+	location, nonce, rquery ) {
 
 var
 	rhash = /#.*$/,

--- a/src/core/ready.js
+++ b/src/core/ready.js
@@ -1,8 +1,9 @@
 define([
 	"../core",
 	"../var/document",
+	"../var/setTimeout",
 	"../deferred"
-], function( jQuery, document ) {
+], function( jQuery, document, setTimeout ) {
 
 // The deferred used on DOM ready
 var readyList;

--- a/src/deferred.js
+++ b/src/deferred.js
@@ -1,8 +1,9 @@
 define([
 	"./core",
 	"./var/slice",
+	"./var/setTimeout",
 	"./callbacks"
-], function( jQuery, slice ) {
+], function( jQuery, slice, setTimeout ) {
 
 function Identity( v ) {
 	return v;

--- a/src/effects.js
+++ b/src/effects.js
@@ -2,6 +2,9 @@ define([
 	"./core",
 	"./var/document",
 	"./var/rcssNum",
+	"./var/setInterval",
+	"./var/clearInterval",
+	"./var/setTimeout",
 	"./css/var/cssExpand",
 	"./css/var/isHidden",
 	"./css/var/swap",
@@ -16,7 +19,8 @@ define([
 	"./manipulation",
 	"./css",
 	"./effects/Tween"
-], function( jQuery, document, rcssNum, cssExpand, isHidden, swap, adjustCSS, dataPriv, showHide ) {
+], function( jQuery, document, rcssNum, setInterval, clearInterval, setTimeout,
+	cssExpand, isHidden, swap, adjustCSS, dataPriv, showHide ) {
 
 var
 	fxNow, timerId,

--- a/src/queue/delay.js
+++ b/src/queue/delay.js
@@ -1,8 +1,10 @@
 define([
 	"../core",
+	"../var/setTimeout",
+	"../var/clearTimeout",
 	"../queue",
 	"../effects" // Delay is optional because of this dependency
-], function( jQuery ) {
+], function( jQuery, setTimeout, clearTimeout ) {
 
 // Based off of the plugin by Clint Helfers, with permission.
 // http://web.archive.org/web/20100324014747/http://blindsignals.com/index.php/2009/07/jquery-delay/

--- a/src/var/clearInterval.js
+++ b/src/var/clearInterval.js
@@ -1,0 +1,3 @@
+define(function() {
+	return window.clearInterval;
+});

--- a/src/var/clearTimeout.js
+++ b/src/var/clearTimeout.js
@@ -1,0 +1,3 @@
+define(function() {
+	return window.clearTimeout;
+});

--- a/src/var/setInterval.js
+++ b/src/var/setInterval.js
@@ -1,0 +1,3 @@
+define(function() {
+	return window.setInterval;
+});

--- a/src/var/setTimeout.js
+++ b/src/var/setTimeout.js
@@ -1,0 +1,3 @@
+define(function() {
+	return window.setTimeout;
+});


### PR DESCRIPTION
Fixes gh-2177

+28 bytes.

An alternative to #2391 (+60), #2392 (+51) & #2394 (+40).