### PR TITLE
Effects: Possible workaround for Android || assignment issue.

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -290,11 +290,7 @@ function Animation( elem, properties, options ) {
 			}
 			var currentTime = fxNow || createFxNow(),
 				remaining = Math.max( 0, animation.startTime + animation.duration - currentTime ),
-
-				// Support: Android 2.3
-				// Archaic crash bug won't allow us to use `1 - ( 0.5 || 0 )` (#12497)
-				temp = remaining / animation.duration || 0,
-				percent = 1 - temp,
+				percent = 1 - ( animation.duration ? remaining / animation.duration : 0 ),
 				index = 0,
 				length = animation.tweens.length;
 


### PR DESCRIPTION
If the ternary operator works in this context we lose one var declaration and save bytes. Unfortunately I don't have an older Android device to test this on.