### PR TITLE
Build: Update grunt-contrib-uglify for security issue in uglify-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "grunt-cli": "0.1.13",
     "grunt-compare-size": "0.4.0",
     "grunt-contrib-jshint": "0.11.2",
-    "grunt-contrib-uglify": "0.7.0",
+    "grunt-contrib-uglify": "0.9.2",
     "grunt-contrib-watch": "0.6.1",
     "grunt-git-authors": "2.0.1",
     "grunt-jscs-checker": "0.8.1",


### PR DESCRIPTION
Update grunt-contrib-uglify dependency to v0.9.2 in order to fix a security issue fixed in uglify-js v2.4.24.

https://github.com/mishoo/UglifyJS2/issues/751
https://zyan.scripts.mit.edu/blog/backdooring-js/