### PR TITLE
Core: Re-throw errors that happened in callbacks wrapped in jQuery ready

### DIFF
--- a/src/core/ready.js
+++ b/src/core/ready.js
@@ -1,6 +1,7 @@
 define( [
 	"../core",
 	"../var/document",
+	"../core/readyException",
 	"../deferred"
 ], function( jQuery, document ) {
 
@@ -11,7 +12,15 @@ var readyList = jQuery.Deferred();
 
 jQuery.fn.ready = function( fn ) {
 
-	readyList.then( fn );
+	readyList
+		.then( fn )
+
+		// Wrap jQuery.readyException in a function so that the lookup
+		// happens at the time of error handling instead of callback
+		// registration.
+		.catch( function( error ) {
+			jQuery.readyException( error );
+		} );
 
 	return this;
 };

--- a/src/core/readyException.js
+++ b/src/core/readyException.js
@@ -1,0 +1,13 @@
+define( [
+	"../core"
+], function( jQuery ) {
+
+"use strict";
+
+jQuery.readyException = function( error ) {
+	window.setTimeout( function() {
+		throw error;
+	} );
+};
+
+} );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
Re-throw errors that happened in callbacks wrapped in jQuery ready

Also, expose jQuery.readyException that allows to overwrite the default
ready error handler.

### Checklist ###
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.

* [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com (https://github.com/jquery/api.jquery.com/issues/942)

Thanks! Bots and humans will be around shortly to check it out.

Fixes gh-3174