### PR TITLE
Build: use commitplease via husky, prohibit #NNNN github-style tickets

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {},
   "devDependencies": {
     "babel-preset-es2015": "6.6.0",
-    "commitplease": "2.3.1",
+    "commitplease": "2.6.0",
     "core-js": "2.2.2",
     "cross-spawn": "2.2.3",
     "eslint-config-jquery": "0.1.2",
@@ -61,9 +61,11 @@
     "build": "npm install && grunt",
     "start": "grunt watch",
     "test": "grunt && grunt test",
-    "precommit": "grunt precommit_lint"
+    "precommit": "grunt precommit_lint",
+    "commitmsg": "node node_modules/commitplease"
   },
   "commitplease": {
+    "nohook": true,
     "components": [
       "Docs",
       "Tests",
@@ -88,6 +90,8 @@
       "Serialize",
       "Traversing",
       "Wrap"
-    ]
+    ],
+    "markerPattern": "^((clos|fix|resolv)(e[sd]|ing))|(refs?)",
+    "ticketPattern": "^((Closes|Fixes) ([a-zA-Z]{2,}-)[0-9]+)|(Refs? [^#])"
   }
 }


### PR DESCRIPTION
### Summary ###
Currently, jQuery uses [husky](https://github.com/typicode/husky) `0.11.4` to use git hooks from package.json and [commitplease ](https://github.com/jzaefferer/commitplease) `2.3.1` to validate its commit message style. Both these packages have a race condition for the `commit-msg` git hook during `npm install` and husky is the first one to install its hook. So, commitplease complains about the presence of another git hook during install and does nothing. Later on it does not validate commit messages as it never gets triggered.

This PR bumps the version of commitplease to `2.4.0` and configures commitplease so that:

1. It does not complain about the presence of husky hook during `npm install`
2. It uses the husky hook and validates commit messages later on
3. It prohibits the use of `Closes #123` and `Fixes #123` github-style ticket references that are written on a separate line (writing them in an ordinary sentence of a commit message is still possible)

To try it out, checkout this branch and do an `npm install` to pull the `2.4.0` version into your node_modules. When you get back to `master`, do not forget to `npm install` again to pull `2.3.1` version back.

### Checklist ###
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.

* [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
* [ ] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

Thanks! Bots and humans will be around shortly to check it out.