### PR TITLE
Traversing: restore jQuery push behavior in .find

### DIFF
--- a/src/traversing/findFilter.js
+++ b/src/traversing/findFilter.js
@@ -53,9 +53,8 @@ jQuery.filter = function( expr, elems, not ) {
 
 jQuery.fn.extend( {
 	find: function( selector ) {
-		var i,
+		var i, ret,
 			len = this.length,
-			ret = [],
 			self = this;
 
 		if ( typeof selector !== "string" ) {
@@ -68,11 +67,13 @@ jQuery.fn.extend( {
 			} ) );
 		}
 
+		ret = this.pushStack( [] );
+
 		for ( i = 0; i < len; i++ ) {
 			jQuery.find( selector, self[ i ], ret );
 		}
 
-		return this.pushStack( len > 1 ? jQuery.uniqueSort( ret ) : ret );
+		return len > 1 ? jQuery.uniqueSort( ret ) : ret;
 	},
 	filter: function( selector ) {
 		return this.pushStack( winnow( this, selector || [], false ) );


### PR DESCRIPTION
It's a minor improvement, but seems to still be an [improvement](http://jsperf.com/find-with-pushstack).

Fixes gh-2370