### PR TITLE
CSS: Enable support to get css path #2777

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -14,6 +14,7 @@ define( [
 	"./css/adjustCSS",
 	"./css/addGetHookIf",
 	"./css/support",
+	"./css/getCSSPath",
 
 	"./core/init",
 	"./core/ready",

--- a/src/css/getCSSPath.js
+++ b/src/css/getCSSPath.js
@@ -1,0 +1,38 @@
+define( [
+	"../core"
+], function( jQuery ) {
+jQuery.fn.extend( {
+	getCSSPath: function( path ) {
+		if ( typeof path === "undefined" ) {
+			path = "";
+		}
+		if ( this.is( "html" ) ) {
+			return "html" + path;
+		}
+
+		var cur = this.get( 0 ).nodeName.toLowerCase(),
+			index = this.index() + 1,
+			id    = this.attr( "id" ),
+			classes = this.attr( "class" );
+
+		if ( typeof id !== "undefined" ) {
+			cur += "#" + id;
+		} else if ( typeof classes !== "undefined" ) {
+			var elemlen = this.parent().children( cur ).length,
+				classesList = classes.split( /[\s\n]+/ ),
+				classname = "";
+			if ( classesList.length > 0 ) {
+				classname = classesList[ 0 ];
+				elemlen = this.parent().children( cur + "." + classname ).length;
+			}
+			if ( elemlen > 1 ) {
+				cur += "." + classname + ":nth-child(" + index + ")";
+			} else {
+				cur += "." + classname;
+			}
+		}
+
+		return this.parent().getCSSPath( ">" + cur + path );
+	}
+} );
+} );


### PR DESCRIPTION
I have implemented the reported features as well tested that as per the given standards. Please let me know if I am missing something.

The use of the implementation as follows:

$(selector).getCSSPath();

returns: html>body>ul.test-class>li.item:nth-child(1)