### PR TITLE
Add bower.json for better dependency injection support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,24 @@
+{
+  "name": "jquery",
+  "version": "3.0.0-alpha1+compat",
+  "homepage": "http://jquery.com",
+  "authors": [
+    "jQuery Foundation and other contributors"
+  ],
+  "description": "JavaScript library for DOM operations",
+  "main": "dist/jquery.js",
+  "keywords": [
+    "jquery",
+    "browser",
+    "javascript",
+    "library"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Since the project doesn't contain a bower.json, using tools like wiredep to inject dependencies is not possible.

Adding the bower.json with a "main" field resolves this.

Let me know if any fields aren't set to appropriate values