### PR TITLE
Tests: Add simple tests for Android 2.3

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -114,6 +114,12 @@ module.exports = function( grunt ) {
 		},
 		testswarm: {
 			tests: [
+				// A special module with basic tests, meant for
+				// not fully supported environments like Android 2.3,
+				// jsdom or PhantomJS. We run it everywhere, though,
+				// to make sure tests are not broken.
+				"basic",
+
 				"ajax",
 				"animation",
 				"attributes",

--- a/build/tasks/testswarm.js
+++ b/build/tasks/testswarm.js
@@ -3,7 +3,7 @@ module.exports = function( grunt ) {
 	"use strict";
 
 	grunt.registerTask( "testswarm", function( commit, configFile, projectName, browserSets,
-			timeout ) {
+			timeout, testMode ) {
 		var jobName, config, tests,
 			testswarm = require( "testswarm" ),
 			runs = {},
@@ -28,9 +28,13 @@ module.exports = function( grunt ) {
 				commit + "'>" + commit.substr( 0, 10 ) + "</a>";
 		}
 
-		tests.forEach(function( test ) {
-			runs[ test ] = config.testUrl + commit + "/test/index.html?module=" + test;
-		});
+		if ( testMode === "basic" ) {
+			runs.basic = config.testUrl + commit + "/test/index.html?module=basic";
+		} else {
+			tests.forEach( function( test ) {
+				runs[ test ] = config.testUrl + commit + "/test/index.html?module=" + test;
+			} );
+		}
 
 		testswarm.createClient({
 			url: config.swarmUrl

--- a/test/data/testinit.js
+++ b/test/data/testinit.js
@@ -268,6 +268,12 @@ this.loadTests = function() {
 	// Get testSubproject from testrunner first
 	require([ "data/testrunner.js" ], function() {
 		var tests = [
+			// A special module with basic tests, meant for
+			// not fully supported environments like Android 2.3,
+			// jsdom or PhantomJS. We run it everywhere, though,
+			// to make sure tests are not broken.
+			"unit/basic.js",
+
 			"unit/core.js",
 			"unit/callbacks.js",
 			"unit/deferred.js",

--- a/test/unit/basic.js
+++ b/test/unit/basic.js
@@ -1,0 +1,258 @@
+module( "basic", {
+	teardown: moduleTeardown
+} );
+
+if ( jQuery.ajax ) {
+test( "ajax", function( assert ) {
+	expect( 4 );
+
+	var done = jQuery.map( new Array( 3 ), function() { return assert.async(); } );
+
+	jQuery.ajax({
+		type: "GET",
+		url: url( "data/name.php?name=foo" ),
+		success: function( msg ) {
+			assert.strictEqual( msg, "bar", "Check for GET" );
+			done.pop()();
+		}
+	});
+
+	jQuery.ajax({
+		type: "POST",
+		url: url( "data/name.php" ),
+		data: "name=peter",
+		success: function( msg ) {
+			strictEqual( msg, "pan", "Check for POST" );
+			done.pop()();
+		}
+	});
+
+	jQuery( "#first" ).load( url( "data/name.html" ), function() {
+		assert.ok( /^ERROR/.test( jQuery( "#first" ).text() ),
+			"Check if content was injected into the DOM" );
+		done.pop()();
+	});
+} );
+}
+
+test( "attributes", function ( assert ) {
+	expect( 6 );
+
+	var a = jQuery( "<a/>" ).appendTo( "#qunit-fixture" ),
+		input = jQuery( "<input/>" ).appendTo( "#qunit-fixture" );
+
+	assert.strictEqual( a.attr( "foo", "bar" ).attr( "foo" ), "bar", ".attr getter/setter" );
+	assert.strictEqual( a.removeAttr( "foo" ).attr( "foo" ), undefined, ".removeAttr" );
+	assert.strictEqual( a.prop( "href", "#5" ).prop( "href" ),
+		location.href.replace( /\#.*$/, "" ) + "#5",
+		".prop getter/setter" );
+
+	a.addClass( "abc def ghj" ).removeClass( "def ghj" );
+	assert.strictEqual( a.hasClass( "abc" ), true, ".(add|remove|has)Class, class present" );
+	assert.strictEqual( a.hasClass( "def" ), false, ".(add|remove|has)Class, class missing" );
+
+	assert.strictEqual( input.val( "xyz" ).val(), "xyz", ".val getter/setter" );
+} );
+
+if ( jQuery.css ) {
+test( "css", function( assert ) {
+	expect( 3 );
+
+	var div = jQuery( "<div/>" ).appendTo( "#qunit-fixture" );
+
+	assert.strictEqual( div.css( "width", "50px" ).css( "width" ), "50px", ".css getter/setter" );
+
+	div.hide();
+	assert.strictEqual( div.css( "display" ), "none", "div hidden" );
+	div.show();
+	assert.strictEqual( div.css( "display" ), "block", "div shown" );
+} );
+}
+
+test( "core", function ( assert ) {
+	expect( 28 );
+
+	var elem = jQuery( "<div></div><span></span>" );
+
+	assert.strictEqual( elem.length, 2, "Correct number of elements" );
+	assert.strictEqual( jQuery.trim("  hello   "), "hello", "jQuery.trim" );
+
+	assert.strictEqual( jQuery.type( null ), "null", "jQuery.type(null)" );
+	assert.strictEqual( jQuery.type( undefined ), "undefined", "jQuery.type(undefined)" );
+	assert.strictEqual( jQuery.type("a"), "string", "jQuery.type(String)" );
+
+	assert.ok( jQuery.isPlainObject({ "a": 2 }), "jQuery.isPlainObject(object)" );
+	assert.ok( !jQuery.isPlainObject( "foo" ), "jQuery.isPlainObject(String)" );
+
+	assert.ok( jQuery.isFunction( jQuery.noop ), "jQuery.isFunction(jQuery.noop)" );
+	assert.ok( !jQuery.isFunction( 2 ), "jQuery.isFunction(Number)" );
+
+	assert.ok( jQuery.isNumeric( "-2" ), "jQuery.isNumeric(String representing a number)" );
+	assert.ok( !jQuery.isNumeric( "" ), "jQuery.isNumeric(\"\")" );
+
+	assert.ok( jQuery.isXMLDoc( jQuery.parseXML(
+		"<?xml version='1.0' encoding='UTF-8'?><foo bar='baz'></foo>"
+	) ), "jQuery.isXMLDoc" );
+
+
+	assert.ok( jQuery.isWindow( window ), "jQuery.isWindow(window)" );
+	assert.ok( !jQuery.isWindow( 2 ), "jQuery.isWindow(Number)" );
+
+	assert.strictEqual( jQuery.inArray( 3, [ "a", 6, false, 3, {} ] ), 3, "jQuery.inArray - true" );
+	assert.strictEqual( jQuery.inArray( 3, [ "a", 6, false, "3", {} ] ), -1, "jQuery.inArray - false" );
+
+	assert.strictEqual( elem.get( 1 ), elem[ 1 ], ".get" );
+	assert.strictEqual( elem.first()[ 0 ], elem[ 0 ], ".first" );
+	assert.strictEqual( elem.last()[ 0 ], elem[ 1 ], ".last" );
+
+	assert.deepEqual( jQuery.map( [ "a", "b", "c" ], function ( v, k ) {
+		return k + v;
+	} ), ["0a", "1b", "2c" ], "jQuery.map" );
+
+	assert.deepEqual( jQuery.merge( [ 1, 2 ], [ "a", "b" ] ), [ 1, 2, "a", "b" ], "jQuery.merge" );
+
+	assert.deepEqual( jQuery.grep( [ 1, 2, 3 ], function( value ) {
+		return value % 2 !== 0;
+	} ), [ 1, 3 ], "jQuery.grep" );
+
+	assert.deepEqual( jQuery.extend( { a: 2 }, { b: 3 } ), { a: 2, b: 3 }, "jQuery.extend" );
+
+	jQuery.each( [ 0, 2 ], function ( k, v ) {
+		assert.strictEqual( k * 2, v, "jQuery.each" );
+	} );
+
+	assert.deepEqual( jQuery.makeArray( { 0: "a", 1: "b", 2: "c", length: 3 } ),
+		[ "a", "b", "c" ], "jQuery.makeArray" );
+
+	assert.strictEqual( jQuery.parseHTML( "<div></div><span></span>" ).length,
+		2, "jQuery.parseHTML" );
+
+	assert.deepEqual( jQuery.parseJSON( "{\"a\": 2}" ), { a: 2 }, "jQuery.parseJON" );
+} );
+
+test( "data", function ( assert ) {
+	expect( 4 );
+
+	var elem = jQuery( "<div data-c='d'/>" ).appendTo( "#qunit-fixture" );
+
+	assert.ok( !jQuery.hasData( elem[ 0 ] ), "jQuery.hasData - false" );
+	assert.strictEqual( elem.data( "a", "b" ).data( "a" ), "b", ".data getter/setter" );
+	assert.strictEqual( elem.data( "c" ), "d", ".data from data-* attributes" );
+	assert.ok( jQuery.hasData( elem[ 0 ] ), "jQuery.hasData - true" );
+} );
+
+test( "dimensions", function ( assert ) {
+	expect( 3 );
+
+	var elem = jQuery(
+		"<div style='margin: 10px; padding: 7px; border: 2px solid black;' /> "
+	).appendTo( "#qunit-fixture");
+
+	assert.strictEqual( elem.width( 50 ).width(), 50, ".width getter/setter" );
+	assert.strictEqual( elem.innerWidth(), 64, ".innerWidth getter" );
+	assert.strictEqual( elem.outerWidth(), 68, ".outerWidth getter" );
+} );
+
+test( "event", function ( assert ) {
+	expect( 1 );
+
+	var elem = jQuery( "<div/>" ).appendTo( "#qunit-fixture" );
+
+	elem
+		.on( "click" , function() {
+			assert.ok( false, "click should not fire" );
+		} )
+		.off( "click" )
+		.trigger( "click" )
+		.on( "click" , function() {
+			assert.ok( true, "click should fire" );
+		} )
+		.trigger( "click" );
+} );
+
+test( "manipulation", function ( assert ) {
+	expect( 5 );
+
+	var child,
+		elem1 = jQuery( "<div><span></span></div>" ).appendTo( "#qunit-fixture" ),
+		elem2 = jQuery( "<div/>" ).appendTo( "#qunit-fixture" );
+
+	assert.strictEqual( elem1.text( "foo" ).text(), "foo", ".html getter/setter" );
+	assert.strictEqual( elem1.html( "<span/>" ).html(), "<span></span>", ".html getter/setter" );
+
+	assert.strictEqual( elem1.append( elem2 )[ 0 ].childNodes[ 1 ], elem2[ 0 ], ".append" );
+	assert.strictEqual( elem1.prepend( elem2 )[ 0 ].childNodes[ 0 ], elem2[ 0 ], ".prepend" );
+
+	child = elem1.find( "span" );
+	child.after( "<a/>" );
+	child.before( "<b/>" );
+	assert.strictEqual( elem1.html(), "<div></div><b></b><span></span><a></a>", ".after/.before" );
+} );
+
+test( "offset", function ( assert ) {
+    expect( 3 );
+
+	var parent = jQuery( "<div style='position:fixed;top:20px;'/>" ).appendTo( "#qunit-fixture" ),
+		elem = jQuery( "<div style='position:absolute;top:5px;'/>" ).appendTo( parent );
+
+	assert.strictEqual( elem.offset().top, 25, ".offset getter" );
+	assert.strictEqual( elem.position().top, 5, ".position getter" );
+	assert.strictEqual( elem.offsetParent()[ 0 ], parent[ 0 ], ".offsetParent" );
+} );
+
+test( "selector", function ( assert ) {
+    expect( 2 );
+
+	var elem = jQuery( "<div><span class='a'></span><span class='b'><a></a></span></div>" )
+		.appendTo( "#qunit-fixture" );
+
+	assert.strictEqual( elem.find( ".a a" ).length, 0, ".find - no result" );
+	assert.strictEqual( elem.find( "span.b a" )[ 0 ].nodeName, "A", ".find - one result" );
+} );
+
+test( "serialize", function ( assert ) {
+    expect( 2 );
+
+	var params = {"someName": [ 1, 2, 3 ], "regularThing": "blah" };
+	assert.strictEqual( jQuery.param( params ),
+		"someName%5B%5D=1&someName%5B%5D=2&someName%5B%5D=3&regularThing=blah",
+		"jQuery.param" );
+
+	assert.strictEqual( jQuery("#form").serialize(),
+		"action=Test&radio2=on&check=on&hidden=&foo%5Bbar%5D=&name=name&search=search&select1=&select2=3&select3=1&select3=2&select5=3",
+		"form serialization as query string" );
+} );
+
+test( "traversing", function ( assert ) {
+    expect( 12 );
+
+	var elem = jQuery( "<div><a><b><em></em></b></a><i></i><span></span>foo</div>" )
+		.appendTo( "#qunit-fixture" );
+
+	assert.strictEqual( elem.find( "em" ).parent()[ 0 ].nodeName, "B", ".parent" );
+	assert.strictEqual( elem.find( "em" ).parents()[ 1 ].nodeName, "A", ".parents" );
+	assert.strictEqual( elem.find( "em" ).parentsUntil( "div" ).length, 2, ".parentsUntil" );
+	assert.strictEqual( elem.find( "i" ).next()[ 0 ].nodeName, "SPAN", ".next" );
+	assert.strictEqual( elem.find( "i" ).prev()[ 0 ].nodeName, "A", ".prev" );
+	assert.strictEqual( elem.find( "a" ).nextAll()[ 1 ].nodeName, "SPAN", ".nextAll" );
+	assert.strictEqual( elem.find( "span" ).prevAll()[ 1 ].nodeName, "A", ".prevAll" );
+	assert.strictEqual( elem.find( "a" ).nextUntil( "span" ).length, 1, ".nextUntil" );
+	assert.strictEqual( elem.find( "span" ).prevUntil( "a" ).length, 1, ".prevUntil" );
+	assert.strictEqual( elem.find( "i" ).siblings().length, 2, ".siblings" );
+	assert.strictEqual( elem.children()[ 2 ].nodeName, "SPAN", ".children" );
+	assert.strictEqual( elem.contents()[ 3 ].nodeType, 3, ".contents" );
+} );
+
+test( "wrap", function ( assert ) {
+    expect( 3 );
+
+	var elem = jQuery( "<div><a><b></b></a><a></a></div>" );
+
+	elem.find( "b" ).wrap( "<span>" );
+	assert.strictEqual( elem.html(), "<a><span><b></b></span></a><a></a>", ".wrap" );
+	elem.find( "span" ).wrapInner( "<em>" );
+	assert.strictEqual( elem.html(), "<a><span><em><b></b></em></span></a><a></a>", ".wrapInner" );
+	elem.find( "a" ).wrapAll( "<i>" );
+	assert.strictEqual( elem.html(), "<i><a><span><em><b></b></em></span></a><a></a></i>", ".wrapAll" );
+
+} );


### PR DESCRIPTION
Fixes gh-2505
Refs gh-2483

@jquery/core This is an initial stab at simple tests for Android 2.3 but please review what I have before I write tests for other modules.

I've created a separate "module" called `basic` to contain those selected tests; I also added it to the list run by regular browsers so that we immediately know if those tests are ok.

Note that tests are *very* basic but testing the whole API even without edge cases (however you define them) would be way too much; if we run more than 10% of assertions in Android 2.3 it will be unstable (older browsers fare better with many modules with few tests in them rather than one module with all). I'd rather remove some CSS tests from this list than add more.

I've temporarily modified our Jenkins jobs to see how that would look:

1. the regular periodic run without Android 2.3: http://swarm.jquery.org/job/1009
2. the basic run just for Android 2.3: http://swarm.jquery.org/job/1011

Even these 18 CSS tests seem to *sometimes* run very slow on Android 2.3: they were running for 11 minutes & timed out, after restarting they passed almost immediately...