### PR TITLE
Event: Make event aliases optional in unit tests

### DIFF
--- a/test/data/event/focusElem.html
+++ b/test/data/event/focusElem.html
@@ -9,7 +9,7 @@
 <body>
 	<a href="#" id="frame-link"></a>
 	<script>
-		jQuery("#frame-link").focus();
+		jQuery( "#frame-link" ).trigger( "focus" );
 		window.parent.iframeCallback( true );
 	</script>
 </body>

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -900,49 +900,6 @@ QUnit.test( "mouseenter, mouseleave don't catch exceptions", function( assert ) 
 	}
 } );
 
-if ( jQuery.fn.click ) {
-
-	QUnit.test( "trigger() shortcuts", function( assert ) {
-		assert.expect( 5 );
-
-		var counter, clickCounter,
-			elem = jQuery( "<li><a href='#'>Change location</a></li>" ).prependTo( "#firstUL" );
-		elem.find( "a" ).on( "click", function() {
-			var close = jQuery( "spanx", this ); // same with jQuery(this).find("span");
-			assert.equal( close.length, 0, "Context element does not exist, length must be zero" );
-			assert.ok( !close[ 0 ], "Context element does not exist, direct access to element must return undefined" );
-			return false;
-		} ).click();
-
-		// manually clean up detached elements
-		elem.remove();
-
-		jQuery( "#check1" ).click( function() {
-			assert.ok( true, "click event handler for checkbox gets fired twice, see #815" );
-		} ).click();
-
-		counter = 0;
-		jQuery( "#firstp" )[ 0 ].onclick = function() {
-			counter++;
-		};
-		jQuery( "#firstp" ).click();
-		assert.equal( counter, 1, "Check that click, triggers onclick event handler also" );
-
-		clickCounter = 0;
-		jQuery( "#simon1" )[ 0 ].onclick = function() {
-			clickCounter++;
-		};
-		jQuery( "#simon1" ).click();
-		assert.equal( clickCounter, 1, "Check that click, triggers onclick event handler on an a tag also" );
-
-		// test that special handlers do not blow up with VML elements (#7071)
-		jQuery( "<xml:namespace ns='urn:schemas-microsoft-com:vml' prefix='v' />" ).appendTo( "head" );
-		jQuery( "<v:oval id='oval' style='width:100pt;height:75pt;' fillcolor='red'> </v:oval>" ).appendTo( "#form" );
-		jQuery( "#oval" ).click().keydown();
-	} );
-
-}
-
 QUnit.test( "trigger() bubbling", function( assert ) {
 	assert.expect( 18 );
 
@@ -2778,7 +2735,7 @@ QUnit.test( "preventDefault() on focusin does not throw exception", function( as
 				"Preventing default on focusin throws no exception" );
 
 			done();
-		} ).focus();
+		} ).trigger( "focus" );
 } );
 
 QUnit.test( "Donor event interference", function( assert ) {
@@ -2841,6 +2798,46 @@ QUnit.test( "originalEvent property for Chrome, Safari, Fx & Edge of simulated e
 		assert.ok( true, "got a focus event from the input" );
 	} );
 	jQuery( "#donor-input" ).trigger( "focus" );
+} );
+
+
+QUnit[ jQuery.fn.click ? "test" : "skip" ]( "trigger() shortcuts", function( assert ) {
+	assert.expect( 5 );
+
+	var counter, clickCounter,
+		elem = jQuery( "<li><a href='#'>Change location</a></li>" ).prependTo( "#firstUL" );
+	elem.find( "a" ).on( "click", function() {
+		var close = jQuery( "spanx", this ); // same with jQuery(this).find("span");
+		assert.equal( close.length, 0, "Context element does not exist, length must be zero" );
+		assert.ok( !close[ 0 ], "Context element does not exist, direct access to element must return undefined" );
+		return false;
+	} ).click();
+
+	// manually clean up detached elements
+	elem.remove();
+
+	jQuery( "#check1" ).click( function() {
+		assert.ok( true, "click event handler for checkbox gets fired twice, see #815" );
+	} ).click();
+
+	counter = 0;
+	jQuery( "#firstp" )[ 0 ].onclick = function() {
+		counter++;
+	};
+	jQuery( "#firstp" ).click();
+	assert.equal( counter, 1, "Check that click, triggers onclick event handler also" );
+
+	clickCounter = 0;
+	jQuery( "#simon1" )[ 0 ].onclick = function() {
+		clickCounter++;
+	};
+	jQuery( "#simon1" ).click();
+	assert.equal( clickCounter, 1, "Check that click, triggers onclick event handler on an a tag also" );
+
+	// test that special handlers do not blow up with VML elements (#7071)
+	jQuery( "<xml:namespace ns='urn:schemas-microsoft-com:vml' prefix='v' />" ).appendTo( "head" );
+	jQuery( "<v:oval id='oval' style='width:100pt;height:75pt;' fillcolor='red'> </v:oval>" ).appendTo( "#form" );
+	jQuery( "#oval" ).click().keydown();
 } );
 
 QUnit[ jQuery.fn.click ? "test" : "skip" ]( "Event aliases", function( assert ) {


### PR DESCRIPTION
Relatively easy fixes, although I did have a question about one strange VML-related test.