### PR TITLE
Docs: Remove supported jQuery versions from ISSUE_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,7 @@ Feature Requests:
   Most features should start as plugins outside of jQuery.
 
 Bug Reports:
-  Note that we only can fix bugs in the latest (1.x, 2.x, 3.x) versions of jQuery.
+  Note that we only can fix bugs in the latest version of jQuery.
   Briefly describe the issue you've encountered
   *  What do you expect to happen?
   *  What acually happens?


### PR DESCRIPTION
### Summary

<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

We no longer support jQuery 1.x/2.x and mentioning 3.x would just mean the text
gets out of date once we release jQuery 4. We only really support the latest
jQuery version so let's make that clear.
### Checklist

Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
- [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
- [x] Grunt build and unit tests pass locally with these changes

Thanks! Bots and humans will be around shortly to check it out.
