### PR TITLE
Offset: Do not attempt to call getClientRects on window object

### DIFF
--- a/src/offset.js
+++ b/src/offset.js
@@ -86,7 +86,7 @@ jQuery.fn.extend({
 		var docElem, win, rect, doc,
 			elem = this[ 0 ];
 
-		if ( !elem ) {
+		if ( !elem || elem === window ) {
 			return;
 		}
 

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -59,6 +59,13 @@ test("disconnected element", function() {
 	equal( result.left, 0, "Retrieving offset on disconnected elements returns zeros (gh-2310)" );
 });
 
+
+test("window element", function() {
+	expect( 1 );
+	strictEqual( jQuery(window).offset(), undefined, "offset() returns undefined for window element" );
+});
+
+
 test("hidden (display: none) element", function() {
 	expect( 2 );
 


### PR DESCRIPTION
Noticed that a few libraries are attempting to call `offset` on `$(window)` (for better or worse). This method does not exist in that context and therefore produces a no method error. Here's a simple fix for that expected case.