### PR TITLE
Traversing: $.fn.contents() supports HTMLTemplateElement

### DIFF
--- a/src/traversing.js
+++ b/src/traversing.js
@@ -143,8 +143,11 @@ jQuery.each( {
 		return siblings( elem.firstChild );
 	},
 	contents: function( elem ) {
-		return elem.contentDocument ||
-            jQuery.merge( [], ( elem.content || elem ).childNodes );
+        switch ( elem.nodeName.toLowerCase() ) {
+            case "iframe":      return elem.contentDocument;
+            case "template":    elem = elem.content;
+            default:            return jQuery.merge( [], elem.childNodes );
+        }
 	}
 }, function( name, fn ) {
 	jQuery.fn[ name ] = function( until, selector ) {

--- a/src/traversing.js
+++ b/src/traversing.js
@@ -148,7 +148,7 @@ jQuery.each( {
         }
 
         if ( jQuery.nodeName( elem, "template" ) ) {
-            elem = elem.content;
+            elem = elem.content || elem;
         }
 
         return jQuery.merge( [], elem.childNodes );

--- a/src/traversing.js
+++ b/src/traversing.js
@@ -143,11 +143,15 @@ jQuery.each( {
 		return siblings( elem.firstChild );
 	},
 	contents: function( elem ) {
-        switch ( elem.nodeName.toLowerCase() ) {
-            case "iframe":      return elem.contentDocument;
-            case "template":    elem = elem.content;
-            default:            return jQuery.merge( [], elem.childNodes );
+        if ( elem.nodeName === "IFRAME" ) {
+            return elem.contentDocument;
         }
+
+        if ( elem.nodeName === "TEMPLATE" ) {
+            elem = elem.content;
+        }
+
+        return jQuery.merge( [], elem.childNodes );
 	}
 }, function( name, fn ) {
 	jQuery.fn[ name ] = function( until, selector ) {

--- a/src/traversing.js
+++ b/src/traversing.js
@@ -143,11 +143,11 @@ jQuery.each( {
 		return siblings( elem.firstChild );
 	},
 	contents: function( elem ) {
-        if ( elem.nodeName === "IFRAME" ) {
+        if ( jQuery.nodeName( elem, "iframe" ) ) {
             return elem.contentDocument;
         }
 
-        if ( elem.nodeName === "TEMPLATE" ) {
+        if ( jQuery.nodeName( elem, "template" ) ) {
             elem = elem.content;
         }
 

--- a/src/traversing.js
+++ b/src/traversing.js
@@ -143,7 +143,8 @@ jQuery.each( {
 		return siblings( elem.firstChild );
 	},
 	contents: function( elem ) {
-		return elem.contentDocument || jQuery.merge( [], elem.childNodes );
+		return elem.contentDocument ||
+            jQuery.merge( [], ( elem.content || elem ).childNodes );
 	}
 }, function( name, fn ) {
 	jQuery.fn[ name ] = function( until, selector ) {

--- a/src/traversing.js
+++ b/src/traversing.js
@@ -147,6 +147,9 @@ jQuery.each( {
             return elem.contentDocument;
         }
 
+        // Support: IE 9 - 11 only, iOS 7 only, Android Browser <=4.3 only
+        // Treat the template element as a regular one in browsers that
+        // don't support it.
         if ( jQuery.nodeName( elem, "template" ) ) {
             elem = elem.content || elem;
         }

--- a/test/index.html
+++ b/test/index.html
@@ -298,5 +298,9 @@ Z</textarea>
 		<div id="template-div1"></div>
 		<div id="template-div2"></div>
     </template>
+    <form id="test_contents">
+        <input type="text" name="contentDocument" />
+        <input type="text" name="content" />
+    </form>
 </body>
 </html>

--- a/test/index.html
+++ b/test/index.html
@@ -291,16 +291,6 @@ Z</textarea>
 	<map name="imgmap" id="imgmap">
 		<area shape="rect" coords="0,0,200,50">
 	</map>
-    <template id="template">
-		<div id="template-div0">
-			<span>Hello, Web Component!</span>
-		</div>
-		<div id="template-div1"></div>
-		<div id="template-div2"></div>
-    </template>
-    <form id="test_contents">
-        <input type="text" name="contentDocument" />
-        <input type="text" name="content" />
-    </form>
+
 </body>
 </html>

--- a/test/index.html
+++ b/test/index.html
@@ -291,6 +291,12 @@ Z</textarea>
 	<map name="imgmap" id="imgmap">
 		<area shape="rect" coords="0,0,200,50">
 	</map>
-
+    <template id="template">
+		<div id="template-div0">
+			<span>Hello, Web Component!</span>
+		</div>
+		<div id="template-div1"></div>
+		<div id="template-div2"></div>
+    </template>
 </body>
 </html>

--- a/test/unit/traversing.js
+++ b/test/unit/traversing.js
@@ -710,7 +710,7 @@ QUnit.test( "prevUntil([String])", function( assert ) {
 } );
 
 QUnit.test( "contents()", function( assert ) {
-	assert.expect( 12 );
+	assert.expect( 16 );
 	var ibody, c;
 
 	assert.equal( jQuery( "#ap" ).contents().length, 9, "Check element contents" );
@@ -741,6 +741,23 @@ QUnit.test( "contents()", function( assert ) {
 	c = jQuery( "#nonnodes" ).contents().contents();
 	assert.equal( c.length, 1, "Check node,textnode,comment contents is just one" );
 	assert.equal( c[ 0 ].nodeValue, "hi", "Check node,textnode,comment contents is just the one from span" );
+
+    c = jQuery( "#template" ).contents();
+    assert.equal( c.length, 7, "Check template element contents" );
+
+    assert.equal( c.find( "span" ).text(), "Hello, Web Component!", "Find span in Template and check its text" );
+
+    jQuery( "<div id=\"templateTest\" />" ).append(
+        jQuery( jQuery.map( c, function( node ) {
+            return document.importNode( node, true );
+        } ) )
+    ).appendTo( document.body );
+
+    c = jQuery( "#templateTest" ).contents();
+    assert.equal( c.length, 7, "Check cloned nodes of template element contents" );
+
+    assert.equal( c.filter( "div" ).length, 3, "Count cloned elements from template" );
+    jQuery( "#templateTest" ).remove();
 } );
 
 QUnit.test( "sort direction", function( assert ) {

--- a/test/unit/traversing.js
+++ b/test/unit/traversing.js
@@ -743,8 +743,7 @@ QUnit.test( "contents()", function( assert ) {
 	assert.equal( c[ 0 ].nodeValue, "hi", "Check node,textnode,comment contents is just the one from span" );
 } );
 
-QUnit.test( "contents() for <template />", function( assert ) {
-	assert.expect( 4 );
+QUnit.test( "contents() for <template />", 4, function( assert ) {
 
     jQuery( "#qunit-fixture" ).append(
         "<template id='template'>" +
@@ -771,8 +770,28 @@ QUnit.test( "contents() for <template />", function( assert ) {
     assert.equal( contents.length, 6, "Check cloned nodes of template element contents" );
 
     assert.equal( contents.filter( "div" ).length, 3, "Count cloned elements from template" );
-    jQuery( "#templateTest" ).remove();
 } );
+
+QUnit[ "content" in document.createElement( "template" ) ? "test" : "skip" ](
+	"contents() for <template /> remains inert",
+    2,
+	function( assert ) {
+		Globals.register( "testScript" );
+		Globals.register( "testImgOnload" );
+
+        jQuery( "#qunit-fixture" ).append(
+            "<template id='template'>" +
+            "    <script>testScript = 1;</script>" +
+            "    <img src='data/1x1.jpg' onload='testImgOnload = 1' >" +
+            "</template>"
+        );
+
+        var content = jQuery( "#template" ).contents();
+
+        assert.strictEqual( window.testScript, true, "script in template isn't executed" );
+        assert.strictEqual( window.testImgOnload, true, "onload of image in template isn't executed" );
+	}
+);
 
 QUnit.test( "sort direction", function( assert ) {
 	assert.expect( 12 );

--- a/test/unit/traversing.js
+++ b/test/unit/traversing.js
@@ -746,7 +746,7 @@ QUnit.test( "contents()", function( assert ) {
 QUnit.test( "contents() for <template />", function( assert ) {
 	assert.expect( 6 );
 
-    jQuery( "body" ).append(
+    jQuery( "#qunit-fixture" ).append(
         "<template id=\"template\">" +
         "    <div id=\"template-div0\">" +
         "        <span>Hello, Web Component!</span>" +

--- a/test/unit/traversing.js
+++ b/test/unit/traversing.js
@@ -743,7 +743,8 @@ QUnit.test( "contents()", function( assert ) {
 	assert.equal( c[ 0 ].nodeValue, "hi", "Check node,textnode,comment contents is just the one from span" );
 } );
 
-QUnit.test( "contents() for <template />", 4, function( assert ) {
+QUnit.test( "contents() for <template />", function( assert ) {
+    assert.expect( 4 );
 
     jQuery( "#qunit-fixture" ).append(
         "<template id='template'>" +
@@ -774,8 +775,9 @@ QUnit.test( "contents() for <template />", 4, function( assert ) {
 
 QUnit[ "content" in document.createElement( "template" ) ? "test" : "skip" ](
 	"contents() for <template /> remains inert",
-    2,
 	function( assert ) {
+        assert.expect( 2 );
+
 		Globals.register( "testScript" );
 		Globals.register( "testImgOnload" );
 

--- a/test/unit/traversing.js
+++ b/test/unit/traversing.js
@@ -710,8 +710,8 @@ QUnit.test( "prevUntil([String])", function( assert ) {
 } );
 
 QUnit.test( "contents()", function( assert ) {
-	assert.expect( 16 );
-	var ibody, c;
+	assert.expect( 18 );
+	var ibody, c, iform;
 
 	assert.equal( jQuery( "#ap" ).contents().length, 9, "Check element contents" );
 	assert.ok( jQuery( "#iframe" ).contents()[ 0 ], "Check existence of IFrame document" );
@@ -758,6 +758,12 @@ QUnit.test( "contents()", function( assert ) {
 
     assert.equal( c.filter( "div" ).length, 3, "Count cloned elements from template" );
     jQuery( "#templateTest" ).remove();
+
+    iform = jQuery( "#test_contents" );
+    assert.equal( iform.contents().length, 5, "Check no conflict with Form shortcuts" );
+
+    iform.children().eq( 0 ).remove();
+    assert.equal( iform.contents().length, 4, "Check no conflict with Form shortcuts" );
 } );
 
 QUnit.test( "sort direction", function( assert ) {

--- a/test/unit/traversing.js
+++ b/test/unit/traversing.js
@@ -744,46 +744,34 @@ QUnit.test( "contents()", function( assert ) {
 } );
 
 QUnit.test( "contents() for <template />", function( assert ) {
-	assert.expect( 6 );
+	assert.expect( 4 );
 
     jQuery( "#qunit-fixture" ).append(
-        "<template id=\"template\">" +
-        "    <div id=\"template-div0\">" +
+        "<template id='template'>" +
+        "    <div id='template-div0'>" +
         "        <span>Hello, Web Component!</span>" +
         "    </div>" +
-        "    <div id=\"template-div1\"></div>" +
-        "    <div id=\"template-div2\"></div>" +
-        "</template>" +
-        "<form id=\"test_contents\">" +
-        "    <input type=\"text\" name=\"contentDocument\" />" +
-        "    <input type=\"text\" name=\"content\" />" +
-        "</form>"
+        "    <div id='template-div1'></div>" +
+        "    <div id='template-div2'></div>" +
+        "</template>"
     );
 
-    var c = jQuery( "#template" ).contents();
-    assert.equal( c.length, 6, "Check template element contents" );
+    var contents = jQuery( "#template" ).contents();
+    assert.equal( contents.length, 6, "Check template element contents" );
 
-    assert.equal( c.find( "span" ).text(), "Hello, Web Component!", "Find span in Template and check its text" );
+    assert.equal( contents.find( "span" ).text(), "Hello, Web Component!", "Find span in template and check its text" );
 
-    jQuery( "<div id=\"templateTest\" />" ).append(
-        jQuery( jQuery.map( c, function( node ) {
+    jQuery( "<div id='templateTest' />" ).append(
+        jQuery( jQuery.map( contents, function( node ) {
             return document.importNode( node, true );
         } ) )
-    ).appendTo( document.body );
+    ).appendTo( "#qunit-fixture" );
 
-    c = jQuery( "#templateTest" ).contents();
-    assert.equal( c.length, 6, "Check cloned nodes of template element contents" );
+    contents = jQuery( "#templateTest" ).contents();
+    assert.equal( contents.length, 6, "Check cloned nodes of template element contents" );
 
-    assert.equal( c.filter( "div" ).length, 3, "Count cloned elements from template" );
+    assert.equal( contents.filter( "div" ).length, 3, "Count cloned elements from template" );
     jQuery( "#templateTest" ).remove();
-
-    var iform = jQuery( "#test_contents" );
-    assert.equal( iform.contents().length, 4, "Check no conflict with Form shortcuts" );
-
-    iform.children().eq( 0 ).remove();
-    assert.equal( iform.contents().length, 3, "Check no conflict with Form shortcuts" );
-
-    iform.add( iform.prev() ).remove();
 } );
 
 QUnit.test( "sort direction", function( assert ) {

--- a/test/unit/traversing.js
+++ b/test/unit/traversing.js
@@ -710,8 +710,8 @@ QUnit.test( "prevUntil([String])", function( assert ) {
 } );
 
 QUnit.test( "contents()", function( assert ) {
-	assert.expect( 18 );
-	var ibody, c, iform;
+	assert.expect( 12 );
+	var ibody, c;
 
 	assert.equal( jQuery( "#ap" ).contents().length, 9, "Check element contents" );
 	assert.ok( jQuery( "#iframe" ).contents()[ 0 ], "Check existence of IFrame document" );
@@ -741,9 +741,27 @@ QUnit.test( "contents()", function( assert ) {
 	c = jQuery( "#nonnodes" ).contents().contents();
 	assert.equal( c.length, 1, "Check node,textnode,comment contents is just one" );
 	assert.equal( c[ 0 ].nodeValue, "hi", "Check node,textnode,comment contents is just the one from span" );
+} );
 
-    c = jQuery( "#template" ).contents();
-    assert.equal( c.length, 7, "Check template element contents" );
+QUnit.test( "contents() for <template />", function( assert ) {
+	assert.expect( 6 );
+
+    jQuery( "body" ).append(
+        "<template id=\"template\">" +
+        "    <div id=\"template-div0\">" +
+        "        <span>Hello, Web Component!</span>" +
+        "    </div>" +
+        "    <div id=\"template-div1\"></div>" +
+        "    <div id=\"template-div2\"></div>" +
+        "</template>" +
+        "<form id=\"test_contents\">" +
+        "    <input type=\"text\" name=\"contentDocument\" />" +
+        "    <input type=\"text\" name=\"content\" />" +
+        "</form>"
+    );
+
+    var c = jQuery( "#template" ).contents();
+    assert.equal( c.length, 6, "Check template element contents" );
 
     assert.equal( c.find( "span" ).text(), "Hello, Web Component!", "Find span in Template and check its text" );
 
@@ -754,16 +772,18 @@ QUnit.test( "contents()", function( assert ) {
     ).appendTo( document.body );
 
     c = jQuery( "#templateTest" ).contents();
-    assert.equal( c.length, 7, "Check cloned nodes of template element contents" );
+    assert.equal( c.length, 6, "Check cloned nodes of template element contents" );
 
     assert.equal( c.filter( "div" ).length, 3, "Count cloned elements from template" );
     jQuery( "#templateTest" ).remove();
 
-    iform = jQuery( "#test_contents" );
-    assert.equal( iform.contents().length, 5, "Check no conflict with Form shortcuts" );
+    var iform = jQuery( "#test_contents" );
+    assert.equal( iform.contents().length, 4, "Check no conflict with Form shortcuts" );
 
     iform.children().eq( 0 ).remove();
-    assert.equal( iform.contents().length, 4, "Check no conflict with Form shortcuts" );
+    assert.equal( iform.contents().length, 3, "Check no conflict with Form shortcuts" );
+
+    iform.add( iform.prev() ).remove();
 } );
 
 QUnit.test( "sort direction", function( assert ) {


### PR DESCRIPTION
### Summary ###

Add support to `$.fn.contents()` for [HTMLTemplateElement](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template).

Related with #3436


### Checklist ###

* [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com