### PR TITLE
Ajax: Remove jsonp callbacks through "jQuery#removeProp" method

### DIFF
--- a/src/ajax/jsonp.js
+++ b/src/ajax/jsonp.js
@@ -64,8 +64,14 @@ jQuery.ajaxPrefilter( "json jsonp", function( s, originalSettings, jqXHR ) {
 
 		// Clean-up function (fires after converters)
 		jqXHR.always(function() {
-			// Restore preexisting value
-			window[ callbackName ] = overwritten;
+			// If previous value didn't exist - remove it
+			if ( overwritten === undefined ) {
+				jQuery( window ).removeProp( callbackName );
+
+			// Otherwise restore preexisting value
+			} else {
+				window[ callbackName ] = overwritten;
+			}
 
 			// Save back as free
 			if ( s[ callbackName ] ) {


### PR DESCRIPTION
Fixes gh-2323

@timmywil that is that one i was talking about, but i was intended to go even further.

Registering callbacks not on window, but on special jQuery object, like `jQuery.jsonpCallbacks`, since according to the specification - http://json-p.org/ dots are allowed to be in get parameter so server scripts should allow them, but even their logic violate the spec, user could apply their own jsonp callback name generation. 

But it seems more radical and in need in discussion, thoughts?