### PR TITLE
removed proto properties.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -287,6 +287,7 @@ jQuery.extend( {
 			}
 		} else {
 			for ( i in obj ) {
+				if (obj.hasOwnProperty(i)) continue;
 				if ( callback.call( obj[ i ], i, obj[ i ] ) === false ) {
 					break;
 				}


### PR DESCRIPTION
This is the test code
```javascript
Object.prototype.__test = function () {};
var t = {};
$.each(t, function (k, v) {console.log(k, v); });
```

This is not what I want.