### PR TITLE
Deferred: Give better stack diagnostics on exceptions

### DIFF
--- a/src/deferred/exceptionHook.js
+++ b/src/deferred/exceptionHook.js
@@ -11,7 +11,7 @@ var rerrorNames = /^(Eval|Internal|Range|Reference|Syntax|Type|URI)Error$/;
 
 jQuery.Deferred.exceptionHook = function( error, stack ) {
 
-	// Support: IE 9 only
+	// Support: IE 8 - 9 only
 	// Console exists when dev tools are open, which can happen at any time
 	if ( window.console && window.console.warn && error && rerrorNames.test( error.name ) ) {
 		window.console.warn( "jQuery.Deferred exception: " + error.message, error.stack, stack );

--- a/src/deferred/exceptionHook.js
+++ b/src/deferred/exceptionHook.js
@@ -11,10 +11,10 @@ var rerrorNames = /^(Eval|Internal|Range|Reference|Syntax|Type|URI)Error$/;
 
 jQuery.Deferred.exceptionHook = function( error, stack ) {
 
-	// Support: IE 8 - 9 only
+	// Support: IE 9 only
 	// Console exists when dev tools are open, which can happen at any time
 	if ( window.console && window.console.warn && error && rerrorNames.test( error.name ) ) {
-		window.console.warn( "jQuery.Deferred exception: " + error.message, stack );
+		window.console.warn( "jQuery.Deferred exception: " + error.message, error.stack, stack );
 	}
 };
 

--- a/test/unit/deferred.js
+++ b/test/unit/deferred.js
@@ -542,28 +542,30 @@ QUnit.test( "jQuery.Deferred.then - spec compatibility", function( assert ) {
 	} catch ( _ ) {}
 } );
 
+// Test fails in IE9 but is skipped there because console is not active
 QUnit[ window.console ? "test" : "skip" ]( "jQuery.Deferred.exceptionHook", function( assert ) {
 
-	assert.expect( 1 );
+	assert.expect( 2 );
 
 	var done = assert.async(),
 		defer = jQuery.Deferred(),
 		oldWarn = window.console.warn;
 
-	window.console.warn = function( msg ) {
+	window.console.warn = function() {
 
 		// Support: Chrome <=41 only
 		// Some Chrome versions newer than 30 but older than 42 display the "undefined is
 		// not a function" error, not mentioning the function name. This has been fixed
 		// in Chrome 42. Relax this test there.
 		// This affects our Android 5.0 & Yandex.Browser testing.
-		var oldChromium = false;
+		var msg = Array.prototype.join.call( arguments, " " ),
+			oldChromium = false;
 		if ( /chrome/i.test( navigator.userAgent ) ) {
 			oldChromium = parseInt(
 					navigator.userAgent.match( /chrome\/(\d+)/i )[ 1 ], 10 ) < 42;
 		}
 		if ( oldChromium ) {
-			assert.ok( /(?:barf|undefined)/.test( msg ), "Message: " + msg );
+			assert.ok( /(?:barf|undefined)/.test( msg ), "Message (weak assertion): " + msg );
 		} else {
 			assert.ok( /barf/.test( msg ), "Message: " + msg );
 		}
@@ -580,7 +582,9 @@ QUnit[ window.console ? "test" : "skip" ]( "jQuery.Deferred.exceptionHook", func
 			// Should NOT get an error
 			throw new Error( "Make me a sandwich" );
 		} ).then( null, jQuery.noop )
-	).then( function( ) {
+	).then( function barf( ) {
+		jQuery.thisDiesToo();
+	} ).then( null, function( ) {
 		window.console.warn = oldWarn;
 		done();
 	} );
@@ -588,6 +592,7 @@ QUnit[ window.console ? "test" : "skip" ]( "jQuery.Deferred.exceptionHook", func
 	defer.resolve();
 } );
 
+// Test fails in IE9 but is skipped there because console is not active
 QUnit[ window.console ? "test" : "skip" ]( "jQuery.Deferred.exceptionHook with stack hooks", function( assert ) {
 
 	assert.expect( 2 );

--- a/test/unit/deferred.js
+++ b/test/unit/deferred.js
@@ -610,24 +610,26 @@ QUnit[ window.console ? "test" : "skip" ]( "jQuery.Deferred.exceptionHook with s
 		return "NO STACK FOR YOU";
 	};
 
-	window.console.warn = function( msg, stack ) {
+	window.console.warn = function() {
 
 		// Support: Chrome <=41 only
 		// Some Chrome versions newer than 30 but older than 42 display the "undefined is
 		// not a function" error, not mentioning the function name. This has been fixed
 		// in Chrome 42. Relax this test there.
 		// This affects our Android 5.0 & Yandex.Browser testing.
-		var oldChromium = false;
+		var msg = Array.prototype.join.call( arguments, " " ),
+			oldChromium = false;
 		if ( /chrome/i.test( navigator.userAgent ) ) {
 			oldChromium = parseInt(
 					navigator.userAgent.match( /chrome\/(\d+)/i )[ 1 ], 10 ) < 42;
 		}
 		if ( oldChromium ) {
-			assert.ok( /(?:cough_up_hairball|undefined)/.test( msg ), "Function mentioned: " + msg );
+			assert.ok( /(?:cough_up_hairball|undefined)/.test( msg ),
+				"Function mentioned (weak assertion): " + msg );
 		} else {
 			assert.ok( /cough_up_hairball/.test( msg ), "Function mentioned: " + msg );
 		}
-		assert.ok( /NO STACK FOR YOU/.test( stack ), "Stack trace included: " + stack );
+		assert.ok( /NO STACK FOR YOU/.test( msg ), "Stack trace included: " + msg );
 	};
 	defer.then( function() {
 		jQuery.cough_up_hairball();


### PR DESCRIPTION
### Summary ###

Ref gh-2736

The exception stack has the name of the immediately outer function where the
exception occurred, which can be very handy for tracing errors. Since we already
have the exception object we might as well use it.

I was debugging some code that had errors inside a document ready function and this would have been really useful to have.

### Checklist ###
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.

* [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

Thanks! Bots and humans will be around shortly to check it out.
