### PR TITLE
Effects: use requestAnimationFrame timestamp if available

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -108,6 +108,7 @@ module.exports = function( grunt ) {
 				"deprecated",
 				"dimensions",
 				"effects",
+				"effects-nostubs",
 				"event",
 				"manipulation",
 				"offset",

--- a/src/effects.js
+++ b/src/effects.js
@@ -27,16 +27,23 @@ var
 	rfxtypes = /^(?:toggle|show|hide)$/,
 	rrun = /queueHooks$/;
 
-function schedule() {
+function schedule( timestamp ) {
 	if ( inProgress ) {
-		if ( document.hidden === false && window.requestAnimationFrame ) {
+		if ( document.hidden === false ) {
 			window.requestAnimationFrame( schedule );
 		} else {
 			window.setTimeout( schedule, jQuery.fx.interval );
 		}
 
-		jQuery.fx.tick();
+		jQuery.fx.tick( timestamp );
 	}
+}
+
+// We need to be using Date.now() or performance.now() consistently as they return different
+// values: performance.now() counter starts on page load.
+// Support: IE <10, Safari <8.0, iOS <9, Android <4.4, Node with jsdom 9.4
+function getTimestamp() {
+	return window.performance.now();
 }
 
 // Animations created synchronously will run synchronously
@@ -44,7 +51,7 @@ function createFxNow() {
 	window.setTimeout( function() {
 		fxNow = undefined;
 	} );
-	return ( fxNow = Date.now() );
+	return ( fxNow = getTimestamp() );
 }
 
 // Generate parameters to create a standard animation
@@ -644,12 +651,12 @@ jQuery.each( {
 } );
 
 jQuery.timers = [];
-jQuery.fx.tick = function() {
+jQuery.fx.tick = function( timestamp ) {
 	var timer,
 		i = 0,
 		timers = jQuery.timers;
 
-	fxNow = Date.now();
+	fxNow = timestamp || getTimestamp();
 
 	for ( ; i < timers.length; i++ ) {
 		timer = timers[ i ];

--- a/test/data/effects/matchingTimestamps.html
+++ b/test/data/effects/matchingTimestamps.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" dir="ltr" id="html">
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+	<title>Effects: matching timestamps</title>
+</head>
+<body>
+	<script src="../../jquery.js"></script>
+	<script src="../iframeTest.js"></script>
+	<div id="test-div" style="height: 1000px;"></div>
+	<script>
+		//<![CDATA[
+		setTimeout( function () {
+
+			// Handle a timeout.
+		    startIframeTest( false, "The test timed out" );
+		}, 5000 );
+
+		var maxNow = 0;
+
+		jQuery( "#test-div" ).animate( {
+			height: '2000px',
+		}, {
+			duration: 300,
+			step: function( now ) {
+				if ( maxNow - now > 100 ) {
+					startIframeTest( false, "Animation is stepping back from " + maxNow + " to " + now );
+				}
+				maxNow = Math.max( now, maxNow );
+			},
+			complete: function() {
+				startIframeTest( true );
+			}
+		} );
+		//]]>
+	</script>
+</body>
+</html>

--- a/test/unit/animation.js
+++ b/test/unit/animation.js
@@ -5,10 +5,9 @@ if ( !jQuery.fx ) {
 	return;
 }
 
-var oldRaf = window.requestAnimationFrame,
-	defaultPrefilter = jQuery.Animation.prefilters[ 0 ],
-	defaultTweener = jQuery.Animation.tweeners[ "*" ][ 0 ],
-	startTime = 505877050;
+var defaultPrefilter = jQuery.Animation.prefilters[ 0 ];
+var defaultTweener = jQuery.Animation.tweeners[ "*" ][ 0 ];
+var startTime = 505877050;
 
 // This module tests jQuery.Animation and the corresponding 1.8+ effects APIs
 QUnit.module( "animation", {
@@ -26,7 +25,6 @@ QUnit.module( "animation", {
 		this.sandbox.restore();
 		jQuery.fx.stop();
 		jQuery.fx.interval = this._oldInterval;
-		window.requestAnimationFrame = oldRaf;
 		return moduleTeardown.apply( this, arguments );
 	}
 } );

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -5,29 +5,42 @@ if ( !jQuery.fx ) {
 	return;
 }
 
-var oldRaf = window.requestAnimationFrame,
-	hideOptions = {
-		inline: function() { jQuery.style( this, "display", "none" ); },
-		cascade: function() { this.className = "hidden"; }
-	};
+var hideOptions = {
+	inline: function() { jQuery.style( this, "display", "none" ); },
+	cascade: function() { this.className = "hidden"; }
+};
 
 QUnit.module( "effects", {
 	beforeEach: function() {
 		this.sandbox = sinon.createSandbox();
 		this.clock = this.sandbox.useFakeTimers( 505877050 );
+
 		this._oldInterval = jQuery.fx.interval;
-		window.requestAnimationFrame = null;
 		jQuery.fx.step = {};
 		jQuery.fx.interval = 10;
+
+		// Simulate rAF using the mocked setTimeout as otherwise we couldn't test
+		// the rAF + performance.now code path.
+		this.sandbox
+			.stub( window, "requestAnimationFrame" )
+			.callsFake( function( callback ) {
+				return window.setTimeout( callback, jQuery.fx.interval,
+					Date.now() - 99989.6394 );
+			} );
+
+		// Fake performance.now() returning lower values than Date.now()
+		// and that its values are fractional.
+		this.sandbox.stub( window.performance, "now" ).callsFake( function() {
+			return Date.now() - 99999.6394;
+		} );
 	},
 	afterEach: function() {
 		this.sandbox.restore();
 		jQuery.fx.stop();
 		jQuery.fx.interval = this._oldInterval;
-		window.requestAnimationFrame = oldRaf;
 		return moduleTeardown.apply( this, arguments );
 	}
-} );
+}, function() {
 
 QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "sanity check", function( assert ) {
 	assert.expect( 1 );
@@ -2623,4 +2636,21 @@ QUnit.test( "jQuery.speed() - durations", function( assert ) {
 	jQuery.fx.off = false;
 } );
 
+} );
+
+QUnit.module( "effects-nostubs", function() {
+
+testIframe(
+	"matching timestamp",
+	"effects/matchingTimestamps.html",
+	function( assert, framejQuery, frameWin, frameDoc, success, failureReason ) {
+		assert.expect( 1 );
+
+		assert.ok( success, failureReason );
+	}
+);
+
+} );
+
 } )();
+

--- a/test/unit/tween.js
+++ b/test/unit/tween.js
@@ -5,14 +5,11 @@ if ( !jQuery.fx ) {
 	return;
 }
 
-var oldRaf = window.requestAnimationFrame;
-
 QUnit.module( "tween", {
 	beforeEach: function() {
 		this.sandbox = sinon.createSandbox();
 		this.clock = this.sandbox.useFakeTimers( 505877050 );
 		this._oldInterval = jQuery.fx.interval;
-		window.requestAnimationFrame = null;
 		jQuery.fx.step = {};
 		jQuery.fx.interval = 10;
 	},
@@ -20,7 +17,6 @@ QUnit.module( "tween", {
 		this.sandbox.restore();
 		jQuery.fx.stop();
 		jQuery.fx.interval = this._oldInterval;
-		window.requestAnimationFrame = oldRaf;
 		return moduleTeardown.apply( this, arguments );
 	}
 } );


### PR DESCRIPTION
### Summary

In some environments that support the requestAnimationFrame timestamp callback
parameter using it results in smoother animations.

Fixes gh-3143

Currently it's +35 bytes, most likely due to the `getTimestamp` function used in `createFxNow()`. Any ideas on how to avoid this size tax?
### Checklist

Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
- [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
- [x] ~~New tests have been added to show the fix or feature works~~
- [x] Grunt build and unit tests pass locally with these changes
- [x] ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~
- [ ] Unit tests need to run on code with rAF enabled, currently we [disable it](https://github.com/mgol/jquery/blob/ee4a067/test/unit/effects.js#L16)
- [ ] Add one test using non-mocked `rAF`/`Date.now()`

Thanks! Bots and humans will be around shortly to check it out.
