### PR TITLE
Build: Strip excessive "use strict" pragmas when building

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -39,7 +39,10 @@ module.exports = function( grunt ) {
 			skipSemiColonInsertion: true,
 			wrap: {
 				start: wrapper[ 0 ].replace( /\/\*jshint .* \*\/\n/, "" ),
-				end: globals + wrapper[ 1 ]
+				end: globals.replace(
+					/\/\*\s*ExcludeStart\s*\*\/[\w\W]*?\/\*\s*ExcludeEnd\s*\*\//ig,
+					""
+				) + wrapper[ 1 ]
 			},
 			rawText: {},
 			onBuildWrite: convert

--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -81,7 +81,7 @@ module.exports = function( grunt ) {
 
 			// Remove define wrappers, closure ends, and empty declarations
 			contents = contents
-				.replace( /define\([^{]*?{/, "" )
+				.replace( /define\([^{]*?{\s*(?:("|')use strict\1(?:;|))?/, "" )
 				.replace( rdefineEnd, "" );
 
 			// Remove anything wrapped with

--- a/src/exports/global.js
+++ b/src/exports/global.js
@@ -1,6 +1,10 @@
+/* ExcludeStart */
+
 // This file is included in a different way from all the others
 // so the "use strict" pragma is not needed.
 /* jshint strict: false */
+
+/* ExcludeEnd */
 
 var
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

1. Strip excessive "use strict" pragmas when building (1st commit)
2. Strip the strict-mode related comment in exports/global.js (2nd commit)

Only the first commit is relevant to #3077, the second one was added mostly because it may reduce confusion and is also related to strict mode. If it's controversial, I may land only the first one.

### Checklist ###
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.

* [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
* [x] ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* [x] ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

Thanks! Bots and humans will be around shortly to check it out.
