### PR TITLE
Ajax: Don't throw exceptions on binary data response

### DIFF
--- a/src/ajax/xhr.js
+++ b/src/ajax/xhr.js
@@ -88,12 +88,10 @@ jQuery.ajaxTransport( function( options ) {
 									xhrSuccessStatus[ xhr.status ] || xhr.status,
 									xhr.statusText,
 
-									// XHR2 responseText throws an exception on binary data,
-									// return it raw and let a converter or caller handle it
-									// https://xhr.spec.whatwg.org/#the-responsetext-attribute
-									// (trac-11426, gh-2498)
-									xhr.responseType === "arraybuffer" ||
-									xhr.responseType === "blob" ||
+									// Support: IE9 only
+									// IE9 has no XHR2 but throws on binary (trac-11426)
+									// For XHR2 non-text, let the caller handle it (gh-2498)
+									( xhr.responseType || "text" ) !== "text"  ||
 									typeof xhr.responseText !== "string" ?
 										{ binary: xhr.response } :
 										{ text: xhr.responseText },

--- a/src/ajax/xhr.js
+++ b/src/ajax/xhr.js
@@ -88,12 +88,15 @@ jQuery.ajaxTransport( function( options ) {
 									xhrSuccessStatus[ xhr.status ] || xhr.status,
 									xhr.statusText,
 
-									// Support: IE9
-									// Accessing binary-data responseText throws an exception
-									// (#11426)
-									typeof xhr.responseText === "string" ? {
-										text: xhr.responseText
-									} : undefined,
+									// XHR2 responseText throws an exception on binary data,
+									// return it raw and let a converter or caller handle it
+									// https://xhr.spec.whatwg.org/#the-responsetext-attribute
+									// (trac-11426, gh-2498)
+									xhr.responseType === "arraybuffer" ||
+									xhr.responseType === "blob" ||
+									typeof xhr.responseText !== "string" ?
+										{ binary: xhr.response } :
+										{ text: xhr.responseText },
 									xhr.getAllResponseHeaders()
 								);
 							}

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -1599,6 +1599,30 @@ QUnit.module( "ajax", {
 		};
 	} );
 
+if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().responseType !== "string" ) {
+
+	QUnit.skip( "No ArrayBuffer support in XHR", jQuery.noop );
+} else {
+
+	// No built-in support for binary data, but it's easy to add via a prefilter
+	jQuery.ajaxPrefilter( "arraybuffer", function ( s ) {
+		s.xhrFields = { responseType: "arraybuffer" };
+		s.responseFields.arraybuffer = "response";
+		s.converters[ "binary arraybuffer" ] = true;
+	});
+
+	ajaxTest( "gh-2498 - jQuery.ajax() - binary data shouldn't throw an exception", 2, function( assert ) {
+		return {
+			url: url( "data/1x1.jpg" ),
+			dataType: "arraybuffer",
+			success: function( data, s, jqxhr ) {
+				assert.ok( data instanceof window.ArrayBuffer, "correct data type" );
+				assert.ok( jqxhr.response instanceof window.ArrayBuffer, "data in jQXHR" );
+			}
+		};
+	} );
+}
+
 	QUnit.asyncTest( "#11743 - jQuery.ajax() - script, throws exception", 1, function( assert ) {
 
 		// Support: Android 2.3 only


### PR DESCRIPTION
Fixes #2498

The added unit test shows how this could be used to support an
ArrayBuffer return, but $.ajax does not support it natively.
The goal with this change was to avoid the exception.