### PR TITLE
Deferred: Propagate progress correctly from unwrapped promises

### DIFF
--- a/src/deferred.js
+++ b/src/deferred.js
@@ -162,7 +162,7 @@ jQuery.extend( {
 												resolve( maxDepth, deferred, Identity, special ),
 												resolve( maxDepth, deferred, Thrower, special ),
 												resolve( maxDepth, deferred, Identity,
-													deferred.notify )
+													deferred.notifyWith )
 											);
 										}
 

--- a/test/unit/deferred.js
+++ b/test/unit/deferred.js
@@ -768,6 +768,36 @@ QUnit.test( "jQuery.Deferred - notify and resolve", function( assert ) {
 	} );
 } );
 
+QUnit.test( "jQuery.Deferred - resolved to a notifying deferred", function( assert ) {
+
+	assert.expect( 2 );
+
+    var deferred = jQuery.Deferred(),
+		done = assert.async( 2 );
+
+	deferred.resolve( jQuery.Deferred( function( notifyingDeferred ) {
+	    notifyingDeferred.notify( "foo", "bar" );
+	    notifyingDeferred.resolve( "baz", "quux" );
+	} ) );
+
+	// Apply an empty then to force thenable unwrapping.
+	// See https://github.com/jquery/jquery/issues/3000 for more info.
+	deferred.then().then( function() {
+		assert.deepEqual(
+			[].slice.call( arguments ),
+			[ "baz", "quux" ],
+			"The fulfilled handler receives proper params"
+		);
+		done();
+	}, null, function() {
+		assert.deepEqual(
+			[].slice.call( arguments ),
+			[ "foo", "bar" ],
+			"The progress handler receives proper params"
+		);
+		done();
+	} );
+} );
 
 QUnit.test( "jQuery.when(nonThenable) - like Promise.resolve", function( assert ) {
 	"use strict";


### PR DESCRIPTION
### Summary ###
Progress parameters are now correctly propagated from a deferred to which
another deferred resolved unwrapping it.

Thanks to @gibson042 for the report and a clear description of the problem
and the needed fix.

Fixes gh-3062

I'd like to get it in 3.0.0 as this bug is really unexpected and we've had a related external report.

Please review @jquery/core.

### Checklist ###
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.

* [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

Thanks! Bots and humans will be around shortly to check it out.

