### PR TITLE
Don't let .param() use jQuery.ajaxSettings.traditional

### DIFF
--- a/src/serialize.js
+++ b/src/serialize.js
@@ -68,11 +68,6 @@ jQuery.param = function( a, traditional ) {
 				encodeURIComponent( value == null ? "" : value );
 		};
 
-	// Set traditional to true for jQuery <= 1.3.2 behavior.
-	if ( traditional === undefined ) {
-		traditional = jQuery.ajaxSettings && jQuery.ajaxSettings.traditional;
-	}
-
 	// If an array was passed in, assume that it is an array of form elements.
 	if ( jQuery.isArray( a ) || ( a.jquery && !jQuery.isPlainObject( a ) ) ) {
 

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -373,6 +373,64 @@ QUnit.module( "ajax", {
 		];
 	} );
 
+	ajaxTest( "jQuery.ajax() - traditional param encoding", 4, function( assert ) {
+		return [
+			{
+				url: "/",
+				traditional: true,
+				data: {
+					"devo": "hat",
+					"answer": 42,
+					"quux": "a space"
+				},
+				beforeSend: function( xhr, settings ) {
+					assert.equal( settings.url, "/?devo=hat&answer=42&quux=a%20space", "Simple case" );
+					return false;
+				},
+				error: true
+			},
+			{
+				url: "/",
+				traditional: true,
+				data: {
+					"a": [ 1, 2, 3 ],
+					"b[]": [ "b1", "b2" ]
+				},
+				beforeSend: function( xhr, settings ) {
+					assert.equal( settings.url, "/?a=1&a=2&a=3&b%5B%5D=b1&b%5B%5D=b2", "Arrays" );
+					return false;
+				},
+				error: true
+			},
+			{
+				url: "/",
+				traditional: true,
+				data: {
+					"a": [ [ 1, 2 ], [ 3, 4 ], 5 ]
+				},
+				beforeSend: function( xhr, settings ) {
+					assert.equal( settings.url, "/?a=1%2C2&a=3%2C4&a=5", "Nested arrays" );
+					return false;
+				},
+				error: true
+			},
+			{
+				url: "/",
+				traditional: true,
+				data: {
+					"a": [ "w", [ [ "x", "y" ], "z" ] ]
+				},
+				cache: false,
+				beforeSend: function( xhr, settings ) {
+					var url = settings.url.replace( /\d{3,}/, "" );
+					assert.equal( url, "/?a=w&a=x%2Cy%2Cz&_=", "Cache-buster" );
+					return false;
+				},
+				error: true
+			}
+		];
+	} );
+
 	ajaxTest( "jQuery.ajax() - cross-domain detection", 8, function( assert ) {
 		function request( url, title, crossDomainOrOptions ) {
 			return jQuery.extend( {

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -56,7 +56,7 @@ QUnit.test( "jQuery.param()", function( assert ) {
 	assert.equal( jQuery.param( params, true ), "a=1&a=2&b=%5Bobject%20Object%5D&i=10&i=11&j=true&k=false&l=&l=0&m=cowboy%20hat%3F", "huge structure" );
 
 	params = { "a": [ 0, [ 1, 2 ], [ 3, [ 4, 5 ], [ 6 ] ], { "b": [ 7, [ 8, 9 ], [ { "c": 10, d: 11 } ], [ [ 12 ] ], [ [ [ 13 ] ] ], { "e": { "f": { "g": [ 14, [ 15 ] ] } } }, 16 ] }, 17 ] };
-	assert.equal( jQuery.param( params, true ), "a=0&a=1%2C2&a=3%2C4%2C5%2C6&a=%5Bobject%20Object%5D&a=17", "nested arrays (not possible when jQuery.param.traditional == true)" );
+	assert.equal( jQuery.param( params, true ), "a=0&a=1%2C2&a=3%2C4%2C5%2C6&a=%5Bobject%20Object%5D&a=17", "nested arrays (not possible when traditional == true)" );
 
 	params = { a:[ 1,2 ], b:{ c:3, d:[ 4,5 ], e:{ x:[ 6 ], y:7, z:[ 8,9 ] }, f:true, g:false, h:undefined }, i:[ 10,11 ], j:true, k:false, l:[ undefined,0 ], m:"cowboy hat?" };
 	assert.equal( decodeURIComponent( jQuery.param( params ) ), "a[]=1&a[]=2&b[c]=3&b[d][]=4&b[d][]=5&b[e][x][]=6&b[e][y]=7&b[e][z][]=8&b[e][z][]=9&b[f]=true&b[g]=false&b[h]=&i[]=10&i[]=11&j=true&k=false&l[]=&l[]=0&m=cowboy hat?", "huge structure, forced not traditional" );
@@ -72,6 +72,19 @@ QUnit.test( "jQuery.param()", function( assert ) {
 
 	params = { "test": [ 1, 2, null ] };
 	assert.equal( jQuery.param( params ), "test%5B%5D=1&test%5B%5D=2&test%5B%5D=", "object with array property with null value" );
+} );
+
+QUnit.test( "jQuery.param() not affected by ajaxSettings", function( assert ) {
+	assert.expect( 1 );
+
+	var oldTraditional = jQuery.ajaxSettings.traditional;
+	jQuery.ajaxSettings.traditional = true;
+	assert.equal(
+		jQuery.param( { "foo": [ "a", "b", "c" ] } ),
+		"foo%5B%5D=a&foo%5B%5D=b&foo%5B%5D=c",
+		"ajaxSettings.traditional is ignored"
+	);
+	jQuery.ajaxSettings.traditional = oldTraditional;
 } );
 
 QUnit.test( "jQuery.param() Constructed prop values", function( assert ) {

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -3,9 +3,7 @@ QUnit.module( "serialize", { teardown: moduleTeardown } );
 QUnit.test( "jQuery.param()", function( assert ) {
 	assert.expect( 24 );
 
-	var params, settings;
-
-	assert.equal( !( jQuery.ajaxSettings && jQuery.ajaxSettings.traditional ), true, "traditional flag, falsy by default" );
+	var params;
 
 	params = { "foo":"bar", "baz":42, "quux":"All your base are belong to us" };
 	assert.equal( jQuery.param( params ), "foo=bar&baz=42&quux=All%20your%20base%20are%20belong%20to%20us", "simple" );
@@ -39,55 +37,41 @@ QUnit.test( "jQuery.param()", function( assert ) {
 	// #7945
 	assert.equal( jQuery.param( { "jquery": "1.4.2" } ), "jquery=1.4.2", "Check that object with a jQuery property get serialized correctly" );
 
-	settings = { traditional: true };
-
-	if ( jQuery.ajaxSettings ) {
-		jQuery.ajaxSetup( settings );
-	} else {
-		jQuery.ajaxSettings = settings;
-	}
-
 	params = { "foo":"bar", "baz":42, "quux":"All your base are belong to us" };
-	assert.equal( jQuery.param( params ), "foo=bar&baz=42&quux=All%20your%20base%20are%20belong%20to%20us", "simple" );
+	assert.equal( jQuery.param( params, true ), "foo=bar&baz=42&quux=All%20your%20base%20are%20belong%20to%20us", "simple" );
 
 	params = { "someName": [ 1, 2, 3 ], "regularThing": "blah" };
-	assert.equal( jQuery.param( params ), "someName=1&someName=2&someName=3&regularThing=blah", "with array" );
+	assert.equal( jQuery.param( params, true ), "someName=1&someName=2&someName=3&regularThing=blah", "with array" );
 
 	params = { "foo": [ "a", "b", "c" ] };
-	assert.equal( jQuery.param( params ), "foo=a&foo=b&foo=c", "with array of strings" );
+	assert.equal( jQuery.param( params, true ), "foo=a&foo=b&foo=c", "with array of strings" );
 
 	params = { "foo[]":[ "baz", 42, "All your base are belong to us" ] };
-	assert.equal( jQuery.param( params ), "foo%5B%5D=baz&foo%5B%5D=42&foo%5B%5D=All%20your%20base%20are%20belong%20to%20us", "more array" );
+	assert.equal( jQuery.param( params, true ), "foo%5B%5D=baz&foo%5B%5D=42&foo%5B%5D=All%20your%20base%20are%20belong%20to%20us", "more array" );
 
 	params = { "foo[bar]":"baz", "foo[beep]":42, "foo[quux]":"All your base are belong to us" };
-	assert.equal( jQuery.param( params ), "foo%5Bbar%5D=baz&foo%5Bbeep%5D=42&foo%5Bquux%5D=All%20your%20base%20are%20belong%20to%20us", "even more arrays" );
+	assert.equal( jQuery.param( params, true ), "foo%5Bbar%5D=baz&foo%5Bbeep%5D=42&foo%5Bquux%5D=All%20your%20base%20are%20belong%20to%20us", "even more arrays" );
 
 	params = { a:[ 1,2 ], b:{ c:3, d:[ 4,5 ], e:{ x:[ 6 ], y:7, z:[ 8,9 ] }, f:true, g:false, h:undefined }, i:[ 10,11 ], j:true, k:false, l:[ undefined,0 ], m:"cowboy hat?" };
-	assert.equal( jQuery.param( params ), "a=1&a=2&b=%5Bobject%20Object%5D&i=10&i=11&j=true&k=false&l=&l=0&m=cowboy%20hat%3F", "huge structure" );
+	assert.equal( jQuery.param( params, true ), "a=1&a=2&b=%5Bobject%20Object%5D&i=10&i=11&j=true&k=false&l=&l=0&m=cowboy%20hat%3F", "huge structure" );
 
 	params = { "a": [ 0, [ 1, 2 ], [ 3, [ 4, 5 ], [ 6 ] ], { "b": [ 7, [ 8, 9 ], [ { "c": 10, d: 11 } ], [ [ 12 ] ], [ [ [ 13 ] ] ], { "e": { "f": { "g": [ 14, [ 15 ] ] } } }, 16 ] }, 17 ] };
-	assert.equal( jQuery.param( params ), "a=0&a=1%2C2&a=3%2C4%2C5%2C6&a=%5Bobject%20Object%5D&a=17", "nested arrays (not possible when jQuery.param.traditional == true)" );
+	assert.equal( jQuery.param( params, true ), "a=0&a=1%2C2&a=3%2C4%2C5%2C6&a=%5Bobject%20Object%5D&a=17", "nested arrays (not possible when jQuery.param.traditional == true)" );
 
 	params = { a:[ 1,2 ], b:{ c:3, d:[ 4,5 ], e:{ x:[ 6 ], y:7, z:[ 8,9 ] }, f:true, g:false, h:undefined }, i:[ 10,11 ], j:true, k:false, l:[ undefined,0 ], m:"cowboy hat?" };
-	assert.equal( decodeURIComponent( jQuery.param( params, false ) ), "a[]=1&a[]=2&b[c]=3&b[d][]=4&b[d][]=5&b[e][x][]=6&b[e][y]=7&b[e][z][]=8&b[e][z][]=9&b[f]=true&b[g]=false&b[h]=&i[]=10&i[]=11&j=true&k=false&l[]=&l[]=0&m=cowboy hat?", "huge structure, forced not traditional" );
+	assert.equal( decodeURIComponent( jQuery.param( params ) ), "a[]=1&a[]=2&b[c]=3&b[d][]=4&b[d][]=5&b[e][x][]=6&b[e][y]=7&b[e][z][]=8&b[e][z][]=9&b[f]=true&b[g]=false&b[h]=&i[]=10&i[]=11&j=true&k=false&l[]=&l[]=0&m=cowboy hat?", "huge structure, forced not traditional" );
 
 	params = { "param1": null };
-	assert.equal( jQuery.param( params, false ), "param1=", "Make sure that null params aren't traversed." );
+	assert.equal( jQuery.param( params ), "param1=", "Make sure that null params aren't traversed." );
 
 	params = { "param1": function() {}, "param2": function() { return null; } };
 	assert.equal( jQuery.param( params, false ), "param1=&param2=", "object with function property that returns null value" );
 
 	params = { "test": { "length": 3, "foo": "bar" } };
-	assert.equal( jQuery.param( params, false ), "test%5Blength%5D=3&test%5Bfoo%5D=bar", "Sub-object with a length property" );
+	assert.equal( jQuery.param( params ), "test%5Blength%5D=3&test%5Bfoo%5D=bar", "Sub-object with a length property" );
 
 	params = { "test": [ 1, 2, null ] };
-	assert.equal( jQuery.param( params, false ), "test%5B%5D=1&test%5B%5D=2&test%5B%5D=", "object with array property with null value" );
-
-	if ( jQuery.ajaxSettings === settings ) {
-		delete jQuery.ajaxSettings;
-	} else {
-		jQuery.ajaxSetup( { traditional: false } );
-	}
+	assert.equal( jQuery.param( params ), "test%5B%5D=1&test%5B%5D=2&test%5B%5D=", "object with array property with null value" );
 } );
 
 QUnit.test( "jQuery.param() Constructed prop values", function( assert ) {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
This PR incorporates the changes in gh-3030 and adds unit tests to ensure no regressions in `$.ajax()`. 

### Checklist ###
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.

* [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

https://github.com/jquery/api.jquery.com/issues/919
