### PR TITLE
Core:Suggest remove unnecessary parameter

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -103,7 +103,7 @@ jQuery.fn = jQuery.prototype = {
 	},
 
 	end: function() {
-		return this.prevObject || this.constructor(null);
+		return this.prevObject || this.constructor();
 	},
 
 	// For internal use only.


### PR DESCRIPTION
Sorry. Again PR #2428
I removed unnecessary parameter for constructor of "end" method. It`s because jQuery constructor with no parameter is the same as jQuery constructor with null parameter.