### PR TITLE
Build: Acknowledge Android 2.3 is not ES5-compatible

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -12,8 +12,11 @@
 
 	"sub": true,
 
+	"es3": true,
+
 	"globals": {
 		"window": true,
+		"JSON": false,
 
 		"jQuery": true,
 		"define": true,

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -10,6 +10,8 @@
 	"undef": true,
 	"unused": true,
 
+	"es3": true,
+
 	"evil": true,
 	"sub": true,
 
@@ -21,6 +23,7 @@
 		"require": false,
 		"define": false,
 		"DOMParser": false,
+		"JSON": false,
 		"Promise": false,
 		"Symbol": false,
 		"QUnit": false,

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -1400,7 +1400,7 @@ test("jQuery.parseJSON", function() {
 	deepEqual(
 		jQuery.parseJSON( "{ \"string\": \"\", \"number\": 4.2e+1, \"object\": {}," +
 			"\"array\": [[]], \"boolean\": [ true, false ], \"null\": null }"),
-		{ string: "", number: 42, object: {}, array: [[]], boolean: [ true, false ], "null": null },
+		{ string: "", number: 42, object: {}, array: [[]], "boolean": [ true, false ], "null": null },
 		"Dictionary of all data types"
 	);
 

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -1225,7 +1225,7 @@ test( "Do not throw on frame elements from css method (#15098)", 1, function() {
 		if ( transformName ) {
 			equal( elemStyle[ transformName ], transformVal, "setting properly-prefixed transform" );
 		}
-		equal( elemStyle.undefined, undefined, "Nothing writes to node.style.undefined" );
+		equal( elemStyle[ "undefined" ], undefined, "Nothing writes to node.style.undefined" );
 	} );
 
 	test( "Don't detect fake set properties on a node when caching the prefixed version", function() {

--- a/test/unit/deferred.js
+++ b/test/unit/deferred.js
@@ -172,7 +172,7 @@ test( "jQuery.Deferred.catch", function( assert ) {
 
 	var value1, value2, value3,
 		defer = jQuery.Deferred(),
-		piped = defer.catch(function( a, b ) {
+		piped = defer[ "catch" ](function( a, b ) {
 			return a * b;
 		}),
 		done = jQuery.map( new Array( 3 ), function() { return assert.async(); } );
@@ -186,18 +186,18 @@ test( "jQuery.Deferred.catch", function( assert ) {
 		value2 = b;
 	});
 
-	defer.reject( 2, 3 ).catch(function() {
+	defer.reject( 2, 3 )[ "catch" ](function() {
 		assert.strictEqual( value1, 2, "first reject value ok" );
 		assert.strictEqual( value2, 3, "second reject value ok" );
 		assert.strictEqual( value3, 6, "result of filter ok" );
 		done.pop().call();
 	});
 
-	jQuery.Deferred().resolve().catch(function() {
+	jQuery.Deferred().resolve()[ "catch" ](function() {
 		assert.ok( false, "then should not be called on resolve" );
 	}).then( done.pop() );
 
-	jQuery.Deferred().reject().catch( jQuery.noop ).done(function( value ) {
+	jQuery.Deferred().reject()[ "catch" ]( jQuery.noop ).done(function( value ) {
 		assert.strictEqual( value, undefined, "then fail callback can return undefined/null" );
 		done.pop().call();
 	});

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -1579,7 +1579,7 @@ test("Initial step callback should show element as :animated (#14623)", 1, funct
 	var foo = jQuery( "#foo" );
 
 	foo.animate({
-		opacity: 0,
+		opacity: 0
 	}, {
 		duration: 100,
 		step: function() {


### PR DESCRIPTION
Android 2.3 chokes on unquoted reserved words being used as property names
which was making Deferred tests not run.

Acknowledge the sad fact that Android 2.3 is not ES5-compliant browser
and enable the "es3" option in JSHint config.

Fixes gh-2478