### PR TITLE
Sizzle: remove test meant for no longer supported browers

### DIFF
--- a/external/sizzle/dist/sizzle.js
+++ b/external/sizzle/dist/sizzle.js
@@ -249,31 +249,17 @@ function Sizzle( selector, context, results, seed ) {
 					// Document context
 					if ( nodeType === 9 ) {
 						if ( (elem = context.getElementById( m )) ) {
-
-							// Support: IE, Opera, Webkit
-							// TODO: identify versions
-							// getElementById can match elements by name instead of ID
-							if ( elem.id === m ) {
-								results.push( elem );
-								return results;
-							}
-						} else {
-							return results;
+							results.push( elem );
 						}
+						return results;
 
 					// Element context
-					} else {
+					} else if ( newContext &&
+						(elem = newContext.getElementById( m )) &&
+						contains( context, elem ) ) {
 
-						// Support: IE, Opera, Webkit
-						// TODO: identify versions
-						// getElementById can match elements by name instead of ID
-						if ( newContext && (elem = newContext.getElementById( m )) &&
-							contains( context, elem ) &&
-							elem.id === m ) {
-
-							results.push( elem );
-							return results;
-						}
+						results.push( elem );
+						return results;
 					}
 
 				// Type selector


### PR DESCRIPTION
#3624 - Remove test meant for IE<8 and Opera<9.50 handling of getDocumentById().

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com