### PR TITLE
Core: Update isFunction to handle unusual-@@toStringTag input

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -214,7 +214,9 @@ jQuery.extend( {
 	isFunction: function( obj ) {
 
 		// Support: Chrome <=57, Firefox <=52
-		// Don't classify callable <object> elements as functions
+		// In some browsers, typeof returns "function" for HTML <object> elements
+		// (i.e., `typeof document.createElement( "object" ) === "function"`).
+		// We don't want to classify *any* DOM node as a function.
 		return typeof obj === "function" && typeof obj.nodeType !== "number";
 	},
 

--- a/src/core.js
+++ b/src/core.js
@@ -212,7 +212,10 @@ jQuery.extend( {
 	noop: function() {},
 
 	isFunction: function( obj ) {
-		return obj instanceof Function && typeof obj === "function";
+
+		// Support: Chrome <=57, Firefox <=52
+		// Don't classify callable <object>s as functions
+		return typeof obj === "function" && typeof obj.nodeType !== "number";
 	},
 
 	isWindow: function( obj ) {

--- a/src/core.js
+++ b/src/core.js
@@ -214,7 +214,7 @@ jQuery.extend( {
 	isFunction: function( obj ) {
 
 		// Support: Chrome <=57, Firefox <=52
-		// Don't classify callable <object>s as functions
+		// Don't classify callable <object> elements as functions
 		return typeof obj === "function" && typeof obj.nodeType !== "number";
 	},
 

--- a/src/core.js
+++ b/src/core.js
@@ -467,7 +467,7 @@ function isArrayLike( obj ) {
 	var length = !!obj && "length" in obj && obj.length,
 		type = jQuery.type( obj );
 
-	if ( type === "function" || jQuery.isWindow( obj ) ) {
+	if ( jQuery.isFunction( obj ) || jQuery.isWindow( obj ) ) {
 		return false;
 	}
 

--- a/src/core.js
+++ b/src/core.js
@@ -212,7 +212,7 @@ jQuery.extend( {
 	noop: function() {},
 
 	isFunction: function( obj ) {
-		return jQuery.type( obj ) === "function";
+		return obj instanceof Function && typeof obj === "function";
 	},
 
 	isWindow: function( obj ) {

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -439,11 +439,11 @@ QUnit.test( "isFunction", function( assert ) {
 	fn = function() {};
 	assert.ok( jQuery.isFunction( fn ), "Normal Function" );
 
-	assert.ok( !jQuery.isFunction( Object.create( fn ) ), "custom Function subclass" );
+	assert.notOk( jQuery.isFunction( Object.create( fn ) ), "custom Function subclass" );
 
 	obj = document.createElement( "object" );
 
-	// Firefox says this is a function
+	// Some versions of Firefox and Chrome say this is a function
 	assert.ok( !jQuery.isFunction( obj ), "Object Element" );
 
 	// Since 1.3, this isn't supported (#2968)

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -503,15 +503,11 @@ QUnit.test( "isFunction", function( assert ) {
 		done();
 	};
 
-	try {
-		iframe = jQuery( "#qunit-fixture" )[ 0 ].appendChild( document.createElement( "iframe" ) );
-		doc = iframe.contentDocument || iframe.contentWindow.document;
-		doc.open();
-		doc.write( "<body onload='window.parent.iframeDone( function() {} );'>" );
-		doc.close();
-	} catch ( e ) {
-		window.iframeDone( function() {}, "iframes not supported" );
-	}
+	iframe = jQuery( "#qunit-fixture" )[ 0 ].appendChild( document.createElement( "iframe" ) );
+	doc = iframe.contentDocument || iframe.contentWindow.document;
+	doc.open();
+	doc.write( "<body onload='window.parent.iframeDone( function() {} );'>" );
+	doc.close();
 } );
 
 ( function() {

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -536,7 +536,8 @@ supportjQuery.each(
 	}
 );
 
-QUnit[ typeof Symbol === "function" ? "test" : "skip" ]( "isFunction(custom @@toStringTag)",
+QUnit[ typeof Symbol === "function" && Symbol.toStringTag ? "test" : "skip" ](
+	"isFunction(custom @@toStringTag)",
 	function( assert ) {
 		assert.expect( 2 );
 

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -406,9 +406,9 @@ QUnit[ "assign" in Object ? "test" : "skip" ]( "isPlainObject(Object.assign(...)
 
 
 QUnit.test( "isFunction", function( assert ) {
-	assert.expect( 19 );
+	assert.expect( 20 );
 
-	var mystr, myarr, myfunction, fn, obj, nodes, first, input, a;
+	var mystr, myarr, myfunction, fn, inheriting, obj, nodes, first, input, a;
 
 	// Make sure that false values return false
 	assert.ok( !jQuery.isFunction(), "No Value" );
@@ -438,6 +438,9 @@ QUnit.test( "isFunction", function( assert ) {
 	// Make sure normal functions still work
 	fn = function() {};
 	assert.ok( jQuery.isFunction( fn ), "Normal Function" );
+
+	inheriting = Object.create( fn );
+	assert.ok( !jQuery.isFunction( inheriting ), "object inheriting function" );
 
 	obj = document.createElement( "object" );
 
@@ -489,6 +492,10 @@ QUnit.test( "isFunction", function( assert ) {
 	callme( function() {
 		callme( function() {} );
 	} );
+
+	function fnExoticToStringTag() {}
+	fnExoticToStringTag[ Symbol.toStringTag ] = "foo";
+	assert.ok( jQuery.isFunction( fnExoticToStringTag ), "function with exotic @@toStringTag" );
 } );
 
 QUnit.test( "isNumeric", function( assert ) {

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -406,10 +406,9 @@ QUnit[ "assign" in Object ? "test" : "skip" ]( "isPlainObject(Object.assign(...)
 
 
 QUnit.test( "isFunction", function( assert ) {
-	assert.expect( 21 );
+	assert.expect( 20 );
 
-	var mystr, myarr, myfunction, fn, inheriting, obj, nodes, first, input, a, iframe, doc,
-		done = assert.async();
+	var mystr, myarr, myfunction, fn, obj, nodes, first, input, a;
 
 	// Make sure that false values return false
 	assert.ok( !jQuery.isFunction(), "No Value" );
@@ -440,8 +439,7 @@ QUnit.test( "isFunction", function( assert ) {
 	fn = function() {};
 	assert.ok( jQuery.isFunction( fn ), "Normal Function" );
 
-	inheriting = Object.create( fn );
-	assert.ok( !jQuery.isFunction( inheriting ), "object inheriting function" );
+	assert.ok( !jQuery.isFunction( Object.create( fn ) ), "custom Function subclass" );
 
 	obj = document.createElement( "object" );
 
@@ -493,6 +491,13 @@ QUnit.test( "isFunction", function( assert ) {
 	callme( function() {
 		callme( function() {} );
 	} );
+} );
+
+QUnit.test( "isFunction(cross-realm function)", function( assert ) {
+	assert.expect( 1 );
+
+	var iframe, doc,
+		done = assert.async();
 
 	// Functions from other windows should be matched
 	Globals.register( "iframeDone" );
@@ -510,20 +515,26 @@ QUnit.test( "isFunction", function( assert ) {
 	doc.close();
 } );
 
-( function() {
-	var generator;
-	try {
-		generator = Function( "return function* () {}" )();
-	} catch ( e ) {}
+supportjQuery.each(
+	{
+		GeneratorFunction: "function*() {}",
+		AsyncFunction: "async function() {}"
+	},
+	function( subclass, source ) {
+		var fn;
+		try {
+			fn = Function( "return " + source )();
+		} catch ( e ) {}
 
-	QUnit[ generator ? "test" : "skip" ]( "isFunction(standard Function subclass)",
-		function( assert ) {
-			assert.expect( 1 );
+		QUnit[ fn ? "test" : "skip" ]( "isFunction(" + subclass + ")",
+			function( assert ) {
+				assert.expect( 1 );
 
-			assert.equal( jQuery.isFunction( generator ), true, "GeneratorFunction" );
-		}
-	);
-} )();
+				assert.equal( jQuery.isFunction( fn ), true, source );
+			}
+		);
+	}
+);
 
 QUnit[ typeof Symbol === "function" ? "test" : "skip" ]( "isFunction(custom @@toStringTag)",
 	function( assert ) {

--- a/test/unit/deferred.js
+++ b/test/unit/deferred.js
@@ -543,7 +543,7 @@ QUnit.test( "jQuery.Deferred.then - spec compatibility", function( assert ) {
 	} catch ( _ ) {}
 } );
 
-QUnit[ typeof Symbol === "function" ? "test" : "skip" ](
+QUnit[ typeof Symbol === "function" && Symbol.toStringTag ? "test" : "skip" ](
 	"jQuery.Deferred.then - IsCallable determination (gh-3596)",
 	function( assert ) {
 

--- a/test/unit/deferred.js
+++ b/test/unit/deferred.js
@@ -555,7 +555,7 @@ QUnit[ typeof Symbol === "function" ? "test" : "skip" ](
 		function faker() {
 			assert.ok( true, "handler with non-'Function' @@toStringTag gets invoked" );
 		}
-		faker[ typeof Symbol === "function" && Symbol.toStringTag ] = "String";
+		faker[ Symbol.toStringTag ] = "String";
 
 		defer.then( faker ).then( done );
 
@@ -882,15 +882,13 @@ QUnit.test( "jQuery.when(nonThenable) - like Promise.resolve", function( assert 
 QUnit.test( "jQuery.when(thenable) - like Promise.resolve", function( assert ) {
 	"use strict";
 
-	function customToStringThen() {
-		var promise = {
-			then: function( onFulfilled ) {
-				onFulfilled();
-			}
-		};
-		promise.then[ typeof Symbol === "function" && Symbol.toStringTag ] = "String";
-
-		return promise;
+	var customToStringThen = {
+		then: function( onFulfilled ) {
+			onFulfilled();
+		}
+	};
+	if ( typeof Symbol === "function" ) {
+		customToStringThen.then[ Symbol.toStringTag ] = "String";
 	}
 
 	var slice = [].slice,
@@ -901,7 +899,7 @@ QUnit.test( "jQuery.when(thenable) - like Promise.resolve", function( assert ) {
 		secondaryRejected = jQuery.Deferred().resolve( eventuallyRejected ),
 		inputs = {
 			promise: Promise.resolve( true ),
-			customToStringThen: customToStringThen(),
+			customToStringThen: customToStringThen,
 			rejectedPromise: Promise.reject( false ),
 			deferred: jQuery.Deferred().resolve( true ),
 			eventuallyFulfilled: eventuallyFulfilled,


### PR DESCRIPTION
### Summary ###
Generators and async functions are still functions (cf. [ECMAScript Language Specification](http://www.ecma-international.org/ecma-262/7.0/#sec-generatorfunction-objects)), and we can recognize them with `typeof` (but still need a guard to reject elements).

Fixes gh-3600
Fixes gh-3596

### Checklist ###
* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com