### PR TITLE
Event: Don't try to read data on a non-element on IE8 form attribute

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -805,7 +805,8 @@ if ( !support.submitBubbles ) {
 				// Node name check avoids a VML-related crash in IE (#9807)
 				var elem = e.target,
 					form = jQuery.nodeName( elem, "input" ) || jQuery.nodeName( elem, "button" ) ? elem.form : undefined;
-				if ( form && !jQuery._data( form, "submitBubbles" ) ) {
+				// Don't try to read data on non-element (#14126)
+				if ( form && form.nodeType === 1 && !jQuery._data( form, "submitBubbles" ) ) {
 					jQuery.event.add( form, "submit._submit", function( event ) {
 						event._submit_bubble = true;
 					});


### PR DESCRIPTION
This one is related to the error described in #2332
which is caused by jQuery trying to set data on a string, eg having:
```html
<button form="foo-form">Submit</button>
```
jQuery would try to do:
```js
jQuery._data( "foo-form", "submitBubbles", true );
```

which will throw an error here:
https://github.com/jquery/jquery/blob/062a7d63e4d1a55d72d64152381d93d60b0231e4/src/data.js#L125

This PR won't fix the behavior of form attribute on IE8, but will allow to apply your own polyfill for submit events when you need it (right now jQuery will just crash, and after debugging the only option available turns out to be overloading the whole jQuery.event.special.submit.setup function).