### PR TITLE
Deferred: Provide explicit undefined context for jQuery.when raw casts

### DIFF
--- a/src/deferred.js
+++ b/src/deferred.js
@@ -354,7 +354,10 @@ jQuery.extend( {
 						master.reject
 					);
 				} else {
-					updateFunc( i )( resolveValues[ i ] );
+
+					// Support: Android 4.0 only
+					// Strict mode functions invoked without .call/.apply get global-object context
+					updateFunc( i ).call( undefined, resolveValues[ i ] );
 				}
 			}
 

--- a/test/unit/deferred.js
+++ b/test/unit/deferred.js
@@ -843,7 +843,10 @@ QUnit.test( "jQuery.when - joined", function( assert ) {
 			rejectedStandardPromise: true
 		},
 		counter = 49,
-		expectedContext = (function() { "use strict"; return this; })();
+
+		// Support: Android 4.0 only
+		// Strict mode functions invoked without .call/.apply get global-object context
+		expectedContext = (function() { "use strict"; return this; }).call();
 
 	QUnit.stop();
 


### PR DESCRIPTION
Fixes gh-3082

```
   raw     gz Sizes                                                            
263382  78291 dist/jquery.js                                                   
 86185  29974 dist/jquery.min.js                                               

   raw     gz Compared to master @ 9f268caaf43629addb9a1a2001ab341839300b14    
  +136    +49 dist/jquery.js                                                   
   +13     +9 dist/jquery.min.js
```