### PR TITLE
Core: add unit test for isPlainObject(Symbol)

### DIFF
--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -353,6 +353,15 @@ QUnit.asyncTest( "isPlainObject", function( assert ) {
 	}
 } );
 
+//
+QUnit[ typeof Symbol === "function" ? "test" : "skip" ]( "isPlainObject(Symbol)", function( assert ) {
+	assert.expect( 2 );
+
+	assert.equal( jQuery.isPlainObject( Symbol() ), false, "Symbol" );
+	assert.equal( jQuery.isPlainObject( Object( Symbol() ) ), false, "Symbol inside an object" );
+} );
+
+
 QUnit.test( "isFunction", function( assert ) {
 	assert.expect( 19 );
 


### PR DESCRIPTION
Fixes #2645 

Didn't need unit test for isEmptyObject because this fxn only accepts plain objects & Symbols aren't plain objects 