### PR TITLE
Deferred: fix memory leak of promise callbacks

### DIFF
--- a/src/deferred.js
+++ b/src/deferred.js
@@ -301,8 +301,15 @@ jQuery.extend( {
 					// fulfilled_callbacks.disable
 					tuples[ 3 - i ][ 2 ].disable,
 
+					// rejected_handlers.disable
+					// fulfilled_handlers.disable
+					tuples[ 3 - i ][ 3 ].disable,
+
 					// progress_callbacks.lock
-					tuples[ 0 ][ 2 ].lock
+					tuples[ 0 ][ 2 ].lock,
+
+					// progress_handlers.lock
+					tuples[ 0 ][ 3 ].lock
 				);
 			}
 


### PR DESCRIPTION
Fixes #3606

I'm not sure why we need both [callbacks and .then handlers](https://github.com/jquery/jquery/blob/00e0c7af79cf27b5c52f1f2dcb6770fd26d5119c/src/deferred.js#L56-L61). Could we instead merge those `Callback`s? EDIT: I think it's because error handling works different?