### PR TITLE
Ajax: Make traditional flag explicitly false in options

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -306,6 +306,10 @@ jQuery.extend( {
 		processData: true,
 		async: true,
 		contentType: "application/x-www-form-urlencoded; charset=UTF-8",
+
+		// Make traditional explicit so Migrate can warn about the implicit case
+		traditional: false,
+
 		/*
 		timeout: 0,
 		data: null,
@@ -314,7 +318,6 @@ jQuery.extend( {
 		password: null,
 		cache: null,
 		throws: false,
-		traditional: false,
 		headers: {},
 		*/
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
See https://github.com/jquery/jquery-migrate/issues/173

This allows Migrate to detect cases where traditional is not specified to
jQuery.param() but jQuery.ajaxSettings.traditional is set to true.

### Checklist ###
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.

* [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
* [ ] ~~New tests have been added to show the fix or feature works~~
 - (New tests will be added in Migrate)
* [x] Grunt build and unit tests pass locally with these changes
* [ ] ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

Thanks! Bots and humans will be around shortly to check it out.
