### PR TITLE
Build: Drop support for building on Node.js 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-- "0.12"
 - "4"
 - "6"
 - "7"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,15 +13,7 @@ module.exports = function( grunt ) {
 	}
 
 	var fs = require( "fs" ),
-		gzip = require( "gzip-js" ),
-		oldNode = /^v0\./.test( process.version );
-
-	// Support: Node.js <4
-	// Skip running tasks that dropped support for Node.js 0.12
-	// in this Node version.
-	function runIfNewNode( task ) {
-		return oldNode ? "print_old_node_message:" + task : task;
-	}
+		gzip = require( "gzip-js" );
 
 	if ( !grunt.option( "filename" ) ) {
 		grunt.option( "filename", "jquery.js" );
@@ -187,19 +179,10 @@ module.exports = function( grunt ) {
 	} );
 
 	// Load grunt tasks from NPM packages
-	// Support: Node.js <4
-	// Don't load the eslint task in old Node.js, it won't parse.
-	require( "load-grunt-tasks" )( grunt, {
-		pattern: oldNode ? [ "grunt-*", "!grunt-eslint" ] : [ "grunt-*" ]
-	} );
+	require( "load-grunt-tasks" )( grunt );
 
 	// Integrate jQuery specific tasks
 	grunt.loadTasks( "build/tasks" );
-
-	grunt.registerTask( "print_old_node_message", function() {
-		var task = [].slice.call( arguments ).join( ":" );
-		grunt.log.writeln( "Old Node.js detected, running the task \"" + task + "\" skipped..." );
-	} );
 
 	grunt.registerTask( "lint", [
 		"jsonlint",
@@ -208,20 +191,20 @@ module.exports = function( grunt ) {
 		// would run the dist target first which would point to errors in the built
 		// file, making it harder to fix them. We want to check the built file only
 		// if we already know the source files pass the linter.
-		runIfNewNode( "eslint:dev" ),
-		runIfNewNode( "eslint:dist" )
+		"eslint:dev",
+		"eslint:dist"
 	] );
 
 	grunt.registerTask( "lint:newer", [
 		"newer:jsonlint",
 
 		// Don't replace it with just the task; see the above comment.
-		runIfNewNode( "newer:eslint:dev" ),
-		runIfNewNode( "newer:eslint:dist" )
+		"newer:eslint:dev",
+		"newer:eslint:dist"
 	] );
 
-	grunt.registerTask( "test:fast", runIfNewNode( "node_smoke_tests" ) );
-	grunt.registerTask( "test:slow", runIfNewNode( "promises_aplus_tests" ) );
+	grunt.registerTask( "test:fast", "node_smoke_tests" );
+	grunt.registerTask( "test:slow", "promises_aplus_tests" );
 
 	grunt.registerTask( "test", [
 		"test:fast",
@@ -230,7 +213,7 @@ module.exports = function( grunt ) {
 
 	grunt.registerTask( "dev", [
 		"build:*:*",
-		runIfNewNode( "newer:eslint:dev" ),
+		"newer:eslint:dev",
 		"newer:uglify",
 		"remove_map_comment",
 		"dist:*",
@@ -238,12 +221,12 @@ module.exports = function( grunt ) {
 	] );
 
 	grunt.registerTask( "default", [
-		runIfNewNode( "eslint:dev" ),
+		"eslint:dev",
 		"build:*:*",
 		"uglify",
 		"remove_map_comment",
 		"dist:*",
-		runIfNewNode( "eslint:dist" ),
+		"eslint:dist",
 		"test:fast",
 		"compare_size"
 	] );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Node.js 0.12 is no longer supported by upstream. So far we had to keep
a workaround that would skip running ESLint there (or even load its task)
as it no longer supports Node.js <4; the same applied to Node smoke tests
as jsdom has also dropped support for those old Node versions. Those
workarounds have been removed now.

Ref 030191ae32dfcb7ecb2efb61d17a4964a3633e44

### Checklist ###
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.

* [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
* [x] Grunt build and unit tests pass locally with these changes

Thanks! Bots and humans will be around shortly to check it out.
