### PR TITLE
Core: Fix nodeName-related issues

### DIFF
--- a/src/attributes/val.js
+++ b/src/attributes/val.js
@@ -2,8 +2,8 @@ define( [
 	"../core",
 	"../core/stripAndCollapse",
 	"./support",
-	"../core/init",
-	"../core/nodeName"
+	"../core/nodeName",
+	"../core/init"
 ], function( jQuery, stripAndCollapse, support, nodeName ) {
 
 "use strict";

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -30,11 +30,11 @@ jQuery.fn.extend( {
 		} else {
 			jQuery.ready( true );
 		}
-},
-	nodeName: nodeName
+	}
 } );
 
 jQuery.isArray = Array.isArray;
 jQuery.parseJSON = JSON.parse;
+jQuery.nodeName = nodeName;
 
 } );

--- a/src/event.js
+++ b/src/event.js
@@ -6,8 +6,8 @@ define( [
 	"./var/rcheckableType",
 	"./var/slice",
 	"./data/var/dataPriv",
-	"./core/init",
 	"./core/nodeName",
+	"./core/init",
 	"./selector"
 ], function( jQuery, document, documentElement, rnothtmlwhite, rcheckableType, slice, dataPriv,
   nodeName ) {

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -16,9 +16,9 @@ define( [
 	"./data/var/dataUser",
 	"./data/var/acceptData",
 	"./core/DOMEval",
+	"./core/nodeName",
 
 	"./core/init",
-	"./core/nodeName",
 	"./traversing",
 	"./selector",
 	"./event"

--- a/src/offset.js
+++ b/src/offset.js
@@ -8,8 +8,8 @@ define( [
 	"./css/addGetHookIf",
 	"./css/support",
 
-	"./core/init",
 	"./core/nodeName",
+	"./core/init",
 	"./css",
 	"./selector" // contains
 ], function( jQuery, access, document, documentElement, rnumnonpx, curCSS, addGetHookIf, support,

--- a/src/traversing.js
+++ b/src/traversing.js
@@ -4,8 +4,8 @@ define( [
 	"./traversing/var/dir",
 	"./traversing/var/siblings",
 	"./traversing/var/rneedsContext",
-	"./core/init",
 	"./core/nodeName",
+	"./core/init",
 	"./traversing/findFilter",
 	"./selector"
 ], function( jQuery, indexOf, dir, siblings, rneedsContext, nodeName ) {

--- a/test/unit/deprecated.js
+++ b/test/unit/deprecated.js
@@ -116,3 +116,51 @@ QUnit.test( "jQuery.isArray", function( assert ) {
 
 	assert.strictEqual( jQuery.isArray, Array.isArray, "Array.isArray equals jQuery.isArray" );
 } );
+
+QUnit.test( "jQuery.nodeName", function( assert ) {
+	assert.expect( 8 );
+
+	assert.strictEqual( typeof jQuery.nodeName, "function", "jQuery.nodeName is a function" );
+
+	assert.strictEqual(
+		jQuery.nodeName( document.createElement( "div" ), "div" ),
+		true,
+		"Basic usage (true)"
+	);
+
+	assert.strictEqual(
+		jQuery.nodeName( document.createElement( "div" ), "span" ),
+		false,
+		"Basic usage (false)"
+	);
+
+	assert.strictEqual(
+		jQuery.nodeName( document.createElement( "div" ), "DIV" ),
+		true,
+		"Ignores case in the name parameter"
+	);
+
+	assert.strictEqual(
+		jQuery.nodeName( document.createElement( "section" ), "section" ),
+		true,
+		"Works on HTML5 tags (true)"
+	);
+
+	assert.strictEqual(
+		jQuery.nodeName( document.createElement( "section" ), "article" ),
+		false,
+		"Works on HTML5 tags (false)"
+	);
+
+	assert.strictEqual(
+		jQuery.nodeName( document.createElement( "custom-element" ), "custom-element" ),
+		true,
+		"Works on custom elements (true)"
+	);
+
+	assert.strictEqual(
+		jQuery.nodeName( document.createElement( "custom-element" ), "my-element" ),
+		false,
+		"Works on custom elements (true)"
+	);
+} );


### PR DESCRIPTION
### Summary ###
The jQuery.nodeName deprecation (ac9e3016) introduced a few serious regressions.

1. jQuery.nodeName was undefined, jQuery.fn.nodeName was defined instead.
2. Our AMD modules had parameters passed in incorrect order.

The second issue wasn't breaking the full build due to our custom build script
that removes the AMD wrappers so we didn't catch it in tests.

To avoid repeating the first regression, this commit also adds very basic
tests for the deprecated jQuery.nodeName.

Ref ac9e3016

P.S. Since this PR unbreaks master I'd like to land it quickly. Please review @jquery/core.

### Checklist ###
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.

* [x] All authors have signed the CLA at https://contribute.jquery.com/CLA/
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

Thanks! Bots and humans will be around shortly to check it out.
