### PR TITLE
Attributes: remove the lower-casing logic for attribute names

### DIFF
--- a/src/attributes/attr.js
+++ b/src/attributes/attr.js
@@ -7,14 +7,7 @@ define( [
 ], function( jQuery, access, support, rnotwhite ) {
 
 var boolHook,
-	attrHandle = jQuery.expr.attrHandle,
-
-	// Exclusively lowercase A-Z in attribute names (gh-2730)
-	// https://dom.spec.whatwg.org/#converted-to-ascii-lowercase
-	raz = /[A-Z]+/g,
-	lowercase = function( ch ) {
-		return ch.toLowerCase();
-	};
+	attrHandle = jQuery.expr.attrHandle;
 
 jQuery.fn.extend( {
 	attr: function( name, value ) {
@@ -46,8 +39,7 @@ jQuery.extend( {
 		// All attributes are lowercase
 		// Grab necessary hook if one is defined
 		if ( nType !== 1 || !jQuery.isXMLDoc( elem ) ) {
-			name = name.replace( raz, lowercase );
-			hooks = jQuery.attrHooks[ name ] ||
+			hooks = jQuery.attrHooks[ name.toLowerCase() ] ||
 				( jQuery.expr.match.bool.test( name ) ? boolHook : undefined );
 		}
 


### PR DESCRIPTION
jQuery used to lower-case the attribute names passed to the .attr setter
to workaround an old IE issue. This is no longer in jQuery 3.0 and
removing it may even "accidentally" make this API sort-of work on SVGs
(see gh-2910) so why not.

Manual lowercasing had to be added to the place where the proper
attrHook is retrieved so that it works regardless of the casing of the
provided name. A regular `toLowerCase()` is enough there as those few
attributes don't contain any non-ASCII characters.

Fixes gh-2914

-18 bytes