### PR TITLE
Set Edge's expected support for clearCloneStyle to true

### DIFF
--- a/test/unit/support.js
+++ b/test/unit/support.js
@@ -53,16 +53,17 @@ testIframeWithCallback(
 );
 
 ( function() {
-	var expected,
+	var expected, version,
 		userAgent = window.navigator.userAgent;
 
 	if ( /edge\//i.test( userAgent ) ) {
+		version = userAgent.match( /edge\/(\d+)/i )[1];
 		expected = {
 			"ajax": true,
 			"boxSizingReliable": true,
 			"checkClone": true,
 			"checkOn": true,
-			"clearCloneStyle": false,
+			"clearCloneStyle": version >= 13,
 			"cors": true,
 			"createHTMLDocument": true,
 			"focusin": false,


### PR DESCRIPTION
The Microsoft Edge team noticed the following test failure in Edge from test/unit/support.js: "Verify that support tests resolve as expected per browser." If you're running the tests locally, I isolated the test with the query param `?testId=e1b3f3c8`.

Previous versions of Edge and IE had a bug in which cloning an element and then clearing the cloned element's style would also clear the original element's style. See #886 for an excellent and thorough analysis.

Turns out, somewhere along the line Edge fixed this bug but the unit tests expect Edge to fail still. 

I've copied the code from [support.js#L20](https://github.com/jquery/jquery/blob/487d5ca913c237aafe9efa1179749b46382fddbf/src/css/support.js#L20) that tests the browser for this bug into a [jsbin snippet](http://jsbin.com/gijaquzuwo/2/edit?js,console). If you run it in Edge, you can now see that jQuery determines `$.support.clearCloneStyle == true`.