### PR TITLE
Ajax: Only form-encode requests with a body

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -20,7 +20,6 @@ var
 	// #7653, #8125, #8152: local protocol detection
 	rlocalProtocol = /^(?:about|app|app-storage|.+-extension|file|res|widget):$/,
 	rnoContent = /^(?:GET|HEAD)$/,
-	rformContent = /x-www-form-urlencoded/,
 	rprotocol = /^\/\//,
 
 	/* Prefilters
@@ -604,8 +603,9 @@ jQuery.extend( {
 					cacheURL + ( rquery.test( cacheURL ) ? "&" : "?" ) + "_=" + nonce++;
 			}
 
-		// Change '%20' to '+' if this is encoded form content (gh-2658)
-		} else if ( s.data && s.processData && rformContent.test( s.contentType ) ) {
+		// Change '%20' to '+' if this is encoded form body content (gh-2658)
+		} else if ( s.data && s.processData &&
+			( s.contentType || "" ).indexOf( "application/x-www-form-urlencoded" ) === 0 ) {
 			s.data = s.data.replace( r20, "+" );
 		}
 

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -12,6 +12,7 @@ define( [
 ], function( jQuery, document, rnotwhite, location, nonce, rquery ) {
 
 var
+	r20 = /%20/g,
 	rhash = /#.*$/,
 	rts = /([?&])_=[^&]*/,
 	rheaders = /^(.*?):[ \t]*([^\r\n]*)$/mg,
@@ -19,6 +20,7 @@ var
 	// #7653, #8125, #8152: local protocol detection
 	rlocalProtocol = /^(?:about|app|app-storage|.+-extension|file|res|widget):$/,
 	rnoContent = /^(?:GET|HEAD)$/,
