### PR TITLE
Event: change fixHooks, propHooks to ES5 getter methods

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -93,6 +93,36 @@ function on( elem, types, selector, data, fn, one ) {
 	} );
 }
 
+function addEventGetter( unused, name ) {
+	Object.defineProperty( jQuery.Event.prototype, name, {
+		enumerable: true,
+		configurable: true,
+
+		get: function() {
+			var value, hook;
+
+			if ( this.originalEvent ) {
+				if ( hook = jQuery.event.propHooks[ name ] ) {
+					value = hook( this.originalEvent );
+				} else {
+					value = this.originalEvent[ name ];
+				}
+			}
+
+			return value;
+		},
+
+		set: function( value ) {
+			Object.defineProperty( this, name, {
+				enumerable: true,
+				configurable: true,
+				writable: true,
+				value: value
+			} );
+		}
+	} );
+}
+
 /*
  * Helper functions for managing events -- not part of the public interface.
  * Props to Dean Edwards' addEvent library for many of the ideas.
@@ -398,82 +428,84 @@ jQuery.event = {
 		return handlerQueue;
 	},
 
-	// Includes some event props shared by KeyEvent and MouseEvent
-	props: ( "altKey bubbles cancelable ctrlKey currentTarget detail eventPhase " +
-		"metaKey relatedTarget shiftKey target timeStamp view which" ).split( " " ),
+	// Includes all common event props including KeyEvent and MouseEvent specific props
+	props: ( "altKey bubbles cancelable ctrlKey detail eventPhase " +
+		"metaKey shiftKey view which char charCode key keyCode " +
+		"button buttons clientX clientY offsetX offsetY pageX pageY screenX screenY toElement"
+	).split( " " ),
 
 	fixHooks: {},
 
-	keyHooks: {
-		props: "char charCode key keyCode".split( " " ),
-		filter: function( event, original ) {
+	propHooks: {
+		which: function( event ) {
+			var button = event.button;
 
 			// Add which for key events
-			if ( event.which == null ) {
-				event.which = original.charCode != null ? original.charCode : original.keyCode;
+			if ( event.which == null && rkeyEvent.test( event.type ) ) {
+				return event.charCode != null ? event.charCode : event.keyCode;
 			}
 
-			return event;
-		}
-	},
+			// Add which for click: 1 === left; 2 === middle; 3 === right
+			if ( !event.which && button !== undefined && rmouseEvent.test( event.type ) ) {
+				return ( button & 1 ? 1 : ( button & 2 ? 3 : ( button & 4 ? 2 : 0 ) ) );
+			}
 
-	mouseHooks: {
-		props: ( "button buttons clientX clientY offsetX offsetY pageX pageY " +
-			"screenX screenY toElement" ).split( " " ),
-		filter: function( event, original ) {
-			var eventDoc, doc, body,
-				button = original.button;
+			return event.which;
+		},
 
-			// Calculate pageX/Y if missing and clientX/Y available
-			if ( event.pageX == null && original.clientX != null ) {
+		pageX: function( event ) {
+			var eventDoc, doc, body;
+
+			// Calculate pageX if missing and clientX available
+			if ( event.pageX == null && event.clientX != null ) {
 				eventDoc = event.target.ownerDocument || document;
 				doc = eventDoc.documentElement;
 				body = eventDoc.body;
 
-				event.pageX = original.clientX +
+				return event.clientX +
 					( doc && doc.scrollLeft || body && body.scrollLeft || 0 ) -
 					( doc && doc.clientLeft || body && body.clientLeft || 0 );
-				event.pageY = original.clientY +
-					( doc && doc.scrollTop  || body && body.scrollTop  || 0 ) -
-					( doc && doc.clientTop  || body && body.clientTop  || 0 );
 			}
 
-			// Add which for click: 1 === left; 2 === middle; 3 === right
-			// Note: button is not normalized, so don't use it
-			if ( !event.which && button !== undefined ) {
-				event.which = ( button & 1 ? 1 : ( button & 2 ? 3 : ( button & 4 ? 2 : 0 ) ) );
+			return event.pageX;
+		},
+
+		pageY: function( event ) {
+			var eventDoc, doc, body;
+
+			// Calculate pageY if missing and clientY available
+			if ( event.pageY == null && event.clientY != null ) {
+				eventDoc = event.target.ownerDocument || document;
+				doc = eventDoc.documentElement;
+				body = eventDoc.body;
+
+				return event.clientY +
+					( doc && doc.scrollTop || body && body.scrollTop || 0 ) -
+					( doc && doc.clientTop || body && body.clientTop || 0 );
 			}
 
-			return event;
+			return event.pageY;
 		}
 	},
 
-	fix: function( event ) {
-		if ( event[ jQuery.expando ] ) {
-			return event;
+	fix: function( originalEvent ) {
+		if ( originalEvent[ jQuery.expando ] ) {
+			return originalEvent;
 		}
 
 		// Create a writable copy of the event object and normalize some properties
-		var i, prop, copy,
-			type = event.type,
-			originalEvent = event,
-			fixHook = this.fixHooks[ type ];
+		var event,
+			fixHook = this.fixHooks[ originalEvent.type ];
 
-		if ( !fixHook ) {
-			this.fixHooks[ type ] = fixHook =
-				rmouseEvent.test( type ) ? this.mouseHooks :
-				rkeyEvent.test( type ) ? this.keyHooks :
-				{};
+		// Setup any prop hooks added since the last fix
+		if ( this.props.length ) {
+			jQuery.each( this.props.splice( 0 ), addEventGetter );
 		}
-		copy = fixHook.props ? this.props.concat( fixHook.props ) : this.props;
+		if ( fixHook && fixHook.props && fixHook.props.length ) {
+			jQuery.each( fixHook.props.splice( 0 ), addEventGetter );
+		}
 
 		event = new jQuery.Event( originalEvent );
-
-		i = copy.length;
-		while ( i-- ) {
-			prop = copy[ i ];
-			event[ prop ] = originalEvent[ prop ];
-		}
 
 		// Support: Safari <=6 - 7 only
 		// Target should not be a text node (#504, #13143)
@@ -481,7 +513,7 @@ jQuery.event = {
 			event.target = event.target.parentNode;
 		}
 
-		return fixHook.filter ? fixHook.filter( event, originalEvent ) : event;
+		return fixHook && fixHook.filter ? fixHook.filter( event, originalEvent ) : event;
 	},
 
 	special: {
@@ -568,6 +600,11 @@ jQuery.Event = function( src, props ) {
 				src.returnValue === false ?
 			returnTrue :
 			returnFalse;
+
+		// Create target properties
+		this.target = src.target;
+		this.currentTarget = src.currentTarget;
+		this.relatedTarget = src.relatedTarget;
 
 	// Event type
 	} else {

--- a/src/event.js
+++ b/src/event.js
@@ -491,23 +491,12 @@ jQuery.event = {
 			return originalEvent;
 		}
 
-		// Create a writable copy of the event object and normalize some properties
-		var event;
-
 		// Setup any prop hooks added since the last fix
 		if ( this.props.length ) {
 			jQuery.each( this.props.splice( 0 ), addEventGetter );
 		}
 
-		event = new jQuery.Event( originalEvent );
-
-		// Support: Safari <=6 - 7 only
-		// Target should not be a text node (#504, #13143)
-		if ( event.target.nodeType === 3 ) {
-			event.target = event.target.parentNode;
-		}
-
-		return event;
+		return new jQuery.Event( originalEvent );
 	},
 
 	special: {
@@ -596,7 +585,12 @@ jQuery.Event = function( src, props ) {
 			returnFalse;
 
 		// Create target properties
-		this.target = src.target;
+		// Support: Safari <=6 - 7 only
+		// Target should not be a text node (#504, #13143)
+		this.target = ( src.target.nodeType === 3 ) ?
+			src.target.parentNode :
+			src.target;
+
 		this.currentTarget = src.currentTarget;
 		this.relatedTarget = src.relatedTarget;
 

--- a/src/event.js
+++ b/src/event.js
@@ -501,9 +501,6 @@ jQuery.event = {
 		if ( this.props.length ) {
 			jQuery.each( this.props.splice( 0 ), addEventGetter );
 		}
-		if ( fixHook && fixHook.props && fixHook.props.length ) {
-			jQuery.each( fixHook.props.splice( 0 ), addEventGetter );
-		}
 
 		event = new jQuery.Event( originalEvent );
 

--- a/src/event.js
+++ b/src/event.js
@@ -434,8 +434,6 @@ jQuery.event = {
 		"button buttons clientX clientY offsetX offsetY pageX pageY screenX screenY toElement"
 	).split( " " ),
 
-	fixHooks: {},
-
 	propHooks: {
 		which: function( event ) {
 			var button = event.button;
@@ -494,8 +492,7 @@ jQuery.event = {
 		}
 
 		// Create a writable copy of the event object and normalize some properties
-		var event,
-			fixHook = this.fixHooks[ originalEvent.type ];
+		var event;
 
 		// Setup any prop hooks added since the last fix
 		if ( this.props.length ) {
@@ -510,7 +507,7 @@ jQuery.event = {
 			event.target = event.target.parentNode;
 		}
 
-		return fixHook && fixHook.filter ? fixHook.filter( event, originalEvent ) : event;
+		return event;
 	},
 
 	special: {

--- a/src/event.js
+++ b/src/event.js
@@ -399,23 +399,21 @@ jQuery.event = {
 	},
 
 	addProp: function( name, hook ) {
-		var getter = jQuery.isFunction( hook ) ?
-			function hookGetter() {
-				if ( this.originalEvent ) {
-						return hook( this.originalEvent );
-				}
-			} :
-			function propGetter() {
-				if ( this.originalEvent ) {
-						return this.originalEvent[ name ];
-				}
-			};
-
 		Object.defineProperty( jQuery.Event.prototype, name, {
 			enumerable: true,
 			configurable: true,
 
-			get: getter,
+			get: jQuery.isFunction( hook ) ?
+				function() {
+					if ( this.originalEvent ) {
+							return hook( this.originalEvent );
+					}
+				} :
+				function() {
+					if ( this.originalEvent ) {
+							return this.originalEvent[ name ];
+					}
+				},
 
 			set: function( value ) {
 				Object.defineProperty( this, name, {

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -2410,38 +2410,6 @@ QUnit.test( "event object properties on natively-triggered event", function( ass
 	$link.off( "click" ).remove();
 } );
 
-QUnit.test( "fixHooks extensions", function( assert ) {
-	assert.expect( 2 );
-
-	// IE requires focusable elements to be visible, so append to body
-	var $fixture = jQuery( "<input type='text' id='hook-fixture' />" ).appendTo( "body" ),
-		saved = jQuery.event.fixHooks.click;
-
-	// Ensure the property doesn't exist
-	$fixture.on( "click", function( event ) {
-		assert.ok( !( "blurrinessLevel" in event ), "event.blurrinessLevel does not exist" );
-	} );
-	fireNative( $fixture[ 0 ], "click" );
-	$fixture.off( "click" );
-
-	jQuery.event.fixHooks.click = {
-		filter: function( event ) {
-			event.blurrinessLevel = 42;
-			return event;
-		}
-	};
-
-	// Trigger a native click and ensure the property is set
-	$fixture.on( "click", function( event ) {
-		assert.equal( event.blurrinessLevel, 42, "event.blurrinessLevel was set" );
-	} );
-	fireNative( $fixture[ 0 ], "click" );
-
-	delete jQuery.event.fixHooks.click;
-	$fixture.off( "click" ).remove();
-	jQuery.event.fixHooks.click = saved;
-} );
-
 QUnit.test( "drag/drop events copy mouse-related event properties (gh-1925, gh-2009)", function( assert ) {
 	assert.expect( 4 );
 

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -2410,6 +2410,30 @@ QUnit.test( "event object properties on natively-triggered event", function( ass
 	$link.off( "click" ).remove();
 } );
 
+QUnit.test( "addProp extensions", function( assert ) {
+	assert.expect( 2 );
+
+	var $fixture = jQuery( "<div>" ).appendTo( "#qunit-fixture" );
+
+	// Ensure the property doesn't exist
+	$fixture.on( "click", function( event ) {
+		assert.ok( !( "testProperty" in event ), "event.testProperty does not exist" );
+	} );
+	fireNative( $fixture[ 0 ], "click" );
+	$fixture.off( "click" );
+
+	jQuery.event.addProp( "testProperty", function() { return 42; } );
+
+	// Trigger a native click and ensure the property is set
+	$fixture.on( "click", function( event ) {
+		assert.equal( event.testProperty, 42, "event.testProperty getter was invoked" );
+	} );
+	fireNative( $fixture[ 0 ], "click" );
+	$fixture.off( "click" );
+
+	$fixture.remove();
+} );
+
 QUnit.test( "drag/drop events copy mouse-related event properties (gh-1925, gh-2009)", function( assert ) {
 	assert.expect( 4 );
 


### PR DESCRIPTION
- removes the copy loop in jQuery.event.fix
- avoids accessing properties such as client/offset/page/screen X/Y which may cause style recalc or layouts

This is a potential solution for #1746. @dmethvin also mentioned using this for #2337. This also removes the slow (even if no layout is forced) loop from `fix`.

The main problems with this approach:
* getter properties are slow (but unless you call them N+ times still faster then today's `fix` loop, and fixes #1746)
* ~~putting getter properties on the prototype means `event.hasOwnProperty(eventProp)` is false~~ (EDIT: this is actually what native events do, so this is probably a good thing)

Potential changes to this approach:
* drop the setter part (normally faster, except when the getter is called X+ times)
* create `jQuery.MouseEvent` and `jQuery.KeyboardEvent` so properties like `shiftKey` are only on keyboard events
* only use getters for properties which might force a layout and keep the fix-loop for copying other properties (requires new getter-properties API)