### PR TITLE
Ajax: Account for Android 2.3 not firing window.onerror on script errors

### DIFF
--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -1450,6 +1450,15 @@ module( "ajax", {
 	});
 
 	asyncTest( "#11743 - jQuery.ajax() - script, throws exception", 1, function() {
+		// Support: Android 2.3 only
+		// Android 2.3 doesn't fire the window.onerror handler, just accept the reality there.
+		if ( /android 2\.3/i.test( navigator.userAgent ) ) {
+			ok( true, "Test skipped, Android 2.3 doesn't fire window.onerror for " +
+				"errors in dynamically included scripts" );
+			start();
+			return;
+		}
+
 		var onerror = window.onerror;
 		window.onerror = function() {
 			ok( true, "Exception thrown" );

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -2241,6 +2241,17 @@ test( "Ensure oldIE creates a new set on appendTo (#8894)", function() {
 });
 
 asyncTest( "html() - script exceptions bubble (#11743)", 2, function() {
+	// Support: Android 2.3 only
+	// Android 2.3 doesn't fire the window.onerror handler, just accept the reality there.
+	if ( /android 2\.3/i.test( navigator.userAgent ) ) {
+		ok( true, "Test skipped, Android 2.3 doesn't fire window.onerror for " +
+			"errors in dynamically included scripts" );
+		ok( true, "Test skipped, Android 2.3 doesn't fire window.onerror for " +
+			"errors in dynamically included scripts" );
+		start();
+		return;
+	}
+
 	var onerror = window.onerror;
 
 	setTimeout(function() {


### PR DESCRIPTION
Android 2.3 doesn't fire the window.onerror handler, just accept the reality
there and skip the test.

Refs gh-1573
Refs gh-1786

TBH, this seems pretty bad. My initial attempt was to add the code block at the end of the test but then, once the following:
```js
jQuery.ajax({
	url: "data/badjson.js",
	dataType: "script",
	throws: true
});
```
is invoked, `jQuery.active` stays `>=1` forever. This may affect all subsequent AJAX requests, right? If I understand it correctly, one error in a script loaded via `jQuery.ajax` with `dataType: "script"` breaks all subsequent `jQuery.ajax` uses, no `ajaxStart` & `ajaxStop` events will fire.

cc @jaubourg