### PR TITLE
Tests: Fix incorrect assert name for ensure_iterability_es6

### DIFF
--- a/test/node_smoke_tests/lib/ensure_iterability_es6.js
+++ b/test/node_smoke_tests/lib/ensure_iterability_es6.js
@@ -18,6 +18,6 @@ module.exports = function ensureIterability() {
 			result += i.nodeName;
 		}
 
-		assert.strictEqual( result, "DIVSPANA", "for-of doesn't work on jQuery objects" );
+		assert.strictEqual( result, "DIVSPANA", "for-of works on jQuery objects" );
 	} );
 };


### PR DESCRIPTION
### Summary ###
Fix incorrect assert name for ensure_iterability_es6. Follows-up bb026fc1.

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] Grunt build and unit tests pass locally with these changes
