### PR TITLE
Add global window.jquery object

### DIFF
--- a/src/jquery.js
+++ b/src/jquery.js
@@ -32,6 +32,6 @@ define( [
 	"./exports/amd"
 ], function( jQuery ) {
 
-return ( window.jQuery = window.$ = jQuery );
+return ( window.jQuery = window.jquery = window.$ = jQuery );
 
 } );


### PR DESCRIPTION
This introduces the ability to reference jQuery through window.jquery in addition to the original window.$ or window.jQuery. This makes the AMD and CommonJS module name (`jquery`) match the possible global name (`window.jquery`).