### PR TITLE
Docs: add a note about loading source with AMD

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,12 +101,6 @@ Run the build script
 $ npm run build
 ```
 
-Build a local copy of jQuery using grunt
-
-```bash
-$ grunt
-```
-
 Now open the jQuery test suite in a browser at http://localhost/test. If there is a port, be sure to include it.
 
 Success! You just built and tested jQuery!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,10 +101,10 @@ Run the build script
 $ npm run build
 ```
 
-Run the Grunt tools:
+Build a local copy of jQuery using grunt
 
 ```bash
-$ grunt && grunt watch
+$ grunt
 ```
 
 Now open the jQuery test suite in a browser at http://localhost/test. If there is a port, be sure to include it.
@@ -118,11 +118,24 @@ During the process of writing your patch, you will run the test suite MANY times
 
 Example:
 
-http://localhost/test/?filter=css
+http://localhost/test/?module=css
 
 This will only run the "css" module tests. This will significantly speed up your development and debugging.
 
 **ALWAYS RUN THE FULL SUITE BEFORE COMMITTING AND PUSHING A PATCH!**
+
+
+#### Loading changes on the test page
+
+Rather than rebuilding jQuery with `grunt` every time you make a change, you can use the included `grunt watch` task to rebuild distribution files whenever a file is saved.
+
+```bash
+$ grunt watch
+```
+
+Alternatively, you can **load tests in AMD** to avoid the need for rebuilding altogether.
+
+Click "Load with AMD" after loading the test page.
 
 
 ### Browser support


### PR DESCRIPTION
- Moves the note about the watch task and the note about loading with AMD to their own section under "Test Suite Tips"

Fixes gh-2714