### PR TITLE
Core: param serializes first element of an array without an index

### DIFF
--- a/src/serialize.js
+++ b/src/serialize.js
@@ -30,7 +30,7 @@ function buildParams( prefix, obj, traditional, add ) {
 
 				// Item is non-scalar (array or object), encode its numeric index.
 				buildParams(
-					prefix + "[" + ( typeof v === "object" && v != null ? i : "" ) + "]",
+					prefix + "[" + ( i > 0 && typeof v === "object" && v != null ? i : "" ) + "]",
 					v,
 					traditional,
 					add

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -27,7 +27,7 @@ QUnit.test( "jQuery.param()", function( assert ) {
 	assert.equal( decodeURIComponent( jQuery.param( params ) ), "a[]=1&a[]=2&b[c]=3&b[d][]=4&b[d][]=5&b[e][x][]=6&b[e][y]=7&b[e][z][]=8&b[e][z][]=9&b[f]=true&b[g]=false&b[h]=&i[]=10&i[]=11&j=true&k=false&l[]=&l[]=0&m=cowboy hat?", "huge structure" );
 
 	params = { "a": [ 0, [ 1, 2 ], [ 3, [ 4, 5 ], [ 6 ] ], { "b": [ 7, [ 8, 9 ], [ { "c": 10, "d": 11 } ], [ [ 12 ] ], [ [ [ 13 ] ] ], { "e": { "f": { "g": [ 14, [ 15 ] ] } } }, 16 ] }, 17 ] };
-	assert.equal( decodeURIComponent( jQuery.param( params ) ), "a[]=0&a[1][]=1&a[1][]=2&a[2][]=3&a[2][1][]=4&a[2][1][]=5&a[2][2][]=6&a[3][b][]=7&a[3][b][1][]=8&a[3][b][1][]=9&a[3][b][2][0][c]=10&a[3][b][2][0][d]=11&a[3][b][3][0][]=12&a[3][b][4][0][0][]=13&a[3][b][5][e][f][g][]=14&a[3][b][5][e][f][g][1][]=15&a[3][b][]=16&a[]=17", "nested arrays" );
+	assert.equal( decodeURIComponent( jQuery.param( params ) ), "a[]=0&a[1][]=1&a[1][]=2&a[2][]=3&a[2][1][]=4&a[2][1][]=5&a[2][2][]=6&a[3][b][]=7&a[3][b][1][]=8&a[3][b][1][]=9&a[3][b][2][][c]=10&a[3][b][2][][d]=11&a[3][b][3][][]=12&a[3][b][4][][][]=13&a[3][b][5][e][f][g][]=14&a[3][b][5][e][f][g][1][]=15&a[3][b][]=16&a[]=17", "nested arrays" );
 
 	params = { "a":[ 1, 2 ], "b":{ "c":3, "d":[ 4, 5 ], "e":{ "x":[ 6 ], "y":7, "z":[ 8, 9 ] }, "f":true, "g":false, "h":undefined }, "i":[ 10, 11 ], "j":true, "k":false, "l":[ undefined, 0 ], "m":"cowboy hat?" };
 	assert.equal( jQuery.param( params, true ), "a=1&a=2&b=%5Bobject%20Object%5D&i=10&i=11&j=true&k=false&l=&l=0&m=cowboy%20hat%3F", "huge structure, forced traditional" );
@@ -60,6 +60,9 @@ QUnit.test( "jQuery.param()", function( assert ) {
 
 	params = { a:[ 1, 2 ], b:{ c:3, d:[ 4, 5 ], e:{ x:[ 6 ], y:7, z:[ 8, 9 ] }, f:true, g:false, h:undefined }, i:[ 10, 11 ], j:true, k:false, l:[ undefined, 0 ], m:"cowboy hat?" };
 	assert.equal( decodeURIComponent( jQuery.param( params ) ), "a[]=1&a[]=2&b[c]=3&b[d][]=4&b[d][]=5&b[e][x][]=6&b[e][y]=7&b[e][z][]=8&b[e][z][]=9&b[f]=true&b[g]=false&b[h]=&i[]=10&i[]=11&j=true&k=false&l[]=&l[]=0&m=cowboy hat?", "huge structure, forced not traditional" );
+
+	params = { a:[ { b:1, c:2 }, 3 ] };
+	assert.equal( decodeURIComponent( jQuery.param( params ) ), "a[][b]=1&a[][c]=2&a[1]=3" );
 
 	params = { "param1": null };
 	assert.equal( jQuery.param( params ), "param1=", "Make sure that null params aren't traversed." );


### PR DESCRIPTION
### Summary ###
`jQuery.param` will serialize the first element of an array without an index, this prevents ambiguity between an object with numeric keys and an array, and will therefor allow properly serializing an array of objects.

**Before:**
```javascript
jQuery.param({ a: [{ b: 1 }, { c: 2 }] })
=> a[0][b]=1&a[1][c]=2
```

This *could* falsely be deserialized as: `{ a: { "0": { b: 1 }, "1": { c: 2 } } }` (and it absolutely will).

**After:**
```javascript
jQuery.param({ a: [{ b: 1 }, { c: 2 }] })
=> a[][b]=1&a[1][c]=2
```

This first element ensures `a` should be considered an array.

This follows this PR in rack: rack/rack#1165

Unfortunately this is not backward compatibly (would actually break rack before it pulls this request), but this is somewhat mandatory as you simply cannot properly serialize some scenarios (see the tests in rack's PR for more scenarios). Should this be a configuration option somewhere?

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
