### PR TITLE
Build: Update grunt-jscs-checker which was renamed to grunt-jscs

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "grunt-contrib-uglify": "0.7.0",
     "grunt-contrib-watch": "0.6.1",
     "grunt-git-authors": "2.0.1",
-    "grunt-jscs-checker": "0.8.1",
+    "grunt-jscs": "0.8.1",
     "grunt-jsonlint": "1.0.4",
     "grunt-npmcopy": "0.1.0",
     "gzip-js": "0.3.2",


### PR DESCRIPTION
This commit aims to fix NPM WARN caused by using old name of grunt-jscs

![image](https://cloud.githubusercontent.com/assets/7764293/9422907/2650d59a-4880-11e5-8c10-8de692bbaf25.png)

