### PR TITLE
Ajax: make jqXHR an instance of jQuery.Deferred

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -444,80 +444,80 @@ jQuery.extend( {
 			// Default abort message
 			strAbort = "canceled",
 
-			// Fake xhr
-			jqXHR = {
-				readyState: 0,
+			// Fake xhr (as a true Deferred instance)
+			jqXHR = deferred.promise();
 
-				// Builds headers hashtable if needed
-				getResponseHeader: function( key ) {
-					var match;
-					if ( completed ) {
-						if ( !responseHeaders ) {
-							responseHeaders = {};
-							while ( ( match = rheaders.exec( responseHeadersString ) ) ) {
-								responseHeaders[ match[ 1 ].toLowerCase() ] = match[ 2 ];
-							}
-						}
-						match = responseHeaders[ key.toLowerCase() ];
-					}
-					return match == null ? null : match;
-				},
+		// Attach xhr capabilities
+		jQuery.extend( jqXHR, {
+			readyState: 0,
 
-				// Raw string
-				getAllResponseHeaders: function() {
-					return completed ? responseHeadersString : null;
-				},
-
-				// Caches the header
-				setRequestHeader: function( name, value ) {
-					if ( completed == null ) {
-						name = requestHeadersNames[ name.toLowerCase() ] =
-							requestHeadersNames[ name.toLowerCase() ] || name;
-						requestHeaders[ name ] = value;
-					}
-					return this;
-				},
-
-				// Overrides response content-type header
-				overrideMimeType: function( type ) {
-					if ( completed == null ) {
-						s.mimeType = type;
-					}
-					return this;
-				},
-
-				// Status-dependent callbacks
-				statusCode: function( map ) {
-					var code;
-					if ( map ) {
-						if ( completed ) {
-
-							// Execute the appropriate callbacks
-							jqXHR.always( map[ jqXHR.status ] );
-						} else {
-
-							// Lazy-add the new callbacks in a way that preserves old ones
-							for ( code in map ) {
-								statusCode[ code ] = [ statusCode[ code ], map[ code ] ];
-							}
+			// Builds headers hashtable if needed
+			getResponseHeader: function( key ) {
+				var match;
+				if ( completed ) {
+					if ( !responseHeaders ) {
+						responseHeaders = {};
+						while ( ( match = rheaders.exec( responseHeadersString ) ) ) {
+							responseHeaders[ match[ 1 ].toLowerCase() ] = match[ 2 ];
 						}
 					}
-					return this;
-				},
-
-				// Cancel the request
-				abort: function( statusText ) {
-					var finalText = statusText || strAbort;
-					if ( transport ) {
-						transport.abort( finalText );
-					}
-					done( 0, finalText );
-					return this;
+					match = responseHeaders[ key.toLowerCase() ];
 				}
-			};
+				return match == null ? null : match;
+			},
 
-		// Attach deferreds
-		deferred.promise( jqXHR );
+			// Raw string
+			getAllResponseHeaders: function() {
+				return completed ? responseHeadersString : null;
+			},
+
+			// Caches the header
+			setRequestHeader: function( name, value ) {
+				if ( completed == null ) {
+					name = requestHeadersNames[ name.toLowerCase() ] =
+						requestHeadersNames[ name.toLowerCase() ] || name;
+					requestHeaders[ name ] = value;
+				}
+				return this;
+			},
+
+			// Overrides response content-type header
+			overrideMimeType: function( type ) {
+				if ( completed == null ) {
+					s.mimeType = type;
+				}
+				return this;
+			},
+
+			// Status-dependent callbacks
+			statusCode: function( map ) {
+				var code;
+				if ( map ) {
+					if ( completed ) {
+
+						// Execute the appropriate callbacks
+						jqXHR.always( map[ jqXHR.status ] );
+					} else {
+
+						// Lazy-add the new callbacks in a way that preserves old ones
+						for ( code in map ) {
+							statusCode[ code ] = [ statusCode[ code ], map[ code ] ];
+						}
+					}
+				}
+				return this;
+			},
+
+			// Cancel the request
+			abort: function( statusText ) {
+				var finalText = statusText || strAbort;
+				if ( transport ) {
+					transport.abort( finalText );
+				}
+				done( 0, finalText );
+				return this;
+			}
+		} );
 
 		// Add protocol if not provided (prefilters might expect it)
 		// Handle falsy url in the settings object (#10093: consistency with old signature)

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -431,7 +431,7 @@ jQuery.extend( {
 					jQuery.event,
 
 			// Deferreds
-			deferred = jQuery.Deferred(),
+			deferred = new jQuery.Deferred(),
 			completeDeferred = jQuery.Callbacks( "once memory" ),
 
 			// Status-dependent callbacks
@@ -444,8 +444,8 @@ jQuery.extend( {
 			// Default abort message
 			strAbort = "canceled",
 
-			// Fake xhr (as a true Deferred instance)
-			jqXHR = deferred.promise();
+			// Fake xhr (ref the true Deferred instance above)
+			jqXHR = deferred;
 
 		// Attach xhr capabilities
 		jQuery.extend( jqXHR, {

--- a/src/deferred.js
+++ b/src/deferred.js
@@ -301,7 +301,7 @@ jQuery.extend( {
 		}
 
 		// All done!
-		return deferred;
+		return this === jQuery ? deferred : jQuery.extend( this, deferred );
 	},
 
 	// Deferred helper

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -1966,6 +1966,11 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 		};
 	} );
 
+	QUnit.test( "jQuery.ajax() returns jqXHR as an instance of jQuery.Deferred", function( assert ) {
+		assert.expect( 1 );
+		assert.ok( jQuery.ajax( "data/json_obj.js" ) instanceof jQuery.Deferred, "jqXHR should be an instance of jQuery.Deferred." );
+	} );
+
 //----------- jQuery.ajaxPrefilter()
 
 	ajaxTest( "jQuery.ajaxPrefilter() - abort", 1, function( assert ) {


### PR DESCRIPTION
So that `$.ajax() instanceof $.Deferred` will be True. This is to enable accurate async grouping (all-done-timing) based on the return object types of individual callbacks. Right now, the returned jqXHR object is of no class at all but does have full promise interfaces. Would like to suggest a class for it to enable a rigid type switching on callback queue returns, please consider. 

I am using 
```
//callback n 
{
   return $.ajax();
} 
```
then
```
result = callback();
if(result && result.done)
  ...
```
now for detecting a return of the jqXHR object.

Cheers,
Tim.