### PR TITLE
CSS: Support custom properties

### DIFF
--- a/src/css/curCSS.js
+++ b/src/css/curCSS.js
@@ -15,8 +15,9 @@ function curCSS( elem, name, computed ) {
 
 	computed = computed || getStyles( elem );
 
-	// Support: IE <=9 only
-	// getPropertyValue is only needed for .css('filter') (#12537)
+	// getPropertyValue is needed for:
+	//   .css('filter') (IE 9 only, #12537)
+	//   .css('--customProperty) (#3144)
 	if ( computed ) {
 		ret = computed.getPropertyValue( name ) || computed[ name ];
 

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -1556,4 +1556,68 @@ QUnit.test( "Do not throw on frame elements from css method (#15098)", function(
 
 } )();
 
+
+QUnit.test( "css(--customProperty)", function( assert ) {
+	jQuery( "#qunit-fixture" ).append(
+		"<style>\n" +
+		"    .test__customProperties {\n" +
+		"        --prop1:val1;\n" +
+		"        --prop2: val2;\n" +
+		"        --prop3:val3 ;\n" +
+		"        --prop4:\"val4\";\n" +
+		"        --prop5:'val5';\n" +
+		"    }\n" +
+		"</style>"
+	);
+
+	var div = jQuery( "<div>" ).appendTo( "#qunit-fixture" ),
+		$elem = jQuery( "<div>" ).addClass( "test__customProperties" ).appendTo( "#qunit-fixture" ),
+		webkit = /\bsafari\b/i.test( navigator.userAgent ) &&
+			!/\firefox\b/i.test( navigator.userAgent ) &&
+			!/\edge\b/i.test( navigator.userAgent ),
+		oldSafari = webkit && ( /\b9\.\d(\.\d+)* safari/i.test( navigator.userAgent ) ||
+			/\b10\.0(\.\d+)* safari/i.test( navigator.userAgent ) ),
+		expected = 10;
+
+	if ( webkit ) {
+		expected -= 2;
+	}
+	if ( oldSafari ) {
+		expected -= 2;
+	}
+	assert.expect( expected );
+
+	div.css( "--color", "blue" );
+	assert.equal( div.css( "--color" ), "blue", "Modified CSS custom property using string" );
+
+	div.css( "--color", "yellow" );
+	assert.equal( div.css( "--color" ), "yellow", "Overwrite CSS custom property" );
+
+	div.css( { "--color": "red" } );
+	assert.equal( div.css( "--color" ), "red", "Modified CSS custom property using object" );
+
+	div.css( { "--mixedCase": "green" } );
+	assert.equal( div.css( "--mixedCase" ), "green", "Modified CSS custom property with mixed case" );
+
+	div.css( { "--theme-dark": "purple" } );
+	assert.equal( div.css( "--theme-dark" ), "purple", "Modified CSS custom property with dashed name" );
+
+	assert.equal( $elem.css( "--prop1" ), "val1", "Basic CSS custom property" );
+
+	// Support: Safari 9.1-10.0 only
+	// Safari collapses whitespaces & quotes. Ignore it.
+	if ( !oldSafari ) {
+		assert.equal( $elem.css( "--prop2" ), " val2", "Preceding whitespace maintained" );
+		assert.equal( $elem.css( "--prop3" ), "val3 ", "Following whitespace maintained" );
+	}
+
+	// Support: Chrome 49-55, Safari 9.1-10.0
+	// Chrome treats single quotes as double ones.
+	// Safari treats double quotes as single ones.
+	if ( !webkit ) {
+		assert.equal( $elem.css( "--prop4" ), "\"val4\"", "Works with double quotes" );
+		assert.equal( $elem.css( "--prop5" ), "'val5'", "Works with single quotes" );
+	}
+} );
+
 }


### PR DESCRIPTION
Fixes gh-3144
Closes gh-3199

### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
This PR adds suppport for CSS Custom Properties (a.k.a. CSS Variables). This is a finalized version of the PR #3199 with passing tests.

### Checklist ###
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.

* [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/ (the old jQuery one has been signed before the foundation name change, is that enough?)
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

Thanks! Bots and humans will be around shortly to check it out.
