### PR TITLE
Build: Make sourcemap updates in two .replace() passes

### DIFF
--- a/build/release/cdn.js
+++ b/build/release/cdn.js
@@ -43,9 +43,9 @@ function makeReleaseCopies( Release ) {
 			// "file":"jquery.min.js" ... "sources":["jquery.js"]
 			text = fs.readFileSync( builtFile, "utf8" )
 				.replace( /"file":"([^"]+)"/,
-					"\"file\":\"" + unpathedFile.replace( /\.min\.map/, ".min.js" ) )
+					"\"file\":\"" + unpathedFile.replace( /\.min\.map/, ".min.js\"" ) )
 				.replace( /"sources":\["([^"]+)"\]/,
-					"\",\"sources\":[\"" + unpathedFile.replace( /\.min\.map/, ".js" ) + "\"]" );
+					"\"sources\":[\"" + unpathedFile.replace( /\.min\.map/, ".js" ) + "\"]" );
 			fs.writeFileSync( releaseFile, text );
 		} else if ( builtFile !== releaseFile ) {
 			shell.cp( "-f", builtFile, releaseFile );

--- a/build/release/cdn.js
+++ b/build/release/cdn.js
@@ -40,10 +40,11 @@ function makeReleaseCopies( Release ) {
 
 			// Map files need to reference the new uncompressed name;
 			// assume that all files reside in the same directory.
-			// "file":"jquery.min.js","sources":["jquery.js"]
+			// "file":"jquery.min.js" ... "sources":["jquery.js"]
 			text = fs.readFileSync( builtFile, "utf8" )
-				.replace( /"file":"([^"]+)","sources":\["([^"]+)"\]/,
-					"\"file\":\"" + unpathedFile.replace( /\.min\.map/, ".min.js" ) +
+				.replace( /"file":"([^"]+)"/,
+					"\"file\":\"" + unpathedFile.replace( /\.min\.map/, ".min.js" ) )
+				.replace( /"sources":\["([^"]+)"\]/,
 					"\",\"sources\":[\"" + unpathedFile.replace( /\.min\.map/, ".js" ) + "\"]" );
 			fs.writeFileSync( releaseFile, text );
 		} else if ( builtFile !== releaseFile ) {


### PR DESCRIPTION
### Summary ###

Fixes gh-3260

The problem was that the [current regexp](https://github.com/jquery/jquery/blob/3bbcce68d7b8b8a7a2164a0f7a280ae9daf70b5c/build/release/cdn.js#L41-L48) assumes that the two fields to be changed are adjacent. At some point that's the way uglify generated them but now the "file" field is at the very end. The solution is simple, make the changes with two separate regexp passes.

Testing this *in situ* with a jquery-release run is super painful because of the safety checks that go on before we get to the CDN creation which is at the tail end of the whole long complicated process, but I tested the regexp replace with this script:

```js
var fs = require("fs");

var unpathedFile = "jquery-3.1.0.min.map";
var text;

text = fs.readFileSync( unpathedFile, "utf8" )
	.replace( /"file":"([^"]+)"/,
		"\"file\":\"" + unpathedFile.replace( /\.min\.map/, ".min.js" ) )
	.replace( /"sources":\["([^"]+)"\]/,
		"\",\"sources\":[\"" + unpathedFile.replace( /\.min\.map/, ".js" ) + "\"]" );
		
fs.writeFileSync( "result.txt", text );
```
### Checklist ###
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.

* [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
* [ ] ~~New tests have been added to show the fix or feature works~~ (see above)
* [x] Grunt build and unit tests pass locally with these changes
* [ ] ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

Thanks! Bots and humans will be around shortly to check it out.
