### PR TITLE
fix isWindow in core.js

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -216,7 +216,7 @@ jQuery.extend( {
 	},
 
 	isWindow: function( obj ) {
-		return obj != null && obj === obj.window;
+		return obj != null && obj === obj.window && toString.call(obj) === '[object Window]';
 	},
 
 	isNumeric: function( obj ) {

--- a/src/core.js
+++ b/src/core.js
@@ -216,7 +216,7 @@ jQuery.extend( {
 	},
 
 	isWindow: function( obj ) {
-		return obj != null && obj === obj.window && toString.call(obj) === '[object Window]';
+		return obj != null && obj === obj.window && toString.call( obj ) === '[object Window]';
 	},
 
 	isNumeric: function( obj ) {

--- a/src/core.js
+++ b/src/core.js
@@ -216,7 +216,7 @@ jQuery.extend( {
 	},
 
 	isWindow: function( obj ) {
-		return obj != null && obj === obj.window && toString.call( obj ) === '[object Window]';
+		return obj != null && obj === obj.window && toString.call( obj ) === "[object Window]";
 	},
 
 	isNumeric: function( obj ) {


### PR DESCRIPTION
```js
var a = {};
a.window = a;
console.log(a.window === a); // => true
```

so we need to fix it with `Object.prototype.toString.call(obj) === '[object Window]'`