### PR TITLE
Core: Restore 1.x isPlainObject constructor checks

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -236,7 +236,7 @@ jQuery.extend( {
 		// Not own constructor property must be Object
 		if ( obj.constructor &&
 				!hasOwn.call( obj, "constructor" ) &&
-				!hasOwn.call( obj.constructor.prototype, "isPrototypeOf" ) ) {
+				!hasOwn.call( obj.constructor.prototype || {}, "isPrototypeOf" ) ) {
 			return false;
 		}
 

--- a/src/core.js
+++ b/src/core.js
@@ -233,7 +233,9 @@ jQuery.extend( {
 			return false;
 		}
 
+		// Not own constructor property must be Object
 		if ( obj.constructor &&
+				!hasOwn.call( obj, "constructor" ) &&
 				!hasOwn.call( obj.constructor.prototype, "isPrototypeOf" ) ) {
 			return false;
 		}

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -268,7 +268,8 @@ QUnit.test( "type for `Symbol`", function( assert ) {
 } );
 
 QUnit.asyncTest( "isPlainObject", function( assert ) {
-	assert.expect( 21 );
+
+	assert.expect( 22 );
 
 	var pass, iframe, doc, parentObj, childObj, deep,
 		fn = function() {};
@@ -313,6 +314,10 @@ QUnit.asyncTest( "isPlainObject", function( assert ) {
 
 	// Again, instantiated objects shouldn't be matched
 	assert.ok( !jQuery.isPlainObject( new fn() ), "new fn" );
+
+	// Instantiated objects with primitive constructors shouldn't be matched
+	fn.prototype.constructor = "foo";
+	assert.ok( !jQuery.isPlainObject( new fn() ), "new fn with primitive constructor" );
 
 	// Deep object
 	deep = { "foo": { "baz": true }, "foo2": document };

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -268,7 +268,7 @@ QUnit.test( "type for `Symbol`", function( assert ) {
 } );
 
 QUnit.asyncTest( "isPlainObject", function( assert ) {
-	assert.expect( 19 );
+	assert.expect( 21 );
 
 	var pass, iframe, doc, parentObj, childObj, deep,
 		fn = function() {};
@@ -276,6 +276,10 @@ QUnit.asyncTest( "isPlainObject", function( assert ) {
 	// The use case that we want to match
 	assert.ok( jQuery.isPlainObject( {} ), "{}" );
 	assert.ok( jQuery.isPlainObject( new window.Object() ), "new Object" );
+	assert.ok( jQuery.isPlainObject( { constructor: fn } ),
+		"plain object with constructor property" );
+	assert.ok( jQuery.isPlainObject( { constructor: "foo" } ),
+		"plain object with primitive constructor property" );
 
 	parentObj = { foo: "bar" };
 	childObj = Object.create( parentObj );


### PR DESCRIPTION
Fixes gh-2982

To be merged into 2.2-stable and (probably) cherry-picked into master, although I would still like to see 3.0 revamped along the lines of https://github.com/jquery/jquery/pull/2970#discussion_r54991520 .