### PR TITLE
Data: avoid using delete on DOM nodes

### DIFF
--- a/src/data/Data.js
+++ b/src/data/Data.js
@@ -21,13 +21,12 @@ Data.prototype = {
 		if ( owner.nodeType ) {
 			owner[ this.expando ] = value;
 
-		// Otherwise secure it in a non-enumerable, non-writable property
-		// configurability must be true to allow the property to be
-		// deleted with the delete operator
+		// Otherwise secure it in a non-enumerable property
+		// configurable must be true to allow the property to be
+		// deleted when data is removed
 		} else {
 			Object.defineProperty( owner, this.expando, {
 				value: value,
-				writable: true,
 				configurable: true
 			});
 		}
@@ -147,7 +146,15 @@ Data.prototype = {
 
 		// Remove the expando if there's no more data
 		if ( key === undefined || jQuery.isEmptyObject( cache ) ) {
-			delete owner[ this.expando ];
+			// Support: Chrome <=35 - 45
+			// Webkit & Blink performance suffers when deleting properties
+			// from DOM nodes, so set to undefined instead
+			// https://code.google.com/p/chromium/issues/detail?id=378607
+			if ( owner.nodeType ) {
+				owner[ this.expando ] = undefined;
+			} else {
+				delete owner[ this.expando ];
+			}
 		}
 	},
 	hasData: function( owner ) {

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -283,10 +283,14 @@ jQuery.extend({
 							}
 						}
 					}
-					delete elem[ dataPriv.expando ];
+					// Support: Chrome <=35 - 45
+					// Assign undefined instead of using delete, see Data#remove
+					elem[ dataPriv.expando ] = undefined;
 				}
 				if ( elem[ dataUser.expando ] ) {
-					delete elem[ dataUser.expando ];
+					// Support: Chrome <=35 - 45
+					// Assign undefined instead of using delete, see Data#remove
+					elem[ dataUser.expando ] = undefined;
 				}
 			}
 		}

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -859,7 +859,7 @@ testIframeWithCallback( "enumerate data attrs on body (#14894)", "data/dataAttrs
 });
 
 test( "Check that the expando is removed when there's no more data", function() {
-	expect( 1 );
+	expect( 2 );
 
 	var key,
 		div = jQuery( "<div/>" );
@@ -869,6 +869,23 @@ test( "Check that the expando is removed when there's no more data", function() 
 
 	// Make sure the expando is gone
 	for ( key in div[ 0 ] ) {
+		if ( /^jQuery/.test( key ) ) {
+			strictEqual( div[ 0 ][ key ], undefined, "Expando was not removed when there was no more data" );
+		}
+	}
+});
+
+test( "Check that the expando is removed when there's no more data on non-nodes", function() {
+	expect( 1 );
+
+	var key,
+		obj = jQuery( {key: 42} );
+	obj.data( "some", "data" );
+	equal( obj.data( "some" ), "data", "Data is added" );
+	obj.removeData( "some" );
+
+	// Make sure the expando is gone
+	for ( key in obj[ 0 ] ) {
 		if ( /^jQuery/.test( key ) ) {
 			ok( false, "Expando was not removed when there was no more data" );
 		}

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -2089,7 +2089,7 @@ test( "jQuery.cleanData eliminates all private data (gh-2127)", function() {
 });
 
 test( "jQuery.cleanData eliminates all public data", function() {
-	expect( 2 );
+	expect( 3 );
 
 	var key,
 		div = jQuery( "<div/>" );
@@ -2103,7 +2103,7 @@ test( "jQuery.cleanData eliminates all public data", function() {
 	// Make sure the expando is gone
 	for ( key in div[ 0 ] ) {
 		if ( /^jQuery/.test( key ) ) {
-			ok( false, "Expando was not removed when there was no more data" );
+			strictEqual( div[ 0 ][ key ], undefined, "Expando was not removed when there was no more data" );
 		}
 	}
 });


### PR DESCRIPTION
The jQuery3 data changes started doing `delete elem[ expando ]` similar to what jQuery1 originally did (see #1664). jQuery2 previously left the data property on the nodes and never deleted it so this wasn't an issue.

#1664 has the originally jQuery1 discussion. Unfortunately jsperf is down right now and the [chrome bug](https://code.google.com/p/chromium/issues/detail?id=378607) seems to be hidden so I'm not sure if it has actually been fixed. But I ran the jsperf a [while back](https://github.com/jquery/jquery/commit/56bb677725b21415905e5c3eeb1e05be4480e780#commitcomment-11557817) and it seemed to still be an issue.