### PR TITLE
Build: remove needless instruction from .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,2 @@
 # Auto detect text files and perform LF normalization
 * text=auto
-
-# JS files must always use LF for tools to work
-*.js eol=lf


### PR DESCRIPTION
"JS files must always use LF for tools to work" -
assuming that was relevant when we were young and trees were tall