### PR TITLE
Check before setting style property

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -252,7 +252,9 @@ jQuery.extend({
 			if ( !hooks || !("set" in hooks) ||
 				(value = hooks.set( elem, value, extra )) !== undefined ) {
 
-				if ( style[ name ] !== value ) style[ name ] = value;
+				if ( style[ name ] !== value ) {
+					style[ name ] = value;
+				}
 			}
 
 		} else {

--- a/src/css.js
+++ b/src/css.js
@@ -252,7 +252,7 @@ jQuery.extend({
 			if ( !hooks || !("set" in hooks) ||
 				(value = hooks.set( elem, value, extra )) !== undefined ) {
 
-				style[ name ] = value;
+				if ( style[ name ] !== value ) style[ name ] = value;
 			}
 
 		} else {


### PR DESCRIPTION
According to [this jsperf](http://jsperf.com/check-style-attributes-before-setting-or-just-constant-), checking if a style property has changed before setting it gives a speedup of 40% (Chrome) to 80% (Firefox) if the value is the same. This check is also hard to to in userland because the user would have to replicate camel case, vendor prefixes, hooks etc. which are applied inside `jQuery.style`.