### PR TITLE
Fix .offset() and .position() bugs

### DIFF
--- a/src/offset.js
+++ b/src/offset.js
@@ -81,7 +81,7 @@ jQuery.fn.extend( {
 				} );
 		}
 
-		var doc, docElem, rect, win,
+		var rect, win,
 			elem = this[ 0 ];
 
 		if ( !elem ) {
@@ -97,14 +97,22 @@ jQuery.fn.extend( {
 		}
 
 		rect = elem.getBoundingClientRect();
+		win = elem.ownerDocument.defaultView;
 
-		doc = elem.ownerDocument;
-		docElem = doc.documentElement;
-		win = doc.defaultView;
+		// Check for viewport-relative data
+		for ( ; elem; elem = elem.offsetParent ) {
+			if ( jQuery.css( elem, "position" ) === "fixed" ) {
+				return {
+					top: rect.top,
+					left: rect.left
+				};
+			}
+		}
 
+		// Absent fixed positioning, add back the viewport scroll
 		return {
-			top: rect.top + win.pageYOffset - docElem.clientTop,
-			left: rect.left + win.pageXOffset - docElem.clientLeft
+			top: rect.top + win.pageYOffset,
+			left: rect.left + win.pageXOffset
 		};
 	},
 

--- a/src/offset.js
+++ b/src/offset.js
@@ -97,21 +97,9 @@ jQuery.fn.extend( {
 			return { top: 0, left: 0 };
 		}
 
-		// gBCR returns position relative to the viewport
+		// Get document-relative position by adding viewport scroll to viewport-relative gBCR
 		rect = elem.getBoundingClientRect();
 		win = elem.ownerDocument.defaultView;
-
-		// Check for viewport-relative data
-		for ( ; elem; elem = elem.offsetParent ) {
-			if ( jQuery.css( elem, "position" ) === "fixed" ) {
-				return {
-					top: rect.top,
-					left: rect.left
-				};
-			}
-		}
-
-		// Add the viewport scroll to get document-relative values
 		return {
 			top: rect.top + win.pageYOffset,
 			left: rect.left + win.pageXOffset

--- a/src/offset.js
+++ b/src/offset.js
@@ -144,7 +144,7 @@ jQuery.fn.extend( {
 
 				offsetParent = offsetParent.parentNode;
 			}
-			if ( offsetParent && offsetParent.nodeType === 1 ) {
+			if ( offsetParent && offsetParent !== elem && offsetParent.nodeType === 1 ) {
 
 				// Incorporate borders into its offset, since they are outside its content origin
 				parentOffset = jQuery( offsetParent ).offset();

--- a/src/offset.js
+++ b/src/offset.js
@@ -69,6 +69,8 @@ jQuery.offset = {
 };
 
 jQuery.fn.extend( {
+
+	// Get or set position relative to document origin
 	offset: function( options ) {
 
 		// Preserve chaining for setter
@@ -115,6 +117,7 @@ jQuery.fn.extend( {
 		};
 	},
 
+	// Get position relative to offset parent, excluding contributions from margins
 	position: function() {
 		if ( !this[ 0 ] ) {
 			return;
@@ -124,11 +127,10 @@ jQuery.fn.extend( {
 			elem = this[ 0 ],
 			parentOffset = { top: 0, left: 0 };
 
-		// Fixed elements are offset from window (parentOffset = {top:0, left: 0},
-		// because it is its only offset parent
+		// position:fixed elements are offset from the viewport, which itself always has zero offset
 		if ( jQuery.css( elem, "position" ) === "fixed" ) {
 
-			// Assume getBoundingClientRect is there when computed position is fixed
+			// Assume position:fixed implies availability of getBoundingClientRect
 			offset = elem.getBoundingClientRect();
 
 		} else {

--- a/src/offset.js
+++ b/src/offset.js
@@ -7,13 +7,12 @@ define( [
 	"./css/curCSS",
 	"./css/addGetHookIf",
 	"./css/support",
-	"./core/nodeName",
 
 	"./core/init",
 	"./css",
 	"./selector" // contains
 ], function( jQuery, access, document, documentElement, rnumnonpx,
-             curCSS, addGetHookIf, support, nodeName ) {
+             curCSS, addGetHookIf, support ) {
 
 "use strict";
 
@@ -121,7 +120,7 @@ jQuery.fn.extend( {
 			return;
 		}
 
-		var offsetParent, offset,
+		var offsetParent, offset, doc,
 			elem = this[ 0 ],
 			parentOffset = { top: 0, left: 0 };
 
@@ -133,21 +132,27 @@ jQuery.fn.extend( {
 			offset = elem.getBoundingClientRect();
 
 		} else {
-
-			// Get *real* offsetParent
-			offsetParent = this.offsetParent();
-
-			// Get correct offsets
 			offset = this.offset();
-			if ( !nodeName( offsetParent[ 0 ], "html" ) ) {
-				parentOffset = offsetParent.offset();
-			}
 
-			// Add offsetParent borders
-			parentOffset = {
-				top: parentOffset.top + jQuery.css( offsetParent[ 0 ], "borderTopWidth", true ),
-				left: parentOffset.left + jQuery.css( offsetParent[ 0 ], "borderLeftWidth", true )
-			};
+			// Account for the *real* offset parent, which can be the document or its root element
+			// when a statically positioned element is identified
+			doc = elem.ownerDocument;
+			offsetParent = elem.offsetParent || doc.documentElement;
+			while ( offsetParent &&
+				( offsetParent === doc.body || offsetParent === doc.documentElement ) &&
+				jQuery.css( offsetParent, "position" ) === "static" ) {
+
+				offsetParent = offsetParent.parentNode;
+			}
+			if ( offsetParent && offsetParent.nodeType === 1 ) {
+
+				// Incorporate borders into its offset, since they are outside its content origin
+				parentOffset = jQuery( offsetParent ).offset();
+				parentOffset = {
+					top: parentOffset.top + jQuery.css( offsetParent, "borderTopWidth", true ),
+					left: parentOffset.left + jQuery.css( offsetParent, "borderLeftWidth", true )
+				};
+			}
 		}
 
 		// Subtract parent offsets and element margins

--- a/src/offset.js
+++ b/src/offset.js
@@ -70,7 +70,7 @@ jQuery.offset = {
 
 jQuery.fn.extend( {
 
-	// Get or set position relative to document origin
+	// offset() relates an element's border box to the document origin
 	offset: function( options ) {
 
 		// Preserve chaining for setter
@@ -97,6 +97,7 @@ jQuery.fn.extend( {
 			return { top: 0, left: 0 };
 		}
 
+		// gBCR returns position relative to the viewport
 		rect = elem.getBoundingClientRect();
 		win = elem.ownerDocument.defaultView;
 
@@ -110,14 +111,15 @@ jQuery.fn.extend( {
 			}
 		}
 
-		// Absent fixed positioning, add back the viewport scroll
+		// Add the viewport scroll to get document-relative values
 		return {
 			top: rect.top + win.pageYOffset,
 			left: rect.left + win.pageXOffset
 		};
 	},
 
-	// Get position relative to offset parent, excluding contributions from margins
+	// position() relates an element's margin box to its offset parent's padding box
+	// This corresponds to the behavior of CSS absolute positioning
 	position: function() {
 		if ( !this[ 0 ] ) {
 			return;

--- a/test/data/offset/boxes.html
+++ b/test/data/offset/boxes.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html id="documentElement">
+	<head>
+		<meta http-equiv="Content-type" content="text/html; charset=utf-8">
+		<meta name="description" content="horizontal values 2^N; vertical doubled">
+		<title>Nonempty margin/border/padding/position</title>
+		<style type="text/css" media="screen">
+			html, body, div {
+				font-size: 4px;
+				border-style: solid;
+			}
+			html {
+				/* start the index at 16 to allow for doubled div displacement */
+				margin: 32em 16em;
+				border-width: 64em 32em;
+				padding: 128em 64em;
+			}
+			body {
+				margin: 256em 128em;
+				border-width: 512em 256em;
+				padding: 1024em 512em;
+			}
+			div {
+				min-width: 300px;
+
+				top: 2em;
+				left: 1em;
+				margin: 8em 4em;
+				border-width: 4px 2px;
+			}
+			.forceScroll { width: 5000px; height: 5000px; }
+			.static { position: static; }
+			.relative { position: relative; }
+			.absolute { position: absolute; }
+			.fixed { position: fixed; }
+
+			/* for humans */
+			html {
+				border-color: hsl(20, 100%, 70%);
+				background-color: hsl(110, 100%, 70%);
+			}
+			body {
+				border-color: hsl(200, 100%, 70%);
+				background-color: hsl(290, 100%, 70%);
+			}
+			html::after,
+			body::after {
+				font: italic 16px sans-serif;
+				content: attr(id);
+			}
+			div {
+				background-color: hsla(0, 0%, 70%, 0.5);
+				opacity: 0.7;
+			}
+			div div {
+				background-color: hsla(60, 100%, 70%, 0.5);
+			}
+			p {
+				font: 20px sans-serif;
+			}
+			span {
+				font: 20px monospace;
+			}
+		</style>
+		<script src="../../jquery.js"></script>
+		<script src="../iframeTest.js"></script>
+		<script type="text/javascript" charset="utf-8">
+			jQuery( function() {
+				window.scrollTo( 1, 2 );
+				startIframeTest();
+			} );
+		</script>
+	</head>
+	<body id="body" class="forceScroll">
+		<div id="relative" class="relative">
+			<div id="relative-relative" class="relative"><span>relative &gt; relative</span></div>
+			<div id="relative-absolute" class="absolute"><span>relative &gt; absolute</span></div>
+		</div>
+		<div id="absolute" class="absolute">
+			<div id="absolute-relative" class="relative"><span>absolute &gt; relative</span></div>
+			<div id="absolute-absolute" class="absolute"><span>absolute &gt; absolute</span></div>
+		</div>
+		<div id="fixed" class="fixed">
+			<div id="fixed-relative" class="relative"><span>fixed &gt; relative</span></div>
+			<div id="fixed-absolute" class="absolute"><span>fixed &gt; absolute</span></div>
+		</div>
+		<p id="positionTest" class="absolute">position:absolute with no top/left values</p>
+		<div class="forceScroll"></div>
+	</body>
+</html>

--- a/test/data/offset/boxes.html
+++ b/test/data/offset/boxes.html
@@ -1,47 +1,49 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html id="documentElement">
+<html id="documentElement" class="box">
 	<head>
 		<meta http-equiv="Content-type" content="text/html; charset=utf-8">
 		<meta name="description" content="horizontal values 2^N; vertical doubled">
 		<title>Nonempty margin/border/padding/position</title>
 		<style type="text/css" media="screen">
-			html, body, div {
-				font-size: 4px;
-				border-style: solid;
-			}
-			html {
-				/* start the index at 16 to allow for doubled div displacement */
-				margin: 32em 16em;
-				border-width: 64em 32em;
-				padding: 128em 64em;
-
-				top: 2048em;
-				left: 1024em;
-			}
-			body {
-				margin: 256em 128em;
-				border-width: 512em 256em;
-				padding: 1024em 512em;
-
-				top: 4096em;
-				left: 2048em;
-			}
-			div {
-				min-width: 300px;
-
-				top: 2em;
-				left: 1em;
-				margin: 8em 4em;
-				border-width: 4px 2px;
-			}
-			.forceScroll { width: 5000px; height: 5000px; }
+			/* work with convenient classes, units, and dimensions */
 			.static { position: static; }
 			.relative { position: relative; }
 			.absolute { position: absolute; }
 			.fixed { position: fixed; }
+			.box {
+				font-size: 4px;
+				border-style: solid;
+				min-width: 300px;
+			}
 
-			/* for humans */
+			/* start the exponential scales, reserving the first bit for scroll position */
+			.box {
+				border-width:    1em         0.5em;
+				top:             2em; left:    1em;
+				margin:          8em           4em;
+			}
+			#documentElement {
+				margin:         32em          16em;
+				border-width:   64em          32em;
+				padding:       128em          64em;
+			}
+			#body {
+				margin:        256em         128em;
+				border-width:  512em         256em;
+				padding:      1024em         512em;
+			}
+			#documentElement {
+				top:          2048em; left: 1024em;
+			}
+			#body {
+				top:          4096em; left: 2048em;
+			}
+
+			/* style for humans */
+			:not(.box) {
+				font-size: 20px;
+			}
 			html {
 				border-color: hsl(20, 100%, 70%);
 				background-color: hsl(110, 100%, 70%);
@@ -55,18 +57,12 @@
 				font: italic 16px sans-serif;
 				content: attr(id);
 			}
-			div {
+			div.box {
 				background-color: hsla(0, 0%, 70%, 0.5);
 				opacity: 0.7;
 			}
-			div div {
+			div.box div.box {
 				background-color: hsla(60, 100%, 70%, 0.5);
-			}
-			p {
-				font: 20px sans-serif;
-			}
-			span {
-				font: 20px monospace;
 			}
 		</style>
 		<script src="../../jquery.js"></script>
@@ -78,20 +74,25 @@
 			} );
 		</script>
 	</head>
-	<body id="body" class="forceScroll">
-		<div id="relative" class="relative">
-			<div id="relative-relative" class="relative"><span>relative &gt; relative</span></div>
-			<div id="relative-absolute" class="absolute"><span>relative &gt; absolute</span></div>
+	<body id="body" class="box">
+		<div id="relative" class="relative box">
+			<div id="relative-relative" class="relative box"><code
+				>relative &gt; relative</code></div>
+			<div id="relative-absolute" class="absolute box"><code
+				>relative &gt; absolute</code></div>
 		</div>
-		<div id="absolute" class="absolute">
-			<div id="absolute-relative" class="relative"><span>absolute &gt; relative</span></div>
-			<div id="absolute-absolute" class="absolute"><span>absolute &gt; absolute</span></div>
+		<div id="absolute" class="absolute box">
+			<div id="absolute-relative" class="relative box"><code
+				>absolute &gt; relative</code></div>
+			<div id="absolute-absolute" class="absolute box"><code
+				>absolute &gt; absolute</code></div>
 		</div>
-		<div id="fixed" class="fixed">
-			<div id="fixed-relative" class="relative"><span>fixed &gt; relative</span></div>
-			<div id="fixed-absolute" class="absolute"><span>fixed &gt; absolute</span></div>
+		<div id="fixed" class="fixed box">
+			<div id="fixed-relative" class="relative box"><code
+				>fixed &gt; relative</code></div>
+			<div id="fixed-absolute" class="absolute box"><code
+				>fixed &gt; absolute</code></div>
 		</div>
 		<p id="positionTest" class="absolute">position:absolute with no top/left values</p>
-		<div class="forceScroll"></div>
 	</body>
 </html>

--- a/test/data/offset/boxes.html
+++ b/test/data/offset/boxes.html
@@ -15,11 +15,17 @@
 				margin: 32em 16em;
 				border-width: 64em 32em;
 				padding: 128em 64em;
+
+				top: 2048em;
+				left: 1024em;
 			}
 			body {
 				margin: 256em 128em;
 				border-width: 512em 256em;
 				padding: 1024em 512em;
+
+				top: 4096em;
+				left: 2048em;
 			}
 			div {
 				min-width: 300px;

--- a/test/data/offset/boxes.html
+++ b/test/data/offset/boxes.html
@@ -21,23 +21,24 @@
 			.box {
 				border-width:    1em         0.5em;
 				top:             2em; left:    1em;
-				margin:          8em           4em;
+				margin:          4em           2em;
+				padding:         8em           4em;
 			}
 			#documentElement {
-				margin:         32em          16em;
-				border-width:   64em          32em;
-				padding:       128em          64em;
+				margin:         16em           8em;
+				border-width:   32em          16em;
+				padding:        64em          32em;
 			}
 			#body {
-				margin:        256em         128em;
-				border-width:  512em         256em;
-				padding:      1024em         512em;
+				margin:        128em          64em;
+				border-width:  256em         128em;
+				padding:       512em         256em;
 			}
 			#documentElement {
+				top:          1024em; left:  512em;
+			}
+			#body {
 				top:          2048em; left: 1024em;
-			}
-			#body {
-				top:          4096em; left: 2048em;
 			}
 
 			/* style for humans */

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -517,15 +517,15 @@ QUnit.test( "chaining", function( assert ) {
 			return propObj;
 		},
 		divProps = function( position, parentId ) {
-			return props( 4, 8,  16, 32,  2, 4,  0, 0,  position, parentId );
+			return props( 4, 8,  8, 16,  2, 4,  16, 32,  position, parentId );
 		},
 		docProps = function( position ) {
-			return props( position === "static" ? 0 : 4096, position === "static" ? 0 : 8192,
-				64, 128,  128, 256,  256, 512,  position );
+			return props( position === "static" ? 0 : 2048, position === "static" ? 0 : 4096,
+				32, 64,  64, 128,  128, 256,  position );
 		},
 		bodyProps = function( position ) {
-			return props( position === "static" ? 0 : 8192, position === "static" ? 0 : 16384,
-				512, 1024,  1024, 2048,  2048, 4096,  position,
+			return props( position === "static" ? 0 : 4096, position === "static" ? 0 : 8192,
+				256, 512,  512, 1024,  1024, 2048,  position,
 				position !== "fixed" && "documentElement" );
 		};
 

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -585,13 +585,13 @@ QUnit.test( "chaining", function( assert ) {
 
 			// Test them
 			testIframe( label, "offset/boxes.html", function( assert, $, iframe, doc ) {
-				assert.expect( 22 );
+				assert.expect( 33 );
 
 				// Setup documentElement and body styles
 				doc.documentElement.style.position = docPos;
 				doc.body.style.position = bodyPos;
 
-				// offset (relative to document)
+				// Verify expected document offset
 				supportjQuery.each( expectations, function( id, descriptor ) {
 					assert.deepEqual(
 						supportjQuery.extend( {}, $( "#" + id ).offset() ),
@@ -599,16 +599,34 @@ QUnit.test( "chaining", function( assert ) {
 						"jQuery('#" + id + "').offset()" );
 				} );
 
-				// position (relative to offset parent, excluding contributions from margins)
+				// Verify expected relative position
 				supportjQuery.each( expectations, function( id, descriptor ) {
-
 					assert.deepEqual(
 						supportjQuery.extend( {}, $( "#" + id ).position() ),
 						descriptor.pos,
 						"jQuery('#" + id + "').position()" );
 				} );
 
-				// TODO assert round-tripping
+				// Verify that values round-trip
+				supportjQuery.each( Object.keys( expectations ).reverse(), function( _, id ) {
+					var $el = $( "#" + id ),
+						pos = supportjQuery.extend( {}, $el.position() );
+
+					$el.css( { top: pos.top, left: pos.left } );
+					if ( $el.css( "position" ) === "relative" ) {
+
+						// $relative.position() includes parent padding; switch to absolute
+						// positioning so we don't double its effects.
+						$el.css( { position: "absolute" } );
+					}
+					assert.deepEqual( supportjQuery.extend( {}, $el.position() ), pos,
+						"jQuery('#" + id + "').position() round-trips" );
+
+					// TODO Verify .offset(...)
+					// assert.deepEqual( $el.offset( offset ).offset(), offset )
+					// assert.deepEqual( $el.offset( adjustedOffset ).offset(), adjustedOffset )
+					// assert.deepEqual( $new.offset( offset ).offset(), offset )
+				} );
 			} );
 		} );
 	} );

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -504,7 +504,7 @@ QUnit.test( "chaining", function( assert ) {
 } );
 
 testIframe( "getters", "offset/boxes.html", function( assert, $, iframe ) {
-	assert.expect( 9 );
+	assert.expect( 18 );
 
 	var tests,
 
@@ -546,6 +546,21 @@ testIframe( "getters", "offset/boxes.html", function( assert, $, iframe ) {
 	jQuery.each( tests, function( id, offset ) {
 		assert.deepEqual( $.extend( {}, $( "#" + id ).offset() ), offset,
 			"jQuery(#" + id + ").offset()" );
+	} );
+
+	// position (relative to offset parent, excluding contributions from margins)
+	jQuery.each( tests, function( id, offset ) {
+
+		// computed left/top values are accurate for most positioned elements
+		var expected = { top: pY, left: pX };
+
+		// ...but elements relative to a static body are _actually_ relative to the document
+		if ( id === "relative" ) {
+			expected = { top: offset.top - mY, left: offset.left - mX };
+		}
+
+		assert.deepEqual( $.extend( {}, $( "#" + id ).position() ), expected,
+			"jQuery(#" + id + ").position()" );
 	} );
 } );
 

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -510,7 +510,7 @@ QUnit.test( "chaining", function( assert ) {
 		// Use shorthands for describing an element's relevant properties
 		BOX_PROPS =
 			( "top left  marginTop marginLeft  borderTop borderLeft  paddingTop paddingLeft" +
-            "  style  parent" ).split( /\s+/g ),
+			"  style  parent" ).split( /\s+/g ),
 		props = function() {
 			var propObj = {};
 			supportjQuery.each( arguments, function( i, value ) {

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -509,7 +509,7 @@ QUnit.test( "chaining", function( assert ) {
 
 		// Use shorthands for describing an element's relevant properties
 		BOX_PROPS =
-			( "left top  marginLeft marginTop  borderLeft borderTop  paddingLeft paddingTop" +
+			( "top left  marginTop marginLeft  borderTop borderLeft  paddingTop paddingLeft" +
             "  style  parent" ).split( /\s+/g ),
 		props = function() {
 			var propObj = {};
@@ -521,18 +521,18 @@ QUnit.test( "chaining", function( assert ) {
 
 		// Values must stay synchronized with test/data/offset/boxes.html
 		divProps = function( position, parentId ) {
-			return props( 4, 8,  8, 16,  2, 4,  16, 32,  position, parentId );
+			return props( 8, 4,  16, 8,  4, 2,  32, 16,  position, parentId );
 		},
 		htmlProps = function( position ) {
-			return props( position === "static" ? 0 : 2048, position === "static" ? 0 : 4096,
-				32, 64,  64, 128,  128, 256,  position );
+			return props( position === "static" ? 0 : 4096, position === "static" ? 0 : 2048,
+				64, 32,  128, 64,  256, 128,  position );
 		},
 		bodyProps = function( position ) {
-			return props( position === "static" ? 0 : 4096, position === "static" ? 0 : 8192,
-				256, 512,  512, 1024,  1024, 2048,  position,
+			return props( position === "static" ? 0 : 8192, position === "static" ? 0 : 4096,
+				512, 256,  1024, 512,  2048, 1024,  position,
 				position !== "fixed" && "documentElement" );
 		},
-		viewportScroll = { left: 1, top: 2 },
+		viewportScroll = { top: 2, left: 1 },
 
 		alwaysScrollable = false;
 

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -531,7 +531,8 @@ QUnit.test( "chaining", function( assert ) {
 			return props( position === "static" ? 0 : 4096, position === "static" ? 0 : 8192,
 				256, 512,  512, 1024,  1024, 2048,  position,
 				position !== "fixed" && "documentElement" );
-		};
+		},
+		viewportScroll = { left: 1, top: 2 };
 
 	// Cover each combination of <html> position and <body> position
 	supportjQuery.each( POSITION_VALUES, function( _, htmlPos ) {
@@ -602,6 +603,13 @@ QUnit.test( "chaining", function( assert ) {
 						}
 					}
 					break;
+				}
+
+				// Viewport scroll affects position:fixed elements, except when a position:fixed
+				// html element makes the page unscrollable
+				if ( props.style === "fixed" && expectations.documentElement.style !== "fixed" ) {
+					offset.top += viewportScroll.top;
+					offset.left += viewportScroll.left;
 				}
 			} );
 

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -503,6 +503,52 @@ QUnit.test( "chaining", function( assert ) {
 	assert.equal( jQuery( "#absolute-1" ).offset( undefined ).jquery, jQuery.fn.jquery, "offset(undefined) returns jQuery object (#5571)" );
 } );
 
+testIframe( "getters", "offset/boxes.html", function( assert, $, iframe ) {
+	assert.expect( 9 );
+
+	var tests,
+
+		// em-to-px
+		scale = 4,
+
+		// body content origin
+		oX = scale * ( 16 + 32 + 64 + 128 + 256 + 512 ),
+		oY = 2 * oX,
+
+		// position displacement
+		pX = scale * 1,
+		pY = 2 * pX,
+
+		// margin displacement
+		mX = scale * 4,
+		mY = 2 * mX,
+
+		// combined position/margin displacement
+		dX = pX + mX,
+		dY = pY + mY,
+
+		// intervening borders
+		iX = 2,
+		iY = 2 * iX;
+
+	// offset (relative to document)
+	tests = {
+		"relative":          { top: oY + dY,           left:  oX + dX },
+		"relative-relative": { top: oY + dY + iY + dY, left:  oX + dX + iX + dX },
+		"relative-absolute": { top: oY + dY + iY + dY, left:  oX + dX + iX + dX },
+		"absolute":          { top:      dY,           left:       dX },
+		"absolute-relative": { top:      dY + iY + dY, left:       dX + iX + dX },
+		"absolute-absolute": { top:      dY + iY + dY, left:       dX + iX + dX },
+		"fixed":             { top:      dY,           left:       dX },
+		"fixed-relative":    { top:      dY + iY + dY, left:       dX + iX + dX },
+		"fixed-absolute":    { top:      dY + iY + dY, left:       dX + iX + dX }
+	};
+	jQuery.each( tests, function( id, offset ) {
+		assert.deepEqual( $.extend( {}, $( "#" + id ).offset() ), offset,
+			"jQuery(#" + id + ").offset()" );
+	} );
+} );
+
 QUnit.test( "offsetParent", function( assert ) {
 	assert.expect( 13 );
 

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -637,10 +637,14 @@ QUnit.test( "chaining", function( assert ) {
 		// Support: IE<=10 only
 		// Fudge the tests to work around <html>.gBCR() erroneously including margins
 		if ( /MSIE (?:9|10)\./.test( navigator.userAgent ) ) {
-			expectations.documentElement.pos.top -= 62;
-			expectations.documentElement.offset.top -= 62;
-			expectations.documentElement.pos.left -= 31;
-			expectations.documentElement.offset.left -= 31;
+			expectations.documentElement.pos.top -= expectations.documentElement.marginTop -
+				viewportScroll.top;
+			expectations.documentElement.offset.top -= expectations.documentElement.marginTop -
+				viewportScroll.top;
+			expectations.documentElement.pos.left -= expectations.documentElement.marginLeft -
+				viewportScroll.left;
+			expectations.documentElement.offset.left -= expectations.documentElement.marginLeft -
+				viewportScroll.left;
 			if ( htmlPos !== "static" ) {
 				delete expectations.documentElement;
 				delete expectations.body;

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -596,7 +596,7 @@ QUnit.test( "chaining", function( assert ) {
 					assert.deepEqual(
 						supportjQuery.extend( {}, $( "#" + id ).offset() ),
 						descriptor.offset,
-						"jQuery(#" + id + ").offset()" );
+						"jQuery('#" + id + "').offset()" );
 				} );
 
 				// position (relative to offset parent, excluding contributions from margins)
@@ -605,7 +605,7 @@ QUnit.test( "chaining", function( assert ) {
 					assert.deepEqual(
 						supportjQuery.extend( {}, $( "#" + id ).position() ),
 						descriptor.pos,
-						"jQuery(#" + id + ").position()" );
+						"jQuery('#" + id + "').position()" );
 				} );
 
 				// TODO assert round-tripping

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -634,6 +634,21 @@ QUnit.test( "chaining", function( assert ) {
 			}
 		} );
 
+		// Support: IE<=10 only
+		// Fudge the tests to work around <html>.gBCR() erroneously including margins
+		if ( /MSIE (?:9|10)\./.test( navigator.userAgent ) ) {
+			expectations.documentElement.pos.top -= 62;
+			expectations.documentElement.offset.top -= 62;
+			expectations.documentElement.pos.left -= 31;
+			expectations.documentElement.offset.left -= 31;
+			if ( htmlPos !== "static" ) {
+				delete expectations.documentElement;
+				delete expectations.body;
+				delete expectations.relative;
+				delete expectations.absolute;
+			}
+		}
+
 		return expectations;
 	}
 
@@ -646,7 +661,7 @@ QUnit.test( "chaining", function( assert ) {
 				// Define expectations at runtime so alwaysScrollable is correct
 				var expectations = getExpectations( htmlPos, bodyPos );
 
-				assert.expect( 33 );
+				assert.expect( 3 * Object.keys( expectations ).length );
 
 				// Setup documentElement and body styles
 				doc.documentElement.style.position = htmlPos;


### PR DESCRIPTION
### Summary ###
Makes `.offset()` always relative to the document and `.position()` always relative to the closest [containing block](https://drafts.csswg.org/css-display-3/#containing-block) offsetParent (if any).

Some new tests fail on IE\<11 (where `document.documentElement.getBoundingClientRect()` erroneously includes margins and disregards viewport scrolling), and have been manually disabled/patched up.

Fixes gh-3080
Fixes gh-3107
Closes gh-3096
Ref gh-3479

### Checklist ###
* [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created: https://github.com/jquery/api.jquery.com/pull/1027