### PR TITLE
Use `matchesSelector` for serializeArray.

### DIFF
--- a/src/serialize.js
+++ b/src/serialize.js
@@ -2,7 +2,7 @@ define([
 	"./core",
 	"./manipulation/var/rcheckableType",
 	"./core/init",
-	"./traversing", // filter
+	"./traversing", // filter, selector
 	"./attributes/prop"
 ], function( jQuery, rcheckableType ) {
 
@@ -93,8 +93,8 @@ jQuery.fn.extend({
 		.filter(function() {
 			var type = this.type;
 
-			// Use .is( ":disabled" ) so that fieldset[disabled] works
-			return this.name && !jQuery( this ).is( ":disabled" ) &&
+			// Test by selector because the disabled property ignores ancestor fieldsets
+			return this.name && !jQuery.find.matchesSelector( this, ":disabled" ) &&
 				rsubmittable.test( this.nodeName ) && !rsubmitterTypes.test( type ) &&
 				( this.checked || !rcheckableType.test( type ) );
 		})


### PR DESCRIPTION
This is slight performance enhancement.

Old method will create a jQuery object with a single element and pass it to `.is()` which loops through a single item array and winds up at `matchesSelector` after some more needless logic.

This method just uses `matchesSelector` directly which bypasses the looping and other logic.

```
   raw     gz Sizes
255090  75474 dist/jquery.js
 84466  29360 dist/jquery.min.js

   raw     gz Compared to master @ 8e4aac8cb03ffb88373ea99629165d82ff5eccdd
   +34    +12 dist/jquery.js
   +17     +7 dist/jquery.min.js
```