### PR TITLE
CSS: Stop Firefox from treating disconnected elements as cascade-hidden

### DIFF
--- a/src/css/showHide.js
+++ b/src/css/showHide.js
@@ -54,7 +54,12 @@ function showHide( elements, show ) {
 					elem.style.display = "";
 				}
 			}
-			if ( elem.style.display === "" && jQuery.css( elem, "display" ) === "none" ) {
+			if ( elem.style.display === "" && jQuery.css( elem, "display" ) === "none" &&
+
+					// Support: Firefox <=42 - 43
+					// Don't set inline display on disconnected elements with computed display: none
+					jQuery.contains( elem.ownerDocument, elem ) ) {
+
 				values[ index ] = getDefaultDisplay( elem );
 			}
 		} else {


### PR DESCRIPTION
Fixes gh-2833
Ref dba93f79c405373ec3a492fd0a4bf89b3136a6e6