### PR TITLE
Attributes: fix setting selected on an option in IE<=11

### DIFF
--- a/src/attributes/prop.js
+++ b/src/attributes/prop.js
@@ -79,7 +79,7 @@ jQuery.extend( {
 	}
 } );
 
-// Support: IE<=11
+// Support: IE <=11 only
 // Accessing the selectedIndex property
 // forces the browser to respect setting selected
 // on the option

--- a/src/attributes/prop.js
+++ b/src/attributes/prop.js
@@ -83,6 +83,8 @@ jQuery.extend( {
 // Accessing the selectedIndex property
 // forces the browser to respect setting selected
 // on the option
+// The getter ensures a default option is selected
+// when in an optgroup
 if ( !support.optSelected ) {
 	jQuery.propHooks.selected = {
 		get: function( elem ) {
@@ -94,8 +96,12 @@ if ( !support.optSelected ) {
 		},
 		set: function( elem ) {
 			var parent = elem.parentNode;
-			if ( parent && jQuery.nodeName( elem, "option" ) ) {
+			if ( parent ) {
 				parent.selectedIndex;
+
+				if ( parent && parent.parentNode ) {
+					parent.parentNode.selectedIndex;
+				}
 			}
 		}
 	};

--- a/src/attributes/prop.js
+++ b/src/attributes/prop.js
@@ -79,6 +79,10 @@ jQuery.extend( {
 	}
 } );
 
+// Support: IE<=11
+// Accessing the selectedIndex property
+// forces the browser to respect setting selected
+// on the option
 if ( !support.optSelected ) {
 	jQuery.propHooks.selected = {
 		get: function( elem ) {
@@ -87,6 +91,12 @@ if ( !support.optSelected ) {
 				parent.parentNode.selectedIndex;
 			}
 			return null;
+		},
+		set: function( elem ) {
+			var parent = elem.parentNode;
+			if ( parent && jQuery.nodeName( elem, "option" ) ) {
+				parent.selectedIndex;
+			}
 		}
 	};
 }

--- a/src/attributes/prop.js
+++ b/src/attributes/prop.js
@@ -5,8 +5,7 @@ define( [
 	"../selector"
 ], function( jQuery, access, support ) {
 
-var accessIndex,
-	rfocusable = /^(?:input|select|textarea|button)$/i,
+var rfocusable = /^(?:input|select|textarea|button)$/i,
 	rclickable = /^(?:a|area)$/i;
 
 jQuery.fn.extend( {
@@ -87,19 +86,24 @@ jQuery.extend( {
 // The getter ensures a default option is selected
 // when in an optgroup
 if ( !support.optSelected ) {
-	accessIndex = function( elem ) {
-		var parent = elem.parentNode;
-		if ( parent ) {
-			parent.selectedIndex;
-
+	jQuery.propHooks.selected = {
+		get: function( elem ) {
+			var parent = elem.parentNode;
 			if ( parent && parent.parentNode ) {
 				parent.parentNode.selectedIndex;
 			}
+			return null;
+		},
+		set: function( elem ) {
+			var parent = elem.parentNode;
+			if ( parent ) {
+				parent.selectedIndex;
+
+				if ( parent && parent.parentNode ) {
+					parent.parentNode.selectedIndex;
+				}
+			}
 		}
-	};
-	jQuery.propHooks.selected = {
-		get: accessIndex,
-		set: accessIndex
 	};
 }
 

--- a/src/attributes/prop.js
+++ b/src/attributes/prop.js
@@ -5,7 +5,8 @@ define( [
 	"../selector"
 ], function( jQuery, access, support ) {
 
-var rfocusable = /^(?:input|select|textarea|button)$/i,
+var accessIndex,
+	rfocusable = /^(?:input|select|textarea|button)$/i,
 	rclickable = /^(?:a|area)$/i;
 
 jQuery.fn.extend( {
@@ -86,24 +87,19 @@ jQuery.extend( {
 // The getter ensures a default option is selected
 // when in an optgroup
 if ( !support.optSelected ) {
-	jQuery.propHooks.selected = {
-		get: function( elem ) {
-			var parent = elem.parentNode;
+	accessIndex = function( elem ) {
+		var parent = elem.parentNode;
+		if ( parent ) {
+			parent.selectedIndex;
+
 			if ( parent && parent.parentNode ) {
 				parent.parentNode.selectedIndex;
 			}
-			return null;
-		},
-		set: function( elem ) {
-			var parent = elem.parentNode;
-			if ( parent ) {
-				parent.selectedIndex;
-
-				if ( parent && parent.parentNode ) {
-					parent.parentNode.selectedIndex;
-				}
-			}
 		}
+	};
+	jQuery.propHooks.selected = {
+		get: accessIndex,
+		set: accessIndex
 	};
 }
 

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -797,21 +797,34 @@ QUnit.test( "prop('tabindex', value)", function( assert ) {
 } );
 
 QUnit.test( "option.prop('selected', true) affects select.selectedIndex (gh-2732)", function( assert ) {
-	assert.expect( 1 );
+	assert.expect( 2 );
 
-	var $select = jQuery( "<select/>" )
-		.addClass( "check-select-index" )
-		.append(
+	function addOptions( $elem ) {
+		return $elem.append(
 			jQuery( "<option/>" ).val( "a" ).text( "One" ),
 			jQuery( "<option/>" ).val( "b" ).text( "Two" ),
 			jQuery( "<option/>" ).val( "c" ).text( "Three" )
 		)
 		.find( "[value=a]" ).prop( "selected", true ).end()
-		.find( "[value=c]" ).prop( "selected", true ).end().appendTo( "#qunit-fixture" );
+		.find( "[value=c]" ).prop( "selected", true ).end();
+	}
 
+	var $optgroup,
+		$select = jQuery( "<select/>" );
+
+	// Check select with options
+	addOptions( $select ).appendTo( "#qunit-fixture" );
+	$select.find( "[value=b]" ).prop( "selected", true );
+	assert.equal( $select[ 0 ].selectedIndex, 1, "Setting option selected affects selectedIndex" );
+
+	$select.empty();
+
+	// Check select with optgroup
+	$optgroup = jQuery( "<optgroup/>" );
+	addOptions( $optgroup ).appendTo( $select );
 	$select.find( "[value=b]" ).prop( "selected", true );
 
-	assert.equal( $select[ 0 ].selectedIndex, 1, "Setting option selected affects selectedIndex" );
+	assert.equal( $select[ 0 ].selectedIndex, 1, "Setting option in optgroup selected affects selectedIndex" );
 } );
 
 QUnit.test( "removeProp(String)", function( assert ) {

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -796,6 +796,24 @@ QUnit.test( "prop('tabindex', value)", function( assert ) {
 	assert.equal( clone[ 0 ].getAttribute( "tabindex" ), "1", "set tabindex on cloned element" );
 } );
 
+QUnit.test( "option.prop('selected', true) affects select.selectedIndex (gh-2732)", function( assert ) {
+	assert.expect( 1 );
+
+	var $select = jQuery( "<select/>" )
+		.addClass( "check-select-index" )
+		.append(
+			jQuery( "<option/>" ).val( "a" ).text( "One" ),
+			jQuery( "<option/>" ).val( "b" ).text( "Two" ),
+			jQuery( "<option/>" ).val( "c" ).text( "Three" )
+		)
+		.find( "[value=a]" ).prop( "selected", true ).end()
+		.find( "[value=c]" ).prop( "selected", true ).end().appendTo( "#qunit-fixture" );
+
+	$select.find( "[value=b]" ).prop( "selected", true );
+
+	assert.equal( $select[ 0 ].selectedIndex, 1, "Setting option selected affects selectedIndex" );
+} );
+
 QUnit.test( "removeProp(String)", function( assert ) {
 	assert.expect( 6 );
 	var attributeNode = document.createAttribute( "irrelevant" ),


### PR DESCRIPTION
- Same as the getter fix. All that was required was accessing the selectedIndex property.
- Also added support for optgroups

Fixes gh-2732