### PR TITLE
Manipulation: Switch rnoInnerhtml to a version more performant in IE

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -27,7 +27,10 @@ define([
 
 var
 	rxhtmlTag = /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([\w:-]+)[^>]*)\/>/gi,
-	rnoInnerhtml = /<(?:script|style|link)/i,
+	// Support: IE 10-11, Edge 10240+
+	// In IE/Edge using regex groups here causes severe slowdowns.
+	// See https://connect.microsoft.com/IE/feedback/details/1736512/
+	rnoInnerhtml = /<script|<style|<link/i,
 	// checked="checked" or checked
 	rchecked = /checked\s*(?:[^=]|=\s*.checked.)/i,
 	rscriptTypeMasked = /^true\/(.*)/,


### PR DESCRIPTION
IE versions greater than 9 do not handle the old regular expression well with large html content
This is due to the use of a non-capturing group after a very common html character (<).

Test suite: http://jsfiddle.net/Lwa0t5rp/3/
Microsoft bug: https://connect.microsoft.com/IE/feedback/details/1736512/regular-expressions-are-slower-in-edge-than-in-ie8

Fixes gh-2563
Closes gh-2568