### PR TITLE
Deferred: Fix exceptions silent swallowing

### DIFF
--- a/src/core/init.js
+++ b/src/core/init.js
@@ -106,8 +106,16 @@ var rootjQuery,
 		// HANDLE: $(function)
 		// Shortcut for document ready
 		} else if ( jQuery.isFunction( selector ) ) {
+			var except;
+
+			// HANDLE: $(function, function)
+			// Shortcut for document ready
+			// with exception handler.
+			if ( jQuery.isFunction( context ) ) {
+				except = context;
+			}
 			return root.ready !== undefined ?
-				root.ready( selector ) :
+				root.ready( selector, except ) :
 
 				// Execute immediately if ready is not present
 				selector( jQuery );

--- a/src/core/ready.js
+++ b/src/core/ready.js
@@ -9,10 +9,10 @@ define( [
 // The deferred used on DOM ready
 var readyList = jQuery.Deferred();
 
-jQuery.fn.ready = function( fn ) {
+jQuery.fn.ready = function( fn, except ) {
 
-	readyList.then( fn );
-
+	// Pass only the function and its exception function.
+	readyList.then( fn, null, null, except );
 	return this;
 };
 

--- a/src/deferred.js
+++ b/src/deferred.js
@@ -103,7 +103,10 @@ jQuery.extend( {
 						fns = null;
 					} ).promise();
 				},
-				then: function( onFulfilled, onRejected, onProgress ) {
+
+                // The onException is there to manage that an exception is thrown
+                // inside the onFullfilled without being catched.
+				then: function( onFulfilled, onRejected, onProgress, onException ) {
 					var maxDepth = 0;
 					function resolve( depth, deferred, handler, special ) {
 						return function() {
@@ -190,10 +193,18 @@ jQuery.extend( {
 											mightThrow();
 										} catch ( e ) {
 
-											if ( jQuery.Deferred.exceptionHook ) {
+											if ( typeof onException === "function" ) {
+
+												// Call the onException if provided.
+												onException( e );
+
+											// If onException is not provided, then print out
+											// the error.
+											} else if ( jQuery.Deferred.exceptionHook ) {
 												jQuery.Deferred.exceptionHook( e,
 													process.stackTrace );
 											}
+
 
 											// Support: Promises/A+ section 2.3.3.3.4.1
 											// https://promisesaplus.com/#point-61

--- a/src/deferred/exceptionHook.js
+++ b/src/deferred/exceptionHook.js
@@ -7,14 +7,20 @@ define( [
 
 // These usually indicate a programmer mistake during development,
 // warn about them ASAP rather than swallowing them by default.
-var rerrorNames = /^(Eval|Internal|Range|Reference|Syntax|Type|URI)Error$/;
+// Notice that Error is a choice too, as ? regex means (0-1) times.
+var rerrorNames = /^(Eval|Internal|Range|Reference|Syntax|Type|URI)?Error$/;
 
 jQuery.Deferred.exceptionHook = function( error, stack ) {
 
 	// Support: IE 8 - 9 only
 	// Console exists when dev tools are open, which can happen at any time
 	if ( window.console && window.console.warn && error && rerrorNames.test( error.name ) ) {
-		window.console.warn( "jQuery.Deferred exception: " + error.message, error.stack, stack );
+		window.console.warn( "jQuery.Deferred exception: " + error.message, error.stack );
+
+		// If process stack exists, then give it out as a second warning too.
+		if ( stack ) {
+			window.console.warn( stack );
+		}
 	}
 };
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
Currently, jQuery silently swallows exceptions thrown in the body of a function passed as argument
in the `ready()` event handler. For instance:

```javascript
$(function() {
  throw new Error("Error");
});
````

will not result in any exception raise in the browser. This PR attempts to fix it by giving the ability
of adding another function in the `ready()` handler, so that if an exception occurs in such situation described above, the exception function will be fired. This function takes as argument the Error object given - internally propagated to it, so that it can be used inside the function.

```javascript
$(function() {
  throw new Error("Error");
}, function(e) {
  console.log("An error occured, and it says: " + e.message);
});
```

If no such function is provided, code now outputs the exception error message in the console.
This fix works in all `$(fn);`, `$(document).ready(fn);` and `$().ready(fn);` calls.

Note: This fix is applied on the `ready` implementation, not the `ready-not-deferred` one.


Fixes #3174

### Checklist ###
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.

* [ ] All authors have signed the CLA at https://contribute.jquery.com/CLA/
* [ ] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

Thanks! Bots and humans will be around shortly to check it out.
