### PR TITLE
Build: Fixed issue with base path that contain 'var'

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -53,7 +53,7 @@ module.exports = function( grunt ) {
 		var amdName;
 
 		// Convert var modules
-		if ( /.\/var\//.test( path ) ) {
+		if ( /.\/var\//.test( path.replace( process.cwd(), "" ) ) ) {
 			contents = contents
 				.replace( /define\([\w\W]*?return/, "var " + ( /var\/([\w-]+)/.exec( name )[ 1 ] ) + " =" )
 				.replace( rdefineEnd, "" );


### PR DESCRIPTION
This fixes #2450 by removing the cwd from the paths, so the regex doesn't kick in on "var"