### PR TITLE
Deferred: Remove undocumented progress notifications in $.when

### DIFF
--- a/src/deferred.js
+++ b/src/deferred.js
@@ -295,7 +295,7 @@ jQuery.extend( {
 
 	// Deferred helper
 	when: function() {
-		var method,
+		var method, resolveContexts,
 			i = 0,
 			resolveValues = slice.call( arguments ),
 			length = resolveValues.length,
@@ -306,20 +306,19 @@ jQuery.extend( {
 			// the master Deferred.
 			master = jQuery.Deferred(),
 
-			// Update function for both resolve and progress values
-			updateFunc = function( i, contexts, values ) {
+			// Update function for both resolving subordinates
+			updateFunc = function( i ) {
 				return function( value ) {
-					contexts[ i ] = this;
-					values[ i ] = arguments.length > 1 ? slice.call( arguments ) : value;
+					resolveContexts[ i ] = this;
+					resolveValues[ i ] = arguments.length > 1 ? slice.call( arguments ) : value;
 					if ( !( --remaining ) ) {
 						master.resolveWith(
-							contexts.length === 1 ? contexts[ 0 ] : contexts,
-							values
+							resolveContexts.length === 1 ? resolveContexts[ 0 ] : resolveContexts,
+							resolveValues
 						);
 					}
 				};
-			},
-			resolveContexts;
+			};
 
 		// Add listeners to promise-like subordinates; treat others as resolved
 		if ( length > 0 ) {
@@ -331,7 +330,7 @@ jQuery.extend( {
 					jQuery.isFunction( ( method = resolveValues[ i ].promise ) ) ) {
 
 					method.call( resolveValues[ i ] )
-						.done( updateFunc( i, resolveContexts, resolveValues ) )
+						.done( updateFunc( i ) )
 						.fail( master.reject );
 
 				// Other thenables
@@ -340,11 +339,11 @@ jQuery.extend( {
 
 					method.call(
 						resolveValues[ i ],
-						updateFunc( i, resolveContexts, resolveValues ),
+						updateFunc( i ),
 						master.reject
 					);
 				} else {
-					updateFunc( i, resolveContexts, resolveValues )( resolveValues[ i ] );
+					updateFunc( i )( resolveValues[ i ] );
 				}
 			}
 

--- a/src/deferred.js
+++ b/src/deferred.js
@@ -311,9 +311,7 @@ jQuery.extend( {
 				return function( value ) {
 					contexts[ i ] = this;
 					values[ i ] = arguments.length > 1 ? slice.call( arguments ) : value;
-					if ( values === progressValues ) {
-						master.notifyWith( contexts, values );
-					} else if ( !( --remaining ) ) {
+					if ( !( --remaining ) ) {
 						master.resolveWith(
 							contexts.length === 1 ? contexts[ 0 ] : contexts,
 							values
@@ -321,29 +319,29 @@ jQuery.extend( {
 					}
 				};
 			},
-			progressValues, progressContexts, resolveContexts;
+			resolveContexts;
 
-		// Add listeners to Deferred subordinates; treat others as resolved
+		// Add listeners to promise-like subordinates; treat others as resolved
 		if ( length > 0 ) {
-			progressValues = new Array( length );
-			progressContexts = new Array( length );
 			resolveContexts = new Array( length );
 			for ( ; i < length; i++ ) {
+
+				// jQuery.Deferred - treated specially to get resolve-sync behavior
 				if ( resolveValues[ i ] &&
 					jQuery.isFunction( ( method = resolveValues[ i ].promise ) ) ) {
 
 					method.call( resolveValues[ i ] )
-						.progress( updateFunc( i, progressContexts, progressValues ) )
 						.done( updateFunc( i, resolveContexts, resolveValues ) )
 						.fail( master.reject );
+
+				// Other thenables
 				} else if ( resolveValues[ i ] &&
 					jQuery.isFunction( ( method = resolveValues[ i ].then ) ) ) {
 
 					method.call(
 						resolveValues[ i ],
 						updateFunc( i, resolveContexts, resolveValues ),
-						master.reject,
-						updateFunc( i, progressContexts, progressValues )
+						master.reject
 					);
 				} else {
 					updateFunc( i, resolveContexts, resolveValues )( resolveValues[ i ] );

--- a/test/unit/deferred.js
+++ b/test/unit/deferred.js
@@ -710,13 +710,12 @@ QUnit.test( "jQuery.when", function( assert ) {
 
 QUnit.test( "jQuery.when - joined", function( assert ) {
 
-	assert.expect( 195 );
+	assert.expect( 81 );
 
 	var deferreds = {
 			rawValue: 1,
 			fulfilled: jQuery.Deferred().resolve( 1 ),
 			rejected: jQuery.Deferred().reject( 0 ),
-			notified: jQuery.Deferred().notify( true ),
 			eventuallyFulfilled: jQuery.Deferred().notify( true ),
 			eventuallyRejected: jQuery.Deferred().notify( true ),
 			fulfilledStandardPromise: Promise.resolve( 1 ),
@@ -733,11 +732,6 @@ QUnit.test( "jQuery.when - joined", function( assert ) {
 			eventuallyRejected: true,
 			rejectedStandardPromise: true
 		},
-		willNotify = {
-			notified: true,
-			eventuallyFulfilled: true,
-			eventuallyRejected: true
-		},
 		counter = 49;
 
 	QUnit.stop();
@@ -752,9 +746,7 @@ QUnit.test( "jQuery.when - joined", function( assert ) {
 		jQuery.each( deferreds, function( id2, defer2 ) {
 			var shouldResolve = willSucceed[ id1 ] && willSucceed[ id2 ],
 				shouldError = willError[ id1 ] || willError[ id2 ],
-				shouldNotify = willNotify[ id1 ] || willNotify[ id2 ],
 				expected = shouldResolve ? [ 1, 1 ] : [ 0, undefined ],
-				expectedNotify = shouldNotify && [ willNotify[ id1 ], willNotify[ id2 ] ],
 				code = "jQuery.when( " + id1 + ", " + id2 + " )",
 				context1 = defer1 && jQuery.isFunction( defer1.promise ) ? defer1.promise() : window,
 				context2 = defer2 && jQuery.isFunction( defer2.promise ) ? defer2.promise() : window;
@@ -773,10 +765,6 @@ QUnit.test( "jQuery.when - joined", function( assert ) {
 				} else {
 					assert.ok( false, code + " => reject" );
 				}
-			} ).progress( function( a, b ) {
-				assert.deepEqual( [ a, b ], expectedNotify, code + " => progress" );
-				assert.strictEqual( this[ 0 ], expectedNotify[ 0 ] ? context1 : undefined, code + " => first context OK" );
-				assert.strictEqual( this[ 1 ], expectedNotify[ 1 ] ? context2 : undefined, code + " => second context OK" );
 			} ).always( restart );
 		} );
 	} );
@@ -784,19 +772,15 @@ QUnit.test( "jQuery.when - joined", function( assert ) {
 	deferreds.eventuallyRejected.reject( 0 );
 } );
 
-QUnit.test( "jQuery.when - resolved", function( assert ) {
+QUnit.test( "jQuery.when - notify does not affect resolved", function( assert ) {
 
-	assert.expect( 6 );
+	assert.expect( 3 );
 
 	var a = jQuery.Deferred().notify( 1 ).resolve( 4 ),
 		b = jQuery.Deferred().notify( 2 ).resolve( 5 ),
 		c = jQuery.Deferred().notify( 3 ).resolve( 6 );
 
-	jQuery.when( a, b, c ).progress( function( a, b, c ) {
-		assert.strictEqual( a, 1, "first notify value ok" );
-		assert.strictEqual( b, 2, "second notify value ok" );
-		assert.strictEqual( c, 3, "third notify value ok" );
-	} ).done( function( a, b, c ) {
+	jQuery.when( a, b, c ).done( function( a, b, c ) {
 		assert.strictEqual( a, 4, "first resolve value ok" );
 		assert.strictEqual( b, 5, "second resolve value ok" );
 		assert.strictEqual( c, 6, "third resolve value ok" );


### PR DESCRIPTION
Fixes gh-2710

Although we could add a new feature to notify on the new Deferred once each thenable resolved/rejected, it seemed like that would encourage more Deferred-specific behavior and I wasn't sure I wanted to go there. The important 3.0 behavior change here is removing the notification pass-through, which was [undocumented](http://api.jquery.com/jquery.when/). We can always add new functionality in a 3.x.0 if it's requested.