### PR TITLE
Data: remove user data in cleanData

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -270,19 +270,24 @@ jQuery.extend({
 			i = 0;
 
 		for ( ; (elem = elems[ i ]) !== undefined; i++ ) {
-			if ( jQuery.acceptData( elem ) && (data = elem[ dataPriv.expando ])) {
-				if ( data.events ) {
-					for ( type in data.events ) {
-						if ( special[ type ] ) {
-							jQuery.event.remove( elem, type );
+			if ( jQuery.acceptData( elem ) ) {
+				if ( (data = elem[ dataPriv.expando ] ) ) {
+					if ( data.events ) {
+						for ( type in data.events ) {
+							if ( special[ type ] ) {
+								jQuery.event.remove( elem, type );
 
-						// This is a shortcut to avoid jQuery.event.remove's overhead
-						} else {
-							jQuery.removeEvent( elem, type, data.handle );
+							// This is a shortcut to avoid jQuery.event.remove's overhead
+							} else {
+								jQuery.removeEvent( elem, type, data.handle );
+							}
 						}
 					}
+					delete elem[ dataPriv.expando ];
 				}
-				delete elem[ dataPriv.expando ];
+				if ( elem[ dataUser.expando ] ) {
+					delete elem[ dataUser.expando ];
+				}
 			}
 		}
 	}

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -2064,7 +2064,7 @@ test( "jQuery.cleanData", function() {
 });
 
 test( "jQuery.cleanData eliminates all private data (gh-2127)", function() {
-	expect( 2 );
+	expect( 3 );
 
 	var div = jQuery( "<div/>" ).appendTo( "#qunit-fixture" );
 
@@ -2074,10 +2074,32 @@ test( "jQuery.cleanData eliminates all private data (gh-2127)", function() {
 
 	div.remove();
 
+	ok( !jQuery.hasData( div[ 0 ] ), "Removed element hasData should return false" );
+
 	ok( jQuery.isEmptyObject( jQuery._data( div[ 0 ] ) ),
 		"Private data is empty after node is removed" );
 
 	div.remove();
+});
+
+test( "jQuery.cleanData eliminates all public data", function() {
+	expect( 2 );
+
+	var key,
+		div = jQuery( "<div/>" );
+	div.data( "some", "data" );
+	ok( !jQuery.isEmptyObject( jQuery.data( div[ 0 ] ) ),  "Ensure some public data exists" );
+
+	div.remove();
+
+	ok( !jQuery.hasData( div[ 0 ] ), "Removed element hasData should return false" );
+
+	// Make sure the expando is gone
+	for ( key in div[ 0 ] ) {
+		if ( /^jQuery/.test( key ) ) {
+			ok( false, "Expando was not removed when there was no more data" );
+		}
+	}
 });
 
 test( "domManip plain-text caching (trac-6779)", function() {


### PR DESCRIPTION
Shouldn't user data be removed like [v1](https://github.com/jquery/jquery/blob/22120cea66ad88f83b96535416f5baab605fe530/src/manipulation.js#L442) and [v2](https://github.com/jquery/jquery/blob/d837f119c3729565103005d5d7fa89e1dd8110cb/src/manipulation.js#L304)? Or was that change intentional?

Note that this needs to change if/when #2479 is merged.