### PR TITLE
Build: Skip running ESLint on Node.js 0.x

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,9 +14,14 @@ module.exports = function( grunt ) {
 
 	var fs = require( "fs" ),
 		gzip = require( "gzip-js" ),
+		oldNode = /^v0\./.test( process.version );
 
-		// Skip jsdom-related tests in Node.js 0.10 & 0.12
-		runJsdomTests = !/^v0/.test( process.version );
+	// Support: Node.js <4
+	// Skip running tasks that dropped support for Node.js 0.10 & 0.12
+	// in those Node versions.
+	function runIfNewNode( task ) {
+		return oldNode ? "print_old_node_message:" + task : task;
+	}
 
 	if ( !grunt.option( "filename" ) ) {
 		grunt.option( "filename", "jquery.js" );
@@ -176,33 +181,50 @@ module.exports = function( grunt ) {
 	} );
 
 	// Load grunt tasks from NPM packages
-	require( "load-grunt-tasks" )( grunt );
+	// Support: Node.js <4
+	// Don't load the eslint task in old Node.js, it won't parse.
+	require( "load-grunt-tasks" )( grunt, {
+		pattern: oldNode ? [ "grunt-*", "!grunt-eslint" ] : [ "grunt-*" ]
+	} );
 
 	// Integrate jQuery specific tasks
 	grunt.loadTasks( "build/tasks" );
 
-	grunt.registerTask( "lint", [ "jsonlint", "eslint:all" ] );
+	grunt.registerTask( "print_old_node_message", function() {
+		var task = [].slice.call( arguments ).join( ":" );
+		grunt.log.writeln( "Old Node.js detected, running the task \"" + task + "\" skipped..." );
+	} );
 
-	// Don't run Node-related tests in Node.js < 1.0.0 as they require an old
-	// jsdom version that needs compiling, making it harder for people to compile
-	// jQuery on Windows. (see gh-2519)
-	grunt.registerTask( "test_fast", runJsdomTests ? [ "node_smoke_tests" ] : [] );
+	grunt.registerTask( "lint", [
+		"jsonlint",
+		runIfNewNode( "eslint:all" )
+	] );
+
+	grunt.registerTask( "test_fast", [ runIfNewNode( "node_smoke_tests" ) ] );
 
 	grunt.registerTask( "test", [ "test_fast" ].concat(
-		runJsdomTests ? [ "promises_aplus_tests" ] : []
+		[ runIfNewNode( "promises_aplus_tests" ) ]
 	) );
 
 	// Short list as a high frequency watch task
 	grunt.registerTask( "dev", [
 			"build:*:*",
-			"newer:eslint:dev",
+			runIfNewNode( "newer:eslint:dev" ),
 			"uglify",
 			"remove_map_comment",
 			"dist:*"
 		]
 	);
 
-	grunt.registerTask( "default", [ "dev", "eslint:dist", "test_fast", "compare_size" ] );
+	grunt.registerTask( "default", [
+		"dev",
+		runIfNewNode( "eslint:dist" ),
+		"test_fast",
+		"compare_size"
+	] );
 
-	grunt.registerTask( "precommit_lint", [ "newer:jsonlint", "newer:eslint:all" ] );
+	grunt.registerTask( "precommit_lint", [
+		"newer:jsonlint",
+		runIfNewNode( "newer:eslint:all" )
+	] );
 };

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "grunt-compare-size": "0.4.2",
     "grunt-contrib-uglify": "1.0.1",
     "grunt-contrib-watch": "1.0.0",
-    "grunt-eslint": "18.0.0",
+    "grunt-eslint": "19.0.0",
     "grunt-git-authors": "3.2.0",
     "grunt-jsonlint": "1.0.7",
     "grunt-newer": "1.2.0",


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
The PR makes it possible to use the new ESLint 3.x that's incompatible with Node.js older than 4.x but at the same time allows to build jQuery in an older Node. The tasks using problematic modules (like ESLint & jsdom) are skipped there.

### Checklist ###
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.

* [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
* [x] ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* [x] ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

Thanks! Bots and humans will be around shortly to check it out.

Fixes gh-3222

cc @markelog 