### PR TITLE
Effects: sync .stop/.finish with .tick to maintain proper queue (#3497)

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -483,7 +483,7 @@ jQuery.speed = function( speed, easing, fn ) {
 
 	return opt;
 };
-
+var lis = [];
 jQuery.fn.extend( {
 	fadeTo: function( speed, to, easing, callback ) {
 
@@ -552,6 +552,7 @@ jQuery.fn.extend( {
 
 					timers[ index ].anim.stop( gotoEnd );
 					dequeue = false;
+					lis.push(index);
 					timers.splice( index, 1 );
 				}
 			}
@@ -590,6 +591,7 @@ jQuery.fn.extend( {
 			for ( index = timers.length; index--; ) {
 				if ( timers[ index ].elem === this && timers[ index ].queue === type ) {
 					timers[ index ].anim.stop( true );
+					lis.push( index );
 					timers.splice( index, 1 );
 				}
 			}
@@ -631,15 +633,25 @@ jQuery.each( {
 } );
 
 jQuery.timers = [];
+var oldLength = 0;
 jQuery.fx.tick = function() {
 	var timer,
 		i = 0,
 		timers = jQuery.timers;
 
 	fxNow = jQuery.now();
+	oldLength = timers.length;
+	for ( ; i < old_length; i++ ) {
+		var removedTimers = 0;
 
-	for ( ; i < timers.length; i++ ) {
-		timer = timers[ i ];
+		for (var j = 0; j < lis.length; j++) {
+			if ( lis[ j ] <= i ) {
+				removeTimers++;
+			}
+				lis.splice( j, 1 );
+			}
+			i = i - removedTimers;
+			timer = timers[ i ];
 
 		// Checks the timer has not already been removed
 		if ( !timer() && timers[ i ] === timer ) {

--- a/src/effects.js
+++ b/src/effects.js
@@ -552,7 +552,7 @@ jQuery.fn.extend( {
 
 					timers[ index ].anim.stop( gotoEnd );
 					dequeue = false;
-					lis.push(index);
+					lis.push( index );
 					timers.splice( index, 1 );
 				}
 			}
@@ -641,12 +641,12 @@ jQuery.fx.tick = function() {
 
 	fxNow = jQuery.now();
 	oldLength = timers.length;
-	for ( ; i < old_length; i++ ) {
+	for ( ; i < oldLength; i++ ) {
 		var removedTimers = 0;
 
-		for (var j = 0; j < lis.length; j++) {
+		for ( var j = 0; j < lis.length; j++ ) {
 			if ( lis[ j ] <= i ) {
-				removeTimers++;
+				removedTimers++;
 			}
 				lis.splice( j, 1 );
 			}


### PR DESCRIPTION
#3497 

### Summary ###

1.Whenever the .finish or the .stop functions modify the timers queue, we maintain all those indexes that are removed in a list (  i.e, lis[ ]  ). Whenever the tick function iterates over the queue, we update the iterator based on the value of the indexes removed ( only when the indexes less than the current iterator value are removed there will be a skipping over the animations  ).

2. Handled extra processing of the same animation by doing as mentioned below:
  All the new animations that are added to the timers queue in the middle of a particular iteration of the tick function are processed in the next iteration.



### Checklist ###

* [x] Handled the "skipping over multiple animations " of tick function.
* [ ] Handled extra processing.



