### PR TITLE
Hidden attribute solution for show/hide/toggle

### DIFF
--- a/src/css/showHide.js
+++ b/src/css/showHide.js
@@ -24,7 +24,7 @@ function showHide( elements, show ) {
 				elements[ index ].removeAttribute('hidden');
 			}
 			else {
-				elements[ index ].setAttribute('hidden', 'hidden';
+				elements[ index ].setAttribute('hidden', 'hidden');
 			}
 		}
 	}

--- a/src/css/showHide.js
+++ b/src/css/showHide.js
@@ -11,8 +11,7 @@ function showHide( elements, show ) {
 	// Determine whether the element's hidden status needs to be changed
 	for ( ; index < length; index++ ) {
 		elem = elements[ index ];
-		
-		if ( elem.getAttribute("hidden") !== "hidden") {
+		if ( elem.getAttribute( "hidden" ) !== "hidden" ) {
 			values[ index ] = show === true;
 		}
 	}
@@ -20,11 +19,10 @@ function showHide( elements, show ) {
 	// Set the hidden status of an element in a second loop to prevent constant reflow
 	for ( index = 0; index < length; index++ ) {
 		if ( values[ index ] != null ) {
-			if (values [ index ]) {
-				elements[ index ].removeAttribute("hidden");
-			}
-			else {
-				elements[ index ].setAttribute("hidden", "hidden");
+			if ( values [ index ] ) {
+				elements[ index ].removeAttribute( "hidden" );
+			} else {
+				elements[ index ].setAttribute( "hidden", "hidden" );
 			}
 		}
 	}
@@ -45,7 +43,7 @@ jQuery.fn.extend( {
 		}
 
 		return this.each( function() {
-			if ( this.getAttribute("hidden") !== null ) {
+			if ( this.getAttribute( "hidden" ) !== null ) {
 				jQuery( this ).show();
 			} else {
 				jQuery( this ).hide();

--- a/src/css/showHide.js
+++ b/src/css/showHide.js
@@ -1,81 +1,31 @@
 define( [
-	"../core",
-	"../data/var/dataPriv",
-	"../css/var/isHiddenWithinTree"
-], function( jQuery, dataPriv, isHiddenWithinTree ) {
-
-var defaultDisplayMap = {};
-
-function getDefaultDisplay( elem ) {
-	var temp,
-		doc = elem.ownerDocument,
-		nodeName = elem.nodeName,
-		display = defaultDisplayMap[ nodeName ];
-
-	if ( display ) {
-		return display;
-	}
-
-	temp = doc.body.appendChild( doc.createElement( nodeName ) ),
-	display = jQuery.css( temp, "display" );
-
-	temp.parentNode.removeChild( temp );
-
-	if ( display === "none" ) {
-		display = "block";
-	}
-	defaultDisplayMap[ nodeName ] = display;
-
-	return display;
-}
+	"../core"
+], function( jQuery ) {
 
 function showHide( elements, show ) {
-	var display, elem,
+	var elem,
 		values = [],
 		index = 0,
 		length = elements.length;
 
-	// Determine new display value for elements that need to change
+	// Determine whether the element's hidden status needs to be changed
 	for ( ; index < length; index++ ) {
 		elem = elements[ index ];
-		if ( !elem.style ) {
-			continue;
-		}
-
-		display = elem.style.display;
-		if ( show ) {
-
-			// Since we force visibility upon cascade-hidden elements, an immediate (and slow)
-			// check is required in this first loop unless we have a nonempty display value (either
-			// inline or about-to-be-restored)
-			if ( display === "none" ) {
-				values[ index ] = dataPriv.get( elem, "display" ) || null;
-				if ( !values[ index ] ) {
-					elem.style.display = "";
-				}
-			}
-			if ( elem.style.display === "" && jQuery.css( elem, "display" ) === "none" &&
-
-					// Support: Firefox <=42 - 43
-					// Don't set inline display on disconnected elements with computed display: none
-					jQuery.contains( elem.ownerDocument, elem ) ) {
-
-				values[ index ] = getDefaultDisplay( elem );
-			}
-		} else {
-			if ( display !== "none" ) {
-				values[ index ] = "none";
-
-				// Remember what we're overwriting
-				dataPriv.set( elem, "display", display );
-			}
+		
+		if ( elem.getAttribute('hidden') !== 'hidden') {
+			values[ index ] = show;
 		}
 	}
 
-	// Set the display of the elements in a second loop to avoid constant reflow
+	// Set the hidden status of an element in a second loop to prevent constant reflow
 	for ( index = 0; index < length; index++ ) {
 		if ( values[ index ] != null ) {
-			elements[ index ].style.display = values[ index ];
+			if (values [ index ]) {
+				elements[ index ].removeAttribute('hidden');
+			}
+			else {
+				elements[ index ].setAttribute('hidden', 'hidden';
+			}
 		}
 	}
 

--- a/src/css/showHide.js
+++ b/src/css/showHide.js
@@ -12,7 +12,7 @@ function showHide( elements, show ) {
 	for ( ; index < length; index++ ) {
 		elem = elements[ index ];
 		
-		if ( elem.getAttribute('hidden') !== "hidden") {
+		if ( elem.getAttribute("hidden") !== "hidden") {
 			values[ index ] = show === true;
 		}
 	}

--- a/src/css/showHide.js
+++ b/src/css/showHide.js
@@ -12,8 +12,8 @@ function showHide( elements, show ) {
 	for ( ; index < length; index++ ) {
 		elem = elements[ index ];
 		
-		if ( elem.getAttribute('hidden') !== 'hidden') {
-			values[ index ] = show;
+		if ( elem.getAttribute('hidden') !== "hidden") {
+			values[ index ] = show === true;
 		}
 	}
 
@@ -21,10 +21,10 @@ function showHide( elements, show ) {
 	for ( index = 0; index < length; index++ ) {
 		if ( values[ index ] != null ) {
 			if (values [ index ]) {
-				elements[ index ].removeAttribute('hidden');
+				elements[ index ].removeAttribute("hidden");
 			}
 			else {
-				elements[ index ].setAttribute('hidden', 'hidden');
+				elements[ index ].setAttribute("hidden", "hidden");
 			}
 		}
 	}
@@ -45,7 +45,7 @@ jQuery.fn.extend( {
 		}
 
 		return this.each( function() {
-			if ( isHiddenWithinTree( this ) ) {
+			if ( this.getAttribute("hidden") !== null ) {
 				jQuery( this ).show();
 			} else {
 				jQuery( this ).hide();


### PR DESCRIPTION
A simpler solution for show/hide/toggle based on the HTML5 hidden attribute.

To avoid ambiguity regarding how to write CSS to ensure hidden elements should be hidden, the hidden attribute value is set to hidden instead of empty.

This solution is more in line with best practices regarding how to show/hide elements, as it leaves it up to the author to ensure it's hidden properly via CSS (essentially the same as the class-based recommendation, removing/adding classes to control display). 

It will also leave the inline style intact, in case this is needed to overrule jQuery's toggling.

For responsive web sites, this will also provide a better way to control whether or not the element should be shown, as it can be controlled through the hidden attribute selector within the context being styled.

Not to mention: this probably performs better than having to remember the computed styles and resetting these when showing the element.

Another option is to add a method "unhide" that removes the hidden attribute, whereas "show" retains the functionality of the current code where its inline style is changed to force it to show.