### PR TITLE
Ajax: Don't mangle the URL when removing the anti-cache param

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -18,8 +18,7 @@ define( [
 var
 	r20 = /%20/g,
 	rhash = /#.*$/,
-	rantiCache = /(?:[?&])_=[^&]*&?/,
-	remptyQuery = /\?$/,
+	rantiCache = /([?&])_=[^&]*/,
 	rheaders = /^(.*?):[ \t]*([^\r\n]*)$/mg,
 
 	// #7653, #8125, #8152: local protocol detection
@@ -599,8 +598,7 @@ jQuery.extend( {
 
 			// If data is available, append data to url
 			if ( s.data ) {
-				cacheURL = cacheURL.replace( remptyQuery, "" ) +
-					( rquery.test( cacheURL ) ? "&" : "?" ) + s.data;
+				cacheURL += ( rquery.test( cacheURL ) ? "&" : "?" ) + s.data;
 
 				// #9682: remove data so that it's not used in an eventual retry
 				delete s.data;
@@ -608,7 +606,7 @@ jQuery.extend( {
 
 			// Add or update anti-cache param if needed
 			if ( s.cache === false ) {
-				cacheURL = cacheURL.replace( rantiCache, "" ).replace( remptyQuery, "" );
+				cacheURL = cacheURL.replace( rantiCache, "$1" );
 				uncached = ( rquery.test( cacheURL ) ? "&" : "?" ) + "_=" + ( nonce++ ) + uncached;
 			}
 

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -18,7 +18,8 @@ define( [
 var
 	r20 = /%20/g,
 	rhash = /#.*$/,
-	rts = /([?&])_=[^&]*/,
+	rantiCache = /(?:[?&])_=[^&]*&?/,
+	remptyQuery = /\?$/,
 	rheaders = /^(.*?):[ \t]*([^\r\n]*)$/mg,
 
 	// #7653, #8125, #8152: local protocol detection
@@ -598,15 +599,16 @@ jQuery.extend( {
 
 			// If data is available, append data to url
 			if ( s.data ) {
-				cacheURL += ( rquery.test( cacheURL ) ? "&" : "?" ) + s.data;
+				cacheURL = cacheURL.replace( remptyQuery, "" ) +
+					( rquery.test( cacheURL ) ? "&" : "?" ) + s.data;
 
 				// #9682: remove data so that it's not used in an eventual retry
 				delete s.data;
 			}
 
-			// Add anti-cache in uncached url if needed
+			// Add or update anti-cache param if needed
 			if ( s.cache === false ) {
-				cacheURL = cacheURL.replace( rts, "" );
+				cacheURL = cacheURL.replace( rantiCache, "" ).replace( remptyQuery, "" );
 				uncached = ( rquery.test( cacheURL ) ? "&" : "?" ) + "_=" + ( nonce++ ) + uncached;
 			}
 

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -828,8 +828,9 @@ QUnit.module( "ajax", {
 		} ), "generic" );
 	} );
 
-	ajaxTest( "jQuery.ajax() - cache", 12, function( assert ) {
-		var re = /_=(.*?)(&|$)/g;
+	ajaxTest( "jQuery.ajax() - cache", 35, function( assert ) {
+		var re = /_=(.*?)(&|$)/g,
+			rootUrl = "data/text.php";
 
 		function request( url, title ) {
 			return {
@@ -837,6 +838,12 @@ QUnit.module( "ajax", {
 				cache: false,
 				beforeSend: function() {
 					var parameter, tmp;
+
+					// URL sanity check, cases should not have `&` followed by `?`
+					assert.equal( this.url.indexOf( rootUrl ), 0, "root url not mangled: " + this.url );
+					assert.equal( /\&.*\?/.test( this.url ), false, "parameter delimiters in order" );
+					assert.equal( /[?&]\&/.test( this.url ), false, "no empty parameters" );
+
 					while ( ( tmp = re.exec( this.url ) ) ) {
 						assert.strictEqual( parameter, undefined, title + ": only one 'no-cache' parameter" );
 						parameter = tmp[ 1 ];
@@ -850,27 +857,31 @@ QUnit.module( "ajax", {
 
 		return [
 			request(
-				"data/text.php",
-				"no parameter"
+				rootUrl,
+				"no query"
 			),
 			request(
-				"data/text.php?pizza=true",
+				rootUrl + "?",
+				"empty query"
+			),
+			request(
+				rootUrl + "?pizza=true",
 				"1 parameter"
 			),
 			request(
-				"data/text.php?_=tobereplaced555",
+				rootUrl + "?_=tobereplaced555",
 				"_= parameter"
 			),
 			request(
-				"data/text.php?pizza=true&_=tobereplaced555",
+				rootUrl + "?pizza=true&_=tobereplaced555",
 				"1 parameter and _="
 			),
 			request(
-				"data/text.php?_=tobereplaced555&tv=false",
+				rootUrl + "?_=tobereplaced555&tv=false",
 				"_= and 1 parameter"
 			),
 			request(
-				"data/text.php?name=David&_=tobereplaced555&washere=true",
+				rootUrl + "?name=David&_=tobereplaced555&washere=true",
 				"2 parameters surrounding _="
 			)
 		];


### PR DESCRIPTION
### Summary ###

Fixes gh-3229.

There was an existing unit test that actually showed the URL being mangled but there were not any checks for the problem.

### Checklist ###
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.

* [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

Thanks! Bots and humans will be around shortly to check it out.

