### PR TITLE
Docs: Change "baar" to "bar"

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ t( testName, selector, [ "array", "of", "ids" ] );
 Example:
 
 ```js
-t("Check for something", "//[a]", ["foo", "baar"]);
+t("Check for something", "//[a]", ["foo", "bar"]);
 ```
 
 

--- a/test/data/testinit.js
+++ b/test/data/testinit.js
@@ -35,8 +35,8 @@ this.q = function() {
  * @param {String} a - Assertion name
  * @param {String} b - Sizzle selector
  * @param {String} c - Array of ids to construct what is expected
- * @example t("Check for something", "//[a]", ["foo", "baar"]);
- * @result returns true if "//[a]" return two elements with the IDs 'foo' and 'baar'
+ * @example t("Check for something", "//[a]", ["foo", "bar"]);
+ * @result returns true if "//[a]" return two elements with the IDs 'foo' and 'bar'
  */
 QUnit.assert.t = function( a, b, c ) {
 	var f = jQuery( b ).get(),

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -293,7 +293,7 @@ testIframe(
 
 		/**
 		 * Asserts that a select matches the given IDs
-		 * @example t("Check for something", "//[a]", ["foo", "baar"]);
+		 * @example t("Check for something", "//[a]", ["foo", "bar"]);
 		 * @param {String} a - Assertion name
 		 * @param {String} b - Sizzle selector
 		 * @param {Array} c - Array of ids to construct what is expected


### PR DESCRIPTION
Changes "baar" to "bar" when used with "foo" in readme and comments of js files

Hi, I wasn't sure if this was a typo or intentional, but I saw "baar" being used with "foo" in the readme and some comments.  It's just a minor change, but this is a fantastic library so I thought that it would look better if it was consistent across the repo, so I changed it to "bar".

Keep up the great work!

![image](https://cloud.githubusercontent.com/assets/8218686/9965966/bd1adb64-5dee-11e5-9a19-7b736a499a44.png)
![image](https://cloud.githubusercontent.com/assets/8218686/9965977/da1c7574-5dee-11e5-9af9-6c050d9a6e70.png)


