### PR TITLE
Make sure elem.ownerDocument.defaultView is not null

### DIFF
--- a/src/css/var/getStyles.js
+++ b/src/css/var/getStyles.js
@@ -6,7 +6,7 @@ define( function() {
 		// FF meanwhile throws on frame elements through "defaultView.getComputedStyle"
 		var view = elem.ownerDocument.defaultView;
 
-		if ( !view.opener ) {
+		if ( !view || !view.opener ) {
 			view = window;
 		}
 


### PR DESCRIPTION
Since v2.2.0: Cannot read property 'opener' of null when $.parseHTML and then get css style #2866