### PR TITLE
Tests: don't use deprecated argument in test declaration

### DIFF
--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -6,7 +6,9 @@ module( "ajax", {
 });
 
 (function() {
-	test("Unit Testing Environment", 2, function () {
+	test("Unit Testing Environment", function () {
+		expect( 2 );
+
 		ok( hasPHP, "Running in an environment with PHP support. The AJAX tests only run if the environment supports PHP!" );
 		ok( !isLocal, "Unit tests are not ran from file:// (especially in Chrome. If you must test from file:// with Chrome, run it with the --allow-file-access-from-files flag!)" );
 	});
@@ -1288,7 +1290,9 @@ module( "ajax", {
 		}
 	});
 
-	test( "#7531 - jQuery.ajax() - Location object as url", 1, function () {
+	test( "#7531 - jQuery.ajax() - Location object as url", function () {
+		expect( 1 );
+
 		var xhr,
 			success = false;
 		try {
@@ -1389,7 +1393,9 @@ module( "ajax", {
 		});
 	});
 
-	test( "#9887 - jQuery.ajax() - Context with circular references (#9887)", 2, function () {
+	test( "#9887 - jQuery.ajax() - Context with circular references (#9887)", function () {
+		expect( 2 );
+
 		var success = false,
 			context = {};
 		context.field = context;
@@ -1699,7 +1705,9 @@ module( "ajax", {
 
 //----------- jQuery.domManip()
 
-	test( "#11264 - jQuery.domManip() - no side effect because of ajaxSetup or global events", 1, function() {
+	test( "#11264 - jQuery.domManip() - no side effect because of ajaxSetup or global events", function() {
+		expect( 1 );
+
 		jQuery.ajaxSetup({
 			type: "POST"
 		});
@@ -2086,7 +2094,9 @@ module( "ajax", {
 
 //----------- jQuery.active
 
-	test( "jQuery.active", 1, function() {
+	test( "jQuery.active", function() {
+		expect( 1 );
+
 		ok( jQuery.active === 0, "ajax active counter should be zero: " + jQuery.active );
 	});
 

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -734,7 +734,8 @@ test( "prop('tabindex')", function() {
 	equal( jQuery("#linkWithNoHrefWithNegativeTabIndex").prop("tabindex"), -1, "anchor without href, no tabindex set" );
 });
 
-test( "prop('tabindex', value)", 10, function() {
+test( "prop('tabindex', value)", function() {
+	expect( 10 );
 
 	var clone,
 		element = jQuery("#divWithNoTabIndex");
@@ -1452,7 +1453,9 @@ test( "coords returns correct values in IE6/IE7, see #10828", function() {
 	equal( area.attr("coords"), "0,0,0,0", "did not retrieve coords correctly" );
 });
 
-test( "should not throw at $(option).val() (#14686)", 1, function() {
+test( "should not throw at $(option).val() (#14686)", function() {
+	expect( 1 );
+
 	try {
 		jQuery( "<option/>" ).val();
 		ok( true );

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -174,7 +174,9 @@ test( "globalEval with 'use strict'", function() {
 	equal( window.strictEvalTest, 1, "Test variable declarations are global (strict mode)" );
 });
 
-test( "globalEval execution after script injection (#7862)", 1, function() {
+test( "globalEval execution after script injection (#7862)", function() {
+	expect( 1 );
+
 	var now,
 		script = document.createElement( "script" );
 
@@ -1198,7 +1200,9 @@ test("jQuery.each(Object,Function)", function() {
 	equal( i, document.styleSheets.length, "Iteration over document.styleSheets" );
 });
 
-test("jQuery.each/map(undefined/null,Function)", 1, function() {
+test("jQuery.each/map(undefined/null,Function)", function() {
+	expect( 1 );
+
 	try {
 		jQuery.each( undefined, jQuery.noop );
 		jQuery.each( null, jQuery.noop );
@@ -1477,7 +1481,9 @@ test("jQuery.parseJSON", function() {
 	strictEqual( jQuery.parseJSON([ 0 ]), 0, "Input cast to string" );
 });
 
-test("jQuery.parseXML", 8, function(){
+test("jQuery.parseXML", function(){
+	expect( 8 );
+
 	var xml, tmp;
 	try {
 		xml = jQuery.parseXML( "<p>A <b>well-formed</b> xml string</p>" );

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -116,7 +116,9 @@ test("css(String|Hash)", function() {
 		"Make sure that a string z-index is returned from css('z-index') (#14432)." );
 });
 
-test( "css() explicit and relative values", 29, function() {
+test( "css() explicit and relative values", function() {
+	expect( 29 );
+
 	var $elem = jQuery("#nothiddendiv");
 
 	$elem.css({ "width": 1, "height": 1, "paddingLeft": "1px", "opacity": 1 });
@@ -203,7 +205,9 @@ test( "css() explicit and relative values", 29, function() {
 	equal( $elem.css("opacity"), "1", "'+=0.5' on opacity (params)" );
 });
 
-test( "css() non-px relative values (gh-1711)", 17, function() {
+test( "css() non-px relative values (gh-1711)", function() {
+	expect( 17 );
+
 	var cssCurrent,
 		units = {},
 		$child = jQuery( "#nothiddendivchild" ),
@@ -903,7 +907,9 @@ test("certain css values of 'normal' should be convertable to a number, see #862
 
 // only run this test in IE9
 if ( document.documentMode === 9 ) {
-	test( ".css('filter') returns a string in IE9, see #12537", 1, function() {
+	test( ".css('filter') returns a string in IE9, see #12537", function() {
+		expect( 1 );
+
 		equal( jQuery("<div style='-ms-filter:\"progid:DXImageTransform.Microsoft.gradient(startColorstr=#FFFFFF, endColorstr=#ECECEC)\";'></div>").css("filter"), "progid:DXImageTransform.Microsoft.gradient(startColorstr=#FFFFFF, endColorstr=#ECECEC)", "IE9 returns the correct value from css('filter')." );
 	});
 }
@@ -1111,7 +1117,9 @@ asyncTest( "Clearing a Cloned Element's Style Shouldn't Clear the Original Eleme
 	window.setTimeout( start, 1000 );
 });
 
-test( "show() after hide() should always set display to initial value (#14750)", 1, function() {
+test( "show() after hide() should always set display to initial value (#14750)", function() {
+	expect( 1 );
+
 	var div = jQuery( "<div />" ),
 		fixture = jQuery( "#qunit-fixture" );
 
@@ -1130,7 +1138,9 @@ test( "show() after hide() should always set display to initial value (#14750)",
 		exist = "order" in style || "WebkitOrder" in style;
 
 	if ( exist ) {
-		test( "Don't append px to CSS \"order\" value (#14049)", 1, function() {
+		test( "Don't append px to CSS \"order\" value (#14049)", function() {
+			expect( 1 );
+
 			var $elem = jQuery( "<div/>" );
 
 			$elem.css( "order", 2 );
@@ -1139,7 +1149,9 @@ test( "show() after hide() should always set display to initial value (#14750)",
 	}
 })();
 
-test( "Do not throw on frame elements from css method (#15098)", 1, function() {
+test( "Do not throw on frame elements from css method (#15098)", function() {
+	expect( 1 );
+
 	var frameWin, frameDoc,
 		frameElement = document.createElement( "iframe" ),
 		frameWrapDiv = document.createElement( "div" );

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -126,7 +126,9 @@ function dataTests( elem ) {
 	equal( jQuery._data(elem, "foo"), "foo2", "(sanity check) jQuery.removeData for user data does not remove internal data" );
 }
 
-test("jQuery.data(div)", 25, function() {
+test("jQuery.data(div)", function() {
+	expect( 25 );
+
 	var div = document.createElement("div");
 
 	dataTests( div );
@@ -137,11 +139,15 @@ test("jQuery.data(div)", 25, function() {
 	QUnit.expectJqData( this, div, "foo" );
 });
 
-test("jQuery.data({})", 25, function() {
+test("jQuery.data({})", function() {
+	expect( 25 );
+
 	dataTests( {} );
 });
 
-test("jQuery.data(window)", 25, function() {
+test("jQuery.data(window)", function() {
+	expect( 25 );
+
 	// remove bound handlers from window object to stop potential false positives caused by fix for #5280 in
 	// transports/xhr.js
 	jQuery( window ).off( "unload" );
@@ -149,17 +155,23 @@ test("jQuery.data(window)", 25, function() {
 	dataTests( window );
 });
 
-test("jQuery.data(document)", 25, function() {
+test("jQuery.data(document)", function() {
+	expect( 25 );
+
 	dataTests( document );
 
 	QUnit.expectJqData( this, document, "foo" );
 });
 
-test("jQuery.data(<embed>)", 25, function() {
+test("jQuery.data(<embed>)", function() {
+	expect( 25 );
+
 	dataTests( document.createElement("embed") );
 });
 
-test("jQuery.data(object/flash)", 25, function() {
+test("jQuery.data(object/flash)", function() {
+	expect( 25 );
+
 	var flash = document.createElement("object");
 	flash.setAttribute( "classid", "clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" );
 
@@ -167,7 +179,9 @@ test("jQuery.data(object/flash)", 25, function() {
 });
 
 // attempting to access the data of an undefined jQuery element should be undefined
-test("jQuery().data() === undefined (#14101)", 2, function() {
+test("jQuery().data() === undefined (#14101)", function() {
+	expect( 2 );
+
 	strictEqual(jQuery().data(), undefined);
 	strictEqual(jQuery().data("key"), undefined);
 });
@@ -826,7 +840,9 @@ test("jQuery.acceptData", function() {
 		"form with aliased DOM properties" );
 });
 
-test("Check proper data removal of non-element descendants nodes (#8335)", 1, function() {
+test("Check proper data removal of non-element descendants nodes (#8335)", function() {
+	expect( 1 );
+
 	var div = jQuery("<div>text</div>"),
 		text = div.contents();
 

--- a/test/unit/dimensions.js
+++ b/test/unit/dimensions.js
@@ -306,7 +306,9 @@ test("getting dimensions shouldn't modify runtimeStyle see #9233", function() {
 	$div.remove();
 });
 
-test( "table dimensions", 2, function() {
+test( "table dimensions", function() {
+	expect( 2 );
+
 	var table = jQuery("<table><colgroup><col/><col/></colgroup><tbody><tr><td></td><td>a</td></tr><tr><td></td><td>a</td></tr></tbody></table>").appendTo("#qunit-fixture"),
 		tdElem = table.find("td").first(),
 		colElem = table.find("col").first().width( 300 );
@@ -460,7 +462,9 @@ testIframe( "dimensions/documentLarge", "window vs. large document", function( j
 	ok( jQuery( document ).width() > jQuery( window ).width(), "document width is larger than window width" );
 });
 
-test( "allow modification of coordinates argument (gh-1848)", 1, function() {
+test( "allow modification of coordinates argument (gh-1848)", function() {
+	expect( 1 );
+
 	var offsetTop,
 		element = jQuery( "<div/>" ).appendTo( "#qunit-fixture" );
 

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -32,7 +32,9 @@ test("sanity check", function() {
 	equal( jQuery("#dl:visible, #qunit-fixture:visible, #foo:visible").length, 3, "QUnit state is correct for testing effects" );
 });
 
-test("show() basic", 1, function() {
+test("show() basic", function() {
+	expect( 1 );
+
 	var div = jQuery("<div>").hide().appendTo("#qunit-fixture").show();
 
 	equal( div.css("display"), "block", "Make sure pre-hidden divs show" );
@@ -41,7 +43,9 @@ test("show() basic", 1, function() {
 	div.remove();
 });
 
-test("show()", 27, function () {
+test("show()", function () {
+	expect( 27 );
+
 	var div, speeds, old, test,
 		hiddendiv = jQuery("div.hidden");
 
@@ -781,7 +785,9 @@ test("toggle()", function() {
 	ok( x.is(":visible"), "is visible again" );
 });
 
-test( "jQuery.fx.prototype.cur() - <1.8 Back Compat", 7, function() {
+test( "jQuery.fx.prototype.cur() - <1.8 Back Compat", function() {
+	expect( 7 );
+
 	var div = jQuery( "<div></div>" ).appendTo( "#qunit-fixture" ).css({
 			color: "#ABC",
 			border: "5px solid black",
@@ -1253,7 +1259,9 @@ test("hide hidden elements, with animation (bug #7141)", function() {
 	this.clock.tick( 10 );
 });
 
-test("animate unit-less properties (#4966)", 2, function() {
+test("animate unit-less properties (#4966)", function() {
+	expect( 2 );
+
 	var div = jQuery( "<div style='z-index: 0; position: absolute;'></div>" ).appendTo( "#qunit-fixture" );
 	equal( div.css( "z-index" ), "0", "z-index is 0" );
 	div.animate({ zIndex: 2 }, function() {
@@ -1262,8 +1270,9 @@ test("animate unit-less properties (#4966)", 2, function() {
 	this.clock.tick( 400 );
 });
 
-test( "animate properties missing px w/ opacity as last (#9074)", 2, function() {
+test( "animate properties missing px w/ opacity as last (#9074)", function() {
 	expect( 6 );
+
 	var ml, l,
 		div = jQuery( "<div style='position: absolute; margin-left: 0; left: 0px;'></div>" )
 		.appendTo( "#qunit-fixture" );
@@ -1360,7 +1369,9 @@ test("animate will scale margin properties individually", function() {
 	});
 });
 
-test("Do not append px to 'fill-opacity' #9548", 1, function() {
+test("Do not append px to 'fill-opacity' #9548", function() {
+	expect( 1 );
+
 	var $div = jQuery("<div>").appendTo("#qunit-fixture");
 
 	$div.css("fill-opacity", 0).animate({ "fill-opacity": 1.0 }, 0, function () {
@@ -1374,7 +1385,9 @@ test("Do not append px to 'fill-opacity' #9548", 1, function() {
 	});
 });
 
-test("line-height animates correctly (#13855)", 12, function() {
+test("line-height animates correctly (#13855)", function() {
+	expect( 12 );
+
 	var t0,
 		clock = this.clock,
 		longDuration = 2000,
@@ -1436,7 +1449,9 @@ clock.tick( 50 );
 });
 
 // Start 1.8 Animation tests
-test( "jQuery.Animation( object, props, opts )", 4, function() {
+test( "jQuery.Animation( object, props, opts )", function() {
+	expect( 4 );
+
 	var animation,
 		testObject = {
 			"foo": 0,
@@ -1461,7 +1476,9 @@ test( "jQuery.Animation( object, props, opts )", 4, function() {
 	this.clock.tick( 10 );
 });
 
-test( "Animate Option: step: function( percent, tween )", 1, function() {
+test( "Animate Option: step: function( percent, tween )", function() {
+	expect( 1 );
+
 	var counter = {};
 	jQuery( "#foo" ).animate({
 		prop1: 1,
@@ -1486,7 +1503,9 @@ test( "Animate Option: step: function( percent, tween )", 1, function() {
 	this.clock.tick( 10 );
 });
 
-test( "Animate callbacks have correct context", 2, function() {
+test( "Animate callbacks have correct context", function() {
+	expect( 2 );
+
 	var foo = jQuery( "#foo" );
 	foo.animate({
 		height: 10
@@ -1501,7 +1520,9 @@ test( "Animate callbacks have correct context", 2, function() {
 	this.clock.tick( 10 );
 });
 
-test( "User supplied callback called after show when fx off (#8892)", 2, function() {
+test( "User supplied callback called after show when fx off (#8892)", function() {
+	expect( 2 );
+
 	var foo = jQuery( "#foo" );
 	jQuery.fx.off = true;
 	foo.hide();
@@ -1564,7 +1585,9 @@ test( "animate should set display for disconnected nodes", function() {
 	clock.tick( 400 );
 });
 
-test("Animation callback should not show animated element as :animated (#7157)", 1, function() {
+test("Animation callback should not show animated element as :animated (#7157)", function() {
+	expect( 1 );
+
 	var foo = jQuery( "#foo" );
 
 	foo.animate({
@@ -1575,7 +1598,9 @@ test("Animation callback should not show animated element as :animated (#7157)",
 	this.clock.tick( 100 );
 });
 
-test("Initial step callback should show element as :animated (#14623)", 1, function() {
+test("Initial step callback should show element as :animated (#14623)", function() {
+	expect( 1 );
+
 	var foo = jQuery( "#foo" );
 
 	foo.animate({
@@ -1590,7 +1615,9 @@ test("Initial step callback should show element as :animated (#14623)", 1, funct
 	foo.stop();
 });
 
-test( "hide called on element within hidden parent should set display to none (#10045)", 3, function() {
+test( "hide called on element within hidden parent should set display to none (#10045)", function() {
+	expect( 3 );
+
 	var hidden = jQuery(".hidden"),
 		elems = jQuery("<div>hide</div><div>hide0</div><div>hide1</div>");
 
@@ -1610,7 +1637,9 @@ test( "hide called on element within hidden parent should set display to none (#
 	this.clock.tick( 10 );
 });
 
-test( "hide, fadeOut and slideUp called on element width height and width = 0 should set display to none", 5, function() {
+test( "hide, fadeOut and slideUp called on element width height and width = 0 should set display to none", function() {
+	expect( 5 );
+
 	var foo = jQuery("#foo"),
 		i = 0,
 		elems = jQuery();
@@ -1639,7 +1668,9 @@ test( "hide, fadeOut and slideUp called on element width height and width = 0 sh
 	this.clock.tick( 400 );
 });
 
-test( "hide should not leave hidden inline elements visible (#14848)", 2, function() {
+test( "hide should not leave hidden inline elements visible (#14848)", function() {
+	expect( 2 );
+
 	var el = jQuery("#simon1");
 
 	el.hide( 1, function() {
@@ -1652,7 +1683,9 @@ test( "hide should not leave hidden inline elements visible (#14848)", 2, functi
 	this.clock.tick( 100 );
 });
 
-test( "Handle queue:false promises", 10, function() {
+test( "Handle queue:false promises", function() {
+	expect( 10 );
+
 	var foo = jQuery( "#foo" ).clone().addBack(),
 		step = 1;
 
@@ -1703,7 +1736,9 @@ test( "Handle queue:false promises", 10, function() {
 	this.clock.tick( 10 );
 });
 
-test( "multiple unqueued and promise", 4, function() {
+test( "multiple unqueued and promise", function() {
+	expect( 4 );
+
 	var foo = jQuery( "#foo" ),
 		step = 1;
 	foo.animate({
@@ -1735,7 +1770,9 @@ test( "multiple unqueued and promise", 4, function() {
 	this.clock.tick( 1000 );
 });
 
-test( "animate does not change start value for non-px animation (#7109)", 1, function() {
+test( "animate does not change start value for non-px animation (#7109)", function() {
+	expect( 1 );
+
 	var parent = jQuery( "<div><div></div></div>" ).css({ width: 284, height: 1 }).appendTo( "#qunit-fixture" ),
 		child = parent.children().css({ fontSize: "98.6in", width: "0.01em", height: 1 }),
 		actual = parseFloat( child.css( "width" ) ),
@@ -1755,7 +1792,9 @@ test( "animate does not change start value for non-px animation (#7109)", 1, fun
 	this.clock.tick( 10 );
 });
 
-test( "non-px animation handles non-numeric start (#11971)", 2, function() {
+test( "non-px animation handles non-numeric start (#11971)", function() {
+	expect( 2 );
+
 	var foo = jQuery("#foo"),
 		initial = foo.css("backgroundPositionX");
 
@@ -1785,7 +1824,9 @@ test( "non-px animation handles non-numeric start (#11971)", 2, function() {
 	this.clock.tick( 10 );
 });
 
-test("Animation callbacks (#11797)", 15, function() {
+test("Animation callbacks (#11797)", function() {
+	expect( 15 );
+
 	var targets = jQuery("#foo").children(),
 		done = false,
 		expectedProgress = 0;
@@ -1866,7 +1907,9 @@ test("Animation callbacks (#11797)", 15, function() {
 	this.clock.tick( 10 );
 });
 
-test( "Animate properly sets overflow hidden when animating width/height (#12117)", 8, function() {
+test( "Animate properly sets overflow hidden when animating width/height (#12117)", function() {
+	expect( 8 );
+
 	jQuery.each( [ "height", "width" ], function( _, prop ) {
 		jQuery.each( [ 100, 0 ], function( _, value ) {
 			var div = jQuery("<div>").css( "overflow", "auto" ),
@@ -1907,7 +1950,9 @@ test( "Each tick of the timer loop uses a fresh time (#12837)", function() {
 	tmp.stop();
 });
 
-test( "Animations with 0 duration don't ease (#12273)", 1, function() {
+test( "Animations with 0 duration don't ease (#12273)", function() {
+	expect( 1 );
+
 	jQuery.easing.test = function() {
 		ok( false, "Called easing" );
 	};
@@ -2146,7 +2191,9 @@ test( ".finish() is applied correctly when multiple elements were animated (#139
 	this.clock.tick( 1500 );
 });
 
-test( "slideDown() after stop() (#13483)", 2, function() {
+test( "slideDown() after stop() (#13483)", function() {
+		expect( 2 );
+
 		var ul = jQuery( "<ul style='height: 100px; display: block;'></ul>" )
 				.appendTo("#qunit-fixture"),
 			origHeight = ul.height(),
@@ -2177,7 +2224,9 @@ test( "slideDown() after stop() (#13483)", 2, function() {
 		clock.tick( 10 );
 });
 
-test( "Respect display value on inline elements (#14824)", 2, function() {
+test( "Respect display value on inline elements (#14824)", function() {
+	expect( 2 );
+
 	var clock = this.clock,
 		fromStyleSheet = jQuery( "<span id='span-14824' />" ),
 		fromStyleAttr = jQuery( "<span style='display: block;' />" );

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -443,7 +443,9 @@ test("on(), trigger change on select", function() {
 	}).trigger("change");
 });
 
-test("on(), namespaced events, cloned events", 18, function() {
+test("on(), namespaced events, cloned events", function() {
+	expect( 18 );
+
 	var firstp = jQuery( "#firstp" );
 
 	firstp.on("custom.test",function(){
@@ -2576,7 +2578,9 @@ test( "Namespace preserved when passed an Event (#12739)", function() {
 	equal( triggered, 3, "foo.bar triggered" );
 });
 
-test( "make sure events cloned correctly", 18, function() {
+test( "make sure events cloned correctly", function() {
+	expect( 18 );
+
 	var clone,
 		fixture = jQuery("#qunit-fixture"),
 		checkbox = jQuery("#check1"),
@@ -2760,7 +2764,9 @@ test( "originalEvent property for Chrome, Safari and FF of simualted event", fun
 
 // This tests are unreliable in Firefox
 if ( !(/firefox/i.test( window.navigator.userAgent )) ) {
-	test( "Check order of focusin/focusout events", 2, function() {
+	test( "Check order of focusin/focusout events", function() {
+		expect( 2 );
+
 		var focus, blur,
 			input = jQuery( "#name" );
 

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -1870,7 +1870,9 @@ test( "remove() with filters", function() {
 	equal( jQuery("#nonnodes").contents().length, 0, "Check node,textnode,comment remove works" );
 });
 
-test( "remove() event cleaning ", 1, function() {
+test( "remove() event cleaning ", function() {
+	expect( 1 );
+
 	var count, first, cleanUp;
 
 	count = 0;
@@ -1885,7 +1887,9 @@ test( "remove() event cleaning ", 1, function() {
 	cleanUp.remove();
 });
 
-test( "remove() in document order #13779", 1, function() {
+test( "remove() in document order #13779", function() {
+	expect( 1 );
+
 	var last,
 		cleanData = jQuery.cleanData;
 
@@ -1957,7 +1961,9 @@ test("detach() with filters", function () {
   equal(jQuery("#nonnodes").contents().length, 0, "Check node,textnode,comment remove works");
 });
 
-test( "detach() event cleaning ", 1, function() {
+test( "detach() event cleaning ", function() {
+	expect( 1 );
+
 	var count, first, cleanUp;
 
 	count = 0;
@@ -2487,7 +2493,9 @@ test( "insertAfter, insertBefore, etc do not work when destination is original e
 	});
 });
 
-test( "Index for function argument should be received (#13094)", 2, function() {
+test( "Index for function argument should be received (#13094)", function() {
+	expect( 2 );
+
 	var i = 0;
 
 	jQuery("<div/><div/>").before(function( index ) {
@@ -2496,7 +2504,9 @@ test( "Index for function argument should be received (#13094)", 2, function() {
 
 });
 
-test( "Make sure jQuery.fn.remove can work on elements in documentFragment", 1, function() {
+test( "Make sure jQuery.fn.remove can work on elements in documentFragment", function() {
+	expect( 1 );
+
 	var fragment = document.createDocumentFragment(),
 		div = fragment.appendChild( document.createElement("div") );
 
@@ -2505,7 +2515,9 @@ test( "Make sure jQuery.fn.remove can work on elements in documentFragment", 1, 
 	equal( fragment.childNodes.length, 0, "div element was removed from documentFragment" );
 });
 
-test( "Make sure specific elements with content created correctly (#13232)", 20, function() {
+test( "Make sure specific elements with content created correctly (#13232)", function() {
+	expect( 20 );
+
 	var results = [],
 		args = [],
 		elems = {
@@ -2534,7 +2546,9 @@ test( "Make sure specific elements with content created correctly (#13232)", 20,
 	});
 });
 
-test( "Validate creation of multiple quantities of certain elements (#13818)", 44, function() {
+test( "Validate creation of multiple quantities of certain elements (#13818)", function() {
+	expect( 44 );
+
 	var tags = [ "thead", "tbody", "tfoot", "colgroup", "col", "caption", "tr", "th", "td", "optgroup", "option" ];
 
 	jQuery.each( tags, function( index, tag ) {

--- a/test/unit/queue.js
+++ b/test/unit/queue.js
@@ -1,6 +1,8 @@
 module( "queue", { teardown: moduleTeardown });
 
-test( "queue() with other types", 14, function() {
+test( "queue() with other types", function() {
+	expect( 14 );
+
 	stop();
 
 	var $div = jQuery({}),
@@ -121,7 +123,9 @@ test("callbacks keep their place in the queue", function() {
 	});
 });
 
-test( "jQuery.queue should return array while manipulating the queue", 1, function() {
+test( "jQuery.queue should return array while manipulating the queue", function() {
+	expect( 1 );
+
 	var div = document.createElement("div");
 
 	ok( jQuery.isArray( jQuery.queue( div, "fx", jQuery.noop ) ), "jQuery.queue should return an array while manipulating the queue" );

--- a/test/unit/wrap.js
+++ b/test/unit/wrap.js
@@ -148,7 +148,9 @@ test( "wrapAll(String)", function() {
 
 });
 
-test( "wrapAll(Function)", 5, function() {
+test( "wrapAll(Function)", function() {
+	expect( 5 );
+
 	var prev = jQuery( "#firstp" )[ 0 ].previousSibling,
 		p = jQuery( "#firstp,#first" )[ 0 ].parentNode,
 		result = jQuery( "#firstp,#first" ).wrapAll(function() {
@@ -162,7 +164,9 @@ test( "wrapAll(Function)", 5, function() {
 	strictEqual( jQuery( "#first" ).parent().parent()[ 0 ].previousSibling, prev, "Correct Previous Sibling" );
 });
 
-test( "wrapAll(Function) check execution characteristics", 3, function() {
+test( "wrapAll(Function) check execution characteristics", function() {
+	expect( 3 );
+
 	var i = 0;
 
 	jQuery( "non-existent" ).wrapAll(function() {


### PR DESCRIPTION
@FagnerMartinsBrack hope you will be happy about this :-).

Did it with CST script manipulation - https://github.com/markelog/qunit-migration/blob/master/src/migration.js

@scottgonzalez, @jzaefferer, @Krinkle
I suppose it would be useful if qunit would provide scripts like that, here it only replaces deprecated argument, but it could do a lot more.

@nzakas i guess this could be another example of manipulation with CST. 


