### PR TITLE
Deferred: Warn on exceptions that are likely programming errors

### DIFF
--- a/src/deferred.js
+++ b/src/deferred.js
@@ -157,6 +157,10 @@ jQuery.extend( {
 											mightThrow();
 										} catch ( e ) {
 
+											if ( jQuery.Deferred.exceptionHook ) {
+												jQuery.Deferred.exceptionHook( e );
+											}
+
 											// Support: Promises/A+ section 2.3.3.3.4.1
 											// https://promisesaplus.com/#point-61
 											// Ignore post-resolution exceptions
@@ -358,6 +362,23 @@ jQuery.extend( {
 		return master.promise();
 	}
 } );
+
+if ( window.console && window.console.warn ) {
+
+	// These usually indicate a programmer mistake during development,
+	// warn about them ASAP rather than swallowing them by default.
+
+	var rerrorNames = /^(Eval|Internal|Range|Reference|Syntax|Type|URI)Error$/;
+
+	jQuery.Deferred.exceptionHook = function( error ) {
+		if ( error && rerrorNames.test( error.name ) ) {
+			window.console.warn( "jQuery.Deferred exception: " + error.message );
+			if ( window.console.trace ) {
+				window.console.trace();
+			}
+		}
+	};
+}
 
 return jQuery;
 } );

