### PR TITLE
Spelling fixes

### DIFF
--- a/build/release/dist.js
+++ b/build/release/dist.js
@@ -73,7 +73,7 @@ module.exports = function( Release, files, complete ) {
 		Release.exec( "git add .", "Error adding files." );
 		Release.exec(
 			"git commit -m 'Release " + Release.newVersion + "'",
-			"Error commiting files."
+			"Error committing files."
 		);
 		console.log();
 

--- a/src/deferred.js
+++ b/src/deferred.js
@@ -135,7 +135,7 @@ jQuery.extend( {
 									// Handle all other returned values
 									} else {
 
-										// Only substitue handlers pass on context
+										// Only substitute handlers pass on context
 										// and multiple values (non-spec behavior)
 										if ( handler !== Identity ) {
 											that = undefined;
@@ -162,7 +162,7 @@ jQuery.extend( {
 											// Ignore post-resolution exceptions
 											if ( depth + 1 >= maxDepth ) {
 
-												// Only substitue handlers pass on context
+												// Only substitute handlers pass on context
 												// and multiple values (non-spec behavior)
 												if ( handler !== Thrower ) {
 													that = undefined;

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -364,7 +364,7 @@ QUnit.module( "ajax", {
 				},
 				cache: false,
 				beforeSend: function( xhr, settings ) {
-					// Remove the random number, but ensure the cashe-buster param is there
+					// Remove the random number, but ensure the cache-buster param is there
 					var url = settings.url.replace( /\d+/, "" );
 					assert.equal( url, "data/name.html?abc&devo=hat&_=#brownies", "Make sure that the URL has its hash." );
 					return false;

--- a/test/unit/animation.js
+++ b/test/unit/animation.js
@@ -169,7 +169,7 @@ QUnit.test( "Animation.prefilter - prefilter return hooks", function( assert ) {
 	);
 	assert.equal( TweenSpy.callCount, 0, "Returning something never creates tweens" );
 
-	// Test overriden usage on queues:
+	// Test overridden usage on queues:
 	prefilter.reset();
 	element = jQuery( "<div>" )
 		.css( "height", 50 )

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -484,7 +484,7 @@ QUnit.test( "isNumeric", function( assert ) {
 	assert.equal( t( true ), false, "Boolean true literal" );
 	assert.equal( t( false ), false, "Boolean false literal" );
 	assert.equal( t( "bcfed5.2" ), false, "Number with preceding non-numeric characters" );
-	assert.equal( t( "7.2acdgs" ), false, "Number with trailling non-numeric characters" );
+	assert.equal( t( "7.2acdgs" ), false, "Number with trailing non-numeric characters" );
 	assert.equal( t( undefined ), false, "Undefined value" );
 	assert.equal( t( null ), false, "Null value" );
 	assert.equal( t( NaN ), false, "NaN value" );

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -495,9 +495,9 @@ QUnit.test( "html(String) tag-hyphenated elements (Bug #1987)", function( assert
 	} );
 
 	var j = jQuery( "<tr-multiple-hyphens><td-with-hyphen>text</td-with-hyphen></tr-multiple-hyphens>" );
-	assert.ok( jQuery.nodeName( j[ 0 ], "TR-MULTIPLE-HYPHENS" ), "Tags with multiple hypens" );
-	assert.ok( jQuery.nodeName( j.children()[ 0 ], "TD-WITH-HYPHEN" ), "Tags with multiple hypens" );
-	assert.equal( j.children().text(), "text", "Tags with multiple hypens behave normally" );
+	assert.ok( jQuery.nodeName( j[ 0 ], "TR-MULTIPLE-HYPHENS" ), "Tags with multiple hyphens" );
+	assert.ok( jQuery.nodeName( j.children()[ 0 ], "TD-WITH-HYPHEN" ), "Tags with multiple hyphens" );
+	assert.equal( j.children().text(), "text", "Tags with multiple hyphens behave normally" );
 } );
 
 QUnit.test( "IE8 serialization bug", function( assert ) {


### PR DESCRIPTION
Please feel free to squash/whatever;
No testing was done on this.
I've intentionally omitted fixes for `external/` (there are 9), I found the upstream for them, and they've been landed:
https://github.com/jquery/qunit/pull/898
https://github.com/jquery/sizzle/pull/369