### PR TITLE
Manipulation: Restrict the tbody search to child nodes

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -52,7 +52,7 @@ function manipulationTarget( elem, content ) {
 	if ( jQuery.nodeName( elem, "table" ) &&
 		jQuery.nodeName( content.nodeType !== 11 ? content : content.firstChild, "tr" ) ) {
 
-		return jQuery.filter( "tbody", elem.childNodes )[ 0 ] || elem;
+		return jQuery( ">tbody", elem )[ 0 ] || elem;
 	}
 
 	return elem;

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -47,6 +47,7 @@ var
 	rscriptTypeMasked = /^true\/(.*)/,
 	rcleanScript = /^\s*<!(?:\[CDATA\[|--)|(?:\]\]|--)>\s*$/g;
 
+// Append table rows to a tbody when one is present
 function manipulationTarget( elem, content ) {
 	if ( jQuery.nodeName( elem, "table" ) &&
 		jQuery.nodeName( content.nodeType !== 11 ? content : content.firstChild, "tr" ) ) {

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -51,7 +51,7 @@ function manipulationTarget( elem, content ) {
 	if ( jQuery.nodeName( elem, "table" ) &&
 		jQuery.nodeName( content.nodeType !== 11 ? content : content.firstChild, "tr" ) ) {
 
-		return elem.getElementsByTagName( "tbody" )[ 0 ] || elem;
+		return jQuery.filter( "tbody", elem.childNodes )[ 0 ] || elem;
 	}
 
 	return elem;

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -47,7 +47,7 @@ var
 	rscriptTypeMasked = /^true\/(.*)/,
 	rcleanScript = /^\s*<!(?:\[CDATA\[|--)|(?:\]\]|--)>\s*$/g;
 
-// Append table rows to a tbody when one is present
+// Prefer a tbody over its parent table for containing new rows
 function manipulationTarget( elem, content ) {
 	if ( jQuery.nodeName( elem, "table" ) &&
 		jQuery.nodeName( content.nodeType !== 11 ? content : content.firstChild, "tr" ) ) {

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -2730,6 +2730,26 @@ QUnit.test( "Make sure col element is appended correctly", function( assert ) {
 	assert.strictEqual( table.find( "td" ).width(), 150 );
 } );
 
+QUnit.test( "Make sure tr is not appended to the wrong tbody (gh-3439)", function( assert ) {
+	assert.expect( 1 );
+
+	var htmlOut,
+		htmlIn =
+			"<thead><tr><td>" +
+				"<table><tbody><tr><td>nested</td></tr></tbody></table>" +
+			"</td></tr></thead>",
+		newRow = "<tr><td>added</td></tr>",
+		htmlExpected = htmlIn.replace( "</thead>", "</thead>" + newRow ),
+		table = supportjQuery( "<table/>" ).html( htmlIn ).appendTo( "#qunit-fixture" )[ 0 ];
+
+	jQuery( table ).append( newRow );
+
+	// Lowercase and replace spaces to remove possible browser inconsistencies
+	htmlOut = table.innerHTML.toLowerCase().replace( /\s/g, "" );
+
+	assert.strictEqual( htmlOut, htmlExpected );
+} );
+
 QUnit.test( "Insert script with data-URI (gh-1887)", 1, function( assert ) {
 	Globals.register( "testFoo" );
 	Globals.register( "testSrcFoo" );


### PR DESCRIPTION
Fixes gh-3439

```
   raw     gz Sizes                                                            
267269  79153 dist/jquery.js                                                   
 86863  30052 dist/jquery.min.js                                               

   raw     gz Compared to master @ bf3a43eff8682b59cec785be6003753fa4b93706    
   +59    +19 dist/jquery.js                                                   
    -1     +9 dist/jquery.min.js
```