+	rformContent = /x-www-form-urlencoded/,
 	rprotocol = /^\/\//,
 
 	/* Prefilters
@@ -601,6 +603,10 @@ jQuery.extend( {
 					// Otherwise add one to the end
 					cacheURL + ( rquery.test( cacheURL ) ? "&" : "?" ) + "_=" + nonce++;
 			}
+
+		// Change '%20' to '+' if this is encoded form content (gh-2658)
+		} else if ( s.data && s.processData && rformContent.test( s.contentType ) ) {
+			s.data = s.data.replace( r20, "+" );
 		}
 
 		// Set the If-Modified-Since and/or If-None-Match header, if in ifModified mode.

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -6,7 +6,7 @@ define( [
 	"./attributes/prop"
 ], function( jQuery, rcheckableType ) {
 
-var r20 = /%20/g,
+var
 	rbracket = /\[\]$/,
 	rCRLF = /\r?\n/g,
 	rsubmitterTypes = /^(?:submit|button|image|reset|file)$/i,
@@ -85,7 +85,7 @@ jQuery.param = function( a, traditional ) {
 	}
 
 	// Return the resulting serialization
-	return s.join( "&" ).replace( r20, "+" );
+	return s.join( "&" );
 };
 
 jQuery.fn.extend( {

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -1129,6 +1129,32 @@ QUnit.module( "ajax", {
 		};
 	} );
 
+	ajaxTest( "jQuery.ajax() - data - x-www-form-urlencoded (gh-2658)", 1, function( assert ) {
+		return {
+			url: "bogus.html",
+			data: { devo: "A Beautiful World" },
+			type: "post",
+			beforeSend: function( _, s ) {
+				assert.strictEqual( s.data, "devo=A+Beautiful+World", "data is '+'-encoded" );
+				return false;
+			},
+			error: true
+		};
+	} );
+
+	ajaxTest( "jQuery.ajax() - data - URL data isn't form encoded (gh-2658)", 1, function( assert ) {
+		return {
+			url: "bogus.html",
+			data: { devo: "A Beautiful World" },
+			type: "get",
+			beforeSend: function( _, s ) {
+				assert.strictEqual( s.url, "bogus.html?devo=A%20Beautiful%20World", "data is NOT '+'-encoded" );
+				return false;
+			},
+			error: true
+		};
+	} );
+
 	var ifModifiedNow = new Date();
 
 	jQuery.each(

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -1142,13 +1142,29 @@ QUnit.module( "ajax", {
 		};
 	} );
 
-	ajaxTest( "jQuery.ajax() - data - URL data isn't form encoded (gh-2658)", 1, function( assert ) {
+	ajaxTest( "jQuery.ajax() - data - text/plain (gh-2658)", 1, function( assert ) {
 		return {
 			url: "bogus.html",
 			data: { devo: "A Beautiful World" },
-			type: "get",
+			type: "post",
+			contentType: "text/plain",
 			beforeSend: function( _, s ) {
-				assert.strictEqual( s.url, "bogus.html?devo=A%20Beautiful%20World", "data is NOT '+'-encoded" );
+				assert.strictEqual( s.data, "devo=A%20Beautiful%20World", "data is %20-encoded" );
+				return false;
+			},
+			error: true
+		};
+	} );
+
+	ajaxTest( "jQuery.ajax() - data - no processing ", 1, function( assert ) {
+		return {
+			url: "bogus.html",
+			data: { devo: "A Beautiful World" },
+			type: "post",
+			contentType: "x-special-sauce",
+			processData: false,
+			beforeSend: function( _, s ) {
+				assert.deepEqual( s.data, { devo: "A Beautiful World" }, "data is not processed" );
 				return false;
 			},
 			error: true

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -8,7 +8,7 @@ QUnit.test( "jQuery.param()", function( assert ) {
 	assert.equal( !( jQuery.ajaxSettings && jQuery.ajaxSettings.traditional ), true, "traditional flag, falsy by default" );
 
 	params = { "foo":"bar", "baz":42, "quux":"All your base are belong to us" };
-	assert.equal( jQuery.param( params ), "foo=bar&baz=42&quux=All+your+base+are+belong+to+us", "simple" );
+	assert.equal( jQuery.param( params ), "foo=bar&baz=42&quux=All%20your%20base%20are%20belong%20to%20us", "simple" );
 
 	params = { "string":"foo","null":null,"undefined":undefined };
 	assert.equal( jQuery.param( params ), "string=foo&null=&undefined=", "handle nulls and undefineds properly" );
@@ -20,19 +20,19 @@ QUnit.test( "jQuery.param()", function( assert ) {
 	assert.equal( jQuery.param( params ), "foo%5B%5D=a&foo%5B%5D=b&foo%5B%5D=c", "with array of strings" );
 
 	params = { "foo": [ "baz", 42, "All your base are belong to us" ] };
-	assert.equal( jQuery.param( params ), "foo%5B%5D=baz&foo%5B%5D=42&foo%5B%5D=All+your+base+are+belong+to+us", "more array" );
+	assert.equal( jQuery.param( params ), "foo%5B%5D=baz&foo%5B%5D=42&foo%5B%5D=All%20your%20base%20are%20belong%20to%20us", "more array" );
 
 	params = { "foo": { "bar": "baz", "beep": 42, "quux": "All your base are belong to us" } };
-	assert.equal( jQuery.param( params ), "foo%5Bbar%5D=baz&foo%5Bbeep%5D=42&foo%5Bquux%5D=All+your+base+are+belong+to+us", "even more arrays" );
+	assert.equal( jQuery.param( params ), "foo%5Bbar%5D=baz&foo%5Bbeep%5D=42&foo%5Bquux%5D=All%20your%20base%20are%20belong%20to%20us", "even more arrays" );
 
 	params = { a:[ 1,2 ], b:{ c:3, d:[ 4,5 ], e:{ x:[ 6 ], y:7, z:[ 8,9 ] }, f:true, g:false, h:undefined }, i:[ 10,11 ], j:true, k:false, l:[ undefined,0 ], m:"cowboy hat?" };
-	assert.equal( decodeURIComponent( jQuery.param( params ) ), "a[]=1&a[]=2&b[c]=3&b[d][]=4&b[d][]=5&b[e][x][]=6&b[e][y]=7&b[e][z][]=8&b[e][z][]=9&b[f]=true&b[g]=false&b[h]=&i[]=10&i[]=11&j=true&k=false&l[]=&l[]=0&m=cowboy+hat?", "huge structure" );
+	assert.equal( decodeURIComponent( jQuery.param( params ) ), "a[]=1&a[]=2&b[c]=3&b[d][]=4&b[d][]=5&b[e][x][]=6&b[e][y]=7&b[e][z][]=8&b[e][z][]=9&b[f]=true&b[g]=false&b[h]=&i[]=10&i[]=11&j=true&k=false&l[]=&l[]=0&m=cowboy hat?", "huge structure" );
 
 	params = { "a": [ 0, [ 1, 2 ], [ 3, [ 4, 5 ], [ 6 ] ], { "b": [ 7, [ 8, 9 ], [ { "c": 10, "d": 11 } ], [ [ 12 ] ], [ [ [ 13 ] ] ], { "e": { "f": { "g": [ 14, [ 15 ] ] } } }, 16 ] }, 17 ] };
 	assert.equal( decodeURIComponent( jQuery.param( params ) ), "a[]=0&a[1][]=1&a[1][]=2&a[2][]=3&a[2][1][]=4&a[2][1][]=5&a[2][2][]=6&a[3][b][]=7&a[3][b][1][]=8&a[3][b][1][]=9&a[3][b][2][0][c]=10&a[3][b][2][0][d]=11&a[3][b][3][0][]=12&a[3][b][4][0][0][]=13&a[3][b][5][e][f][g][]=14&a[3][b][5][e][f][g][1][]=15&a[3][b][]=16&a[]=17", "nested arrays" );
 
 	params = { "a":[ 1,2 ], "b":{ "c":3, "d":[ 4,5 ], "e":{ "x":[ 6 ], "y":7, "z":[ 8,9 ] }, "f":true, "g":false, "h":undefined }, "i":[ 10,11 ], "j":true, "k":false, "l":[ undefined,0 ], "m":"cowboy hat?" };
-	assert.equal( jQuery.param( params, true ), "a=1&a=2&b=%5Bobject+Object%5D&i=10&i=11&j=true&k=false&l=&l=0&m=cowboy+hat%3F", "huge structure, forced traditional" );
+	assert.equal( jQuery.param( params, true ), "a=1&a=2&b=%5Bobject%20Object%5D&i=10&i=11&j=true&k=false&l=&l=0&m=cowboy%20hat%3F", "huge structure, forced traditional" );
 
 	assert.equal( decodeURIComponent( jQuery.param( { "a": [ 1,2,3 ], "b[]": [ 4,5,6 ], "c[d]": [ 7,8,9 ], "e": { "f": [ 10 ], "g": [ 11,12 ], "h": 13 } } ) ), "a[]=1&a[]=2&a[]=3&b[]=4&b[]=5&b[]=6&c[d][]=7&c[d][]=8&c[d][]=9&e[f][]=10&e[g][]=11&e[g][]=12&e[h]=13", "Make sure params are not double-encoded." );
 
@@ -48,7 +48,7 @@ QUnit.test( "jQuery.param()", function( assert ) {
 	}
 
 	params = { "foo":"bar", "baz":42, "quux":"All your base are belong to us" };
-	assert.equal( jQuery.param( params ), "foo=bar&baz=42&quux=All+your+base+are+belong+to+us", "simple" );
+	assert.equal( jQuery.param( params ), "foo=bar&baz=42&quux=All%20your%20base%20are%20belong%20to%20us", "simple" );
 
 	params = { "someName": [ 1, 2, 3 ], "regularThing": "blah" };
 	assert.equal( jQuery.param( params ), "someName=1&someName=2&someName=3&regularThing=blah", "with array" );
@@ -57,19 +57,19 @@ QUnit.test( "jQuery.param()", function( assert ) {
 	assert.equal( jQuery.param( params ), "foo=a&foo=b&foo=c", "with array of strings" );
 
 	params = { "foo[]":[ "baz", 42, "All your base are belong to us" ] };
-	assert.equal( jQuery.param( params ), "foo%5B%5D=baz&foo%5B%5D=42&foo%5B%5D=All+your+base+are+belong+to+us", "more array" );
+	assert.equal( jQuery.param( params ), "foo%5B%5D=baz&foo%5B%5D=42&foo%5B%5D=All%20your%20base%20are%20belong%20to%20us", "more array" );
 
 	params = { "foo[bar]":"baz", "foo[beep]":42, "foo[quux]":"All your base are belong to us" };
-	assert.equal( jQuery.param( params ), "foo%5Bbar%5D=baz&foo%5Bbeep%5D=42&foo%5Bquux%5D=All+your+base+are+belong+to+us", "even more arrays" );
+	assert.equal( jQuery.param( params ), "foo%5Bbar%5D=baz&foo%5Bbeep%5D=42&foo%5Bquux%5D=All%20your%20base%20are%20belong%20to%20us", "even more arrays" );
 
 	params = { a:[ 1,2 ], b:{ c:3, d:[ 4,5 ], e:{ x:[ 6 ], y:7, z:[ 8,9 ] }, f:true, g:false, h:undefined }, i:[ 10,11 ], j:true, k:false, l:[ undefined,0 ], m:"cowboy hat?" };
-	assert.equal( jQuery.param( params ), "a=1&a=2&b=%5Bobject+Object%5D&i=10&i=11&j=true&k=false&l=&l=0&m=cowboy+hat%3F", "huge structure" );
+	assert.equal( jQuery.param( params ), "a=1&a=2&b=%5Bobject%20Object%5D&i=10&i=11&j=true&k=false&l=&l=0&m=cowboy%20hat%3F", "huge structure" );
 
 	params = { "a": [ 0, [ 1, 2 ], [ 3, [ 4, 5 ], [ 6 ] ], { "b": [ 7, [ 8, 9 ], [ { "c": 10, d: 11 } ], [ [ 12 ] ], [ [ [ 13 ] ] ], { "e": { "f": { "g": [ 14, [ 15 ] ] } } }, 16 ] }, 17 ] };
-	assert.equal( jQuery.param( params ), "a=0&a=1%2C2&a=3%2C4%2C5%2C6&a=%5Bobject+Object%5D&a=17", "nested arrays (not possible when jQuery.param.traditional == true)" );
+	assert.equal( jQuery.param( params ), "a=0&a=1%2C2&a=3%2C4%2C5%2C6&a=%5Bobject%20Object%5D&a=17", "nested arrays (not possible when jQuery.param.traditional == true)" );
 
 	params = { a:[ 1,2 ], b:{ c:3, d:[ 4,5 ], e:{ x:[ 6 ], y:7, z:[ 8,9 ] }, f:true, g:false, h:undefined }, i:[ 10,11 ], j:true, k:false, l:[ undefined,0 ], m:"cowboy hat?" };
-	assert.equal( decodeURIComponent( jQuery.param( params, false ) ), "a[]=1&a[]=2&b[c]=3&b[d][]=4&b[d][]=5&b[e][x][]=6&b[e][y]=7&b[e][z][]=8&b[e][z][]=9&b[f]=true&b[g]=false&b[h]=&i[]=10&i[]=11&j=true&k=false&l[]=&l[]=0&m=cowboy+hat?", "huge structure, forced not traditional" );
+	assert.equal( decodeURIComponent( jQuery.param( params, false ) ), "a[]=1&a[]=2&b[c]=3&b[d][]=4&b[d][]=5&b[e][x][]=6&b[e][y]=7&b[e][z][]=8&b[e][z][]=9&b[f]=true&b[g]=false&b[h]=&i[]=10&i[]=11&j=true&k=false&l[]=&l[]=0&m=cowboy hat?", "huge structure, forced not traditional" );
 
 	params = { "param1": null };
 	assert.equal( jQuery.param( params, false ), "param1=", "Make sure that null params aren't traversed." );
@@ -131,19 +131,19 @@ QUnit.test( "serialize()", function( assert ) {
 		"Check input serialization as query string" );
 
 	assert.equal( jQuery( "#testForm" ).serialize(),
-		"T3=%3F%0D%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My+Name=me&S1=abc&S3=YES&S4=",
+		"T3=%3F%0D%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My%20Name=me&S1=abc&S3=YES&S4=",
 		"Check form serialization as query string" );
 
 	assert.equal( jQuery( "input,select,textarea,button", "#testForm" ).serialize(),
-		"T3=%3F%0D%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My+Name=me&S1=abc&S3=YES&S4=",
+		"T3=%3F%0D%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My%20Name=me&S1=abc&S3=YES&S4=",
 		"Check input serialization as query string" );
 
 	assert.equal( jQuery( "#form, #testForm" ).serialize(),
-		"action=Test&radio2=on&check=on&hidden=&foo%5Bbar%5D=&name=name&search=search&email=dave%40jquery.com&number=43&select1=&select2=3&select3=1&select3=2&select5=3&T3=%3F%0D%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My+Name=me&S1=abc&S3=YES&S4=",
+		"action=Test&radio2=on&check=on&hidden=&foo%5Bbar%5D=&name=name&search=search&email=dave%40jquery.com&number=43&select1=&select2=3&select3=1&select3=2&select5=3&T3=%3F%0D%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My%20Name=me&S1=abc&S3=YES&S4=",
 		"Multiple form serialization as query string" );
 
 	assert.equal( jQuery( "#form, #testForm :input" ).serialize(),
-		"action=Test&radio2=on&check=on&hidden=&foo%5Bbar%5D=&name=name&search=search&email=dave%40jquery.com&number=43&select1=&select2=3&select3=1&select3=2&select5=3&T3=%3F%0D%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My+Name=me&S1=abc&S3=YES&S4=",
+		"action=Test&radio2=on&check=on&hidden=&foo%5Bbar%5D=&name=name&search=search&email=dave%40jquery.com&number=43&select1=&select2=3&select3=1&select3=2&select5=3&T3=%3F%0D%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My%20Name=me&S1=abc&S3=YES&S4=",
 		"Mixed form/input serialization as query string" );
 	jQuery( "#html5email, #html5number" ).remove();
 } );


### PR DESCRIPTION
Fixes #2658 

This is a (minor) behavior change for `jQuery.param()` and `jQuery.serialize()` since they no longer convert `%20` to `+`, and for `jQuery.ajax()` when the `data` ends up on the URL.

I had some conflict trying to determine the right place to put this conversion. If we want prefilters to see it this would have to be moved higher. However, the prefilters have the opportunity to change all kinds of stuff that might affect whether we do this at all. So I decided to do it a bit further down once the `hasContent` variable is set and the content-type is known. Other suggestions welcome.