### PR TITLE
Core: expose noConflict in AMD mode

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -17,7 +17,6 @@ module.exports = function( grunt ) {
 		read = function( fileName ) {
 			return grunt.file.read( srcFolder + fileName );
 		},
-		globals = read( "exports/global.js" ),
 		wrapper = read( "wrapper.js" ).split( /\/\/ \@CODE\n\/\/[^\n]+/ ),
 		config = {
 			baseUrl: "src",
@@ -39,10 +38,7 @@ module.exports = function( grunt ) {
 			skipSemiColonInsertion: true,
 			wrap: {
 				start: wrapper[ 0 ].replace( /\/\*\s*eslint(?: |-).*\s*\*\/\n/, "" ),
-				end: globals.replace(
-					/\/\*\s*ExcludeStart\s*\*\/[\w\W]*?\/\*\s*ExcludeEnd\s*\*\//ig,
-					""
-				) + wrapper[ 1 ]
+				end: wrapper[ 1 ]
 			},
 			rawText: {},
 			onBuildWrite: convert

--- a/src/exports/global.js
+++ b/src/exports/global.js
@@ -1,10 +1,8 @@
-/* ExcludeStart */
+define( [
+	"../core"
+], function( jQuery, noGlobal ) {
 
-// This file is included in a different way from all the others
-// so the "use strict" pragma is not needed.
-/* eslint strict: "off" */
-
-/* ExcludeEnd */
+"use strict";
 
 var
 
@@ -32,3 +30,5 @@ jQuery.noConflict = function( deep ) {
 if ( !noGlobal ) {
 	window.jQuery = window.$ = jQuery;
 }
+
+} );

--- a/src/jquery.js
+++ b/src/jquery.js
@@ -30,11 +30,12 @@ define( [
 	"./offset",
 	"./dimensions",
 	"./deprecated",
-	"./exports/amd"
+	"./exports/amd",
+	"./exports/global"
 ], function( jQuery ) {
 
 "use strict";
 
-return ( window.jQuery = window.$ = jQuery );
+return jQuery;
 
 } );

--- a/test/data/testinit.js
+++ b/test/data/testinit.js
@@ -320,9 +320,7 @@ this.loadTests = function() {
 				/**
 				 * Run in noConflict mode
 				 */
-				if ( jQuery.noConflict ) {
-					jQuery.noConflict();
-				}
+				jQuery.noConflict();
 
 				// Load the TestSwarm listener if swarmURL is in the address.
 				if ( QUnit.isSwarm ) {

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -197,27 +197,24 @@ QUnit.test( "globalEval execution after script injection (#7862)", function( ass
 	assert.ok( window.strictEvalTest - now < 500, "Code executed synchronously" );
 } );
 
-// This is not run in AMD mode
-if ( jQuery.noConflict ) {
-	QUnit.test( "noConflict", function( assert ) {
-		assert.expect( 7 );
+QUnit.test( "noConflict", function( assert ) {
+	assert.expect( 7 );
 
-		var $$ = jQuery;
+	var $$ = jQuery;
 
-		assert.strictEqual( jQuery, jQuery.noConflict(), "noConflict returned the jQuery object" );
-		assert.strictEqual( window[ "jQuery" ], $$, "Make sure jQuery wasn't touched." );
-		assert.strictEqual( window[ "$" ], original$, "Make sure $ was reverted." );
+	assert.strictEqual( jQuery, jQuery.noConflict(), "noConflict returned the jQuery object" );
+	assert.strictEqual( window[ "jQuery" ], $$, "Make sure jQuery wasn't touched." );
+	assert.strictEqual( window[ "$" ], original$, "Make sure $ was reverted." );
 
-		jQuery = $ = $$;
+	jQuery = $ = $$;
 
-		assert.strictEqual( jQuery.noConflict( true ), $$, "noConflict returned the jQuery object" );
-		assert.strictEqual( window[ "jQuery" ], originaljQuery, "Make sure jQuery was reverted." );
-		assert.strictEqual( window[ "$" ], original$, "Make sure $ was reverted." );
-		assert.ok( $$().pushStack( [] ), "Make sure that jQuery still works." );
+	assert.strictEqual( jQuery.noConflict( true ), $$, "noConflict returned the jQuery object" );
+	assert.strictEqual( window[ "jQuery" ], originaljQuery, "Make sure jQuery was reverted." );
+	assert.strictEqual( window[ "$" ], original$, "Make sure $ was reverted." );
+	assert.ok( $$().pushStack( [] ), "Make sure that jQuery still works." );
 
-		window[ "jQuery" ] = jQuery = $$;
-	} );
-}
+	window[ "jQuery" ] = jQuery = $$;
+} );
 
 QUnit.test( "trim", function( assert ) {
 	assert.expect( 13 );


### PR DESCRIPTION
### Summary ###

- For compability reasons, we had already added the global
  in AMD mode, but without noConflict. This adds back noConflict
  to AMD (which fixes noConflict mode in the tests).

### Checklist ###

* [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

Fixes gh-2930