### PR TITLE
Fix typo

### DIFF
--- a/src/deferred.js
+++ b/src/deferred.js
@@ -184,7 +184,7 @@ jQuery.extend( {
 								},
 
 								// Only normal processors (resolve) catch and reject exceptions
-								process = special ?
+								var process = special ?
 									mightThrow :
 									function() {
 										try {


### PR DESCRIPTION
Variable referred to without "var" keyword.

Causes stupid errors when interacting with the node "process" module.

### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
