### PR TITLE
CSS: getting proper window object for getComputedStyle call in getStyles

### DIFF
--- a/src/css/var/getStyles.js
+++ b/src/css/var/getStyles.js
@@ -1,15 +1,9 @@
-define( function() {
-	return function( elem ) {
+define( [
+	"../../core"
+], function( jQuery ) {
 
-		// Support: IE<=11+, Firefox<=30+ (#15098, #14150)
-		// IE throws on elements created in popups
-		// FF meanwhile throws on frame elements through "defaultView.getComputedStyle"
-		var view = elem.ownerDocument.defaultView;
-
-		if ( !view.opener ) {
-			view = window;
-		}
-
-		return view.getComputedStyle( elem );
-	};
+return function( elem ) {
+    return ( jQuery.isWindow( elem ) ? elem : elem.nodeType === 9 ?
+        elem.defaultView : elem.ownerDocument.defaultView ).getComputedStyle( elem );
+};
 } );


### PR DESCRIPTION
Problem is described in #2622. Origin seems to be that `getComputedStyle` is called on main `window` object, and not on iframe `window` object. 
In this fix `window` object is _always_ received from an element (`elem.ownerDocument.defaultView`) with additional check for `window`/`document` elements - and thus check for `opener` is removed as useless.
Similar issue is described in #2259, but in proposed there solution check for `parent` in additional to `opener` is made. I think getting `window` object from element every time is better.