### PR TITLE
Core: Support Symbol wrapper objects in jQuery.type

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -442,7 +442,7 @@ if ( typeof Symbol === "function" ) {
 /* jshint ignore: end */
 
 // Populate the class2type map
-jQuery.each( "Boolean Number String Function Array Date RegExp Object Error".split( " " ),
+jQuery.each( "Boolean Number String Function Array Date RegExp Object Error Symbol".split( " " ),
 function( i, name ) {
 	class2type[ "[object " + name + "]" ] = name.toLowerCase();
 } );

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -270,6 +270,12 @@ QUnit.test( "type", function( assert ) {
 	assert.equal( jQuery.type( new MyNumber( 1 ) ), "number", "Number" );
 	assert.equal( jQuery.type( new MyString( "a" ) ), "string", "String" );
 	assert.equal( jQuery.type( new MyObject() ), "object", "Object" );
+
+	// Prevent reference errors
+	if( typeof Symbol === "function" ) {
+		assert.equal( jQuery.type( Symbol() ), "symbol", "Symbol" );
+		assert.equal( jQuery.type( Object( Symbol() ) ), "symbol", "Symbol" );
+	}
 } );
 
 QUnit.asyncTest( "isPlainObject", function( assert ) {


### PR DESCRIPTION
In ECMAScript 2015 (ES6), the native `typeof` operator returns `"symbol"`
for `Symbol` primitives. As it is possible to wrap symbols using the
`Object` constructor, symbols can be objects as well as any other
primitive type in JavaScript and should be determined by `jQuery.type`.