### PR TITLE
Typos in the comments

### DIFF
--- a/test/data/jquery-1.9.1.js
+++ b/test/data/jquery-1.9.1.js
@@ -4328,7 +4328,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 		assert( function( div ) {
 
 			// Select is set to empty string on purpose
-			// This is to test IE's treatment of not explictly
+			// This is to test IE's treatment of not explicitly
 			// setting a boolean content attribute,
 			// since its presence should be enough
 			// http://bugs.jquery.com/ticket/12359
@@ -7036,7 +7036,7 @@ jQuery.extend( {
 				value += "px";
 			}
 
-			// Fixes #8908, it can be done more correctly by specifing setters in cssHooks,
+			// Fixes #8908, it can be done more correctly by specifying setters in cssHooks,
 			// but it would mean to define eight (for every problematic property) identical functions
 			if ( !jQuery.support.clearCloneStyle && value === "" && name.indexOf( "background" ) === 0 ) {
 				style[ name ] = "inherit";


### PR DESCRIPTION
Here are tiny typo fixes.
* s/explictly/explicitly/
* s/specifing/specifying/