### PR TITLE
IE Memory leak clean

### DIFF
--- a/src/css/support.js
+++ b/src/css/support.js
@@ -43,6 +43,7 @@ define( [
 		// Nullify the div so it wouldn't be stored in the memory and
 		// it will also be a sign that checks already performed
 		div = null;
+		container = null;
 	}
 
 	var pixelPositionVal, boxSizingReliableVal, pixelMarginRightVal, reliableMarginLeftVal,
@@ -51,6 +52,8 @@ define( [
 
 	// Finish early in limited (non-browser) environments
 	if ( !div.style ) {
+		container = null;
+		div = null;
 		return;
 	}
 
@@ -67,18 +70,22 @@ define( [
 	jQuery.extend( support, {
 		pixelPosition: function() {
 			computeStyleTests();
+			div = null;
 			return pixelPositionVal;
 		},
 		boxSizingReliable: function() {
 			computeStyleTests();
+			div = null;
 			return boxSizingReliableVal;
 		},
 		pixelMarginRight: function() {
 			computeStyleTests();
+			div = null;
 			return pixelMarginRightVal;
 		},
 		reliableMarginLeft: function() {
 			computeStyleTests();
+			div = null;
 			return reliableMarginLeftVal;
 		}
 	} );

--- a/src/event.js
+++ b/src/event.js
@@ -214,6 +214,9 @@ jQuery.event = {
 			jQuery.event.global[ type ] = true;
 		}
 
+		eventHandle = undefined;
+		elemData = undefined;
+
 	},
 
 	// Detach an event or set of events from an element

--- a/src/event.js
+++ b/src/event.js
@@ -214,8 +214,9 @@ jQuery.event = {
 			jQuery.event.global[ type ] = true;
 		}
 
-		eventHandle = undefined;
-		elemData = undefined;
+		// Nullify the eventHandle so it wouldn't be stored in the memory
+		eventHandle = null;
+		elemData = null;
 
 	},
 


### PR DESCRIPTION
### Summary ###
There circular reference memory leak when adding an event at eventHandle  object

Css support module computeStyleTests create a memory leak in a node un-attached to the DOM

### Checklist ###
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.

* [ ] All authors have signed the CLA at https://contribute.jquery.com/CLA/
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

Thanks! Bots and humans will be around shortly to check it out.
