### PR TITLE
CSS: Make Edge not trim whitespace-only values in the .css() setter

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -28,6 +28,7 @@ var
 	// except "table", "table-cell", or "table-caption"
 	// See here for display values: https://developer.mozilla.org/en-US/docs/CSS/display
 	rdisplayswap = /^(none|table(?!-c[ea]).+)/,
+	rnonemptywhite = /^\s+$/,
 	cssShow = { position: "absolute", visibility: "hidden", display: "block" },
 	cssNormalTransform = {
 		letterSpacing: "0",
@@ -257,7 +258,11 @@ jQuery.extend( {
 			if ( !hooks || !( "set" in hooks ) ||
 				( value = hooks.set( elem, value, extra ) ) !== undefined ) {
 
-				style[ name ] = value;
+				// Support: Edge 14
+				// Edge collapses a pure-whitespace value which causes the value to reset.
+				if ( !rnonemptywhite.test( value ) ) {
+					style[ name ] = value;
+				}
 			}
 
 		} else {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
It checks whether a browser erroneously trims whitespace-only values and skips setting them.

### Checklist ###
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.

* [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
* [x] ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* [x] ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

Thanks! Bots and humans will be around shortly to check it out.

Fixes gh-3204

+45 bytes. Another option would be to skip the support test and just apply the workaround everywhere.