### PR TITLE
Tests: Added tests for colon separated tag names

### DIFF
--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -691,17 +691,20 @@ QUnit.test( "jQuery(element with non-alphanumeric name)", function( assert ) {
 	assert.expect( 36 );
 
 	jQuery.each( [ "-", ":" ], function( i, symbol ) {
-		jQuery.each( [ "thead", "tbody", "tfoot", "colgroup", "caption", "tr", "th", "td" ], function( j, tag ) {
+		jQuery.each( [ "thead", "tbody", "tfoot", "colgroup", "caption", "tr", "th", "td" ],
+			function( j, tag ) {
 			var tagName = tag + symbol + "test";
 			var el = jQuery( "<" + tagName + "></" + tagName + ">" );
 			assert.ok( el[ 0 ], "Create a " + tagName + " element" );
-			assert.ok( jQuery.nodeName( el[ 0 ], tagName.toUpperCase() ), tagName + " element has expected node name" );
+			assert.ok( jQuery.nodeName( el[ 0 ], tagName.toUpperCase() ),
+				tagName + " element has expected node name" );
 		} );
 
 		var tagName = [ "tr", "multiple", "symbol" ].join( symbol );
 		var el = jQuery( "<" + tagName + "></" + tagName + ">" );
 		assert.ok( el[ 0 ], "Create a " + tagName + " element" );
-		assert.ok( jQuery.nodeName( el[ 0 ], tagName.toUpperCase() ), tagName + " element has expected node name" );
+		assert.ok( jQuery.nodeName( el[ 0 ], tagName.toUpperCase() ),
+			tagName + " element has expected node name" );
 	} );
 } );
 

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -687,18 +687,21 @@ QUnit.test( "jQuery('html')", function( assert ) {
 	assert.equal( jQuery( "\\<div\\>" ).length, 0, "Ignore escaped html characters" );
 } );
 
-QUnit.test( "jQuery(symbol separated elements)", function( assert ) {
-	assert.expect( 34 );
+QUnit.test( "jQuery(element with non-alphanumeric name)", function( assert ) {
+	assert.expect( 36 );
 
-	jQuery.each( "- :".split( " " ), function( i, symbol ) {
-		jQuery.each( "thead tbody tfoot colgroup caption tr th td".split( " " ), function( k, element ) {
-			var j = jQuery( "<" + element + symbol + "test></" + element + symbol + "test>" );
-			assert.ok( j[ 0 ], "Create an element with \"" + symbol + "\" in its tag" );
-			assert.ok( jQuery.nodeName( j[ 0 ], element.toUpperCase() + symbol + "TEST" ), "Element with \"" + symbol + "\" in its tag has expected node name" );
+	jQuery.each( [ "-", ":" ], function( i, symbol ) {
+		jQuery.each( [ "thead", "tbody", "tfoot", "colgroup", "caption", "tr", "th", "td" ], function( j, tag ) {
+			var tagName = tag + symbol + "test";
+			var el = jQuery( "<" + tagName + "></" + tagName + ">" );
+			assert.ok( el[ 0 ], "Create a " + tagName + " element" );
+			assert.ok( jQuery.nodeName( el[ 0 ], tagName.toUpperCase() ), tagName + " element has expected node name" );
 		} );
 
-		var j = jQuery( "<tr" + symbol + "multiple" + symbol + "symbols></tr" + symbol + "multiple" + symbol + "symbols>" );
-		assert.ok( jQuery.nodeName( j[ 0 ], "TR" + symbol + "MULTIPLE" + symbol + "SYMBOLS" ), "Element with multiple \"" + symbol + "\" in its tag has expected node name" );
+		var tagName = [ "tr", "multiple", "symbol" ].join( symbol );
+		var el = jQuery( "<" + tagName + "></" + tagName + ">" );
+		assert.ok( el[ 0 ], "Create a " + tagName + " element" );
+		assert.ok( jQuery.nodeName( el[ 0 ], tagName.toUpperCase() ), tagName + " element has expected node name" );
 	} );
 } );
 

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -687,17 +687,19 @@ QUnit.test( "jQuery('html')", function( assert ) {
 	assert.equal( jQuery( "\\<div\\>" ).length, 0, "Ignore escaped html characters" );
 } );
 
-QUnit.test( "jQuery(tag-hyphenated elements) gh-1987", function( assert ) {
-	assert.expect( 17 );
+QUnit.test( "jQuery(symbol separated elements)", function( assert ) {
+	assert.expect( 34 );
 
-	jQuery.each( "thead tbody tfoot colgroup caption tr th td".split( " " ), function( i, name ) {
-		var j = jQuery( "<" + name + "-d></" + name + "-d>" );
-		assert.ok( j[ 0 ], "Create a tag-hyphenated elements" );
-		assert.ok( jQuery.nodeName( j[ 0 ], name.toUpperCase() + "-D" ), "Tag-hyphenated element has expected node name" );
+	jQuery.each( "- :".split( " " ), function( i, symbol ) {
+		jQuery.each( "thead tbody tfoot colgroup caption tr th td".split( " " ), function( k, element ) {
+			var j = jQuery( "<" + element + symbol + "test></" + element + symbol + "test>" );
+			assert.ok( j[ 0 ], "Create an element with \"" + symbol + "\" in its tag" );
+			assert.ok( jQuery.nodeName( j[ 0 ], element.toUpperCase() + symbol + "TEST" ), "Element with \"" + symbol + "\" in its tag has expected node name" );
+		} );
+
+		var j = jQuery( "<tr" + symbol + "multiple" + symbol + "symbols></tr" + symbol + "multiple" + symbol + "symbols>" );
+		assert.ok( jQuery.nodeName( j[ 0 ], "TR" + symbol + "MULTIPLE" + symbol + "SYMBOLS" ), "Element with multiple \"" + symbol + "\" in its tag has expected node name" );
 	} );
-
-	var j = jQuery( "<tr-multiple-hyphens></tr-multiple-hyphens>" );
-	assert.ok( jQuery.nodeName( j[ 0 ], "TR-MULTIPLE-HYPHENS" ), "Element with multiple hyphens in its tag has expected node name" );
 } );
 
 QUnit.test( "jQuery('massive html #7990')", function( assert ) {


### PR DESCRIPTION
### Summary ###
This should cover #2006. Are there any other symbols we would specifically like to test?

### Checklist ###
* [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com