### PR TITLE
9d822bc1c13dd3393b418210a99537c22c06f2c3 followup

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -392,7 +392,7 @@ function Animation( elem, properties, options ) {
 		animation.opts.start.call( elem, animation );
 	}
 
-	// attach callbacks from options
+	// Attach callbacks from options
 	animation
 		.progress( animation.opts.progress )
 		.done( animation.opts.done, animation.opts.complete )

--- a/src/effects.js
+++ b/src/effects.js
@@ -392,6 +392,13 @@ function Animation( elem, properties, options ) {
 		animation.opts.start.call( elem, animation );
 	}
 
+	// attach callbacks from options
+	animation
+		.progress( animation.opts.progress )
+		.done( animation.opts.done, animation.opts.complete )
+		.fail( animation.opts.fail )
+		.always( animation.opts.always );
+
 	jQuery.fx.timer(
 		jQuery.extend( tick, {
 			elem: elem,
@@ -400,11 +407,7 @@ function Animation( elem, properties, options ) {
 		} )
 	);
 
-	// attach callbacks from options
-	return animation.progress( animation.opts.progress )
-		.done( animation.opts.done, animation.opts.complete )
-		.fail( animation.opts.fail )
-		.always( animation.opts.always );
+	return animation;
 }
 
 jQuery.Animation = jQuery.extend( Animation, {

--- a/src/effects.js
+++ b/src/effects.js
@@ -651,7 +651,7 @@ jQuery.fx.tick = function() {
 	for ( ; i < timers.length; i++ ) {
 		timer = timers[ i ];
 
-		// Checks the timer has not already been removed
+		// Run the timer and safely remove it when done (allowing for external removal)
 		if ( !timer() && timers[ i ] === timer ) {
 			timers.splice( i--, 1 );
 		}
@@ -664,11 +664,16 @@ jQuery.fx.tick = function() {
 };
 
 jQuery.fx.timer = function( timer ) {
-	jQuery.timers.push( timer );
+	var i = jQuery.timers.push( timer ) - 1,
+		timers = jQuery.timers;
+
 	if ( timer() ) {
 		jQuery.fx.start();
-	} else {
-		jQuery.timers.pop();
+
+	// If the timer finished immediately, safely remove it (allowing for external removal)
+	// Use a superfluous post-decrement for better compressibility w.r.t. jQuery.fx.tick above
+	} else if ( timers[ i ] === timer ) {
+		timers.splice( i--, 1 );
 	}
 };
 

--- a/src/effects.js
+++ b/src/effects.js
@@ -315,12 +315,19 @@ function Animation( elem, properties, options ) {
 
 			deferred.notifyWith( elem, [ animation, percent, remaining ] );
 
+			// If there's more to do, yield
 			if ( percent < 1 && length ) {
 				return remaining;
-			} else {
-				deferred.resolveWith( elem, [ animation ] );
-				return false;
 			}
+
+			// If this was an empty animation, synthesize a final progress notification
+			if ( !length ) {
+				deferred.notifyWith( elem, [ animation, 1, 0 ] );
+			}
+
+			// Resolve the animation and report its conclusion
+			deferred.resolveWith( elem, [ animation ] );
+			return false;
 		},
 		animation = deferred.promise( {
 			elem: elem,

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -1256,17 +1256,18 @@ QUnit.test( "animate with CSS shorthand properties", function( assert ) {
 } );
 
 QUnit.test( "hide hidden elements, with animation (bug #7141)", function( assert ) {
-	assert.expect( 3 );
+	assert.expect( 4 );
 
-	var div = jQuery( "<div style='display:none'></div>" ).appendTo( "#qunit-fixture" );
-	assert.equal( div.css( "display" ), "none", "Element is hidden by default" );
-	div.hide( 1, function() {
-		assert.ok( !jQuery._data( div, "olddisplay" ), "olddisplay is undefined after hiding an already-hidden element" );
-		div.show( 1, function() {
-			assert.equal( div.css( "display" ), "block", "Show a double-hidden element" );
+	var div = jQuery( "<div id='bug7141' style='display:none'/>" ).appendTo( "#qunit-fixture" );
+	assert.equal( div.css( "display" ), "none", "Element is initially hidden" );
+	div.hide( 10, function() {
+		assert.equal( div.css( "display" ), "none", "Element is hidden in .hide() callback" );
+		div.show( 11, function() {
+			assert.equal( div.css( "display" ), "block", "Element is visible in .show() callback" );
 		} );
 	} );
-	this.clock.tick( 10 );
+	this.clock.tick( 50 );
+	assert.equal( div.css( "display" ), "block", "Element is visible after animations" );
 } );
 
 QUnit.test( "animate unit-less properties (#4966)", function( assert ) {


### PR DESCRIPTION
9d822bc1c13dd3393b418210a99537c22c06f2c3 failed an effects test (cf. https://github.com/jquery/jquery/pull/3470#issuecomment-271388489 ), but it turns out that things were already broken in subtle ways when animations spawn each other:
* immediately-done animations miss the final progress notification
* callbacks are registered _after_ the first tick
* animations get skipped when old ones are forcefully stopped mid-tick

Each fix revealed the next flaw, so all are addressed here in order to resolve the current CI failure. I should probably make real issues so they can be resolved by this PR.