### PR TITLE
Event: Add touch event properties, eliminates need for a plugin

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -607,6 +607,7 @@ jQuery.each( {
 	offsetY: true,
 	screenX: true,
 	screenY: true,
+	targetTouches: true,
 	toElement: true,
 	touches: true,
 

--- a/src/event.js
+++ b/src/event.js
@@ -588,6 +588,7 @@ jQuery.each( {
 	altKey: true,
 	bubbles: true,
 	cancelable: true,
+	changedTouches: true,
 	ctrlKey: true,
 	detail: true,
 	eventPhase: true,
@@ -607,6 +608,7 @@ jQuery.each( {
 	screenX: true,
 	screenY: true,
 	toElement: true,
+	touches: true,
 
 	which: function( event ) {
 		var button = event.button;


### PR DESCRIPTION
### Summary ###

Fixes #3104

See https://github.com/aarongloege/jquery.touchHooks

Other properties are already present thanks to mouse events. I am going to assume this doesn't need tests since we've proven elsewhere that things are copied as long as they're spelled right.

Does need a docs update, I'll open a ticket when it gets the thumbs up.

### Checklist ###
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.

* [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
* [ ] ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

Thanks! Bots and humans will be around shortly to check it out.
