### PR TITLE
Build: Make the @CODE-replacing regex more robust

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -17,7 +17,11 @@ module.exports = function( grunt ) {
 		read = function( fileName ) {
 			return grunt.file.read( srcFolder + fileName );
 		},
-		wrapper = read( "wrapper.js" ).split( /\/\/ \@CODE\n\/\/[^\n]+/ ),
+
+		// Catch `// @CODE` and subsequent comment lines event if they don't start
+		// in the first column.
+		wrapper = read( "wrapper.js" ).split( /[\x20\t]*\/\/ @CODE\n(?:[\x20\t]*\/\/[^\n]+\n)*/ ),
+
 		config = {
 			baseUrl: "src",
 			name: "jquery",


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
The code replacing @CODE in wrapper.js was written so that it expected
both the code and the next line to start in the first column. This commit
adjusts the regex so to get rid of that assumption and to work properly
regardless of number of lines with comments after this block.

While this is technically not necessary for our code, contributors sometimes
re-format the wrapper file in their pull requests and the error
messages they get don't tell them what's the real problem with their code.

### Checklist ###
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.

* [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
* ~~New tests have been added to show the fix or feature works~~
* [X] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

Thanks! Bots and humans will be around shortly to check it out.