### PR TITLE
Event: Remove pageX/pageY fill for event object

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -592,6 +592,8 @@ jQuery.each( {
 	detail: true,
 	eventPhase: true,
 	metaKey: true,
+	pageX: true,
+	pageY: true,
 	shiftKey: true,
 	view: true,
 	"char": true,
@@ -622,40 +624,6 @@ jQuery.each( {
 		}
 
 		return event.which;
-	},
-
-	pageX: function( event ) {
-		var eventDoc, doc, body;
-
-		// Calculate pageX if missing and clientX available
-		if ( event.pageX == null && event.clientX != null ) {
-			eventDoc = event.target.ownerDocument || document;
-			doc = eventDoc.documentElement;
-			body = eventDoc.body;
-
-			return event.clientX +
-				( doc && doc.scrollLeft || body && body.scrollLeft || 0 ) -
-				( doc && doc.clientLeft || body && body.clientLeft || 0 );
-		}
-
-		return event.pageX;
-	},
-
-	pageY: function( event ) {
-		var eventDoc, doc, body;
-
-		// Calculate pageY if missing and clientY available
-		if ( event.pageY == null && event.clientY != null ) {
-			eventDoc = event.target.ownerDocument || document;
-			doc = eventDoc.documentElement;
-			body = eventDoc.body;
-
-			return event.clientY +
-				( doc && doc.scrollTop || body && body.scrollTop || 0 ) -
-				( doc && doc.clientTop || body && body.clientTop || 0 );
-		}
-
-		return event.pageY;
 	}
 }, jQuery.event.addProp );
 


### PR DESCRIPTION
### Summary ###

Fixes gh-3092

IE8 was the last major browser missing these. Support elsewhere looks good, according to http://www.quirksmode.org/mobile/tableViewport.html . Our existing unit tests for them are [pretty sparse](https://github.com/jquery/jquery/blob/e61fccb9d736235b4b011f89cba6866bc0b8997d/test/unit/event.js#L2437-2456) but they did catch when the properties were left off the list. Creating fake events with predefined pageX/Y won't help our ability to determine whether the browser values are correct. Docs issue isn't needed because we will still be copying them.

### Checklist ###
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.

* [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
* [ ] ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* [ ] ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

Thanks! Bots and humans will be around shortly to check it out.
