### PR TITLE
Event: evaluate selector at add time

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -120,6 +120,11 @@ jQuery.event = {
 			selector = handleObjIn.selector;
 		}
 
+		// If the selector is invalid, throw any exceptions at attach time
+		if ( selector ) {
+			jQuery.find( selector, elem );
+		}
+
 		// Make sure that the handler has a unique ID, used to find/remove it later
 		if ( !handler.guid ) {
 			handler.guid = jQuery.guid++;

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -1291,21 +1291,13 @@ QUnit.test( "Delegated events in SVG (#10791; #13180)", function( assert ) {
 
 QUnit.test( "Delegated events with malformed selectors (#3071)", function( assert ) {
 	assert.expect( 2 );
-	try {
-		jQuery( "#qunit-fixture" ).on( "click", "div:not", function () { } );
-		assert.ok( false, "malformed selector throws on attach" );
-	}
-	catch ( e ) {
-		assert.ok( true, "malformed selector throws on attach" );
-	}
 
-	try {
-		jQuery( "#qunit-fixture" ).click();
-		assert.ok( true, "malformed selector does not throw on event" );
-	}
-	catch ( e ) {
-		assert.ok( false, "malformed selector does not throw on event" );
-	}
+	assert.throws( function () {
+		jQuery( "#qunit-fixture" ).on( "click", "div:not", function () { } );
+	}, null, "malformed selector throws on attach" );
+
+	jQuery( "#qunit-fixture" ).click();
+	assert.ok( true, "malformed selector does not throw on event" );
 
 	jQuery( "#qunit-fixture" ).off( "click" );
 } );

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -1289,6 +1289,27 @@ QUnit.test( "Delegated events in SVG (#10791; #13180)", function( assert ) {
 	jQuery( "#qunit-fixture" ).off( "click" );
 } );
 
+QUnit.test( "Delegated events with malformed selectors (#3071)", function( assert ) {
+	assert.expect( 2 );
+	try {
+		jQuery( "#qunit-fixture" ).on( "click", "div:not", function () { } );
+		assert.ok( false, "malformed selector throws on attach" );
+	}
+	catch ( e ) {
+		assert.ok( true, "malformed selector throws on attach" );
+	}
+
+	try {
+		jQuery( "#qunit-fixture" ).click();
+		assert.ok( true, "malformed selector does not throw on event" );
+	}
+	catch ( e ) {
+		assert.ok( false, "malformed selector does not throw on event" );
+	}
+
+	jQuery( "#qunit-fixture" ).off( "click" );
+} );
+
 QUnit.test( "Delegated events in forms (#10844; #11145; #8165; #11382, #11764)", function( assert ) {
 	assert.expect( 5 );
 


### PR DESCRIPTION
### Summary ###

This ensures events with invalid selectors throw at attach time instead
of event time. This is done by instantiating a Sizzle for the selector.

`jQuery.find()` is used instead of `jQuery.find.matchesSelector` (as suggested in https://github.com/jquery/jquery/issues/3071#issuecomment-213254660) , because `matchesSelector` requires a `DOMElement`, which won't be if the element is actually document.

Fixes: #3071 

### Checklist ###
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.

* [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

Thanks! Bots and humans will be around shortly to check it out.
