### PR TITLE
Check if xhr.responseType == arraybuffer

### DIFF
--- a/src/ajax/plain.js
+++ b/src/ajax/plain.js
@@ -1,0 +1,44 @@
+define([
+	"../core",
+	"../var/document",
+	"../ajax"
+], function( jQuery, document ) {
+
+// Install plain dataType
+jQuery.ajaxSetup({
+	accepts: {
+		plain: "text/plain"
+	},
+	responseFields: {
+		plain: "response"
+	}
+	/* converters: {
+		"plain plain": function (arrayBuffer) {
+			if (arrayBuffer) {
+				return new Uint8Array(arrayBuffer);
+			}
+		}
+	} /**/
+});
+
+jQuery.ajaxPrefilter("plain", function (s, originalSettings, jqXHR) {
+
+	s.xhrFields = {
+		responseType: "arraybuffer"
+	};
+});
+
+/* Bind plain hack transport
+jQuery.ajaxTransport("plain", function (s) {
+	return {
+		send: function (_, complete) {
+			complete(
+				s.response,
+				s.statusText,
+				s
+			);
+		}
+	};
+}); /**/
+
+});

--- a/src/ajax/plain.js
+++ b/src/ajax/plain.js
@@ -2,7 +2,7 @@ define([
 	"../core",
 	"../var/document",
 	"../ajax"
-], function( jQuery, document ) {
+], function( jQuery ) {
 
 // Install plain dataType
 jQuery.ajaxSetup({
@@ -21,7 +21,7 @@ jQuery.ajaxSetup({
 	} /**/
 });
 
-jQuery.ajaxPrefilter("plain", function (s, originalSettings, jqXHR) {
+jQuery.ajaxPrefilter("plain", function (s /*, originalSettings, jqXHR */) {
 
 	s.xhrFields = {
 		responseType: "arraybuffer"

--- a/src/ajax/plain.js
+++ b/src/ajax/plain.js
@@ -21,7 +21,7 @@ jQuery.ajaxSetup({
 	} /**/
 });
 
-jQuery.ajaxPrefilter("plain", function (s /*, originalSettings, jqXHR */) {
+jQuery.ajaxPrefilter("plain", function (s) {  // originalSettings, jqXHR
 
 	s.xhrFields = {
 		responseType: "arraybuffer"

--- a/src/ajax/xhr.js
+++ b/src/ajax/xhr.js
@@ -80,6 +80,18 @@ jQuery.ajaxTransport(function( options ) {
 									xhr.status,
 									xhr.statusText
 								);
+							} else if (xhr.responseType
+								&& (xhr.responseType === "blob" || xhr.responseType === "arraybuffer")) {
+								// Accessing non-binary (responseText) when getting binary (response)
+								// throws an exception in Firefox (github.com/jquery/jquery/issues...)
+								complete(
+									xhrSuccessStatus[xhr.status] || xhr.status,
+									xhr.statusText,
+									typeof xhr.response === "undefined" 
+										? { plain: xhr.response }
+										: undefined,
+									xhr.getAllResponseHeaders()
+								);
 							} else {
 								complete(
 									xhrSuccessStatus[ xhr.status ] || xhr.status,

--- a/src/ajax/xhr.js
+++ b/src/ajax/xhr.js
@@ -80,16 +80,13 @@ jQuery.ajaxTransport(function( options ) {
 									xhr.status,
 									xhr.statusText
 								);
-							} else if (xhr.responseType
-								&& (xhr.responseType === "blob" || xhr.responseType === "arraybuffer")) {
+							} else if (xhr.responseType && (xhr.responseType === "blob" || xhr.responseType === "arraybuffer")) {
 								// Accessing non-binary (responseText) when getting binary (response)
 								// throws an exception in Firefox (github.com/jquery/jquery/issues...)
 								complete(
 									xhrSuccessStatus[xhr.status] || xhr.status,
 									xhr.statusText,
-									typeof xhr.response !== "undefined" 
-										? { plain: xhr.response }
-										: undefined,
+									typeof xhr.response !== "undefined" ? { plain: xhr.response } : undefined,
 									xhr.getAllResponseHeaders()
 								);
 							} else {

--- a/src/ajax/xhr.js
+++ b/src/ajax/xhr.js
@@ -87,7 +87,7 @@ jQuery.ajaxTransport(function( options ) {
 								complete(
 									xhrSuccessStatus[xhr.status] || xhr.status,
 									xhr.statusText,
-									typeof xhr.response === "undefined" 
+									typeof xhr.response !== "undefined" 
 										? { plain: xhr.response }
 										: undefined,
 									xhr.getAllResponseHeaders()

--- a/src/ajax/xhr.js
+++ b/src/ajax/xhr.js
@@ -80,13 +80,17 @@ jQuery.ajaxTransport(function( options ) {
 									xhr.status,
 									xhr.statusText
 								);
-							} else if (xhr.responseType && (xhr.responseType === "blob" || xhr.responseType === "arraybuffer")) {
-								// Accessing non-binary (responseText) when getting binary (response)
-								// throws an exception in Firefox (github.com/jquery/jquery/issues...)
+							} else if (xhr.responseType && 
+								(xhr.responseType === "blob" ||
+									xhr.responseType === "arraybuffer")) {
+								// Accessing responseText when getting binary response
+								// throws an exception in Firefox
 								complete(
 									xhrSuccessStatus[xhr.status] || xhr.status,
 									xhr.statusText,
-									typeof xhr.response !== "undefined" ? { plain: xhr.response } : undefined,
+									typeof xhr.response !== "undefined" ? {
+										plain: xhr.response 
+									} : undefined,
 									xhr.getAllResponseHeaders()
 								);
 							} else {

--- a/src/jquery.js
+++ b/src/jquery.js
@@ -20,6 +20,7 @@ define([
 	"./ajax",
 	"./ajax/xhr",
 	"./ajax/script",
+	"./ajax/plain",
 	"./ajax/jsonp",
 	"./ajax/load",
 	"./event/ajax",


### PR DESCRIPTION
Hello Friends of jQuery!

I'm just doing `else if (xhr.responseType` to get `xhr.response` instead of `xhr.responseText`)... mainly just because Firefox happens to throw an InvalidStateError if you do so.

You can now use this as follows (someone needs a converter):

	$.ajax("/robots.txt", {
		dataType: "plain",
		type: "POST",
		data: {
			"name": "Hannes"
		}
	}).done(function (data, textStatus, jqXHR) {
		if (data) {
			var bytes = new Uint8Array(data);
			console.log(bytes);
		}
	}).fail(function (jqXHR, textStatus, error) { 
		console.log(error); 
	});

BEWARE: I didn't make a test and also don't wan't to run npm right now. Please, would someone have a look on these things, to get that update down the pipe (bugs.jquery.com)?