### PR TITLE
Make event dispatch optimizable by engines

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -279,19 +279,24 @@ jQuery.event = {
 		}
 	},
 
-	dispatch: function( event ) {
+	dispatch: function( nativeEvent ) {
 
 		// Make a writable jQuery.Event from the native event object
-		event = jQuery.event.fix( event );
+		var event = jQuery.event.fix( nativeEvent );
 
 		var i, j, ret, matched, handleObj,
 			handlerQueue = [],
-			args = slice.call( arguments ),
+			args = [],
 			handlers = ( dataPriv.get( this, "events" ) || {} )[ event.type ] || [],
 			special = jQuery.event.special[ event.type ] || {};
 
 		// Use the fix-ed jQuery.Event rather than the (read-only) native event
 		args[ 0 ] = event;
+
+		for ( i = 1; i < arguments.length; i++ ) {
+			args[ i ] = arguments[ i ];
+		}
+
 		event.delegateTarget = this;
 
 		// Call the preDispatch hook for the mapped type, and let it bail if desired

--- a/src/event.js
+++ b/src/event.js
@@ -284,9 +284,8 @@ jQuery.event = {
 		// Make a writable jQuery.Event from the native event object
 		var event = jQuery.event.fix( nativeEvent );
 
-		var i, j, ret, matched, handleObj,
-			handlerQueue = [],
-			args = [],
+		var i, j, ret, matched, handleObj, handlerQueue,
+			args = new Array( arguments.length ),
 			handlers = ( dataPriv.get( this, "events" ) || {} )[ event.type ] || [],
 			special = jQuery.event.special[ event.type ] || {};
 


### PR DESCRIPTION
The event dispatch method is not optimizable by modern JS engines. This is especially crucial if a lot of events are dispatched (mousemove and touchmove come to mind).

![no-param-reassign](https://cloud.githubusercontent.com/assets/213788/12336257/ea0aeb42-bb03-11e5-814f-d0c47d833d0d.png)
Fixed by not reassigning function param

![dont-pass-arguments](https://cloud.githubusercontent.com/assets/213788/12336273/f88e0b72-bb03-11e5-97af-11add062da67.png)
Fixed by not pass arguments object to other Array#slice()

Now optimizable by v8, spidermonkey and most probably all the other engines:
![optimizable](https://cloud.githubusercontent.com/assets/213788/12336291/0e88a0e0-bb04-11e5-96c8-011a6f5ca476.png)

\o/