### PR TITLE
Docs:Tests: Remove obsolete code from tests, update support comments

### DIFF
--- a/src/ajax/parseXML.js
+++ b/src/ajax/parseXML.js
@@ -9,7 +9,8 @@ jQuery.parseXML = function( data ) {
 		return null;
 	}
 
-	// Support: IE9
+	// Support: IE 9-11 only
+	// IE throws on parseFromString with invalid input.
 	try {
 		xml = ( new window.DOMParser() ).parseFromString( data, "text/xml" );
 	} catch ( e ) {

--- a/src/ajax/xhr.js
+++ b/src/ajax/xhr.js
@@ -15,7 +15,7 @@ var xhrSuccessStatus = {
 		// File protocol always yields status code 0, assume 200
 		0: 200,
 
-		// Support: IE9
+		// Support: IE9 only
 		// #1450: sometimes IE returns 1223 when it should be 204
 		1223: 204
 	},
@@ -79,7 +79,7 @@ jQuery.ajaxTransport( function( options ) {
 								xhr.abort();
 							} else if ( type === "error" ) {
 
-								// Support: IE9
+								// Support: IE9 only
 								// On a manual native abort, IE9 throws
 								// errors on any property access that is not readyState
 								if ( typeof xhr.status !== "number" ) {
@@ -115,7 +115,7 @@ jQuery.ajaxTransport( function( options ) {
 				xhr.onload = callback();
 				errorCallback = xhr.onerror = callback( "error" );
 
-				// Support: IE9
+				// Support: IE9 only
 				// Use onreadystatechange to replace onabort
 				// to handle uncaught aborts
 				if ( xhr.onabort !== undefined ) {

--- a/src/core/support.js
+++ b/src/core/support.js
@@ -3,7 +3,7 @@ define( [
 	"../var/support"
 ], function( document, support ) {
 
-// Support: Safari 8+
+// Support: Safari 8 only
 // In Safari 8 documents created via document.implementation.createHTMLDocument
 // collapse sibling forms: the second one becomes a child of the first one.
 // Because of that, this security measure has to be disabled in Safari 8.

--- a/src/css/curCSS.js
+++ b/src/css/curCSS.js
@@ -13,7 +13,7 @@ function curCSS( elem, name, computed ) {
 
 	computed = computed || getStyles( elem );
 
-	// Support: IE9
+	// Support: IE9 only
 	// getPropertyValue is only needed for .css('filter') (#12537)
 	if ( computed ) {
 		ret = computed.getPropertyValue( name ) || computed[ name ];
@@ -47,7 +47,7 @@ function curCSS( elem, name, computed ) {
 
 	return ret !== undefined ?
 
-		// Support: IE9-11+
+		// Support: IE9-11 only
 		// IE returns zIndex value as an integer.
 		ret + "" :
 		ret;

--- a/src/css/showHide.js
+++ b/src/css/showHide.js
@@ -56,7 +56,7 @@ function showHide( elements, show ) {
 			}
 			if ( elem.style.display === "" && jQuery.css( elem, "display" ) === "none" &&
 
-					// Support: Firefox <=42 - 43
+					// Support: Firefox 43+
 					// Don't set inline display on disconnected elements with computed display: none
 					jQuery.contains( elem.ownerDocument, elem ) ) {
 

--- a/src/css/support.js
+++ b/src/css/support.js
@@ -15,7 +15,7 @@ define( [
 		return;
 	}
 
-	// Support: IE9-11+
+	// Support: IE9-11 only
 	// Style of cloned element affects source element cloned (#8908)
 	div.style.backgroundClip = "content-box";
 	div.cloneNode( true ).style.backgroundClip = "";
@@ -66,7 +66,7 @@ define( [
 		},
 		pixelMarginRight: function() {
 
-			// Support: Android 4.0-4.3
+			// Support: Android 4.0 - 4.3 only
 			// We're checking for boxSizingReliableVal here instead of pixelMarginRightVal
 			// since that compresses better and they're computed together anyway.
 			if ( boxSizingReliableVal == null ) {
@@ -76,7 +76,7 @@ define( [
 		},
 		reliableMarginLeft: function() {
 
-			// Support: IE <=8 only, Android 4.0 - 4.3 only, Firefox <=3 - 37
+			// Support: Android 4.0 - 4.3 only, Firefox <=3 - 44+
 			if ( boxSizingReliableVal == null ) {
 				computeStyleTests();
 			}

--- a/src/css/var/getStyles.js
+++ b/src/css/var/getStyles.js
@@ -1,7 +1,7 @@
 define( function() {
 	return function( elem ) {
 
-		// Support: IE<=11+, Firefox<=30+ (#15098, #14150)
+		// Support: IE<=11 only, Firefox<=30+ (#15098, #14150)
 		// IE throws on elements created in popups
 		// FF meanwhile throws on frame elements through "defaultView.getComputedStyle"
 		var view = elem.ownerDocument.defaultView;

--- a/src/data/Data.js
+++ b/src/data/Data.js
@@ -141,7 +141,7 @@ Data.prototype = {
 			// Support: Chrome <= 35-45+
 			// Webkit & Blink performance suffers when deleting properties
 			// from DOM nodes, so set to undefined instead
-			// https://code.google.com/p/chromium/issues/detail?id=378607
+			// https://bugs.chromium.org/p/chromium/issues/detail?id=378607 (bug restricted)
 			if ( owner.nodeType ) {
 				owner[ this.expando ] = undefined;
 			} else {

--- a/src/deferred/exceptionHook.js
+++ b/src/deferred/exceptionHook.js
@@ -9,7 +9,7 @@ var rerrorNames = /^(Eval|Internal|Range|Reference|Syntax|Type|URI)Error$/;
 
 jQuery.Deferred.exceptionHook = function( error, stack ) {
 
-	// Support: IE9
+	// Support: IE9 only
 	// Console exists when dev tools are open, which can happen at any time
 	if ( window.console && window.console.warn && error && rerrorNames.test( error.name ) ) {
 		window.console.warn( "jQuery.Deferred exception: " + error.message, stack );

--- a/src/effects/Tween.js
+++ b/src/effects/Tween.js
@@ -88,7 +88,7 @@ Tween.propHooks = {
 	}
 };
 
-// Support: IE9
+// Support: IE9 only
 // Panic based approach to setting things on disconnected nodes
 Tween.propHooks.scrollTop = Tween.propHooks.scrollLeft = {
 	set: function( tween ) {

--- a/src/event.js
+++ b/src/event.js
@@ -22,7 +22,7 @@ function returnFalse() {
 	return false;
 }
 
-// Support: IE9
+// Support: IE9 only
 // See #13393 for more info
 function safeActiveElement() {
 	try {
@@ -625,7 +625,7 @@ jQuery.Event.prototype = {
 //
 // Support: Safari 7 only
 // Safari sends mouseenter too often; see:
-// https://code.google.com/p/chromium/issues/detail?id=470258
+// https://bugs.chromium.org/p/chromium/issues/detail?id=470258
 // for the description of the bug (it existed in older Chrome versions as well).
 jQuery.each( {
 	mouseenter: "mouseover",

--- a/src/event/focusin.js
+++ b/src/event/focusin.js
@@ -7,14 +7,14 @@ define( [
 	"./trigger"
 ], function( jQuery, dataPriv, support ) {
 
-// Support: Firefox
+// Support: Firefox 44+
 // Firefox doesn't have focus(in | out) events
 // Related ticket - https://bugzilla.mozilla.org/show_bug.cgi?id=687787
 //
-// Support: Chrome, Safari
+// Support: Chrome 48+, Safari 9.0+
 // focus(in | out) events fire after focus & blur events,
 // which is spec violation - http://www.w3.org/TR/DOM-Level-3-Events/#events-focusevent-event-order
-// Related ticket - https://code.google.com/p/chromium/issues/detail?id=449857
+// Related ticket - https://bugs.chromium.org/p/chromium/issues/detail?id=449857
 if ( !support.focusin ) {
 	jQuery.each( { focus: "focusin", blur: "focusout" }, function( orig, fix ) {
 

--- a/src/manipulation/getAll.js
+++ b/src/manipulation/getAll.js
@@ -4,7 +4,7 @@ define( [
 
 function getAll( context, tag ) {
 
-	// Support: IE9-11+
+	// Support: IE9-11 only
 	// Use typeof to avoid zero-argument method invocation on host objects (#15151)
 	var ret = typeof context.getElementsByTagName !== "undefined" ?
 			context.getElementsByTagName( tag || "*" ) :

--- a/src/manipulation/support.js
+++ b/src/manipulation/support.js
@@ -8,7 +8,7 @@ define( [
 		div = fragment.appendChild( document.createElement( "div" ) ),
 		input = document.createElement( "input" );
 
-	// Support: Android 4.0-4.3
+	// Support: Android 4.0 - 4.3 only
 	// Check state lost if the name is set (#11217)
 	// Support: Windows Web Apps (WWA)
 	// `name` and `type` must use .setAttribute for WWA (#14901)
@@ -22,7 +22,7 @@ define( [
 	// Older WebKit doesn't clone checked state correctly in fragments
 	support.checkClone = div.cloneNode( true ).cloneNode( true ).lastChild.checked;
 
-	// Support: IE<=11+
+	// Support: IE<=11 only
 	// Make sure textarea (and checkbox) defaultValue is properly cloned
 	div.innerHTML = "<textarea>x</textarea>";
 	support.noCloneChecked = !!div.cloneNode( true ).lastChild.defaultValue;

--- a/src/offset.js
+++ b/src/offset.js
@@ -203,10 +203,10 @@ jQuery.each( { scrollLeft: "pageXOffset", scrollTop: "pageYOffset" }, function( 
 	};
 } );
 
-// Support: Safari<7-8+, Chrome<37-44+
+// Support: Safari<7-9.0+, Chrome<37-48+
 // Add the top/left cssHooks using jQuery.fn.position
 // Webkit bug: https://bugs.webkit.org/show_bug.cgi?id=29084
-// Blink bug: https://code.google.com/p/chromium/issues/detail?id=229280
+// Blink bug: https://bugs.chromium.org/p/chromium/issues/detail?id=589347
 // getComputedStyle returns percent when specified for top/left/bottom/right;
 // rather than make the css module depend on the offset module, just check for it here
 jQuery.each( [ "top", "left" ], function( i, prop ) {

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -249,9 +249,8 @@ QUnit.module( "ajax", {
 				"Nullable": null,
 				"undefined": undefined
 
-				// Support: Firefox
+				// Support: IE 9 - 11, Edge 12 - 13+
 				// Not all browsers allow empty-string headers
-				// https://bugzilla.mozilla.org/show_bug.cgi?id=815299
 				//"Empty": ""
 			},
 			success: function( data, _, xhr ) {
@@ -1699,16 +1698,6 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 }
 
 	QUnit.asyncTest( "#11743 - jQuery.ajax() - script, throws exception", 1, function( assert ) {
-
-		// Support: Android 2.3 only
-		// Android 2.3 doesn't fire the window.onerror handler, just accept the reality there.
-		if ( /android 2\.3/i.test( navigator.userAgent ) ) {
-			assert.ok( true, "Test skipped, Android 2.3 doesn't fire window.onerror for " +
-				"errors in dynamically included scripts" );
-			QUnit.start();
-			return;
-		}
-
 		var onerror = window.onerror;
 		window.onerror = function() {
 			assert.ok( true, "Exception thrown" );
@@ -1768,13 +1757,6 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 				var parsedXML = jQuery( jQuery.parseXML( "<tab title=\"Added\">blibli</tab>" ) ).find( "tab" );
 				ajaxXML = jQuery( ajaxXML );
 				try {
-
-					// Android 2.3 doesn't automatically adopt nodes from foreign documents.
-					// (see the comment in test/manipulation.js)
-					// Support: Android 2.3
-					if ( /android 2\.3/i.test( navigator.userAgent ) ) {
-						parsedXML = jQuery( ajaxXML[ 0 ].adoptNode( parsedXML[ 0 ] ) );
-					}
 					ajaxXML.find( "infowindowtab" ).append( parsedXML );
 				} catch ( e ) {
 					assert.strictEqual( e, undefined, "error" );

--- a/test/unit/basic.js
+++ b/test/unit/basic.js
@@ -187,10 +187,7 @@ QUnit.test( "manipulation", function( assert ) {
 	assert.strictEqual( elem1.text( "foo" ).text(), "foo", ".html getter/setter" );
 
 	assert.strictEqual(
-
-		// Support: IE 8 only
-		// IE 8 prints tag names in upper case.
-		elem1.html( "<span/>" ).html().toLowerCase(),
+		elem1.html( "<span/>" ).html(),
 		"<span></span>",
 		".html getter/setter"
 	);
@@ -203,10 +200,7 @@ QUnit.test( "manipulation", function( assert ) {
 	child.before( "<b/>" );
 
 	assert.strictEqual(
-
-		// Support: IE 8 only
-		// IE 8 prints tag names in upper case.
-		elem1.html().toLowerCase(),
+		elem1.html(),
 		"<div></div><b></b><span></span><a></a>",
 		".after/.before"
 	);
@@ -275,10 +269,7 @@ QUnit.test( "wrap", function( assert ) {
 	elem.find( "b" ).wrap( "<span>" );
 
 	assert.strictEqual(
-
-		// Support: IE 8 only
-		// IE 8 prints tag names in upper case.
-		elem.html().toLowerCase(),
+		elem.html(),
 		"<a><span><b></b></span></a><a></a>",
 		".wrap"
 	);
@@ -286,10 +277,7 @@ QUnit.test( "wrap", function( assert ) {
 	elem.find( "span" ).wrapInner( "<em>" );
 
 	assert.strictEqual(
-
-		// Support: IE 8 only
-		// IE 8 prints tag names in upper case.
-		elem.html().toLowerCase(),
+		elem.html(),
 		"<a><span><em><b></b></em></span></a><a></a>",
 		".wrapInner"
 	);
@@ -297,10 +285,7 @@ QUnit.test( "wrap", function( assert ) {
 	elem.find( "a" ).wrapAll( "<i>" );
 
 	assert.strictEqual(
-
-		// Support: IE 8 only
-		// IE 8 prints tag names in upper case.
-		elem.html().toLowerCase(),
+		elem.html(),
 		"<i><a><span><em><b></b></em></span></a><a></a></i>",
 		".wrapAll"
 	);

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -1088,12 +1088,7 @@ QUnit.test( "Do not append px (#9548, #12990, #2792)", function( assert ) {
 
 	$div.css( "fill-opacity", 1 );
 
-	// Support: Android 2.3 (no support for fill-opacity)
-	if ( $div.css( "fill-opacity" ) !== undefined ) {
-		assert.equal( $div.css( "fill-opacity" ), 1, "Do not append px to 'fill-opacity'" );
-	} else {
-		assert.ok( true, "No support for fill-opacity CSS property" );
-	}
+	assert.equal( $div.css( "fill-opacity" ), 1, "Do not append px to 'fill-opacity'" );
 
 	$div.css( "column-count", 1 );
 	if ( $div.css( "column-count" ) !== undefined ) {
@@ -1115,8 +1110,7 @@ QUnit.test( "Do not append px (#9548, #12990, #2792)", function( assert ) {
 QUnit.test( "css('width') and css('height') should respect box-sizing, see #11004", function( assert ) {
 	assert.expect( 4 );
 
-	// Support: Android 2.3 (-webkit-box-sizing).
-	var el_dis = jQuery( "<div style='width:300px;height:300px;margin:2px;padding:2px;-webkit-box-sizing:border-box;box-sizing:border-box;'>test</div>" ),
+	var el_dis = jQuery( "<div style='width:300px;height:300px;margin:2px;padding:2px;box-sizing:border-box;'>test</div>" ),
 		el = el_dis.clone().appendTo( "#qunit-fixture" );
 
 	assert.equal( el.css( "width" ), el.css( "width", el.css( "width" ) ).css( "width" ), "css('width') is not respecting box-sizing, see #11004" );
@@ -1189,7 +1183,8 @@ QUnit.test( "certain css values of 'normal' should be convertable to a number, s
 	assert.equal( typeof el.css( "fontWeight" ), "string", ".css() returns a string" );
 } );
 
-// only run this test in IE9
+// Support: IE 9 only
+// Only run this test in IE9
 if ( document.documentMode === 9 ) {
 	QUnit.test( ".css('filter') returns a string in IE9, see #12537", function( assert ) {
 		assert.expect( 1 );

--- a/test/unit/dimensions.js
+++ b/test/unit/dimensions.js
@@ -295,7 +295,7 @@ QUnit.test( "child of a hidden elem (or unconnected node) has accurate inner/out
 	assert.equal( $divChild.outerWidth(), $divNormal.outerWidth(), "child of a hidden element outerWidth() is wrong see #9441" );
 	assert.equal( $divChild.outerWidth( true ), $divNormal.outerWidth( true ), "child of a hidden element outerWidth( true ) is wrong see #9300" );
 
-	// Support: IE 10-11, Edge
+	// Support: IE 10 - 11, Edge 12 - 13+
 	// Child height is not always decimal
 	assert.equal( $divChild.height().toFixed( 3 ), $divNormal.height().toFixed( 3 ), "child of a hidden element height() is wrong see #9441" );
 	assert.equal( $divChild.innerHeight().toFixed( 3 ), $divNormal.innerHeight().toFixed( 3 ), "child of a hidden element innerHeight() is wrong see #9441" );
@@ -308,7 +308,7 @@ QUnit.test( "child of a hidden elem (or unconnected node) has accurate inner/out
 	assert.equal( $divUnconnected.outerWidth(), $divNormal.outerWidth(), "unconnected element outerWidth() is wrong see #9441" );
 	assert.equal( $divUnconnected.outerWidth( true ), $divNormal.outerWidth( true ), "unconnected element outerWidth( true ) is wrong see #9300" );
 
-	// Support: IE 10-11, Edge
+	// Support: IE 10 - 11, Edge 12 - 13+
 	// Child height is not always decimal
 	assert.equal( $divUnconnected.height().toFixed( 3 ), $divNormal.height().toFixed( 3 ), "unconnected element height() is wrong see #9441" );
 	assert.equal( $divUnconnected.innerHeight().toFixed( 3 ), $divNormal.innerHeight().toFixed( 3 ), "unconnected element innerHeight() is wrong see #9441" );
@@ -372,7 +372,7 @@ QUnit.test( "box-sizing:border-box child of a hidden elem (or unconnected node) 
 	assert.equal( $divChild.outerWidth(), $divNormal.outerWidth(), "child of a hidden element outerWidth() is wrong see #10413" );
 	assert.equal( $divChild.outerWidth( true ), $divNormal.outerWidth( true ), "child of a hidden element outerWidth( true ) is wrong see #10413" );
 
-	// Support: IE 10-11, Edge
+	// Support: IE 10 - 11, Edge 12 - 13+
 	// Child height is not always decimal
 	assert.equal( $divChild.height().toFixed( 3 ), $divNormal.height().toFixed( 3 ), "child of a hidden element height() is wrong see #10413" );
 	assert.equal( $divChild.innerHeight().toFixed( 3 ), $divNormal.innerHeight().toFixed( 3 ), "child of a hidden element innerHeight() is wrong see #10413" );
@@ -385,7 +385,7 @@ QUnit.test( "box-sizing:border-box child of a hidden elem (or unconnected node) 
 	assert.equal( $divUnconnected.outerWidth(), $divNormal.outerWidth(), "unconnected element outerWidth() is wrong see #10413" );
 	assert.equal( $divUnconnected.outerWidth( true ), $divNormal.outerWidth( true ), "unconnected element outerWidth( true ) is wrong see #10413" );
 
-	// Support: IE 10-11, Edge
+	// Support: IE 10 - 11, Edge 12 - 13+
 	// Child height is not always decimal
 	assert.equal( $divUnconnected.height().toFixed( 3 ), $divNormal.height().toFixed( 3 ), "unconnected element height() is wrong see #10413" );
 	assert.equal( $divUnconnected.innerHeight().toFixed( 3 ), $divNormal.innerHeight().toFixed( 3 ), "unconnected element innerHeight() is wrong see #10413" );

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -1389,13 +1389,7 @@ QUnit.test( "Do not append px to 'fill-opacity' #9548", function( assert ) {
 	var $div = jQuery( "<div>" ).appendTo( "#qunit-fixture" );
 
 	$div.css( "fill-opacity", 0 ).animate( { "fill-opacity": 1.0 }, 0, function() {
-
-		// Support: Android 2.3 (no support for fill-opacity)
-		if ( jQuery( this ).css( "fill-opacity" ) ) {
-			assert.equal( jQuery( this ).css( "fill-opacity" ), 1, "Do not append px to 'fill-opacity'" );
-		} else {
-			assert.ok( true, "No support for fill-opacity CSS property" );
-		}
+		assert.equal( jQuery( this ).css( "fill-opacity" ), 1, "Do not append px to 'fill-opacity'" );
 		$div.remove();
 	} );
 } );

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -431,20 +431,13 @@ QUnit.test( "on bubbling, isDefaultPrevented, stopImmediatePropagation", functio
 	$anchor2.off( "click" );
 	$main.off( "click", "**" );
 
-	// Android 2.3 doesn't support stopImmediatePropagation; jQuery fallbacks to stopPropagation
-	// in such a case.
-	// Support: Android 2.3
-	if ( /android 2\.3/i.test( navigator.userAgent ) ) {
-		assert.ok( true, "Android 2.3, skipping native stopImmediatePropagation check" );
-	} else {
-		$anchor2.on( "click", function( e ) {
-			e.stopImmediatePropagation();
-			assert.ok( true, "anchor was clicked and prop stopped" );
-		} );
-		$anchor2[ 0 ].addEventListener( "click", neverCallMe, false );
-		fakeClick( $anchor2 );
-		$anchor2[ 0 ].removeEventListener( "click", neverCallMe );
-	}
+	$anchor2.on( "click", function( e ) {
+		e.stopImmediatePropagation();
+		assert.ok( true, "anchor was clicked and prop stopped" );
+	} );
+	$anchor2[ 0 ].addEventListener( "click", neverCallMe, false );
+	fakeClick( $anchor2 );
+	$anchor2[ 0 ].removeEventListener( "click", neverCallMe );
 } );
 
 QUnit.test( "on(), iframes", function( assert ) {
@@ -1389,29 +1382,26 @@ QUnit.test( "Submit event can be stopped (#11049)", function( assert ) {
 	form.remove();
 } );
 
-// Test beforeunload event only if it supported.
-// Support: iOS 7+, Android<4.0
-// iOS & old Android have the window.onbeforeunload field but don't support the beforeunload
+// Support: iOS 7-9+
+// iOS has the window.onbeforeunload field but doesn't support the beforeunload
 // handler making it impossible to feature-detect the support.
-if ( window.onbeforeunload === null &&
-	!/(ipad|iphone|ipod|android 2\.3)/i.test( navigator.userAgent ) ) {
-	QUnit.test( "on(beforeunload)", 1, function( assert ) {
-		var iframe = jQuery( jQuery.parseHTML( "<iframe src='data/event/onbeforeunload.html'><iframe>" ) );
-		var done = assert.async();
+QUnit[ /(ipad|iphone|ipod)/i.test( navigator.userAgent ) ? "skip" : "test" ](
+	"on(beforeunload)", 1, function( assert ) {
+	var iframe = jQuery( jQuery.parseHTML( "<iframe src='data/event/onbeforeunload.html'><iframe>" ) );
+	var done = assert.async();
 
-		window.onmessage = function( event ) {
-			var payload = JSON.parse( event.data );
+	window.onmessage = function( event ) {
+		var payload = JSON.parse( event.data );
 
-			assert.ok( payload.event, "beforeunload", "beforeunload event" );
+		assert.ok( payload.event, "beforeunload", "beforeunload event" );
 
-			iframe.remove();
-			window.onmessage = null;
-			done();
-		};
+		iframe.remove();
+		window.onmessage = null;
+		done();
+	};
 
-		iframe.appendTo( "#qunit-fixture" );
-	} );
-}
+	iframe.appendTo( "#qunit-fixture" );
+} );
 
 QUnit.test( "jQuery.Event( type, props )", function( assert ) {
 
@@ -2406,7 +2396,8 @@ QUnit.test( "event object properties on natively-triggered event", function( ass
 		$link = jQuery( link ),
 		evt = document.createEvent( "MouseEvents" );
 
-	// IE9+ requires element to be in the body before it will dispatch
+	// Support: IE 9-11 only
+	// IE requires element to be in the body before it will dispatch
 	$link.appendTo( "body" ).on( "click", function( e ) {
 
 		// Not trying to assert specific values here, just ensure the property exists
@@ -2876,7 +2867,7 @@ QUnit[ jQuery.fn.click ? "test" : "skip" ]( "Event aliases", function( assert ) 
 	} );
 } );
 
-// Support: IE9 (remove when IE9 is no longer supported)
+// Support: IE9 only
 // https://msdn.microsoft.com/en-us/library/hh801223(v=vs.85).aspx
 QUnit.test( "VML with special event handlers (trac-7071)", function( assert ) {
 	assert.expect( 1 );

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -406,23 +406,13 @@ QUnit.test( "XML DOM manipulation (#9960)", function( assert ) {
 
 	assert.expect( 5 );
 
-	var scxml1Adopted,
-		xmlDoc1 = jQuery.parseXML( "<scxml xmlns='http://www.w3.org/2005/07/scxml' version='1.0'><state x='100' y='100' initial='actions' id='provisioning'></state><state x='100' y='100' id='error'></state><state x='100' y='100' id='finished' final='true'></state></scxml>" ),
+	var xmlDoc1 = jQuery.parseXML( "<scxml xmlns='http://www.w3.org/2005/07/scxml' version='1.0'><state x='100' y='100' initial='actions' id='provisioning'></state><state x='100' y='100' id='error'></state><state x='100' y='100' id='finished' final='true'></state></scxml>" ),
 		xmlDoc2 = jQuery.parseXML( "<scxml xmlns='http://www.w3.org/2005/07/scxml' version='1.0'><state id='provisioning3'></state></scxml>" ),
 		xml1 = jQuery( xmlDoc1 ),
 		xml2 = jQuery( xmlDoc2 ),
 		scxml1 = jQuery( "scxml", xml1 ),
 		scxml2 = jQuery( "scxml", xml2 ),
 		state = scxml2.find( "state" );
-
-	// Android 2.3 doesn't automatically adopt nodes from foreign documents.
-	// Although technically this is compliant behavior, no other browser
-	// (including newer Android Browsers) behave in this way so do the adopting
-	// just for Android 2.3.
-	// Support: Android 2.3
-	if ( /android 2\.3/i.test( navigator.userAgent ) ) {
-		state = jQuery( xmlDoc1.adoptNode( state[ 0 ] ) );
-	}
 
 	scxml1.append( state );
 	assert.strictEqual( scxml1[ 0 ].lastChild, state[ 0 ], "append" );
@@ -436,13 +426,7 @@ QUnit.test( "XML DOM manipulation (#9960)", function( assert ) {
 	scxml1.find( "#provisioning" ).before( state );
 	assert.strictEqual( scxml1[ 0 ].firstChild, state[ 0 ], "before" );
 
-	// Support: Android 2.3
-	if ( /android 2\.3/i.test( navigator.userAgent ) ) {
-		scxml1Adopted = jQuery( xmlDoc2.adoptNode( scxml1[ 0 ] ) );
-		scxml2.replaceWith( scxml1Adopted );
-	} else {
-		scxml2.replaceWith( scxml1 );
-	}
+	scxml2.replaceWith( scxml1 );
 	assert.deepEqual( jQuery( "state", xml2 ).get(), scxml1.find( "state" ).get(), "replaceWith" );
 } );
 
@@ -2377,18 +2361,6 @@ QUnit.test( "Ensure oldIE creates a new set on appendTo (#8894)", function( asse
 } );
 
 QUnit.asyncTest( "html() - script exceptions bubble (#11743)", 2, function( assert ) {
-
-	// Support: Android 2.3 only
-	// Android 2.3 doesn't fire the window.onerror handler, just accept the reality there.
-	if ( /android 2\.3/i.test( navigator.userAgent ) ) {
-		assert.ok( true, "Test skipped, Android 2.3 doesn't fire window.onerror for " +
-			"errors in dynamically included scripts" );
-		assert.ok( true, "Test skipped, Android 2.3 doesn't fire window.onerror for " +
-			"errors in dynamically included scripts" );
-		QUnit.start();
-		return;
-	}
-
 	var onerror = window.onerror;
 
 	setTimeout( function() {

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -553,11 +553,10 @@ QUnit.test( "iframe scrollTop/Left (see gh-1945)", function( assert ) {
 
 	var ifDoc = jQuery( "#iframe" )[ 0 ].contentDocument;
 
-	// Mobile Safari and Android 2.3 resize the iframe by its content
-	// meaning it's not possible to scroll the iframe only its parent element.
+	// Mobile Safari resize the iframe by its content meaning it's not possible to scroll
+	// the iframe but only its parent element.
 	// It seems (not confirmed) in android 4.0 it's not possible to scroll iframes from the code.
 	if ( /iphone os/i.test( navigator.userAgent ) ||
-	    /android 2\.3/i.test( navigator.userAgent ) ||
 	    /android 4\.0/i.test( navigator.userAgent ) ) {
 		assert.equal( true, true, "Can't scroll iframes in this environment" );
 		assert.equal( true, true, "Can't scroll iframes in this environment" );


### PR DESCRIPTION
Support comments that were lacking the final IE/Edge version that exhibits
the bug were checked & updated. Links to the Chromium bug tracker were updated.
Code in tests related to unsupported browsers (like Android 2.3 in non-basic
tests) has been removed.

Fixes gh-2868

The first commit is PR #2948, I just didn't want to introduce conflicts between my 2 PRs. I'll rebase once that lands.