### PR TITLE
Add slim build alias for module bundlers

### DIFF
--- a/slim.js
+++ b/slim.js
@@ -1,0 +1,2 @@
+// Alias for the slim jquery build for use with bundlers (wepback/browserify).
+module.exports = require('./dist/jquery.slim.js')


### PR DESCRIPTION
This PR is related to https://github.com/jquery/jquery/issues/3365.

Basically this adds an alias file `./slim.js` which makes it easier for es6/commonjs modules to require the slim build.

``` js
import 'jquery/dist/jquery.slim'
```

Becomes

``` js
import 'jquery/slim'
```
