### PR TITLE
add useCapture arg for old FF support

### DIFF
--- a/src/core/ready.js
+++ b/src/core/ready.js
@@ -66,8 +66,8 @@ jQuery.extend( {
  */
 function detach() {
 	if ( document.addEventListener ) {
-		document.removeEventListener( "DOMContentLoaded", completed );
-		window.removeEventListener( "load", completed );
+		document.removeEventListener( "DOMContentLoaded", completed, 0);
+		window.removeEventListener( "load", completed, 0);
 
 	} else {
 		document.detachEvent( "onreadystatechange", completed );
@@ -109,10 +109,10 @@ jQuery.ready.promise = function( obj ) {
 		} else if ( document.addEventListener ) {
 
 			// Use the handy event callback
-			document.addEventListener( "DOMContentLoaded", completed );
+			document.addEventListener( "DOMContentLoaded", completed, false);
 
 			// A fallback to window.onload, that will always work
-			window.addEventListener( "load", completed );
+			window.addEventListener( "load", completed, false);
 
 		// If IE event model is used
 		} else {


### PR DESCRIPTION
### Summary ###
Restore old firefox support by adding explicit `useCapture` flag.


### Checklist ###
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.

* [X ] All authors have signed the CLA at https://contribute.jquery.com/CLA/
* [ ] New tests have been added to show the fix or feature works
* [X ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

Thanks! Bots and humans will be around shortly to check it out.

