### PR TITLE
Offset: Operate "relative to document" correctly

### DIFF
--- a/src/offset.js
+++ b/src/offset.js
@@ -86,7 +86,7 @@ jQuery.fn.extend( {
 				} );
 		}
 
-		var docElem, win, rect, doc,
+		var win, rect,
 			elem = this[ 0 ];
 
 		if ( !elem ) {
@@ -104,13 +104,11 @@ jQuery.fn.extend( {
 
 		// Make sure element is not hidden (display: none)
 		if ( rect.width || rect.height ) {
-			doc = elem.ownerDocument;
-			win = getWindow( doc );
-			docElem = doc.documentElement;
+			win = getWindow( elem.ownerDocument );
 
 			return {
-				top: rect.top + win.pageYOffset - docElem.clientTop,
-				left: rect.left + win.pageXOffset - docElem.clientLeft
+				top: rect.top + win.pageYOffset,
+				left: rect.left + win.pageXOffset
 			};
 		}
 

--- a/test/data/offset/rel-doc.html
+++ b/test/data/offset/rel-doc.html
@@ -5,35 +5,10 @@
 		<meta http-equiv="Content-type" content="text/html; charset=utf-8">
 		<title>body</title>
 		<style type="text/css" media="screen">
-			html, body { border: solid maroon; } /* for human */
-			html { background-color: green; } /* for human */
-			body { background-color: yellow; } /* for human */
-			#static { background-color: blue; } /* for human */
-			#absolute { background-color: aqua; } /* for human */
-			#child-static { background-color: darkviolet; } /* for human */
-			#child-absolute { background-color: violet; } /* for human */
-			html {
-				margin: 1px;
-				border-width: 2px;
-				padding: 4px;
-			}
-			body {
-				margin: 8px;
-				border-width: 16px;
-				padding: 32px;
-			}
-			#absolute {
-				position: absolute;
-				top: 64px;
-				left: 64px;
-			}
-			#parent { position: relative; }
-			#child-absolute {
-				position: absolute;
-				/* Specific coordinates for avoiding bug of `.position()` */
-				top: 0;
-				left: 0;
-			}
+			html { font-size: 10px; margin: 1em; border: 2em solid red; padding: 4em; }
+			body { margin: 8em; border: 16em solid blue; padding: 32em; }
+			#static { position: static; }
+			#absolute { position: absolute; top: 2em; left: 2em; }
 		</style>
 		<script src="../../jquery.js"></script>
 		<script src="../iframeTest.js"></script>
@@ -46,9 +21,5 @@
 	<body>
 		<div id="static">static</div>
 		<div id="absolute">absolute</div>
-		<div id="parent">
-			<div id="child-static">child-static</div>
-			<div id="child-absolute">child-absolute</div>
-		</div>
 	</body>
 </html>

--- a/test/data/offset/rel-doc.html
+++ b/test/data/offset/rel-doc.html
@@ -5,11 +5,35 @@
 		<meta http-equiv="Content-type" content="text/html; charset=utf-8">
 		<title>body</title>
 		<style type="text/css" media="screen">
-			html, body { border: solid red; }
-			html { background-color: green; }
-			body { background-color: yellow; }
-			#marker1 { background-color: blue; }
-			#marker2 { background-color: orange; position: absolute; }
+			html, body { border: solid maroon; } /* for human */
+			html { background-color: green; } /* for human */
+			body { background-color: yellow; } /* for human */
+			#static { background-color: blue; } /* for human */
+			#absolute { background-color: aqua; } /* for human */
+			#child-static { background-color: darkviolet; } /* for human */
+			#child-absolute { background-color: violet; } /* for human */
+			html {
+				margin: 1px;
+				border-width: 2px;
+				padding: 4px;
+			}
+			body {
+				margin: 8px;
+				border-width: 16px;
+				padding: 32px;
+			}
+			#absolute {
+				position: absolute;
+				top: 64px;
+				left: 64px;
+			}
+			#parent { position: relative; }
+			#child-absolute {
+				position: absolute;
+				/* Specific coordinates for avoiding bug of `.position()` */
+				top: 0;
+				left: 0;
+			}
 		</style>
 		<script src="../../jquery.js"></script>
 		<script src="../iframeTest.js"></script>
