### PR TITLE
Tests: restrict "p > * > *" test in selector.js to #qunit-fixture

### DIFF
--- a/test/data/testinit.js
+++ b/test/data/testinit.js
@@ -32,14 +32,14 @@ this.q = function() {
 
 /**
  * Asserts that a select matches the given IDs
- * @param {String} a - Assertion name
- * @param {String} b - Sizzle selector
- * @param {String} c - Array of ids to construct what is expected
- * @example t("Check for something", "//[a]", ["foo", "bar"]);
- * @result returns true if "//[a]" return two elements with the IDs 'foo' and 'bar'
+ * @param {String} message - Assertion name
+ * @param {String} selector - Sizzle selector
+ * @param {String} expectedIds - Array of ids to construct what is expected
+ * @param {(String|Node)=document} context - Selector context
+ * @example match("Check for something", "p", ["foo", "bar"]);
  */
-QUnit.assert.t = function( a, b, c ) {
-	var f = jQuery( b ).get(),
+function match( message, selector, expectedIds, context ) {
+	var f = jQuery( selector, context ).get(),
 		s = "",
 		i = 0;
 
@@ -47,7 +47,31 @@ QUnit.assert.t = function( a, b, c ) {
 		s += ( s && "," ) + '"' + f[ i ].id + '"';
 	}
 
-	this.deepEqual( f, q.apply( q, c ), a + " (" + b + ")" );
+	this.deepEqual( f, q.apply( q, expectedIds ), message + " (" + selector + ")" );
+}
+
+/**
+ * Asserts that a select matches the given IDs.
+ * The select is not bound by a context.
+ * @param {String} message - Assertion name
+ * @param {String} selector - Sizzle selector
+ * @param {String} expectedIds - Array of ids to construct what is expected
+ * @example t("Check for something", "p", ["foo", "bar"]);
+ */
+QUnit.assert.t = function( message, selector, expectedIds ) {
+	match( message, selector, expectedIds, undefined );
+};
+
+/**
+ * Asserts that a select matches the given IDs.
+ * The select is performed within the `#qunit-fixture` context.
+ * @param {String} message - Assertion name
+ * @param {String} selector - Sizzle selector
+ * @param {String} expectedIds - Array of ids to construct what is expected
+ * @example selectInFixture("Check for something", "p", ["foo", "bar"]);
+ */
+QUnit.assert.selectInFixture = function( message, selector, expectedIds ) {
+	match( message, selector, expectedIds, "#qunit-fixture" );
 };
 
 this.createDashboardXML = function() {

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -109,7 +109,7 @@ QUnit.test( "child and adjacent", function( assert ) {
 	assert.t( "Child", "p>a", [ "simon1","google","groups","mark","yahoo","simon" ] );
 	assert.t( "Child w/ Class", "p > a.blog", [ "mark","simon" ] );
 	assert.t( "All Children", "code > *", [ "anchor1","anchor2" ] );
-	assert.t( "All Grandchildren", "p > * > *", [ "anchor1","anchor2" ] );
+	assert.selectInFixture( "All Grandchildren", "p > * > *", [ "anchor1","anchor2" ] );
 	assert.t( "Adjacent", "p + p", [ "ap","en","sap" ] );
 	assert.t( "Adjacent", "p#firstp + p", [ "ap" ] );
 	assert.t( "Adjacent", "p[lang=en] + p", [ "sap" ] );


### PR DESCRIPTION
Fix [`p > * > *`][1] assert from selector.js
Ref #2880

I am not sure if I should change any other `assert.t`'s from `selector.js` that do not use an id. The same goes for `css.js` and `manipulation.js`.

This change stops the `selector` test module from failing on Chrome 49 when `<All modules>` are run. It did not use to fail and it does not fail now, if the `selector` module is run alone.

[1]: https://github.com/jquery/jquery/issues/2877#issuecomment-175582442