### PR TITLE
Traversing: Let .not(arraylike) pass non-element nodes

### DIFF
--- a/src/traversing/findFilter.js
+++ b/src/traversing/findFilter.js
@@ -25,14 +25,17 @@ function winnow( elements, qualifier, not ) {
 
 	}
 
-	if ( typeof qualifier === "string" ) {
-		if ( risSimple.test( qualifier ) ) {
-			return jQuery.filter( qualifier, elements, not );
-		}
-
-		qualifier = jQuery.filter( qualifier, elements );
+	if ( typeof qualifier !== "string" ) {
+		return jQuery.grep( elements, function( elem ) {
+			return ( indexOf.call( qualifier, elem ) > -1 ) !== not;
+		} );
 	}
 
+	if ( risSimple.test( qualifier ) ) {
+		return jQuery.filter( qualifier, elements, not );
+	}
+
+	qualifier = jQuery.filter( qualifier, elements );
 	return jQuery.grep( elements, function( elem ) {
 		return ( indexOf.call( qualifier, elem ) > -1 ) !== not && elem.nodeType === 1;
 	} );

--- a/src/traversing/findFilter.js
+++ b/src/traversing/findFilter.js
@@ -15,26 +15,28 @@ function winnow( elements, qualifier, not ) {
 		return jQuery.grep( elements, function( elem, i ) {
 			return !!qualifier.call( elem, i, elem ) !== not;
 		} );
-
 	}
 
+	// Single element
 	if ( qualifier.nodeType ) {
 		return jQuery.grep( elements, function( elem ) {
 			return ( elem === qualifier ) !== not;
 		} );
-
 	}
 
+	// Arraylike of elements (jQuery, arguments, Array)
 	if ( typeof qualifier !== "string" ) {
 		return jQuery.grep( elements, function( elem ) {
 			return ( indexOf.call( qualifier, elem ) > -1 ) !== not;
 		} );
 	}
 
+	// Simple selector that can be filtered directly, removing non-Elements
 	if ( risSimple.test( qualifier ) ) {
 		return jQuery.filter( qualifier, elements, not );
 	}
 
+	// Complex selector, compare the two sets, removing non-Elements
 	qualifier = jQuery.filter( qualifier, elements );
 	return jQuery.grep( elements, function( elem ) {
 		return ( indexOf.call( qualifier, elem ) > -1 ) !== not && elem.nodeType === 1;

--- a/test/unit/traversing.js
+++ b/test/unit/traversing.js
@@ -481,6 +481,19 @@ QUnit.test( "not(Selector) excludes non-element nodes (gh-2808)", function( asse
 	assert.deepEqual( mixedContents.not( "[id=a],*,[id=b]" ).get(), [], "not [id=a],*,[id=b]" );
 } );
 
+QUnit.test( "not(arraylike) passes non-element nodes (gh-3226)", function( assert ) {
+	assert.expect( 4 );
+
+	var mixedContents = jQuery( "#nonnodes" ).contents(),
+		mixedLength = mixedContents.length,
+		childElements = q( "nonnodesElement" );
+
+	assert.deepEqual( mixedContents.not( mixedContents.get() ).get(), [], "not everything" );
+	assert.deepEqual( mixedContents.not( childElements ).length, mixedLength - 1, "not childElements" );
+	assert.deepEqual( mixedContents.not( [ childElements[ 0 ].nextSibling ] ).length, mixedLength - 1, "not textnode" );
+	assert.deepEqual( mixedContents.not( document.body ).get(), mixedContents.get(), "not with unmatched element" );
+} );
+
 QUnit.test( "has(Element)", function( assert ) {
 	assert.expect( 3 );
 	var obj, detached, multipleParent;

--- a/test/unit/traversing.js
+++ b/test/unit/traversing.js
@@ -482,15 +482,16 @@ QUnit.test( "not(Selector) excludes non-element nodes (gh-2808)", function( asse
 } );
 
 QUnit.test( "not(arraylike) passes non-element nodes (gh-3226)", function( assert ) {
-	assert.expect( 4 );
+	assert.expect( 5 );
 
-	var mixedContents = jQuery( "#nonnodes" ).contents(),
+	var mixedContents = jQuery( "<span id='nonnodesElement'>hi</span> there <!-- mon ami -->" ),
 		mixedLength = mixedContents.length,
-		childElements = q( "nonnodesElement" );
+		firstElement = mixedContents.first();
 
-	assert.deepEqual( mixedContents.not( mixedContents.get() ).get(), [], "not everything" );
-	assert.deepEqual( mixedContents.not( childElements ).length, mixedLength - 1, "not childElements" );
-	assert.deepEqual( mixedContents.not( [ childElements[ 0 ].nextSibling ] ).length, mixedLength - 1, "not textnode" );
+	assert.deepEqual( mixedContents.not( mixedContents ).get(), [], "not everything" );
+	assert.deepEqual( mixedContents.not( firstElement ).length, mixedLength - 1, "not firstElement" );
+	assert.deepEqual( mixedContents.not( [ firstElement[ 0 ].nextSibling ] ).length, mixedLength - 1, "not textnode array" );
+	assert.deepEqual( mixedContents.not( firstElement[ 0 ].nextSibling ).length, mixedLength - 1, "not textnode" );
 	assert.deepEqual( mixedContents.not( document.body ).get(), mixedContents.get(), "not with unmatched element" );
 } );
 


### PR DESCRIPTION
### Summary ###

Fixes gh-3226, was only +3 gzip.

The docs at http://api.jquery.com/not/ might need some wording changes to clarify that this is intended behavior?

### Checklist ###
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.

* [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

