### PR TITLE
Build: Add yarn.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .sizecache.json
 
 npm-debug.log*
+package-lock.json
 
 # Ignore everything in dist folder except for eslint config
 /dist/*


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

npm 5 generates a package-lock.json file by default so running `npm install`
with this version puts the local repository copy in a dirty state.

This commit adds package-lock.json to .gitignore so that this doesn't happen.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
