### PR TITLE
Build: Add a comment explaining why the es3 option is needed

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,12 +4,16 @@ module.exports = function( grunt ) {
 	function readOptionalJSON( filepath ) {
 		var data = {};
 		try {
-			data = grunt.file.readJSON( filepath );
+			data = JSON.parse( stripJSONComments(
+				fs.readFileSync( filepath, { encoding: "utf8" } )
+			) );
 		} catch ( e ) {}
 		return data;
 	}
 
-	var gzip = require( "gzip-js" ),
+	var fs = require( "fs" ),
+		stripJSONComments = require( "strip-json-comments" ),
+		gzip = require( "gzip-js" ),
 		srcHintOptions = readOptionalJSON( "src/.jshintrc" );
 
 	// The concatenated file won't pass onevar

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "requirejs": "2.1.17",
     "sinon": "1.10.3",
     "sizzle": "2.2.0",
+    "strip-json-comments": "1.0.3",
     "testswarm": "1.1.0",
     "win-spawn": "2.0.0"
   },

--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -12,6 +12,9 @@
 
 	"sub": true,
 
+	// Support: IE < 10, Android < 4.1
+	// The above browsers are failing a lot of tests in the ES5
+	// test suite at http://test262.ecmascript.org.
 	"es3": true,
 
 	"globals": {


### PR DESCRIPTION
It might not be obvious to everyone that IE 9 & Android 4.0 are not
ES5-compliant browsers (by a large margin) so it's better to add a support
comment. This requires slight changes in parsing the config file
as it's not a pure JSON anymore. JSHint understands such files without
problems.