--- a/src/deferred.js
+++ b/src/deferred.js
@@ -158,7 +158,8 @@ jQuery.extend( {
 										} catch ( e ) {
 
 											if ( jQuery.Deferred.exceptionHook ) {
-												jQuery.Deferred.exceptionHook( e );
+												jQuery.Deferred.exceptionHook( e,
+													process.stackTrace );
 											}
 
 											// Support: Promises/A+ section 2.3.3.3.4.1
@@ -186,6 +187,12 @@ jQuery.extend( {
 							if ( depth ) {
 								process();
 							} else {
+
+								// Call an optional hook to record the stack, in case of exception
+								// since it's otherwise lost when execution goes async
+								if ( jQuery.Deferred.getStackHook ) {
+									process.stackTrace = jQuery.Deferred.getStackHook();
+								}
 								window.setTimeout( process );
 							}
 						};

--- a/src/deferred.js
+++ b/src/deferred.js
@@ -166,7 +166,7 @@ jQuery.extend( {
 											// Ignore post-resolution exceptions
 											if ( depth + 1 >= maxDepth ) {
 
-												// Only substitue handlers pass on context
+												// Only substitute handlers pass on context
 												// and multiple values (non-spec behavior)
 												if ( handler !== Thrower ) {
 													that = undefined;
@@ -362,23 +362,6 @@ jQuery.extend( {
 		return master.promise();
 	}
 } );
-
-if ( window.console && window.console.warn ) {
-
-	// These usually indicate a programmer mistake during development,
-	// warn about them ASAP rather than swallowing them by default.
-
-	var rerrorNames = /^(Eval|Internal|Range|Reference|Syntax|Type|URI)Error$/;
-
-	jQuery.Deferred.exceptionHook = function( error ) {
-		if ( error && rerrorNames.test( error.name ) ) {
-			window.console.warn( "jQuery.Deferred exception: " + error.message );
-			if ( window.console.trace ) {
-				window.console.trace();
-			}
-		}
-	};
-}
 
 return jQuery;
 } );

--- a/src/deferred/exceptionHook.js
+++ b/src/deferred/exceptionHook.js
@@ -11,10 +11,8 @@ jQuery.Deferred.exceptionHook = function( error, stack ) {
 
 	// Support: IE9
 	// Console exists when dev tools are open, which can happen at any time
-	var warn = window.console && window.console.warn;
-
-	if ( warn && error && rerrorNames.test( error.name ) ) {
-		warn.call( window.console, "jQuery.Deferred exception: " + error.message, stack );
+	if ( window.console && window.console.warn && error && rerrorNames.test( error.name ) ) {
+		window.console.warn( "jQuery.Deferred exception: " + error.message, stack );
 	}
 };
 

--- a/src/deferred/exceptionHook.js
+++ b/src/deferred/exceptionHook.js
@@ -1,0 +1,21 @@
+define( [
+	"../core",
+	"../deferred"
+], function( jQuery ) {
+
+// These usually indicate a programmer mistake during development,
+// warn about them ASAP rather than swallowing them by default.
+var rerrorNames = /^(Eval|Internal|Range|Reference|Syntax|Type|URI)Error$/;
+
+jQuery.Deferred.exceptionHook = function( error ) {
+
+	// Support: IE9
+	// Console exists when dev tools are open, which can happen at any time
+	var warn = window.console && window.console.warn;
+
+	if ( error && rerrorNames.test( error.name ) ) {
+		warn( "jQuery.Deferred exception: " + error.message );
+	}
+};
+
+} );

--- a/src/deferred/exceptionHook.js
+++ b/src/deferred/exceptionHook.js
@@ -7,17 +7,13 @@ define( [
 // warn about them ASAP rather than swallowing them by default.
 var rerrorNames = /^(Eval|Internal|Range|Reference|Syntax|Type|URI)Error$/;
 
-jQuery.Deferred.exceptionHook = function( error ) {
+jQuery.Deferred.exceptionHook = function( error, stack ) {
 
 	// Support: IE9
 	// Console exists when dev tools are open, which can happen at any time
-	var stack,
-		warn = window.console && window.console.warn;
+	var warn = window.console && window.console.warn;
 
 	if ( warn && error && rerrorNames.test( error.name ) ) {
-		if ( jQuery.Deferred.getStackHook ) {
-			stack = jQuery.Deferred.getStackHook();
-		}
 		warn.call( window.console, "jQuery.Deferred exception: " + error.message, stack );
 	}
 };

--- a/src/deferred/exceptionHook.js
+++ b/src/deferred/exceptionHook.js
@@ -11,10 +11,14 @@ jQuery.Deferred.exceptionHook = function( error ) {
 
 	// Support: IE9
 	// Console exists when dev tools are open, which can happen at any time
-	var warn = window.console && window.console.warn;
+	var stack,
+		warn = window.console && window.console.warn;
 
-	if ( error && rerrorNames.test( error.name ) ) {
-		warn( "jQuery.Deferred exception: " + error.message );
+	if ( warn && error && rerrorNames.test( error.name ) ) {
+		if ( jQuery.Deferred.getStackHook ) {
+			stack = jQuery.Deferred.getStackHook();
+		}
+		warn.call( window.console, "jQuery.Deferred exception: " + error.message, stack );
 	}
 };
 

--- a/src/jquery.js
+++ b/src/jquery.js
@@ -4,6 +4,7 @@ define( [
 	"./traversing",
 	"./callbacks",
 	"./deferred",
+	"./deferred/exceptionHook",
 	"./core/ready",
 	"./data",
 	"./queue",

--- a/test/unit/deferred.js
+++ b/test/unit/deferred.js
@@ -540,11 +540,11 @@ QUnit[ window.console ? "test" : "skip" ]( "jQuery.Deferred.exceptionHook", func
 		defer.then( function() {
 			// Should get an error
 			jQuery.barf();
-		} ).catch( jQuery.noop ),
+		} ).then( null, jQuery.noop ),
 		defer.then( function() {
 			// Should NOT get an error
 			throw new Error( "Make me a sandwich" );
-		} ).catch( jQuery.noop )
+		} ).then( null, jQuery.noop )
 	).then( function( ) {
 		window.console.warn = oldWarn;
 		done();

--- a/test/unit/deferred.js
+++ b/test/unit/deferred.js
@@ -525,23 +525,30 @@ QUnit.test( "jQuery.Deferred.then - spec compatibility", function( assert ) {
 	} catch ( _ ) {}
 } );
 
-QUnit.test( "jQuery.Deferred.exceptionHook", function( assert ) {
+QUnit[ window.console ? "test" : "skip" ]( "jQuery.Deferred.exceptionHook", function( assert ) {
 
 	assert.expect( 1 );
 
 	var done = assert.async(),
 		defer = jQuery.Deferred(),
-		oldWarn = console.warn;
+		oldWarn = window.console.warn;
 
-	console.warn = function( s ) {
-		assert.ok( true, "Warned -- " + s );
-		oldWarn.apply( console, arguments );
-		console.warn = oldWarn;
+	window.console.warn = function( msg ) {
+		assert.ok( true, "Message: " + msg );
 	};
-
-	defer.then( function() {
-		jQuery.barf();
-	} ).then( null, done );
+	jQuery.when(
+		defer.then( function() {
+			// Should get an error
+			jQuery.barf();
+		} ).catch( jQuery.noop ),
+		defer.then( function() {
+			// Should NOT get an error
+			throw new Error( "Make me a sandwich" );
+		} ).catch( jQuery.noop )
+	).then( function( ) {
+		window.console.warn = oldWarn;
+		done();
+	} );
 
 	defer.resolve();
 } );

--- a/test/unit/deferred.js
+++ b/test/unit/deferred.js
@@ -566,7 +566,6 @@ QUnit[ window.console ? "test" : "skip" ]( "jQuery.Deferred.exceptionHook with s
 		// but a custom getStackHook+exceptionHook pair could save a raw form and
 		// format it to a string only when an exception actually occurs.
 		// For the unit test we just ensure the plumbing works.
-console.trace();
 		return "NO STACK FOR YOU";
 	};
 

--- a/test/unit/deferred.js
+++ b/test/unit/deferred.js
@@ -525,6 +525,27 @@ QUnit.test( "jQuery.Deferred.then - spec compatibility", function( assert ) {
 	} catch ( _ ) {}
 } );
 
+QUnit.test( "jQuery.Deferred.exceptionHook", function( assert ) {
+
+	assert.expect( 1 );
+
+	var done = assert.async(),
+		defer = jQuery.Deferred(),
+		oldWarn = console.warn;
+
+	console.warn = function( s ) {
+		assert.ok( true, "Warned -- " + s );
+		oldWarn.apply( console, arguments );
+		console.warn = oldWarn;
+	};
+
+	defer.then( function() {
+		jQuery.barf();
+	} ).then( null, done );
+
+	defer.resolve();
+} );
+
 QUnit.test( "jQuery.Deferred - 1.x/2.x compatibility", function( assert ) {
 
 	assert.expect( 8 );

--- a/test/unit/deferred.js
+++ b/test/unit/deferred.js
@@ -534,7 +534,7 @@ QUnit[ window.console ? "test" : "skip" ]( "jQuery.Deferred.exceptionHook", func
 		oldWarn = window.console.warn;
 
 	window.console.warn = function( msg ) {
-		assert.ok( true, "Message: " + msg );
+		assert.ok( /barf/.test( msg ), "Message: " + msg );
 	};
 	jQuery.when(
 		defer.then( function() {

--- a/test/unit/deferred.js
+++ b/test/unit/deferred.js
@@ -553,6 +553,38 @@ QUnit[ window.console ? "test" : "skip" ]( "jQuery.Deferred.exceptionHook", func
 	defer.resolve();
 } );
 
+QUnit[ window.console ? "test" : "skip" ]( "jQuery.Deferred.exceptionHook with stack hooks", function( assert ) {
+
+	assert.expect( 2 );
+
+	var done = assert.async(),
+		defer = jQuery.Deferred(),
+		oldWarn = window.console.warn;
+
+	jQuery.Deferred.getStackHook = function() {
+		// Default exceptionHook assumes the stack is in a form console.warn can log,
+		// but a custom getStackHook+exceptionHook pair could save a raw form and
+		// format it to a string only when an exception actually occurs.
+		// For the unit test we just ensure the plumbing works.
+console.trace();
+		return "NO STACK FOR YOU";
+	};
+
+	window.console.warn = function( msg, stack ) {
+		assert.ok( /cough_up_hairball/.test( msg ), "Function mentioned: " + msg );
+		assert.ok( /NO STACK FOR YOU/.test( stack ), "Stack trace included: " + stack );
+	};
+	defer.then( function() {
+		jQuery.cough_up_hairball();
+	} ).then( null, function( ) {
+		window.console.warn = oldWarn;
+		delete jQuery.Deferred.getStackHook;
+		done();
+	} );
+
+	defer.resolve();
+} );
+
 QUnit.test( "jQuery.Deferred - 1.x/2.x compatibility", function( assert ) {
 
 	assert.expect( 8 );


### PR DESCRIPTION
Fixes gh-2736

Still a WIP with some details to be worked out. I'm not really happy with the stack trace that results, it's only showing the immediate prior call. The gist, however, is that nearly all exceptions of these types are programming mistakes and should be reported ASAP. If devs don't like being warned about them they can set `jQuery.Deferred.exceptionHook = null` and not be bothered, or define a custom hook that filters out the noisy false positives.