### PR TITLE
Alias ajax as http

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -837,5 +837,7 @@ jQuery.each( [ "get", "post" ], function( i, method ) {
 	};
 } );
 
+jQuery.http = jQuery.ajax;
+
 return jQuery;
 } );


### PR DESCRIPTION
You've already aliased `type` to `method`, and fixed other semantic "bugs". Why not go all the way? Kick the decade old misnomer in the face and embrace a strong and clear message to the rising generation of developers.

It's just so difficult to explain how x stands for "JSON" and "Binary Data", y'know?