### PR TITLE
Event: Fix delegated radio events when arrow keys are used

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -488,9 +488,10 @@ jQuery.event = {
 		// Find delegate handlers
 		// Black-hole SVG <use> instance trees (#13180)
 		//
-		// Support: Firefox
-		// Avoid non-left-click bubbling in Firefox (#3861)
-		if ( delegateCount && cur.nodeType && ( !event.button || event.type !== "click" ) ) {
+		// Support: Firefox<=42+
+		// Avoid non-left-click in FF but don't block IE radio events (#3861, gh-2343)
+		if ( delegateCount && cur.nodeType &&
+			( event.type !== "click" || isNaN( event.button ) || event.button < 1 ) ) {
 
 			for ( ; cur !== this; cur = cur.parentNode || this ) {
 

--- a/test/integration/gh-2343-ie-radio-click.html
+++ b/test/integration/gh-2343-ie-radio-click.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+	<meta charset="UTF-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<title>Test for gh-2343 (IE11)</title>
+	<script src="../../dist/jquery.js"></script>
+	<script>
+		$(document).ready(function() {
+			$( "fieldset" ).on( "click", "input", function() {
+				$( ".result" ).append( "click " + this.value + "<br />" );
+			} );
+		} );
+	</script>
+</head>
+
+<body>
+
+<h1>Test for gh-2343 (IE11)</h1>
+<p>
+Instructions: In <b>IE11</b>, click on or focus the first radio button.
+Then use the left/right arrow keys to select the other radios.
+You should see events logged in the results below.
+</p>
+<fieldset>
+	<input type="radio" name="rad" value="0" /> 0
+	<input type="radio" name="rad" value="1" /> 1
+	<input type="radio" name="rad" value="2" /> 2
+</fieldset>
+<div class="result"></div>
+
+</body>
+</html>


### PR DESCRIPTION
Fixes gh-2343, gh-2410

This turned out to be trickier than I hoped. Click events that are fired by `$.fn.trigger()` don't have an `event.button` set at all. Also I couldn't figure out a way to test this, for similar reasons. I can set up a unit test that has a fake event with similar incorrect settings as Firefox gives us, but that seems like a bad idea. Ideally this would be a feature detect but that is also impossible since it requires a real user-initiated click and not a fake one.