### PR TITLE
Core: use interactive to evaluate dom ready, barring IE6-10.

### DIFF
--- a/src/core/ready.js
+++ b/src/core/ready.js
@@ -97,11 +97,10 @@ jQuery.ready.promise = function( obj ) {
 
 		// Catch cases where $(document).ready() is called
 		// after the browser event has already occurred.
-		// we once tried to use readyState "interactive" here,
-		// but it caused issues like the one
-		// discovered by ChrisS here:
-		// http://bugs.jquery.com/ticket/12282#comment:15
-		if ( document.readyState === "complete" ) {
+		// Support: IE6-10
+		// Older IE sometimes signals "interactive" too soon
+		if ( document.readyState === "complete" ||
+			( document.readyState !== "loading" && !document.documentElement.doScroll ) ) {
 
 			// Handle it asynchronously to allow scripts the opportunity to delay ready
 			window.setTimeout( jQuery.ready );

--- a/test/data/event/interactiveReady.html
+++ b/test/data/event/interactiveReady.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html>
+<head>
+<meta http-equiv="content-type" content="text/html; charset=utf-8">
+<title>Test case for gh-2100</title>
+<script src="../../jquery.js"></script>
+</head>
+<body>
+
+<script type="text/javascript">
+jQuery( document ).ready(function () {
+	window.parent.iframeCallback( jQuery("#container").length === 1 );
+});
+</script>
+
+<!-- external resources that come before elements trick
+	oldIE into thinking the dom is ready, but it's not...
+	leaving this check here for future trailblazers to attempt
+	fixing this...-->
+<script type="text/javascript" src="../longLoadScript.php?sleep=1"></script>
+<div id="container" style="height: 300px"></div>
+</body>
+</html>

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -2589,6 +2589,18 @@ testIframeWithCallback(
 	}
 );
 
+// need PHP here to make the incepted IFRAME hang
+if ( hasPHP ) {
+	testIframeWithCallback(
+		"jQuery.ready uses interactive",
+		"event/interactiveReady.html",
+		function( isOk, assert ) {
+			assert.expect( 1 );
+			assert.ok( isOk, "jQuery fires ready when the DOM can truly be interacted with" );
+		}
+	);
+}
+
 testIframeWithCallback(
 	"Focusing iframe element",
 	"event/focusElem.html",


### PR DESCRIPTION
This is a copy of @timmywil's commit, applied to the 1.x branch. This shouldn't have any effect on the extra browsers 1.x supports due to the doScroll check, so I was hoping it could be added in order to provide the same benefit to other browsers as that commit :)

Fixes gh-2822