### PR TITLE
Attributes: do not set properties to false when removing booleans

### DIFF
--- a/src/attributes/attr.js
+++ b/src/attributes/attr.js
@@ -86,21 +86,12 @@ jQuery.extend( {
 	},
 
 	removeAttr: function( elem, value ) {
-		var name, propName,
+		var name,
 			i = 0,
 			attrNames = value && value.match( rnotwhite );
 
 		if ( attrNames && elem.nodeType === 1 ) {
 			while ( ( name = attrNames[ i++ ] ) ) {
-				propName = jQuery.propFix[ name ] || name;
-
-				// Boolean attributes get special treatment (#10870)
-				if ( jQuery.expr.match.bool.test( name ) ) {
-
-					// Set corresponding property to false
-					elem[ propName ] = false;
-				}
-
 				elem.removeAttribute( name );
 			}
 		}
@@ -120,6 +111,7 @@ boolHook = {
 		return name;
 	}
 };
+
 jQuery.each( jQuery.expr.match.bool.source.match( /\w+/g ), function( i, name ) {
 	var getter = attrHandle[ name ] || jQuery.find.attr;
 

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -564,7 +564,7 @@ QUnit.test( "attr('tabindex', value)", function( assert ) {
 } );
 
 QUnit.test( "removeAttr(String)", function( assert ) {
-	assert.expect( 12 );
+	assert.expect( 13 );
 	var $first;
 
 	assert.equal( jQuery( "#mark" ).removeAttr( "class" ).attr( "class" ), undefined, "remove class" );
@@ -575,7 +575,9 @@ QUnit.test( "removeAttr(String)", function( assert ) {
 	assert.equal( jQuery( "#fx-test-group" ).attr( "height", "3px" ).removeAttr( "height" ).get( 0 ).style.height, "1px", "Removing height attribute has no effect on height set with style attribute" );
 
 	jQuery( "#check1" ).removeAttr( "checked" ).prop( "checked", true ).removeAttr( "checked" );
-	assert.equal( document.getElementById( "check1" ).checked, false, "removeAttr sets boolean properties to false" );
+	assert.equal( document.getElementById( "check1" ).checked, true, "removeAttr should not set checked to false, since the checked attribute does NOT mirror the checked property" );
+	jQuery( "#option1b" ).attr( "selected", "selected" ).removeAttr( "selected" ).attr( "selected", "selected" );
+	assert.notEqual( document.getElementById( "select1" ).selectedIndex, 1, "Once the selected attribute is dirty, subsequent settings should not select the option (gh-1759)" );
 	jQuery( "#text1" ).prop( "readOnly", true ).removeAttr( "readonly" );
 	assert.equal( document.getElementById( "text1" ).readOnly, false, "removeAttr sets boolean properties to false" );
 


### PR DESCRIPTION
- This is just legacy behavior that somehow stuck around. No docs changes needed.

Fixes gh-1759