### PR TITLE
whatever the s.processData is, if s.data exist, jquery.param should execute if the data is not string for get request

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -557,8 +557,14 @@ jQuery.extend( {
 			}
 		}
 
+		// Uppercase the type
+		s.type = s.type.toUpperCase();
+
+		// Determine if request has content
+		s.hasContent = !rnoContent.test( s.type );
+
 		// Convert data if not already a string
-		if ( s.data && s.processData && typeof s.data !== "string" ) {
+		if ( s.data && ( s.processData || !s.hasContent ) && typeof s.data !== "string" ) {
 			s.data = jQuery.param( s.data, s.traditional );
 		}
 
@@ -578,12 +584,6 @@ jQuery.extend( {
 		if ( fireGlobals && jQuery.active++ === 0 ) {
 			jQuery.event.trigger( "ajaxStart" );
 		}
-
-		// Uppercase the type
-		s.type = s.type.toUpperCase();
-
-		// Determine if request has content
-		s.hasContent = !rnoContent.test( s.type );
 
 		// Save the URL in case we're toying with the If-Modified-Since
 		// and/or If-None-Match header later on


### PR DESCRIPTION
### Summary ###

GET request with data and the processData is false
```
$.ajax({
url: 'test.php',
type:'GET',
processData:false,
data:{a:1,b:2}
})
```

the request url will like test.php?[Object, Object]