### PR TITLE
Event: Move .bind() and .delegate() to deprecated

### DIFF
--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -1,2 +1,24 @@
 define( function() {
+
+jQuery.fn.extend( {
+
+	bind: function( types, data, fn ) {
+		return this.on( types, null, data, fn );
+	},
+	unbind: function( types, fn ) {
+		return this.off( types, null, fn );
+	},
+
+	delegate: function( selector, types, data, fn ) {
+		return this.on( types, selector, data, fn );
+	},
+	undelegate: function( selector, types, fn ) {
+
+		// ( namespace ) or ( selector, types [, fn] )
+		return arguments.length === 1 ?
+			this.off( selector, "**" ) :
+			this.off( types, selector || "**", fn );
+	}
+} );
+
 } );

--- a/src/event/alias.js
+++ b/src/event/alias.js
@@ -19,24 +19,6 @@ jQuery.each( ( "blur focus focusin focusout resize scroll click dblclick " +
 jQuery.fn.extend( {
 	hover: function( fnOver, fnOut ) {
 		return this.mouseenter( fnOver ).mouseleave( fnOut || fnOver );
-	},
-
-	bind: function( types, data, fn ) {
-		return this.on( types, null, data, fn );
-	},
-	unbind: function( types, fn ) {
-		return this.off( types, null, fn );
-	},
-
-	delegate: function( selector, types, data, fn ) {
-		return this.on( types, selector, data, fn );
-	},
-	undelegate: function( selector, types, fn ) {
-
-		// ( namespace ) or ( selector, types [, fn] )
-		return arguments.length === 1 ?
-			this.off( selector, "**" ) :
-			this.off( types, selector || "**", fn );
 	}
 } );
 

--- a/test/data/testinit.js
+++ b/test/data/testinit.js
@@ -295,6 +295,7 @@ this.loadTests = function() {
 				"unit/core.js",
 				"unit/callbacks.js",
 				"unit/deferred.js",
+				"unit/deprecated.js",
 				"unit/support.js",
 				"unit/data.js",
 				"unit/queue.js",

--- a/test/unit/deprecated.js
+++ b/test/unit/deprecated.js
@@ -1,2 +1,42 @@
 QUnit.module( "deprecated", { teardown: moduleTeardown } );
 
+
+QUnit.test( "bind/unbind", function( assert ) {
+	assert.expect( 4 );
+
+	var markup = jQuery(
+		"<div><p><span><b>b</b></span></p></div>"
+	);
+
+	markup
+		.find( "b" )
+		.bind( "click", { bindData: 19 }, function( e, trig ) {
+			assert.equal( e.type, "click", "correct event type" );
+			assert.equal( e.data.bindData, 19, "correct trigger data" );
+			assert.equal( trig, 42, "correct bind data" );
+			assert.equal( e.target.nodeName.toLowerCase(), "b" , "correct element" );
+		} )
+		.trigger( "click", [ 42 ] )
+		.unbind( "click" )
+		.trigger( "click" )
+		.remove();
+} );
+
+QUnit.test( "delegate/undelegate", function( assert ) {
+	assert.expect( 2 );
+
+	var markup = jQuery(
+		"<div><p><span><b>b</b></span></p></div>"
+	);
+
+	markup
+		.delegate( "b", "click", function( e ) {
+			assert.equal( e.type, "click", "correct event type" );
+			assert.equal( e.target.nodeName.toLowerCase(), "b" , "correct element" );
+		} )
+		.find( "b" )
+			.trigger( "click" )
+			.end()
+		.undelegate( "b", "click" )
+		.remove();
+} );


### PR DESCRIPTION
Fixes #2288 

At the moment we don't have any tests at all for .bind() and .delegate(), it seems like we would at least want a sanity check for them. At the very least they should be tested in Migrate.

While I'm in here I'm wondering if we should deprecate anything else in the aliases.