### PR TITLE
Offset: report offset for 0 sized elements

### DIFF
--- a/src/offset.js
+++ b/src/offset.js
@@ -93,6 +93,7 @@ jQuery.fn.extend( {
 			return;
 		}
 
+		// Return zeros for disconnected and hidden (display: none) elements (gh-2310)
 		// Support: IE <=11 only
 		// Running getBoundingClientRect on a
 		// disconnected node in IE throws an error
@@ -102,20 +103,14 @@ jQuery.fn.extend( {
 
 		rect = elem.getBoundingClientRect();
 
-		// Make sure element is not hidden (display: none)
-		if ( rect.width || rect.height ) {
-			doc = elem.ownerDocument;
-			win = getWindow( doc );
-			docElem = doc.documentElement;
+		doc = elem.ownerDocument;
+		win = getWindow( doc );
+		docElem = doc.documentElement;
 
-			return {
-				top: rect.top + win.pageYOffset - docElem.clientTop,
-				left: rect.left + win.pageXOffset - docElem.clientLeft
-			};
-		}
-
-		// Return zeros for disconnected and hidden elements (gh-2310)
-		return rect;
+		return {
+			top: rect.top + win.pageYOffset - docElem.clientTop,
+			left: rect.left + win.pageXOffset - docElem.clientLeft
+		};
 	},
 
 	position: function() {

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -42,7 +42,7 @@ QUnit.test( "empty set", function( assert ) {
 } );
 
 QUnit.test( "disconnected element", function( assert ) {
-	assert.expect( 2 );
+	assert.expect( 3 );
 
 	var result = jQuery( document.createElement( "div" ) ).offset();
 
@@ -51,10 +51,11 @@ QUnit.test( "disconnected element", function( assert ) {
 	// valid input, but will return zeros for back-compat
 	assert.equal( result.top, 0, "Retrieving offset on disconnected elements returns zeros (gh-2310)" );
 	assert.equal( result.left, 0, "Retrieving offset on disconnected elements returns zeros (gh-2310)" );
+	assert.equal( Object.keys( result ).length, 2, "Retrieving offset on disconnected elements returns offset object (gh-3167)" );
 } );
 
 QUnit.test( "hidden (display: none) element", function( assert ) {
-	assert.expect( 2 );
+	assert.expect( 3 );
 
 	var node = jQuery( "<div style='display: none' />" ).appendTo( "#qunit-fixture" ),
 		result = node.offset();
@@ -66,6 +67,33 @@ QUnit.test( "hidden (display: none) element", function( assert ) {
 	// valid input, but will return zeros for back-compat
 	assert.equal( result.top, 0, "Retrieving offset on hidden elements returns zeros (gh-2310)" );
 	assert.equal( result.left, 0, "Retrieving offset on hidden elements returns zeros (gh-2310)" );
+	assert.equal( Object.keys( result ).length, 2, "Retrieving offset on hidden elements returns offset object (gh-3167)" );
+} );
+
+QUnit.test( "0 sized element", function( assert ) {
+	assert.expect( 3 );
+
+	var node = jQuery( "<div style='margin: 5px; width: 0; height: 0' />" ).appendTo( "#qunit-fixture" ),
+		result = node.offset();
+
+	node.remove();
+
+	assert.notEqual( result.top, 0, "Retrieving offset on 0 sized elements (gh-3167)" );
+	assert.notEqual( result.left, 0, "Retrieving offset on 0 sized elements (gh-3167)" );
+	assert.equal( Object.keys( result ).length, 2, "Retrieving offset on 0 sized elements returns offset object (gh-3167)" );
+} );
+
+QUnit.test( "hidden (visibility: hidden) element", function( assert ) {
+	assert.expect( 3 );
+
+	var node = jQuery( "<div style='margin: 5px; visibility: hidden' />" ).appendTo( "#qunit-fixture" ),
+		result = node.offset();
+
+	node.remove();
+
+	assert.notEqual( result.top, 0, "Retrieving offset on visibility:hidden elements (gh-3167)" );
+	assert.notEqual( result.left, 0, "Retrieving offset on visibility:hidden elements (gh-3167)" );
+	assert.equal( Object.keys( result ).length, 2, "Retrieving offset on visibility:hidden elements returns offset object (gh-3167)" );
 } );
 
 testIframe( "absolute", "offset/absolute.html", function( assert, $, iframe ) {


### PR DESCRIPTION
I assume this previously worked (except IE<=11+ which crashed) before 0e4477c676db0427bb9b0bf39df8631501e62f24.

Also previously when `if ( rect.width || rect.height )` failed it would return `rect` which would be the `getBoundingClientRect()` object containing top/bottom/left/right along with the width/height of 0. The top/left in there would probably be quite misleading?

Fixes [gh-3267](https://github.com/jquery/jquery/issues/3167)
- [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
- [x] New tests have been added to show the fix or feature works
- [x] Grunt build and unit tests pass locally with these changes
- [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com
