### PR TITLE
Remove units from a 0 width/height CSS element

### DIFF
--- a/test/data/testsuite.css
+++ b/test/data/testsuite.css
@@ -53,11 +53,11 @@ div.medopacity {
 }
 
 div.nowidth {
-	width: 0px;
+	width: 0;
 }
 
 div.noheight {
-	height: 0px;
+	height: 0;
 }
 
 div.noopacity {


### PR DESCRIPTION
### Summary ###

This is a straightforward PR to remove the units of a 0 width/height element. This will also remove a warning from the [Codacy dashboard](https://www.codacy.com/app/opensource/jquery/issues?&filters=W3siaWQiOiJDYXRlZ29yeSIsInZhbHVlcyI6WyJDb2RlIFN0eWxlIl19XQ==).
![](https://i.gyazo.com/3332c2df60fcd6c5f8639d50476b4c1a.png)

