### PR TITLE
Give the module "selector" name

### DIFF
--- a/src/selector.js
+++ b/src/selector.js
@@ -1,1 +1,1 @@
-define( [ "./selector-sizzle" ], function() {} );
+define( "selector", [ "./selector-sizzle" ], function() {} );


### PR DESCRIPTION
Fixes the following error with custom build and require.js AMD loader:

`Error: Script error for: jquery-src/selector`
`Mismatched anonymous define() module: undefined`