### PR TITLE
Custom builds: use different ready code when excluding Deferred

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,6 +63,10 @@ module.exports = function( grunt ) {
 					callbacks: [ "deferred" ],
 					css: [ "effects", "dimensions", "offset" ],
 					"css/showHide": [ "effects" ],
+					deferred: {
+						remove: [ "ajax", "effects", "queue", "core/ready" ],
+						include: [ "core/ready-no-deferred" ]
+					},
 					sizzle: [ "css/hiddenVisibleSelectors", "effects/animatedSelector" ]
 				}
 			}

--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -168,7 +168,8 @@ module.exports = function( grunt ) {
 			 *  whether it should included or excluded
 			 */
 			excluder = function( flag ) {
-				var m = /^(\+|\-|)([\w\/-]+)$/.exec( flag ),
+				var additional,
+					m = /^(\+|\-|)([\w\/-]+)$/.exec( flag ),
 					exclude = m[ 1 ] === "-",
 					module = m[ 2 ];
 
@@ -192,8 +193,16 @@ module.exports = function( grunt ) {
 							}
 						}
 
+						additional = removeWith[ module ];
+
 						// Check removeWith list
-						excludeList( removeWith[ module ] );
+						if ( additional ) {
+							excludeList( additional.remove || additional );
+							if ( additional.include ) {
+								included = included.concat( additional.include );
+								grunt.log.writeln( "+" + additional.include );
+							}
+						}
 					} else {
 						grunt.log.error( "Module \"" + module + "\" is a minimum requirement." );
 						if ( module === "selector" ) {

--- a/src/core/ready.js
+++ b/src/core/ready.js
@@ -9,8 +9,7 @@ var readyList = jQuery.Deferred();
 
 jQuery.fn.ready = function( fn ) {
 
-	// Add the callback
-	readyList.done( fn );
+	readyList.then( fn );
 
 	return this;
 };

--- a/src/core/ready.js
+++ b/src/core/ready.js
@@ -52,16 +52,21 @@ jQuery.extend( {
 
 			if ( !readyFiring ) {
 				readyFiring = true;
-				while ( readyCallbacks.length ) {
-					fn = readyCallbacks.shift();
-					if ( jQuery.isFunction( fn ) ) {
 
-						// Prefer sync with no try/catch here
-						// Backwards-compatible, maintain execution order
-						fn.call( document, jQuery );
+				// Prevent errors from freezing future callback execution (gh-1823)
+				try {
+					while ( readyCallbacks.length ) {
+						fn = readyCallbacks.shift();
+						if ( jQuery.isFunction( fn ) ) {
+
+							// Prefer sync with no try/catch here
+							// Backwards-compatible, maintain execution order
+							fn.call( document, jQuery );
+						}
 					}
+				} finally {
+					readyFiring = false;
 				}
-				readyFiring = false;
 			}
 		};
 

--- a/src/core/ready.js
+++ b/src/core/ready.js
@@ -70,7 +70,9 @@ jQuery.extend( {
 					// If there was an error in a ready callback,
 					// continue with the rest (gh-1823)
 					if ( readyCallbacks.length ) {
-						whenReady();
+
+						// Retry async to allow the error to propagate to console
+						window.setTimeout( whenReady );
 					}
 				}
 			}

--- a/src/core/ready.js
+++ b/src/core/ready.js
@@ -55,6 +55,9 @@ jQuery.extend( {
 				while ( readyCallbacks.length ) {
 					fn = readyCallbacks.shift();
 					if ( jQuery.isFunction( fn ) ) {
+
+						// Prefer sync with no try/catch here
+						// Backwards-compatible, maintain execution order
 						fn.call( document, jQuery );
 					}
 				}
@@ -66,7 +69,7 @@ jQuery.extend( {
 	}
 } );
 
-// Make jQuery.ready promise compatible (gh-1778)
+// Make jQuery.ready Promise consumable (gh-1778)
 jQuery.ready.then = jQuery.fn.ready;
 
 /**

--- a/src/core/ready.js
+++ b/src/core/ready.js
@@ -5,13 +5,12 @@ define( [
 ], function( jQuery, document ) {
 
 // The deferred used on DOM ready
-var readyList = jQuery.Deferred(),
-	readyPromise = readyList.promise();
+var readyList = jQuery.Deferred();
 
 jQuery.fn.ready = function( fn ) {
 
 	// Add the callback
-	readyPromise.done( fn );
+	readyList.done( fn );
 
 	return this;
 };
@@ -55,7 +54,7 @@ jQuery.extend( {
 	}
 } );
 
-jQuery.ready.then = readyPromise.then;
+jQuery.ready.then = readyList.then;
 
 // The ready event handler and self cleanup method
 function completed() {

--- a/src/core/ready.js
+++ b/src/core/ready.js
@@ -59,8 +59,8 @@ jQuery.extend( {
 						fn = readyCallbacks.shift();
 						if ( jQuery.isFunction( fn ) ) {
 
-							// Prefer sync with no try/catch here
-							// Backwards-compatible, maintain execution order
+							// For backwards compatibility,
+							// invoke synchronously and with document context
 							fn.call( document, jQuery );
 						}
 					}

--- a/src/core/ready.js
+++ b/src/core/ready.js
@@ -66,6 +66,12 @@ jQuery.extend( {
 					}
 				} finally {
 					readyFiring = false;
+
+					// If there was an error in a ready callback,
+					// continue with the rest (gh-1823)
+					if ( readyCallbacks.length ) {
+						whenReady();
+					}
 				}
 			}
 		};

--- a/src/core/ready.js
+++ b/src/core/ready.js
@@ -4,7 +4,7 @@ define( [
 ], function( jQuery, document ) {
 
 var readyCallbacks = [],
-	readyFiring = -1,
+	readyFiring = false,
 	whenReady = function( fn ) {
 		readyCallbacks.push( fn );
 	};
@@ -50,16 +50,16 @@ jQuery.extend( {
 		whenReady = function( fn ) {
 			readyCallbacks.push( fn );
 
-			if ( !++readyFiring ) {
+			if ( !readyFiring ) {
+				readyFiring = true;
 				while ( readyCallbacks.length ) {
 					fn = readyCallbacks.shift();
 					if ( jQuery.isFunction( fn ) ) {
 						fn.call( document, jQuery );
 					}
 				}
+				readyFiring = false;
 			}
-
-			readyFiring--;
 		};
 
 		whenReady();

--- a/test/unit/ready.js
+++ b/test/unit/ready.js
@@ -27,36 +27,13 @@ QUnit.module( "ready" );
 		};
 	}
 
-	function throwError( num ) {
-
-		// Not a global QUnit failure
-		var onerror = window.onerror;
-		window.onerror = function() {
-			window.onerror = onerror;
-		};
-
-		throw new Error( "Ready error " + num );
-	}
-
 	// Bind to the ready event in every possible way.
 	jQuery( makeHandler( "a" ) );
 	jQuery( document ).ready( makeHandler( "b" ) );
 
-	// Throw in an error to ensure other callbacks are called
-	jQuery( function() {
-		throwError( 1 );
-	} );
-
-	// Throw two errors in a row
-	jQuery( function() {
-		throwError( 2 );
-	} );
-	jQuery.when( jQuery.ready ).done( makeHandler( "c" ) );
-
 	// Do it twice, just to be sure.
-	jQuery( makeHandler( "d" ) );
-	jQuery( document ).ready( makeHandler( "e" ) );
-	jQuery.when( jQuery.ready ).done( makeHandler( "f" ) );
+	jQuery( makeHandler( "c" ) );
+	jQuery( document ).ready( makeHandler( "d" ) );
 
 	noEarlyExecution = order.length === 0;
 
@@ -68,7 +45,7 @@ QUnit.module( "ready" );
 			"Handlers bound to DOM ready should not execute before DOM ready" );
 
 		// Ensure execution order.
-		assert.deepEqual( order, [ "a", "b", "c", "d", "e", "f" ],
+		assert.deepEqual( order, [ "a", "b", "c", "d" ],
 			"Bound DOM ready handlers should execute in on-order" );
 
 		// Ensure handler argument is correct.
@@ -103,20 +80,6 @@ QUnit.module( "ready" );
 		Promise.resolve( jQuery.ready ).then( function() {
 			assert.ok( jQuery.isReady, "Native promised resolved" );
 			done.pop()();
-		} );
-	} );
-
-	QUnit.test( "Error in ready callback does not halt all future executions (gh-1823)", function( assert ) {
-		assert.expect( 2 );
-
-		assert.throws( function() {
-			jQuery( function() {
-				throw new Error( "Ready error" );
-			} );
-		}, "First ready handler throws an error" );
-
-		jQuery( function() {
-			assert.ok( true, "Subsequent handler called" );
 		} );
 	} );
 } )();

--- a/test/unit/ready.js
+++ b/test/unit/ready.js
@@ -29,10 +29,12 @@ QUnit.module( "ready" );
 	// Bind to the ready event in every possible way.
 	jQuery( makeHandler( "a" ) );
 	jQuery( document ).ready( makeHandler( "b" ) );
+	jQuery.when( jQuery.ready ).done( makeHandler( "c" ) );
 
 	// Do it twice, just to be sure.
-	jQuery( makeHandler( "c" ) );
-	jQuery( document ).ready( makeHandler( "d" ) );
+	jQuery( makeHandler( "d" ) );
+	jQuery( document ).ready( makeHandler( "e" ) );
+	jQuery.when( jQuery.ready ).done( makeHandler( "f" ) );
 
 	noEarlyExecution = order.length === 0;
 
@@ -44,7 +46,7 @@ QUnit.module( "ready" );
 			"Handlers bound to DOM ready should not execute before DOM ready" );
 
 		// Ensure execution order.
-		assert.deepEqual( order, [ "a", "b", "c", "d" ],
+		assert.deepEqual( order, [ "a", "b", "c", "d", "e", "f" ],
 			"Bound DOM ready handlers should execute in on-order" );
 
 		// Ensure handler argument is correct.

--- a/test/unit/ready.js
+++ b/test/unit/ready.js
@@ -79,16 +79,20 @@ QUnit.module( "ready" );
 
 		order = [];
 
-		// Now that the ready event has fired, again bind to the ready event
-		// in every possible way. These event handlers should execute immediately.
+		// Now that the ready event has fired, again bind to the ready event.
+		// These ready handlers should execute asynchronously.
+		var done = assert.async();
 		jQuery( makeHandler( "g" ) );
-		assert.equal( order.pop(), "g", "Event handler should execute immediately" );
-		assert.equal( args.g, jQuery, "Argument passed to fn in jQuery( fn ) should be jQuery" );
-
 		jQuery( document ).ready( makeHandler( "h" ) );
-		assert.equal( order.pop(), "h", "Event handler should execute immediately" );
-		assert.equal( args.h, jQuery,
-			"Argument passed to fn in jQuery(document).ready( fn ) should be jQuery" );
+		window.setTimeout( function() {
+			assert.equal( order.shift(), "g", "Event handler should execute immediately, but async" );
+			assert.equal( args.g, jQuery, "Argument passed to fn in jQuery( fn ) should be jQuery" );
+
+			assert.equal( order.shift(), "h", "Event handler should execute immediately, but async" );
+			assert.equal( args.h, jQuery,
+				"Argument passed to fn in jQuery(document).ready( fn ) should be jQuery" );
+			done();
+		} );
 	} );
 
 	QUnit.test( "Promise.resolve(jQuery.ready)", function( assert ) {
@@ -107,16 +111,16 @@ QUnit.module( "ready" );
 	} );
 
 	QUnit.test( "Error in ready callback does not halt all future executions (gh-1823)", function( assert ) {
-		assert.expect( 2 );
+		assert.expect( 1 );
+		var done = assert.async();
 
-		assert.throws( function() {
-			jQuery( function() {
-				throw new Error( "Ready error" );
-			} );
-		}, "First ready handler throws an error" );
+		jQuery( function() {
+			throwError( 3 );
+		} );
 
 		jQuery( function() {
 			assert.ok( true, "Subsequent handler called" );
+			done();
 		} );
 	} );
 } )();

--- a/test/unit/ready.js
+++ b/test/unit/ready.js
@@ -72,18 +72,16 @@ QUnit.module( "ready" );
 
 	QUnit.test( "Promise.resolve(jQuery.ready)", function( assert ) {
 		assert.expect( 2 );
-
-		var beforeReady = assert.async();
-		var afterReady = assert.async();
+		var done = jQuery.map( new Array( 2 ), function() { return assert.async(); } );
 
 		promisified.then( function() {
 			assert.ok( jQuery.isReady, "Native promised resolved" );
-			beforeReady();
+			done.pop()();
 		} );
 
 		Promise.resolve( jQuery.ready ).then( function() {
 			assert.ok( jQuery.isReady, "Native promised resolved" );
-			afterReady();
+			done.pop()();
 		} );
 	} );
 } )();

--- a/test/unit/ready.js
+++ b/test/unit/ready.js
@@ -27,6 +27,16 @@ QUnit.module( "ready" );
 		};
 	}
 
+	// Suppress the first error
+	var onerror = window.onerror;
+	window.onerror = function() {
+		window.onerror = onerror;
+	};
+
+	jQuery( function() {
+		throw new Error( "Subsequent callbacks called after an error" );
+	} );
+
 	// Bind to the ready event in every possible way.
 	jQuery( makeHandler( "a" ) );
 	jQuery( document ).ready( makeHandler( "b" ) );

--- a/test/unit/ready.js
+++ b/test/unit/ready.js
@@ -27,19 +27,30 @@ QUnit.module( "ready" );
 		};
 	}
 
-	// Suppress the first error
-	var onerror = window.onerror;
-	window.onerror = function() {
-		window.onerror = onerror;
-	};
+	function throwError( num ) {
 
-	jQuery( function() {
-		throw new Error( "Subsequent callbacks called after an error" );
-	} );
+		// Not a global QUnit failure
+		var onerror = window.onerror;
+		window.onerror = function() {
+			window.onerror = onerror;
+		};
+
+		throw new Error( "Ready error " + num );
+	}
 
 	// Bind to the ready event in every possible way.
 	jQuery( makeHandler( "a" ) );
 	jQuery( document ).ready( makeHandler( "b" ) );
+
+	// Throw in an error to ensure other callbacks are called
+	jQuery( function() {
+		throwError( 1 );
+	} );
+
+	// Throw two errors in a row
+	jQuery( function() {
+		throwError( 2 );
+	} );
 	jQuery.when( jQuery.ready ).done( makeHandler( "c" ) );
 
 	// Do it twice, just to be sure.
@@ -100,7 +111,7 @@ QUnit.module( "ready" );
 
 		assert.throws( function() {
 			jQuery( function() {
-				throw new Error( "Ready handler error" );
+				throw new Error( "Ready error" );
 			} );
 		}, "First ready handler throws an error" );
 

--- a/test/unit/ready.js
+++ b/test/unit/ready.js
@@ -77,12 +77,12 @@ QUnit.module( "ready" );
 		var afterReady = assert.async();
 
 		promisified.then( function() {
-			assert.ok( true, "Native promised resolved" );
+			assert.ok( jQuery.isReady, "Native promised resolved" );
 			beforeReady();
 		} );
 
 		Promise.resolve( jQuery.ready ).then( function() {
-			assert.ok( true, "Native promised resolved" );
+			assert.ok( jQuery.isReady, "Native promised resolved" );
 			afterReady();
 		} );
 	} );

--- a/test/unit/ready.js
+++ b/test/unit/ready.js
@@ -2,6 +2,7 @@ QUnit.module( "ready" );
 
 ( function() {
 	var notYetReady, noEarlyExecution,
+		promisified = Promise.resolve( jQuery.ready ),
 		order = [],
 		args = {};
 
@@ -70,11 +71,19 @@ QUnit.module( "ready" );
 	} );
 
 	QUnit.test( "Promise.resolve(jQuery.ready)", function( assert ) {
-		assert.expect( 1 );
-		var done = assert.async();
+		assert.expect( 2 );
+
+		var beforeReady = assert.async();
+		var afterReady = assert.async();
+
+		promisified.then( function() {
+			assert.ok( true, "Native promised resolved" );
+			beforeReady();
+		} );
+
 		Promise.resolve( jQuery.ready ).then( function() {
 			assert.ok( true, "Native promised resolved" );
-			done();
+			afterReady();
 		} );
 	} );
 } )();

--- a/test/unit/ready.js
+++ b/test/unit/ready.js
@@ -69,4 +69,12 @@ QUnit.module( "ready" );
 			"Argument passed to fn in jQuery(document).ready( fn ) should be jQuery" );
 	} );
 
+	QUnit.test( "Promise.resolve(jQuery.ready)", function( assert ) {
+		assert.expect( 1 );
+		var done = assert.async();
+		Promise.resolve( jQuery.ready ).then( function() {
+			assert.ok( true, "Native promised resolved" );
+			done();
+		} );
+	} );
 } )();

--- a/test/unit/ready.js
+++ b/test/unit/ready.js
@@ -84,4 +84,18 @@ QUnit.module( "ready" );
 			done.pop()();
 		} );
 	} );
+
+	QUnit.test( "Error in ready callback does not halt all future executions (gh-1823)", function( assert ) {
+		assert.expect( 2 );
+
+		assert.throws( function() {
+			jQuery( function() {
+				throw new Error( "Ready handler error" );
+			} );
+		}, "First ready handler throws an error" );
+
+		jQuery( function() {
+			assert.ok( true, "Subsequent handler called" );
+		} );
+	} );
 } )();


### PR DESCRIPTION
- Modules depending on deferred are excluded when deferred is excluded (ajax, effects, queue, and core/ready). Whenever deferred is excluded, core/ready is replaced by core/ready-no-deferred.
- `jQuery.ready.promise` has been removed and `jQuery.ready` made a thenable in core/ready.
- #1823 (error resiliency) has been addressed by giving up our synchronicity guarantee in ready handler execution after the ready event has been fired. This has multiple advantages. Besides error resiliency, it makes use of our standards-compatible `.then` in the `.ready` method.