### PR TITLE
Core: use interactive to evaluate dom ready

### DIFF
--- a/src/core/ready.js
+++ b/src/core/ready.js
@@ -70,10 +70,10 @@ jQuery.ready.promise = function( obj ) {
 
 		// Catch cases where $(document).ready() is called
 		// after the browser event has already occurred.
-		// We once tried to use readyState "interactive" here,
-		// but it caused issues like the one
-		// discovered by ChrisS here: http://bugs.jquery.com/ticket/12282#comment:15
-		if ( document.readyState === "complete" ) {
+		// Support: IE9-10 only
+		// Older IE sometimes signals "interactive" too soon
+		if ( document.readyState === "complete" ||
+			( document.readyState !== "loading" && !document.documentElement.doScroll ) ) {
 
 			// Handle it asynchronously to allow scripts the opportunity to delay ready
 			window.setTimeout( jQuery.ready );

--- a/test/data/event/interactiveReady.html
+++ b/test/data/event/interactiveReady.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html>
+<head>
+<meta http-equiv="content-type" content="text/html; charset=utf-8">
+<title>Test case for gh-2100</title>
+<script src="../../jquery.js"></script>
+</head>
+<body>
+
+<script type="text/javascript">
+jQuery( document ).ready(function () {
+	window.parent.iframeCallback( jQuery("#container").length === 1 );
+});
+</script>
+
+<!-- external resources that come before elements trick
+	oldIE into thinking the dom is ready, but it's not...
+	leaving this check here for future trailblazers to attempt
+	fixing this...-->
+<script type="text/javascript" src="../longLoadScript.php?sleep=1"></script>
+<div id="container" style="height: 300px"></div>
+</body>
+</html>

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -2518,6 +2518,18 @@ testIframeWithCallback(
 	}
 );
 
+// need PHP here to make the incepted IFRAME hang
+if ( hasPHP ) {
+	testIframeWithCallback(
+		"jQuery.ready uses interactive",
+		"event/interactiveReady.html",
+		function( isOk, assert ) {
+			assert.expect( 1 );
+			assert.ok( isOk, "jQuery fires ready when the DOM can truly be interacted with" );
+		}
+	);
+}
+
 testIframeWithCallback(
 	"Focusing iframe element",
 	"event/focusElem.html",


### PR DESCRIPTION
- Now that dom ready is always synchronous, we don't have to deal with ensuring sync execution order.
- I actually couldn't reproduce the IE9 issue where DOM below scripts is not actually interactive, but I ran into a different issue with IE10 (I think it was mostly a test issue, but it had to do with document.write behaving differently so I didn't mess with it). Either way, I just kept the proposed solution of checking doScroll, effectively excluding IE9-10.

Fixes gh-2100