### PR TITLE
Update ajax.js

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -446,7 +446,7 @@ jQuery.extend( {
 
 			// Fake xhr
 			jqXHR = deferred.promise();
-			
+
 		// Attach deferreds
 		jQuery.extend( jqXHR, {
 			readyState: 0,

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -445,79 +445,79 @@ jQuery.extend( {
 			strAbort = "canceled",
 
 			// Fake xhr
-			jqXHR = {
-				readyState: 0,
-
-				// Builds headers hashtable if needed
-				getResponseHeader: function( key ) {
-					var match;
-					if ( completed ) {
-						if ( !responseHeaders ) {
-							responseHeaders = {};
-							while ( ( match = rheaders.exec( responseHeadersString ) ) ) {
-								responseHeaders[ match[ 1 ].toLowerCase() ] = match[ 2 ];
-							}
-						}
-						match = responseHeaders[ key.toLowerCase() ];
-					}
-					return match == null ? null : match;
-				},
-
-				// Raw string
-				getAllResponseHeaders: function() {
-					return completed ? responseHeadersString : null;
-				},
-
-				// Caches the header
-				setRequestHeader: function( name, value ) {
-					if ( completed == null ) {
-						name = requestHeadersNames[ name.toLowerCase() ] =
-							requestHeadersNames[ name.toLowerCase() ] || name;
-						requestHeaders[ name ] = value;
-					}
-					return this;
-				},
-
-				// Overrides response content-type header
-				overrideMimeType: function( type ) {
-					if ( completed == null ) {
-						s.mimeType = type;
-					}
-					return this;
-				},
-
-				// Status-dependent callbacks
-				statusCode: function( map ) {
-					var code;
-					if ( map ) {
-						if ( completed ) {
-
-							// Execute the appropriate callbacks
-							jqXHR.always( map[ jqXHR.status ] );
-						} else {
-
-							// Lazy-add the new callbacks in a way that preserves old ones
-							for ( code in map ) {
-								statusCode[ code ] = [ statusCode[ code ], map[ code ] ];
-							}
-						}
-					}
-					return this;
-				},
-
-				// Cancel the request
-				abort: function( statusText ) {
-					var finalText = statusText || strAbort;
-					if ( transport ) {
-						transport.abort( finalText );
-					}
-					done( 0, finalText );
-					return this;
-				}
-			};
-
+			jqXHR = deferred.promise();
+			
 		// Attach deferreds
-		deferred.promise( jqXHR );
+		jQuery.extend( jqXHR, {
+			readyState: 0,
+
+			// Builds headers hashtable if needed
+			getResponseHeader: function( key ) {
+				var match;
+				if ( completed ) {
+					if ( !responseHeaders ) {
+						responseHeaders = {};
+						while ( ( match = rheaders.exec( responseHeadersString ) ) ) {
+							responseHeaders[ match[ 1 ].toLowerCase() ] = match[ 2 ];
+						}
+					}
+					match = responseHeaders[ key.toLowerCase() ];
+				}
+				return match == null ? null : match;
+			},
+
+			// Raw string
+			getAllResponseHeaders: function() {
+				return completed ? responseHeadersString : null;
+			},
+
+			// Caches the header
+			setRequestHeader: function( name, value ) {
+				if ( completed == null ) {
+					name = requestHeadersNames[ name.toLowerCase() ] =
+						requestHeadersNames[ name.toLowerCase() ] || name;
+					requestHeaders[ name ] = value;
+				}
+				return this;
+			},
+
+			// Overrides response content-type header
+			overrideMimeType: function( type ) {
+				if ( completed == null ) {
+					s.mimeType = type;
+				}
+				return this;
+			},
+
+			// Status-dependent callbacks
+			statusCode: function( map ) {
+				var code;
+				if ( map ) {
+					if ( completed ) {
+
+						// Execute the appropriate callbacks
+						jqXHR.always( map[ jqXHR.status ] );
+					} else {
+
+						// Lazy-add the new callbacks in a way that preserves old ones
+						for ( code in map ) {
+							statusCode[ code ] = [ statusCode[ code ], map[ code ] ];
+						}
+					}
+				}
+				return this;
+			},
+
+			// Cancel the request
+			abort: function( statusText ) {
+				var finalText = statusText || strAbort;
+				if ( transport ) {
+					transport.abort( finalText );
+				}
+				done( 0, finalText );
+				return this;
+			}
+		} );
 
 		// Add protocol if not provided (prefilters might expect it)
 		// Handle falsy url in the settings object (#10093: consistency with old signature)

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -444,10 +444,10 @@ jQuery.extend( {
 			// Default abort message
 			strAbort = "canceled",
 
-			// Fake xhr
+			// Fake xhr (as a true Deferred instance)
 			jqXHR = deferred.promise();
 
-		// Attach deferreds
+		// Attach xhr capabilities
 		jQuery.extend( jqXHR, {
 			readyState: 0,
 


### PR DESCRIPTION
So that `$.ajax() instanceof $.Deferred` will be True. This is to enable accurate async grouping (all-done-timing) based on the return object types of individual callbacks. Right now, the returned jqXHR object is of no class at all but does have full promise interfaces. Would like to suggest a class for it to enable a rigid type switching on callback queue returns, please consider. 

I am using 
```
//callback n 
{
   return $.ajax();
} 
```
then
```
result = callback();
if(result && result.done)
  ...
```
now for detecting a return of the jqXHR object.

Cheers,
Tim.