### PR TITLE
Manipulation: Don't provide the parser with sloppy table markup

### DIFF
--- a/src/manipulation/wrapMap.js
+++ b/src/manipulation/wrapMap.js
@@ -6,21 +6,13 @@ var wrapMap = {
 	// Support: IE9
 	option: [ 1, "<select multiple='multiple'>", "</select>" ],
 
+	// XHTML parsers do not magically insert elements in the
+	// same way that tag soup parsers do. So we cannot shorten
+	// this by omitting <tbody> or other required elements.
 	thead: [ 1, "<table>", "</table>" ],
-
-	// Some of the following wrappers are not fully defined, because
-	// their parent elements (except for "table" element) could be omitted
-	// since browser parsers are smart enough to auto-insert them
-
-	// Support: Android 2.3
-	// Android browser doesn't auto-insert colgroup
 	col: [ 2, "<table><colgroup>", "</colgroup></table>" ],
-
-	// Auto-insert "tbody" element
-	tr: [ 2, "<table>", "</table>" ],
-
-	// Auto-insert "tbody" and "tr" elements
-	td: [ 3, "<table>", "</table>" ],
+	tr: [ 2, "<table><tbody>", "</tbody></table>" ],
+	td: [ 3, "<table><tbody><tr>", "</tr></tbody></table>" ],
 
 	_default: [ 0, "", "" ]
 };


### PR DESCRIPTION
While we can reply on parsers that were designed to cope with malformed syntax to understand what we mean, we shouldn't intentionally provide bad markup, not all parsers will accept it.

Reverts 0ea342a6a6dce793c1b0f14f051c2573f40f4e44
See also gh-2031, gh-2002
Fixes gh-2493