### PR TITLE
Core: make isNumeric limited to strings and numbers

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -210,12 +210,12 @@ jQuery.extend( {
 
 	isNumeric: function( obj ) {
 
-		// parseFloat NaNs numeric-cast false positives (null|true|false|"")
-		// ...but misinterprets leading-number strings, particularly hex literals ("0x...")
-		// subtraction forces infinities to NaN
-		// adding 1 corrects loss of precision from parseFloat (#15100)
-		var realStringObj = obj && obj.toString();
-		return !jQuery.isArray( obj ) && ( realStringObj - parseFloat( realStringObj ) + 1 ) >= 0;
+		// As of jQuery 3.0, isNumeric is limited to
+		// strings and numbers (primitives or objects)
+		// that can be coerced to finite numbers (gh-2662)
+		var type = jQuery.type( obj );
+		return ( type === "number" || type === "string" ) &&
+			( obj - parseFloat( obj ) + 1 ) >= 0;
 	},
 
 	isPlainObject: function( obj ) {

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -474,8 +474,8 @@ QUnit.test( "isNumeric", function( assert ) {
 	assert.ok( t( 1.5999999999999999 ), "Very precise floating point number" );
 	assert.ok( t( 8e5 ), "Exponential notation" );
 	assert.ok( t( "123e-2" ), "Exponential notation string" );
-	assert.ok( t( new ToString( "42" ) ), "Custom .toString returning number" );
 
+	assert.equal( t( new ToString( "42" ) ), false, "Custom .toString returning number" );
 	assert.equal( t( "" ), false, "Empty string" );
 	assert.equal( t( "        " ), false, "Whitespace characters string" );
 	assert.equal( t( "\t\t" ), false, "Tab characters string" );


### PR DESCRIPTION
- This is a little more bulletproof in regards to future JS type additions.
- It is only different than what we currently have in one case.
- While the documentation has good examples, we need to be more explicit about how our isNumeric tries to coerce strings.

Fixes gh-2662