### PR TITLE
Improved guide to testing/contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,12 @@ Get in the habit of pulling in the "upstream" master to stay up to date as jQuer
 $ git pull upstream master
 ```
 
+Run the build script
+
+```bash
+$ npm run build
+```
+
 Run the Grunt tools:
 
 ```bash


### PR DESCRIPTION
- Contributing guide missed the `npm build` step when setting up the repository. 
- Added the suggestion to use PHP's built in webserver for testing, next to setting up with the LAMP. PHP is by default installed on OSX.