### PR TITLE
Attributes: .removeClass() -> .attr( "class", "" )

### DIFF
--- a/src/attributes/classes.js
+++ b/src/attributes/classes.js
@@ -14,9 +14,7 @@ function getClass( elem ) {
 jQuery.fn.extend( {
 	addClass: function( value ) {
 		var classes, elem, cur, curValue, clazz, j, finalValue,
-			proceed = typeof value === "string" && value,
-			i = 0,
-			len = this.length;
+			i = 0;
 
 		if ( jQuery.isFunction( value ) ) {
 			return this.each( function( j ) {
@@ -24,13 +22,10 @@ jQuery.fn.extend( {
 			} );
 		}
 
-		if ( proceed ) {
+		if ( typeof value === "string" && value ) {
+			classes = value.match( rnotwhite ) || [];
 
-			// The disjunction here is for better compressibility (see removeClass)
-			classes = ( value || "" ).match( rnotwhite ) || [];
-
-			for ( ; i < len; i++ ) {
-				elem = this[ i ];
+			while ( ( elem = this[ i++ ] ) ) {
 				curValue = getClass( elem );
 				cur = elem.nodeType === 1 &&
 					( " " + curValue + " " ).replace( rclass, " " );
@@ -57,20 +52,22 @@ jQuery.fn.extend( {
 
 	removeClass: function( value ) {
 		var classes, elem, cur, curValue, clazz, j, finalValue,
-			proceed = arguments.length === 0 || typeof value === "string" && value,
-			i = 0,
-			len = this.length;
+			i = 0;
 
 		if ( jQuery.isFunction( value ) ) {
 			return this.each( function( j ) {
 				jQuery( this ).removeClass( value.call( this, j, getClass( this ) ) );
 			} );
 		}
-		if ( proceed ) {
-			classes = ( value || "" ).match( rnotwhite ) || [];
 
-			for ( ; i < len; i++ ) {
-				elem = this[ i ];
+		if ( !arguments.length ) {
+			return this.attr( "class", "" );
+		}
+
+		if ( typeof value === "string" && value ) {
+			classes = value.match( rnotwhite ) || [];
+
+			while ( ( elem = this[ i++ ] ) ) {
 				curValue = getClass( elem );
 
 				// This expression is here for better compressibility (see addClass)
@@ -88,7 +85,7 @@ jQuery.fn.extend( {
 					}
 
 					// Only assign if different to avoid unneeded rendering.
-					finalValue = value ? jQuery.trim( cur ) : "";
+					finalValue = jQuery.trim( cur );
 					if ( curValue !== finalValue ) {
 						elem.setAttribute( "class", finalValue );
 					}
@@ -160,12 +157,13 @@ jQuery.fn.extend( {
 	},
 
 	hasClass: function( selector ) {
-		var className = " " + selector + " ",
-			i = 0,
-			l = this.length;
-		for ( ; i < l; i++ ) {
-			if ( this[ i ].nodeType === 1 &&
-				( " " + getClass( this[ i ] ) + " " ).replace( rclass, " " )
+		var className, elem,
+			i = 0;
+
+		className = " " + selector + " ";
+		while ( ( elem = this[ i++ ] ) ) {
+			if ( elem.nodeType === 1 &&
+				( " " + getClass( elem ) + " " ).replace( rclass, " " )
 					.indexOf( className ) > -1
 			) {
 				return true;


### PR DESCRIPTION
Hi :)


After asking a question about a specific part of `.removeClass` on IRC and after @Krinkle told me that the call of `.removeClass()` without any arguments cleaning all the `"class"` attribute. I watch the code and I've found that this particularity made the code different compared to `.addClass`.
And if you call `this.attr( "class", "" )` directly in a `if` we can save **17** bytes after gzipped.

I add another change in another commit to save other **2** bytes on `.hasClass`.