### PR TITLE
Core: Don't expose jQuery.access

### DIFF
--- a/src/core/access.js
+++ b/src/core/access.js
@@ -4,7 +4,7 @@ define([
 
 // Multifunctional method to get and set values of a collection
 // The value/s can optionally be executed if it's a function
-var access = jQuery.access = function( elems, fn, key, value, chainable, emptyGet, raw ) {
+var access = function( elems, fn, key, value, chainable, emptyGet, raw ) {
 	var i = 0,
 		len = elems.length,
 		bulk = key == null;


### PR DESCRIPTION
jQuery.access was never documented, there is no need to keep it exposed.

Fixes gh-2513