### PR TITLE
Event: Add the most commonly used pointer event properties

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -615,6 +615,8 @@ jQuery.each( {
 	clientY: true,
 	offsetX: true,
 	offsetY: true,
+	pointerId: true,
+	pointerType: true,
 	screenX: true,
 	screenY: true,
 	targetTouches: true,


### PR DESCRIPTION
### Summary ###

Add `pointerId` and `pointerType` to the list of common properties for events to avoid needing to access `event.originalEvent` in browsers with native support and sites using a polyfill like PEP.

### Checklist ###
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.

* [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
* [ ] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

Ref gh-3104