### PR TITLE
Build: fix markerPattern and ticketPattern regexes in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
       "Traversing",
       "Wrap"
     ],
-    "markerPattern": "^((clos|fix|resolv)(e[sd]|ing))|(refs?)",
-    "ticketPattern": "^((Closes|Fixes) ([a-zA-Z]{2,}-)[0-9]+)|(Refs? [^#])"
+    "markerPattern": "^((clos|fix|resolv)(e[sd]|ing))|^(refs?)",
+    "ticketPattern": "^((Closes|Fixes) ([a-zA-Z]{2,}-)[0-9]+)|^(Refs? [^#])"
   }
 }


### PR DESCRIPTION
### Summary ###

@mgol recently reported in jzaefferer/commitplease#91 that commitplease failed with valid commit messages. That happened because the regular expressions configured here in package.json triggered for any word with a prefix "ref", like reformat or refactor. This PR fixes those regular expressions.

### Checklist ###
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.

* [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
~~~* [ ] New tests have been added to show the fix or feature works~~~
* [x] Grunt build and unit tests pass locally with these changes~~~
~~~* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~~

Thanks! Bots and humans will be around shortly to check it out.

Commit messages used to fail the style check if they contained a word
starting with "ref", like reformat or reference, in their message body.

Refs jzaefferer/commitplease#91