### PR TITLE
Fix for #2808; inconsistent .not/.filter

### DIFF
--- a/src/traversing/findFilter.js
+++ b/src/traversing/findFilter.js
@@ -33,7 +33,7 @@ function winnow( elements, qualifier, not ) {
 	}
 
 	return jQuery.grep( elements, function( elem ) {
-		return ( indexOf.call( qualifier, elem ) > -1 ) !== not;
+		return ( indexOf.call( qualifier, elem ) > -1 ) !== not && elem.nodeType === 1;
 	} );
 }
 

--- a/test/unit/traversing.js
+++ b/test/unit/traversing.js
@@ -430,6 +430,23 @@ QUnit.test( "not(jQuery)", function( assert ) {
 	assert.deepEqual( jQuery( "p" ).not( jQuery( "#ap, #sndp, .result" ) ).get(), q( "firstp", "en", "sap", "first" ), "not(jQuery)" );
 } );
 
+QUnit.test( "contents().not(':not(:not(*)')", function( assert ) {
+	assert.expect( 1 );
+
+	var elem = jQuery( "<div>foo<b>bar</b></div>" );
+
+	assert.deepEqual( elem.contents().not( ":not(:not(*))" ).get(), [ ], "contents().not(':not(:not(*))')" );
+} );
+
+QUnit.test( "contents().not(':not(:not(:not(*))')", function( assert ) {
+	assert.expect( 2 );
+
+	var nodes = jQuery( "<div>foo<b>bar</b></div>" ).contents().not( ":not(:not(:not(*)))" ).get();
+
+	assert.deepEqual( nodes.length, 1, "contents().not(':not(:not(:not(*)))') length" );
+	assert.deepEqual( nodes[0].nodeType, 1, "contents().not(':not(:not(:not(*)))') nodeType" );
+} );
+
 QUnit.test( "has(Element)", function( assert ) {
 	assert.expect( 3 );
 	var obj, detached, multipleParent;


### PR DESCRIPTION
Inconsistent ehaviour for non-element nodes when using multiple recursive pseudo-selectors on `*` in `.not()` and `.filter()`.

Fixes gh-2808