### PR TITLE
Event: Use form prop so that a propHook can be used

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -894,7 +894,12 @@ if ( !support.submit ) {
 				// Node name check avoids a VML-related crash in IE (#9807)
 				var elem = e.target,
 					form = jQuery.nodeName( elem, "input" ) || jQuery.nodeName( elem, "button" ) ?
-						elem.form :
+
+						// Support: IE <=8
+						// We use jQuery.prop instead of elem.form
+						// to allow fixing the IE8 delegated submit issue (gh-2332)
+						// by 3rd party polyfills/workarounds.
+						jQuery.prop( elem, "form" ) :
 						undefined;
 
 				if ( form && !jQuery._data( form, "submit" ) ) {


### PR DESCRIPTION
As @gibson042 suggested, this enables 3rd party polyfills/workarounds to fix the IE8 delegated submit issues when HTML5 form attribute is used (see [#2332 (comment)](https://github.com/jquery/jquery/pull/2332#issuecomment-103911627), [#2547 (comment)](https://github.com/jquery/jquery/pull/2547#issuecomment-136599348))

Fixes gh-2332