### PR TITLE
Ajax: send correct "Content-type" if data is set in "beforeSend" method

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -579,11 +579,6 @@ jQuery.extend({
 			}
 		}
 
-		// Set the correct header, if data is being sent
-		if ( s.data && s.hasContent && s.contentType !== false || options.contentType ) {
-			jqXHR.setRequestHeader( "Content-Type", s.contentType );
-		}
-
 		// Set the Accepts header for the server, depending on the dataType
 		jqXHR.setRequestHeader(
 			"Accept",
@@ -604,6 +599,11 @@ jQuery.extend({
 
 			// Abort if not done already and return
 			return jqXHR.abort();
+		}
+
+		// Set the correct header, if data is being sent
+		if ( s.data && s.hasContent && s.contentType !== false || options.contentType ) {
+			jqXHR.setRequestHeader( "Content-Type", s.contentType );
 		}
 
 		// Aborting is no longer a cancellation

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -2022,6 +2022,37 @@ module( "ajax", {
 		});
 	});
 
+	asyncTest( "Send correct \"Content-type\" if data is set in \"beforeSend\" method gh#1801", 2,
+		function() {
+			var oldSetRequestHeader;
+
+			jQuery.ajax({
+				url: "/",
+				method: "post",
+				beforeSend: function( xhr, settings ) {
+					oldSetRequestHeader = xhr.setRequestHeader;
+					settings.data = "test";
+
+					xhr.setRequestHeader = function( name, value ) {
+						strictEqual( name, "Content-Type", "correct header" );
+						strictEqual( value,
+						    "application/x-www-form-urlencoded; charset=UTF-8",
+						    "correct value"
+						);
+					};
+				}
+			}).done(function( data, textStatus, jqXHR ) {
+				jqXHR.old = oldSetRequestHeader;
+
+				start();
+
+			}).fail(function( jqXHR ) {
+				jqXHR.old = oldSetRequestHeader;
+
+				start();
+			});
+	});
+
 //----------- jQuery.active
 
 	test( "jQuery.active", 1, function() {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
