### PR TITLE
Update CSS prefixes in css.js

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -33,7 +33,7 @@ var
 		fontWeight: "400"
 	},
 
-	cssPrefixes = [ "Webkit", "Moz", "ms" ],
+	cssPrefixes = [ "webkit", "Moz", "ms" ],
 	emptyStyle = document.createElement( "div" ).style;
 
 // Return a css property mapped to a potentially vendor prefixed property


### PR DESCRIPTION
Webkit's DOM element "style" prefixes start with a lowercase "w", not uppercase.