### PR TITLE
Remove window object references and fix whitespace

### DIFF
--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -8,7 +8,6 @@
 	"globals": {
 		"window": true,
 		"jQuery": true,
-		"jQueryDefined": true,
 		"define": true,
 		"module": true,
 		"noGlobal": true

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -8,6 +8,7 @@
 	"globals": {
 		"window": true,
 		"jQuery": true,
+		"jQueryDefined": true,
 		"define": true,
 		"module": true,
 		"noGlobal": true

--- a/src/exports/global.js
+++ b/src/exports/global.js
@@ -7,11 +7,11 @@ define( [
         "use strict";
 
         // Map over jQuery in case of overwrite
-	
+
         var _jQuery = jQuery;
 
 	// Map over the $ in case of overwrite
-        
+
 	var _$ = $;
 
 	jQueryDefined.noConflict = function( deep ) {
@@ -29,7 +29,7 @@ define( [
 	// Expose jQuery and $ identifiers, even in AMD
 	// (#7102#comment:10, https://github.com/jquery/jquery/pull/557)
 	// and CommonJS for browser emulators (#13566)
-        
+
 	if ( !noGlobal ) {
 		jQuery = $ = jQueryDefined;
 	}

--- a/src/exports/global.js
+++ b/src/exports/global.js
@@ -1,34 +1,36 @@
+var $, jQuery;
+
 define( [
 	"../core"
-], function( jQuery, noGlobal ) {
+], function( jQueryDefined, noGlobal ) {
 
-"use strict";
+        "use strict";
 
-var
-
-	// Map over jQuery in case of overwrite
-	_jQuery = window.jQuery,
+        // Map over jQuery in case of overwrite
+	
+        var _jQuery = jQuery;
 
 	// Map over the $ in case of overwrite
-	_$ = window.$;
+        
+	var _$ = $;
 
-jQuery.noConflict = function( deep ) {
-	if ( window.$ === jQuery ) {
-		window.$ = _$;
+	jQueryDefined.noConflict = function( deep ) {
+		if ( $ === jQueryDefined ) {
+			$ = _$;
+		}
+
+		if ( deep && jQuery === jQueryDefined ) {
+			jQuery = _jQuery;
+		}
+
+		return jQueryDefined;
+	};
+
+	// Expose jQuery and $ identifiers, even in AMD
+	// (#7102#comment:10, https://github.com/jquery/jquery/pull/557)
+	// and CommonJS for browser emulators (#13566)
+        
+	if ( !noGlobal ) {
+		jQuery = $ = jQueryDefined;
 	}
-
-	if ( deep && window.jQuery === jQuery ) {
-		window.jQuery = _jQuery;
-	}
-
-	return jQuery;
-};
-
-// Expose jQuery and $ identifiers, even in AMD
-// (#7102#comment:10, https://github.com/jquery/jquery/pull/557)
-// and CommonJS for browser emulators (#13566)
-if ( !noGlobal ) {
-	window.jQuery = window.$ = jQuery;
-}
-
 } );

--- a/src/exports/global.js
+++ b/src/exports/global.js
@@ -1,7 +1,7 @@
 define( [
 	"../core"
 ], function( jQuery, noGlobal ) {
-	
+
         // Map over jQuery in case of overwrite
 
         var _jQuery = this.jQuery;

--- a/src/exports/global.js
+++ b/src/exports/global.js
@@ -1,6 +1,7 @@
 define( [
 	"../core"
 ], function( jQuery, noGlobal ) {
+	
         // Map over jQuery in case of overwrite
 
         var _jQuery = this.jQuery;

--- a/src/exports/global.js
+++ b/src/exports/global.js
@@ -10,11 +10,11 @@ define( [
 	var _$ = this.$;
 
 	jQuery.noConflict = function( deep ) {
-		if ( $ === jQuery ) {
+		if ( this.$ === jQuery ) {
 			this.$ = _$;
 		}
 
-		if ( deep && jQuery === jQuery ) {
+		if ( deep && this.jQuery === jQuery ) {
 			this.jQuery = _jQuery;
 		}
 

--- a/src/exports/global.js
+++ b/src/exports/global.js
@@ -1,29 +1,24 @@
-var $, jQuery;
-
 define( [
 	"../core"
-], function( jQueryDefined, noGlobal ) {
-
-        "use strict";
-
+], function( jQuery, noGlobal ) {
         // Map over jQuery in case of overwrite
 
-        var _jQuery = jQuery;
+        var _jQuery = this.jQuery;
 
 	// Map over the $ in case of overwrite
 
-	var _$ = $;
+	var _$ = this.$;
 
-	jQueryDefined.noConflict = function( deep ) {
-		if ( $ === jQueryDefined ) {
+	jQuery.noConflict = function( deep ) {
+		if ( $ === jQuery ) {
 			$ = _$;
 		}
 
-		if ( deep && jQuery === jQueryDefined ) {
+		if ( deep && jQuery === jQuery ) {
 			jQuery = _jQuery;
 		}
 
-		return jQueryDefined;
+		return jQuery;
 	};
 
 	// Expose jQuery and $ identifiers, even in AMD
@@ -31,6 +26,6 @@ define( [
 	// and CommonJS for browser emulators (#13566)
 
 	if ( !noGlobal ) {
-		jQuery = $ = jQueryDefined;
+		this.jQuery = this.$ = jQuery;
 	}
 } );

--- a/src/exports/global.js
+++ b/src/exports/global.js
@@ -11,11 +11,11 @@ define( [
 
 	jQuery.noConflict = function( deep ) {
 		if ( $ === jQuery ) {
-			$ = _$;
+			this.$ = _$;
 		}
 
 		if ( deep && jQuery === jQuery ) {
-			jQuery = _jQuery;
+			this.jQuery = _jQuery;
 		}
 
 		return jQuery;

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -38,7 +38,7 @@
 	}
 
 // Pass this if window is not defined yet
-} )( typeof window !== "undefined" ? window : this, function( window, noGlobal ) {
+} )( this, function( window, noGlobal ) {
 
 // Edge <= 12 - 13+, Firefox <=18 - 45+, IE 10 - 11, Safari 5.1 - 9+, iOS 6 - 9.1
 // throw exceptions when non-strict code (e.g., ASP.NET 4.5) accesses strict mode


### PR DESCRIPTION
### Summary ###
<!--
Remove window object references and fix whitespace. No open issue that I know if, but the code was still wrong. No new tests needed for this fix as the behavior should not change and no changes to docs needed. You can run the unit tests. Comment if there are any issues.

Also, there's nothing to sign at:
https://js.foundation/CLA/
-->


### Checklist ###
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.

* [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

Thanks! Bots and humans will be around shortly to check it out.

Always declare global variables.

https://gist.github.com/david-mark/7cf93afccf3696a4f6754b36cd6ab34e