### PR TITLE
Hide jQuery.camelCase

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -36,16 +36,7 @@ var
 
 	// Support: Android <=4.0 only
 	// Make sure we trim BOM and NBSP
-	rtrim = /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g,
-
-	// Matches dashed string for camelizing
-	rmsPrefix = /^-ms-/,
-	rdashAlpha = /-([a-z])/g,
-
-	// Used by jQuery.camelCase as callback to replace()
-	fcamelCase = function( all, letter ) {
-		return letter.toUpperCase();
-	};
+	rtrim = /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g;
 
 jQuery.fn = jQuery.prototype = {
 
@@ -280,13 +271,6 @@ jQuery.extend( {
 	// Evaluates a script in a global context
 	globalEval: function( code ) {
 		DOMEval( code );
-	},
-
-	// Convert dashed to camelCase; used by the css and data modules
-	// Support: IE <=9 - 11, Edge 12 - 13
-	// Microsoft forgot to hump their vendor prefix (#9572)
-	camelCase: function( string ) {
-		return string.replace( rmsPrefix, "ms-" ).replace( rdashAlpha, fcamelCase );
 	},
 
 	each: function( obj, callback ) {

--- a/src/core/camelCase.js
+++ b/src/core/camelCase.js
@@ -1,0 +1,23 @@
+define( [], function() {
+
+"use strict";
+
+// Matches dashed string for camelizing
+var rmsPrefix = /^-ms-/,
+	rdashAlpha = /-([a-z])/g;
+
+// Used by camelCase as callback to replace()
+var fcamelCase = function( all, letter ) {
+	return letter.toUpperCase();
+};
+
+// Convert dashed to camelCase; used by the css and data modules
+// Support: IE <=9 - 11, Edge 12 - 13
+// Microsoft forgot to hump their vendor prefix (#9572)
+var camelCase = function( string ) {
+	return string.replace( rmsPrefix, "ms-" ).replace( rdashAlpha, fcamelCase );
+};
+
+return camelCase;
+
+} );

--- a/src/css.js
+++ b/src/css.js
@@ -2,6 +2,7 @@ define( [
 	"./core",
 	"./var/pnum",
 	"./core/access",
+	"./core/camelCase",
 	"./css/var/rmargin",
 	"./var/document",
 	"./var/rcssNum",
@@ -17,7 +18,7 @@ define( [
 	"./core/init",
 	"./core/ready",
 	"./selector" // contains
-], function( jQuery, pnum, access, rmargin, document, rcssNum, rnumnonpx, cssExpand,
+], function( jQuery, pnum, access, camelCase, rmargin, document, rcssNum, rnumnonpx, cssExpand,
 	getStyles, swap, curCSS, adjustCSS, addGetHookIf, support ) {
 
 "use strict";
@@ -215,7 +216,7 @@ jQuery.extend( {
 
 		// Make sure that we're working with the right name
 		var ret, type, hooks,
-			origName = jQuery.camelCase( name ),
+			origName = camelCase( name ),
 			isCustomProp = rcustomProp.test( name ),
 			style = elem.style;
 
@@ -283,7 +284,7 @@ jQuery.extend( {
 
 	css: function( elem, name, extra, styles ) {
 		var val, num, hooks,
-			origName = jQuery.camelCase( name ),
+			origName = camelCase( name ),
 			isCustomProp = rcustomProp.test( name );
 
 		// Make sure that we're working with the right name. We don't

--- a/src/data.js
+++ b/src/data.js
@@ -1,9 +1,10 @@
 define( [
 	"./core",
 	"./core/access",
+	"./core/camelCase",
 	"./data/var/dataPriv",
 	"./data/var/dataUser"
-], function( jQuery, access, dataPriv, dataUser ) {
+], function( jQuery, access, camelCase, dataPriv, dataUser ) {
 
 "use strict";
 
@@ -112,7 +113,7 @@ jQuery.fn.extend( {
 						if ( attrs[ i ] ) {
 							name = attrs[ i ].name;
 							if ( name.indexOf( "data-" ) === 0 ) {
-								name = jQuery.camelCase( name.slice( 5 ) );
+								name = camelCase( name.slice( 5 ) );
 								dataAttr( elem, name, data[ name ] );
 							}
 						}

--- a/src/data/Data.js
+++ b/src/data/Data.js
@@ -1,8 +1,9 @@
 define( [
 	"../core",
+	"../core/camelCase",
 	"../var/rnothtmlwhite",
 	"./var/acceptData"
-], function( jQuery, rnothtmlwhite, acceptData ) {
+], function( jQuery, camelCase, rnothtmlwhite, acceptData ) {
 
 "use strict";
 
@@ -54,14 +55,14 @@ Data.prototype = {
 		// Handle: [ owner, key, value ] args
 		// Always use camelCase key (gh-2257)
 		if ( typeof data === "string" ) {
-			cache[ jQuery.camelCase( data ) ] = value;
+			cache[ camelCase( data ) ] = value;
 
 		// Handle: [ owner, { properties } ] args
 		} else {
 
 			// Copy the properties one-by-one to the cache object
 			for ( prop in data ) {
-				cache[ jQuery.camelCase( prop ) ] = data[ prop ];
+				cache[ camelCase( prop ) ] = data[ prop ];
 			}
 		}
 		return cache;
@@ -71,7 +72,7 @@ Data.prototype = {
 			this.cache( owner ) :
 
 			// Always use camelCase key (gh-2257)
-			owner[ this.expando ] && owner[ this.expando ][ jQuery.camelCase( key ) ];
+			owner[ this.expando ] && owner[ this.expando ][ camelCase( key ) ];
 	},
 	access: function( owner, key, value ) {
 
@@ -119,9 +120,9 @@ Data.prototype = {
 
 				// If key is an array of keys...
 				// We always set camelCase keys, so remove that.
-				key = key.map( jQuery.camelCase );
+				key = key.map( camelCase );
 			} else {
-				key = jQuery.camelCase( key );
+				key = camelCase( key );
 
 				// If a key with the spaces exists, use it.
 				// Otherwise, create an array by matching non-whitespace

--- a/src/effects.js
+++ b/src/effects.js
@@ -1,5 +1,6 @@
 define( [
 	"./core",
+	"./core/camelCase",
 	"./var/document",
 	"./var/rcssNum",
 	"./var/rnothtmlwhite",
@@ -17,8 +18,8 @@ define( [
 	"./manipulation",
 	"./css",
 	"./effects/Tween"
-], function( jQuery, document, rcssNum, rnothtmlwhite, cssExpand, isHiddenWithinTree, swap,
-	adjustCSS, dataPriv, showHide ) {
+], function( jQuery, camelCase, document, rcssNum, rnothtmlwhite, cssExpand, isHiddenWithinTree,
+	swap, adjustCSS, dataPriv, showHide ) {
 
 "use strict";
 
@@ -258,7 +259,7 @@ function propFilter( props, specialEasing ) {
 
 	// camelCase, specialEasing and expand cssHook pass
 	for ( index in props ) {
-		name = jQuery.camelCase( index );
+		name = camelCase( index );
 		easing = specialEasing[ name ];
 		value = props[ index ];
 		if ( Array.isArray( value ) ) {

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -1642,25 +1642,6 @@ QUnit.test( "jQuery.parseXML", function( assert ) {
 	}
 } );
 
-QUnit.test( "jQuery.camelCase()", function( assert ) {
-
-	var tests = {
-		"foo-bar": "fooBar",
-		"foo-bar-baz": "fooBarBaz",
-		"girl-u-want": "girlUWant",
-		"the-4th-dimension": "the-4thDimension",
-		"-o-tannenbaum": "OTannenbaum",
-		"-moz-illa": "MozIlla",
-		"-ms-take": "msTake"
-	};
-
-	assert.expect( 7 );
-
-	jQuery.each( tests, function( key, val ) {
-		assert.equal( jQuery.camelCase( key ), val, "Converts: " + key + " => " + val );
-	} );
-} );
-
 testIframe(
 	"Conditional compilation compatibility (#13274)",
 	"core/cc_on.html",

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -602,7 +602,7 @@ QUnit.test( ".data should not miss attr() set data-* with hyphenated property na
 } );
 
 QUnit.test( ".data always sets data with the camelCased key (gh-2257)", function( assert ) {
-	assert.expect( 18 );
+	assert.expect( 9 );
 
 	var div = jQuery( "<div>" ).appendTo( "#qunit-fixture" ),
 		datas = {
@@ -625,7 +625,6 @@ QUnit.test( ".data always sets data with the camelCased key (gh-2257)", function
 		div.data( key, val );
 		var allData = div.data();
 		assert.equal( allData[ key ], undefined, ".data does not store with hyphenated keys" );
-		assert.equal( allData[ jQuery.camelCase( key ) ], val, ".data stores the camelCased key" );
 	} );
 } );
 
@@ -639,7 +638,7 @@ QUnit.test( ".data should not strip more than one hyphen when camelCasing (gh-20
 	assert.equal( allData[ "nested--Triple" ], "triple", "Key with triple hyphens is correctly camelCased" );
 } );
 
-QUnit.test( ".data supports interoperable hyphenated/camelCase get/set of properties with arbitrary non-null|NaN|undefined values", function( assert ) {
+QUnit.test( ".data supports interoperable hyphenated get/set of properties with arbitrary non-null|NaN|undefined values", function( assert ) {
 
 	var div = jQuery( "<div/>", { id: "hyphened" } ).appendTo( "#qunit-fixture" ),
 		datas = {
@@ -661,17 +660,16 @@ QUnit.test( ".data supports interoperable hyphenated/camelCase get/set of proper
 			"2-num-start": true
 		};
 
-	assert.expect( 24 );
+	assert.expect( 12 );
 
 	jQuery.each( datas, function( key, val ) {
 		div.data( key, val );
 
 		assert.deepEqual( div.data( key ), val, "get: " + key );
-		assert.deepEqual( div.data( jQuery.camelCase( key ) ), val, "get: " + jQuery.camelCase( key ) );
 	} );
 } );
 
-QUnit.test( ".data supports interoperable removal of hyphenated/camelCase properties", function( assert ) {
+QUnit.test( ".data supports interoperable removal of hyphenated properties", function( assert ) {
 	var div = jQuery( "<div/>", { id: "hyphened" } ).appendTo( "#qunit-fixture" ),
 		datas = {
 			"non-empty": "a string",
@@ -689,13 +687,12 @@ QUnit.test( ".data supports interoperable removal of hyphenated/camelCase proper
 			"some-json": "{ \"foo\": \"bar\" }"
 		};
 
-	assert.expect( 27 );
+	assert.expect( 18 );
 
 	jQuery.each( datas, function( key, val ) {
 		div.data( key, val );
 
 		assert.deepEqual( div.data( key ), val, "get: " + key );
-		assert.deepEqual( div.data( jQuery.camelCase( key ) ), val, "get: " + jQuery.camelCase( key ) );
 
 		div.removeData( key );
 

--- a/test/unit/deprecated.js
+++ b/test/unit/deprecated.js
@@ -164,3 +164,22 @@ QUnit.test( "jQuery.nodeName", function( assert ) {
 		"Works on custom elements (true)"
 	);
 } );
+
+QUnit.test( "jQuery.camelCase()", function( assert ) {
+
+	var tests = {
+		"foo-bar": "fooBar",
+		"foo-bar-baz": "fooBarBaz",
+		"girl-u-want": "girlUWant",
+		"the-4th-dimension": "the-4thDimension",
+		"-o-tannenbaum": "OTannenbaum",
+		"-moz-illa": "MozIlla",
+		"-ms-take": "msTake"
+	};
+
+	assert.expect( 7 );
+
+	jQuery.each( tests, function( key, val ) {
+		assert.equal( jQuery.camelCase( key ), val, "Converts: " + key + " => " + val );
+	} );
+} );


### PR DESCRIPTION
Here, I try to resolve this issue by moving the exposed method `jQuery.camelCase()` into a internal module `camelCase` located in `src/core/camelCase.js`, as well as importing it wherever it's been used.