### PR TITLE
Attributes: Remove undocumented .toggleClass( boolean ) signature

### DIFF
--- a/src/attributes/classes.js
+++ b/src/attributes/classes.js
@@ -1,9 +1,8 @@
 define( [
 	"../core",
 	"../var/rnotwhite",
-	"../data/var/dataPriv",
 	"../core/init"
-], function( jQuery, rnotwhite, dataPriv ) {
+], function( jQuery, rnotwhite ) {
 
 var rclass = /[\t\r\n\f]/g;
 
@@ -100,60 +99,29 @@ jQuery.fn.extend( {
 	},
 
 	toggleClass: function( value, stateVal ) {
-		var type = typeof value;
+		var type = typeof value,
+			classNames = type === "string" ? value.match( rnotwhite ) : "",
+			checker = typeof stateVal === "boolean" ?
+				function() { return !stateVal; } :
+				jQuery.fn.hasClass;
 
-		if ( typeof stateVal === "boolean" && type === "string" ) {
-			return stateVal ? this.addClass( value ) : this.removeClass( value );
-		}
+		return this.each( function( i ) {
+			var className,
+				self = jQuery( this ),
+				c = 0;
 
-		if ( jQuery.isFunction( value ) ) {
-			return this.each( function( i ) {
-				jQuery( this ).toggleClass(
-					value.call( this, i, getClass( this ), stateVal ),
-					stateVal
-				);
-			} );
-		}
+			if ( type === "function" ) {
+				classNames = value.call( this, i, getClass( this ), stateVal )
+					.match( rnotwhite ) || [];
+			}
 
-		return this.each( function() {
-			var className, i, self, classNames;
+			// Toggle individual class names based on presence or stateVal
+			while ( ( className = classNames[ c++ ] ) ) {
 
-			if ( type === "string" ) {
-
-				// Toggle individual class names
-				i = 0;
-				self = jQuery( this );
-				classNames = value.match( rnotwhite ) || [];
-
-				while ( ( className = classNames[ i++ ] ) ) {
-
-					// Check each className given, space separated list
-					if ( self.hasClass( className ) ) {
-						self.removeClass( className );
-					} else {
-						self.addClass( className );
-					}
-				}
-
-			// Toggle whole class name
-			} else if ( value === undefined || type === "boolean" ) {
-				className = getClass( this );
-				if ( className ) {
-
-					// Store className if set
-					dataPriv.set( this, "__className__", className );
-				}
-
-				// If the element has a class name or if we're passed `false`,
-				// then remove the whole classname (if there was one, the above saved it).
-				// Otherwise bring back whatever was previously saved (if anything),
-				// falling back to the empty string if nothing was stored.
-				if ( this.setAttribute ) {
-					this.setAttribute( "class",
-						className || value === false ?
-						"" :
-						dataPriv.get( this, "__className__" ) || ""
-					);
+				if ( checker.call( self, className ) ) {
+					self.removeClass( className );
+				} else {
+					self.addClass( className );
 				}
 			}
 		} );

--- a/src/attributes/classes.js
+++ b/src/attributes/classes.js
@@ -100,10 +100,7 @@ jQuery.fn.extend( {
 
 	toggleClass: function( value, stateVal ) {
 		var type = typeof value,
-			classNames = type === "string" ? value.match( rnotwhite ) : "",
-			checker = typeof stateVal === "boolean" ?
-				function() { return !stateVal; } :
-				jQuery.fn.hasClass;
+			classNames = type === "string" ? value.match( rnotwhite ) : [];
 
 		return this.each( function( i ) {
 			var className,
@@ -118,7 +115,7 @@ jQuery.fn.extend( {
 			// Toggle individual class names based on presence or stateVal
 			while ( ( className = classNames[ c++ ] ) ) {
 
-				if ( checker.call( self, className ) ) {
+				if ( stateVal === false || stateVal !== true && self.hasClass( className ) ) {
 					self.removeClass( className );
 				} else {
 					self.addClass( className );

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -1221,7 +1221,7 @@ QUnit.test( "removeClass(undefined) is a no-op", function( assert ) {
 } );
 
 var testToggleClass = function( valueObj, assert ) {
-	assert.expect( 17 );
+	assert.expect( 9 );
 
 	var e = jQuery( "#firstp" );
 	assert.ok( !e.is( ".test" ), "Assert class not present" );
@@ -1245,29 +1245,6 @@ var testToggleClass = function( valueObj, assert ) {
 	assert.ok( ( e.is( ".testA.testC" ) && !e.is( ".testB" ) ), "Assert 1 class added, 1 class removed, and 1 class kept" );
 	e.toggleClass( valueObj( "testA testC" ) );
 	assert.ok( ( !e.is( ".testA" ) && !e.is( ".testB" ) && !e.is( ".testC" ) ), "Assert no class present" );
-
-	// toggleClass storage
-	e.toggleClass( true );
-	assert.ok( e[ 0 ].className === "", "Assert class is empty (data was empty)" );
-	e.addClass( "testD testE" );
-	assert.ok( e.is( ".testD.testE" ), "Assert class present" );
-	e.toggleClass();
-	assert.ok( !e.is( ".testD.testE" ), "Assert class not present" );
-	assert.ok( jQuery._data( e[ 0 ], "__className__" ) === "testD testE", "Assert data was stored" );
-	e.toggleClass();
-	assert.ok( e.is( ".testD.testE" ), "Assert class present (restored from data)" );
-	e.toggleClass( false );
-	assert.ok( !e.is( ".testD.testE" ), "Assert class not present" );
-	e.toggleClass( true );
-	assert.ok( e.is( ".testD.testE" ), "Assert class present (restored from data)" );
-	e.toggleClass();
-	e.toggleClass( false );
-	e.toggleClass();
-	assert.ok( e.is( ".testD.testE" ), "Assert class present (restored from data)" );
-
-	// Cleanup
-	e.removeClass( "testD" );
-	assert.expectJqData( this, e[ 0 ], "__className__" );
 };
 
 QUnit.test( "toggleClass(String|boolean|undefined[, boolean])", function( assert ) {

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -1221,7 +1221,7 @@ QUnit.test( "removeClass(undefined) is a no-op", function( assert ) {
 } );
 
 var testToggleClass = function( valueObj, assert ) {
-	assert.expect( 9 );
+	assert.expect( 11 );
 
 	var e = jQuery( "#firstp" );
 	assert.ok( !e.is( ".test" ), "Assert class not present" );
@@ -1233,8 +1233,12 @@ var testToggleClass = function( valueObj, assert ) {
 	// class name with a boolean
 	e.toggleClass( valueObj( "test" ), false );
 	assert.ok( !e.is( ".test" ), "Assert class not present" );
+	e.toggleClass( valueObj( "test" ), false );
+	assert.ok( !e.is( ".test" ), "Assert class still not present" );
 	e.toggleClass( valueObj( "test" ), true );
 	assert.ok( e.is( ".test" ), "Assert class present" );
+	e.toggleClass( valueObj( "test" ), true );
+	assert.ok( e.is( ".test" ), "Assert class still present" );
 	e.toggleClass( valueObj( "test" ), false );
 	assert.ok( !e.is( ".test" ), "Assert class not present" );
 


### PR DESCRIPTION
Fixes #2491 

I may have gone a little crazy with the refactoring here, so feel free to yell if something looks off. It passes unit tests, and I removed the tests that dealt with the className storage. 

The commit messages needs a little work, I guess I'd describe this as "removing the incorrectly documented `.toggleClass( [ boolean ] )` signature. Here is what we currently say which did not match the old implementation:

> As of jQuery 1.4, if no arguments are passed to .toggleClass(), all class names on the element the first time .toggleClass() is called will be toggled.

Ref https://github.com/jquery/api.jquery.com/issues/781