### PR TITLE
Core: use instanceof and typeof instead of jQuery.type in jQuery.isFunction

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -212,7 +212,7 @@ jQuery.extend( {
 	noop: function() {},
 
 	isFunction: function( obj ) {
-		return jQuery.type( obj ) === "function";
+		return obj instanceof Function && typeof obj === "function";
 	},
 
 	isWindow: function( obj ) {

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -406,9 +406,9 @@ QUnit[ "assign" in Object ? "test" : "skip" ]( "isPlainObject(Object.assign(...)
 
 
 QUnit.test( "isFunction", function( assert ) {
-	assert.expect( 19 );
+	assert.expect( 20 );
 
-	var mystr, myarr, myfunction, fn, obj, nodes, first, input, a;
+	var mystr, myarr, myfunction, fn, inheriting, obj, nodes, first, input, a;
 
 	// Make sure that false values return false
 	assert.ok( !jQuery.isFunction(), "No Value" );
@@ -438,6 +438,9 @@ QUnit.test( "isFunction", function( assert ) {
 	// Make sure normal functions still work
 	fn = function() {};
 	assert.ok( jQuery.isFunction( fn ), "Normal Function" );
+
+	inheriting = Object.create( fn );
+	assert.ok( !jQuery.isFunction( inheriting ), "object inheriting function" );
 
 	obj = document.createElement( "object" );
 
@@ -489,6 +492,10 @@ QUnit.test( "isFunction", function( assert ) {
 	callme( function() {
 		callme( function() {} );
 	} );
+
+	function fnExoticToStringTag() {}
+	fnExoticToStringTag[ Symbol.toStringTag ] = "foo";
+	assert.ok( jQuery.isFunction( fnExoticToStringTag ), "function with exotic @@toStringTag" );
 } );
 
 QUnit.test( "isNumeric", function( assert ) {


### PR DESCRIPTION
### Summary ###
This change allows to detect functions with exotic `@@toStringTag`.

### Checklist ###
* [X] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [X] New tests have been added to show the fix or feature works
* [X] Grunt build and unit tests pass locally with these changes
* [X] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com (https://github.com/jquery/api.jquery.com/issues/1034)