@@ -20,7 +44,11 @@
 		</script>
 	</head>
 	<body>
-		<div id="marker1">marker1</div>
-		<div id="marker2">marker2</div>
+		<div id="static">static</div>
+		<div id="absolute">absolute</div>
+		<div id="parent">
+			<div id="child-static">child-static</div>
+			<div id="child-absolute">child-absolute</div>
+		</div>
 	</body>
 </html>

--- a/test/data/offset/rel-doc.html
+++ b/test/data/offset/rel-doc.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+	<head>
+		<meta http-equiv="Content-type" content="text/html; charset=utf-8">
+		<title>body</title>
+		<style type="text/css" media="screen">
+			html, body { border: solid red; }
+			html { background-color: green; }
+			body { background-color: yellow; }
+			#marker1 { background-color: blue; }
+			#marker2 { background-color: orange; position: absolute; }
+		</style>
+		<script src="../../jquery.js"></script>
+		<script src="../iframeTest.js"></script>
+		<script type="text/javascript" charset="utf-8">
+			jQuery(function() {
+				startIframeTest();
+			});
+		</script>
+	</head>
+	<body>
+		<div id="marker1">marker1</div>
+		<div id="marker2">marker2</div>
+	</body>
+</html>

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -594,90 +594,90 @@ testIframe( "coordinates relative to document", "offset/rel-doc.html", function(
 		FLAG_BODY_BORDER = 16,
 		FLAG_BODY_PADDING = 32;
 
-		// Test it in each situation that is made by combined properties.
-		function situations( affect, markerTopLeft, exBodyPadding, messageHead ) {
-			var flags, offset1, offset2, sumLen, labels, labelsInMessage;
+	// Test it in each situation that is made by combined properties.
+	function situations( affect, markerTopLeft, exBodyPadding, messageHead ) {
+		var flags, offset1, offset2, sumLen, labels, labelsInMessage;
 
-			function switchProp( elem, enable, styleProp, pixels, label ) {
-				if ( enable ) {
-					elem.style[ styleProp ] = pixels + "px";
-					if ( !exBodyPadding || elem !== bodyElem || styleProp !== "padding" ) {
-						sumLen += pixels;
-					}
-					labels.push( label );
-				} else {
-					elem.style[ styleProp ] = "0";
+		function switchProp( elem, enable, styleProp, pixels, label ) {
+			if ( enable ) {
+				elem.style[ styleProp ] = pixels + "px";
+				if ( !exBodyPadding || elem !== bodyElem || styleProp !== "padding" ) {
+					sumLen += pixels;
 				}
-			}
-
-			for ( flags = 0;
-					flags <= ( FLAG_DOC_MARGIN | FLAG_DOC_BORDER | FLAG_DOC_PADDING | FLAG_BODY_MARGIN | FLAG_BODY_BORDER | FLAG_BODY_PADDING );
-					flags++ ) {
-
-				sumLen = 0;
-				labels = [];
-
-				switchProp( docElem, flags & FLAG_DOC_MARGIN, "margin", DOC_MARGIN, "[document-margin]" );
-				switchProp( docElem, flags & FLAG_DOC_BORDER, "borderWidth", DOC_BORDER, "[document-border]" );
-				switchProp( docElem, flags & FLAG_DOC_PADDING, "padding", DOC_PADDING, "[document-padding]" );
-				switchProp( bodyElem, flags & FLAG_BODY_MARGIN, "margin", BODY_MARGIN, "[body-margin]" );
-				switchProp( bodyElem, flags & FLAG_BODY_BORDER, "borderWidth", BODY_BORDER, "[body-border]" );
-				switchProp( bodyElem, flags & FLAG_BODY_PADDING, "padding", BODY_PADDING, "[body-padding]" );
-
-				offset1 = $marker1.offset();
-				// If getter works correctly, the returned values can be compared with result of setter.
-				offset2 = $marker2.offset( offset1 ).offset(); // Set and Get
-
-				labelsInMessage = " - Enabled Properties: " + ( labels.length ? labels.join( ", " ) : "none" );
-				if ( affect ) {
-					assert.equal( offset1.top, markerTopLeft + sumLen, messageHead + " - Get `top` (affected)" + labelsInMessage );
-					assert.equal( offset1.left, markerTopLeft + sumLen, messageHead + " - Get `left` (affected)" + labelsInMessage );
-					assert.equal( offset2.top, markerTopLeft + sumLen, messageHead + " - Get-Set-Get `top` (affected)" + labelsInMessage );
-					assert.equal( offset2.left, markerTopLeft + sumLen, messageHead + " - Get-Set-Get `left` (affected)" + labelsInMessage );
-				} else {
-					assert.equal( offset1.top, markerTopLeft, messageHead + " - Get `top` (NOT affected)" + labelsInMessage );
-					assert.equal( offset1.left, markerTopLeft, messageHead + " - Get `left` (NOT affected)" + labelsInMessage );
-					assert.equal( offset2.top, markerTopLeft, messageHead + " - Get-Set-Get `top` (NOT affected)" + labelsInMessage );
-					assert.equal( offset2.left, markerTopLeft, messageHead + " - Get-Set-Get `left` (NOT affected)" + labelsInMessage );
-				}
+				labels.push( label );
+			} else {
+				elem.style[ styleProp ] = "0";
 			}
 		}
 
-		// ================ CASE 1
-		// When `body` has `position:static` and `marker1` has `position:absolute`,
-		// `marker1` is positioned relative to the initial container (i.e. <html>).
-		// https://developer.mozilla.org/en-US/docs/Web/CSS/position#Absolute_positioning
-		// Therefore, `top` and `left` of `marker1` must be `MARKER_LEFT_TOP` without being affected by
-		// `margin`, `border` and `padding` of document and `body`.
+		for ( flags = 0;
+				flags <= ( FLAG_DOC_MARGIN | FLAG_DOC_BORDER | FLAG_DOC_PADDING | FLAG_BODY_MARGIN | FLAG_BODY_BORDER | FLAG_BODY_PADDING );
+				flags++ ) {
 
-		bodyElem.style.position = "static";
-		marker1.style.position = "absolute";
-		marker1.style.top = MARKER_TOP_LEFT + "px";
-		marker1.style.left = MARKER_TOP_LEFT + "px";
-		situations( false, MARKER_TOP_LEFT, false, "body{position:static}" );
+			sumLen = 0;
+			labels = [];
 
-		// ================ CASE 2
-		// When `body` has `position:(non-static)` and `marker1` has `position:absolute`,
-		// `marker1` is positioned relative to `body`.
-		// Therefore, `top` and `left` of `marker1` must be `MARKER_LEFT_TOP` added
-		// `margin` and `border` of document and `body`, and `padding` of document.
+			switchProp( docElem, flags & FLAG_DOC_MARGIN, "margin", DOC_MARGIN, "[document-margin]" );
+			switchProp( docElem, flags & FLAG_DOC_BORDER, "borderWidth", DOC_BORDER, "[document-border]" );
+			switchProp( docElem, flags & FLAG_DOC_PADDING, "padding", DOC_PADDING, "[document-padding]" );
+			switchProp( bodyElem, flags & FLAG_BODY_MARGIN, "margin", BODY_MARGIN, "[body-margin]" );
+			switchProp( bodyElem, flags & FLAG_BODY_BORDER, "borderWidth", BODY_BORDER, "[body-border]" );
+			switchProp( bodyElem, flags & FLAG_BODY_PADDING, "padding", BODY_PADDING, "[body-padding]" );
 
-		bodyElem.style.position = "relative";
-		marker1.style.position = "absolute";
-		marker1.style.top = MARKER_TOP_LEFT + "px";
-		marker1.style.left = MARKER_TOP_LEFT + "px";
-		situations( true, MARKER_TOP_LEFT, true, "body{position:relative}" );
+			offset1 = $marker1.offset();
+			// If getter works correctly, the returned values can be compared with result of setter.
+			offset2 = $marker2.offset( offset1 ).offset(); // Set and Get
 
-		// ================ CASE 3
-		// When `marker1` has `position:static`, `marker1` is laid out in its current position in the flow.
-		// Therefore, `top` and `left` of `marker1` must be sum of
-		// `margin`, `border` and `padding` of document and `body`.
+			labelsInMessage = " - Enabled Properties: " + ( labels.length ? labels.join( ", " ) : "none" );
+			if ( affect ) {
+				assert.equal( offset1.top, markerTopLeft + sumLen, messageHead + " - Get `top` (affected)" + labelsInMessage );
+				assert.equal( offset1.left, markerTopLeft + sumLen, messageHead + " - Get `left` (affected)" + labelsInMessage );
+				assert.equal( offset2.top, markerTopLeft + sumLen, messageHead + " - Get-Set-Get `top` (affected)" + labelsInMessage );
+				assert.equal( offset2.left, markerTopLeft + sumLen, messageHead + " - Get-Set-Get `left` (affected)" + labelsInMessage );
+			} else {
+				assert.equal( offset1.top, markerTopLeft, messageHead + " - Get `top` (NOT affected)" + labelsInMessage );
+				assert.equal( offset1.left, markerTopLeft, messageHead + " - Get `left` (NOT affected)" + labelsInMessage );
+				assert.equal( offset2.top, markerTopLeft, messageHead + " - Get-Set-Get `top` (NOT affected)" + labelsInMessage );
+				assert.equal( offset2.left, markerTopLeft, messageHead + " - Get-Set-Get `left` (NOT affected)" + labelsInMessage );
+			}
+		}
+	}
 
-		bodyElem.style.position = "static";
-		marker1.style.position = "static";
-		marker1.style.top = "";
-		marker1.style.left = "";
-		situations( true, 0, false, "marker1{position:static}" );
+	// ================ CASE 1
+	// When `body` has `position:static` and `marker1` has `position:absolute`,
+	// `marker1` is positioned relative to the initial container (i.e. <html>).
+	// https://developer.mozilla.org/en-US/docs/Web/CSS/position#Absolute_positioning
+	// Therefore, `top` and `left` of `marker1` must be `MARKER_LEFT_TOP` without being affected by
+	// `margin`, `border` and `padding` of document and `body`.
+
+	bodyElem.style.position = "static";
+	marker1.style.position = "absolute";
+	marker1.style.top = MARKER_TOP_LEFT + "px";
+	marker1.style.left = MARKER_TOP_LEFT + "px";
+	situations( false, MARKER_TOP_LEFT, false, "body{position:static}" );
+
+	// ================ CASE 2
+	// When `body` has `position:(non-static)` and `marker1` has `position:absolute`,
+	// `marker1` is positioned relative to `body`.
+	// Therefore, `top` and `left` of `marker1` must be `MARKER_LEFT_TOP` added
+	// `margin` and `border` of document and `body`, and `padding` of document.
+
+	bodyElem.style.position = "relative";
+	marker1.style.position = "absolute";
+	marker1.style.top = MARKER_TOP_LEFT + "px";
+	marker1.style.left = MARKER_TOP_LEFT + "px";
+	situations( true, MARKER_TOP_LEFT, true, "body{position:relative}" );
+
+	// ================ CASE 3
+	// When `marker1` has `position:static`, `marker1` is laid out in its current position in the flow.
+	// Therefore, `top` and `left` of `marker1` must be sum of
+	// `margin`, `border` and `padding` of document and `body`.
+
+	bodyElem.style.position = "static";
+	marker1.style.position = "static";
+	marker1.style.top = "";
+	marker1.style.left = "";
+	situations( true, 0, false, "marker1{position:static}" );
 
 } );
 

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -568,4 +568,117 @@ QUnit.test( "iframe scrollTop/Left (see gh-1945)", function( assert ) {
 	}
 } );
 
+testIframe( "coordinates relative to document", "offset/rel-doc.html", function( assert, $, iframe, doc ) {
+	assert.expect( 768 );
+
+	var docElem = doc.documentElement, // <html> element
+		bodyElem = doc.body,
+		marker1 = doc.getElementById( "marker1" ),
+		marker2 = doc.getElementById( "marker2" ),
+		$marker1 = $( marker1 ),
+		$marker2 = $( marker2 ),
+
+		// Pixels
+		DOC_MARGIN = 1,
+		DOC_BORDER = 2,
+		DOC_PADDING = 4,
+		BODY_MARGIN = 8,
+		BODY_BORDER = 16,
+		BODY_PADDING = 32,
+		MARKER_TOP_LEFT = 64,
+		// Bit as Flag
+		FLAG_DOC_MARGIN = 1,
+		FLAG_DOC_BORDER = 2,
+		FLAG_DOC_PADDING = 4,
+		FLAG_BODY_MARGIN = 8,
+		FLAG_BODY_BORDER = 16,
+		FLAG_BODY_PADDING = 32;
+
+		// Test it in each situation that is made by combined properties.
+		function situations( affect, markerTopLeft, exBodyPadding, messageHead ) {
+			var flags, offset1, offset2, sumLen, labels, labelsInMessage;
+
+			function switchProp( elem, enable, styleProp, pixels, label ) {
+				if ( enable ) {
+					elem.style[ styleProp ] = pixels + "px";
+					if ( !exBodyPadding || elem !== bodyElem || styleProp !== "padding" ) {
+						sumLen += pixels;
+					}
+					labels.push( label );
+				} else {
+					elem.style[ styleProp ] = "0";
+				}
+			}
+
+			for ( flags = 0;
+					flags <= ( FLAG_DOC_MARGIN | FLAG_DOC_BORDER | FLAG_DOC_PADDING | FLAG_BODY_MARGIN | FLAG_BODY_BORDER | FLAG_BODY_PADDING );
+					flags++ ) {
+
+				sumLen = 0;
+				labels = [];
+
+				switchProp( docElem, flags & FLAG_DOC_MARGIN, "margin", DOC_MARGIN, "[document-margin]" );
+				switchProp( docElem, flags & FLAG_DOC_BORDER, "borderWidth", DOC_BORDER, "[document-border]" );
+				switchProp( docElem, flags & FLAG_DOC_PADDING, "padding", DOC_PADDING, "[document-padding]" );
+				switchProp( bodyElem, flags & FLAG_BODY_MARGIN, "margin", BODY_MARGIN, "[body-margin]" );
+				switchProp( bodyElem, flags & FLAG_BODY_BORDER, "borderWidth", BODY_BORDER, "[body-border]" );
+				switchProp( bodyElem, flags & FLAG_BODY_PADDING, "padding", BODY_PADDING, "[body-padding]" );
+
+				offset1 = $marker1.offset();
+				// If getter works correctly, the returned values can be compared with result of setter.
+				offset2 = $marker2.offset( offset1 ).offset(); // Set and Get
+
+				labelsInMessage = " - Enabled Properties: " + ( labels.length ? labels.join( ", " ) : "none" );
+				if ( affect ) {
+					assert.equal( offset1.top, markerTopLeft + sumLen, messageHead + " - Get `top` (affected)" + labelsInMessage );
+					assert.equal( offset1.left, markerTopLeft + sumLen, messageHead + " - Get `left` (affected)" + labelsInMessage );
+					assert.equal( offset2.top, markerTopLeft + sumLen, messageHead + " - Get-Set-Get `top` (affected)" + labelsInMessage );
+					assert.equal( offset2.left, markerTopLeft + sumLen, messageHead + " - Get-Set-Get `left` (affected)" + labelsInMessage );
+				} else {
+					assert.equal( offset1.top, markerTopLeft, messageHead + " - Get `top` (NOT affected)" + labelsInMessage );
+					assert.equal( offset1.left, markerTopLeft, messageHead + " - Get `left` (NOT affected)" + labelsInMessage );
+					assert.equal( offset2.top, markerTopLeft, messageHead + " - Get-Set-Get `top` (NOT affected)" + labelsInMessage );
+					assert.equal( offset2.left, markerTopLeft, messageHead + " - Get-Set-Get `left` (NOT affected)" + labelsInMessage );
+				}
+			}
+		}
+
+		// ================ CASE 1
+		// When `body` has `position:static` and `marker1` has `position:absolute`,
+		// `marker1` is positioned relative to the initial container (i.e. <html>).
+		// https://developer.mozilla.org/en-US/docs/Web/CSS/position#Absolute_positioning
+		// Therefore, `top` and `left` of `marker1` must be `MARKER_LEFT_TOP` without being affected by
+		// `margin`, `border` and `padding` of document and `body`.
+
+		bodyElem.style.position = "static";
+		marker1.style.position = "absolute";
+		marker1.style.top = MARKER_TOP_LEFT + "px";
+		marker1.style.left = MARKER_TOP_LEFT + "px";
+		situations( false, MARKER_TOP_LEFT, false, "body{position:static}" );
+
+		// ================ CASE 2
+		// When `body` has `position:(non-static)` and `marker1` has `position:absolute`,
+		// `marker1` is positioned relative to `body`.
+		// Therefore, `top` and `left` of `marker1` must be `MARKER_LEFT_TOP` added
+		// `margin` and `border` of document and `body`, and `padding` of document.
+
+		bodyElem.style.position = "relative";
+		marker1.style.position = "absolute";
+		marker1.style.top = MARKER_TOP_LEFT + "px";
+		marker1.style.left = MARKER_TOP_LEFT + "px";
+		situations( true, MARKER_TOP_LEFT, true, "body{position:relative}" );
+
+		// ================ CASE 3
+		// When `marker1` has `position:static`, `marker1` is laid out in its current position in the flow.
+		// Therefore, `top` and `left` of `marker1` must be sum of
+		// `margin`, `border` and `padding` of document and `body`.
+
+		bodyElem.style.position = "static";
+		marker1.style.position = "static";
+		marker1.style.top = "";
+		marker1.style.left = "";
+		situations( true, 0, false, "marker1{position:static}" );
+
+} );
+
 } )();

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -604,6 +604,12 @@ QUnit.test( "iframe scrollTop/Left (see gh-1945)", function( assert ) {
 						BODY_BORDER = 16,
 						BODY_PADDING = 32,
 						MARKER_TOP_LEFT = 64;
+						// These are also each bit in the difference between an expected value and a result
+						// value when the test failed.
+						// For example, when an expected value is 16 and a result value is 34,
+						// document-border (`(34 - 16) & DOC_BORDER`) and body-border (`(34 - 16) & BODY_BORDER`)
+						// were got incorrectly.
+
 
 					// Test it in each situation that is made by combined box-properties.
 					function testWithBoxProps( affectProps, markerTopLeft ) {


### PR DESCRIPTION
### Summary

Fix: `.offset()` doesn't operate "relative to document" correctly
### Checklist

Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
- [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
- [x] New tests have been added to show the fix or feature works
- [x] Grunt build and unit tests pass locally with these changes
- [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

Thanks! Bots and humans will be around shortly to check it out.

Related to: #3080
Remove unnecessary code that subtracts
`document.documentElement.clientTop/clientLeft` (i.e. `border-width` of
`<html>`) from coordinates.
In Firefox, those are not subtracted because `clientTop/clientLeft` are
`0` always by accidentally bug.
