### PR TITLE
Stop propagation on native events

### DIFF
--- a/src/event/trigger.js
+++ b/src/event/trigger.js
@@ -24,7 +24,7 @@ jQuery.extend( jQuery.event, {
 			type = hasOwn.call( event, "type" ) ? event.type : event,
 			namespaces = hasOwn.call( event, "namespace" ) ? event.namespace.split( "." ) : [];
 
-		cur = tmp = elem = elem || document;
+		cur = lastElement = tmp = elem = elem || document;
 
 		// Don't do events on text and comment nodes
 		if ( elem.nodeType === 3 || elem.nodeType === 8 ) {

--- a/src/event/trigger.js
+++ b/src/event/trigger.js
@@ -10,13 +10,16 @@ define( [
 
 "use strict";
 
-var rfocusMorph = /^(?:focusinfocus|focusoutblur)$/;
+var rfocusMorph = /^(?:focusinfocus|focusoutblur)$/,
+	stopPropagationCallback = function( e ) {
+		e.stopPropagation();
+	};
 
 jQuery.extend( jQuery.event, {
 
 	trigger: function( event, data, elem, onlyHandlers ) {
 
-		var i, cur, tmp, bubbleType, ontype, handle, special,
+		var i, cur, tmp, bubbleType, ontype, handle, special, lastElement,
 			eventPath = [ elem || document ],
 			type = hasOwn.call( event, "type" ) ? event.type : event,
 			namespaces = hasOwn.call( event, "namespace" ) ? event.namespace.split( "." ) : [];
@@ -93,7 +96,7 @@ jQuery.extend( jQuery.event, {
 		// Fire handlers on the event path
 		i = 0;
 		while ( ( cur = eventPath[ i++ ] ) && !event.isPropagationStopped() ) {
-
+			lastElement = cur;
 			event.type = i > 1 ?
 				bubbleType :
 				special.bindType || type;
@@ -136,7 +139,17 @@ jQuery.extend( jQuery.event, {
 
 					// Prevent re-triggering of the same event, since we already bubbled it above
 					jQuery.event.triggered = type;
+
+					if ( event.isPropagationStopped() ) {
+						lastElement.addEventListener( type, stopPropagationCallback );
+					}
+
 					elem[ type ]();
+
+					if ( event.isPropagationStopped() ) {
+						lastElement.removeEventListener( type, stopPropagationCallback );
+					}
+
 					jQuery.event.triggered = undefined;
 
 					if ( tmp ) {

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -440,7 +440,7 @@ QUnit.test( "on bubbling, isDefaultPrevented, stopImmediatePropagation", functio
 	$anchor2[ 0 ].removeEventListener( "click", neverCallMe );
 } );
 
-QUnit.test( "triggerd events stopPropagation() for natively-bound events", function( assert ) {
+QUnit.test( "triggered events stopPropagation() for natively-bound events", function( assert ) {
 	assert.expect( 1 );
 
 	var $button = jQuery( "#button" ),

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -440,6 +440,26 @@ QUnit.test( "on bubbling, isDefaultPrevented, stopImmediatePropagation", functio
 	$anchor2[ 0 ].removeEventListener( "click", neverCallMe );
 } );
 
+QUnit.test( "triggerd events stopPropagation() for natively-bound events", function( assert ) {
+	assert.expect( 1 );
+
+	var $button = jQuery( "#button" ),
+		$parent = $button.parent(),
+		neverCallMe = function() {
+			assert.ok( false, "propagation should have been stopped" );
+		},
+		stopPropagationCallback = function( e ) {
+			assert.ok( true, "propagation is stopped" );
+			e.stopPropagation();
+		};
+
+	$parent[ 0 ].addEventListener( "click", neverCallMe );
+	$button.on( "click", stopPropagationCallback );
+	$button.trigger( "click" );
+	$parent[ 0 ].removeEventListener( "click", neverCallMe );
+	$button.off( "click", stopPropagationCallback );
+} );
+
 QUnit.test( "on(), iframes", function( assert ) {
 	assert.expect( 1 );
 

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -460,6 +460,27 @@ QUnit.test( "triggered events stopPropagation() for natively-bound events", func
 	$button.off( "click", stopPropagationCallback );
 } );
 
+QUnit.test( "trigger() works with events that were previously stopped", function( assert ) {
+	assert.expect( 0 );
+
+	var $button = jQuery( "#button" ),
+		$parent = $button.parent(),
+		neverCallMe = function() {
+			assert.ok( false, "propagation should have been stopped" );
+		};
+
+	$parent[ 0 ].addEventListener( "click", neverCallMe );
+	$button.on( "click", neverCallMe );
+
+	var clickEvent =  jQuery.Event( "click" );
+	clickEvent.stopPropagation();
+	$button.trigger( clickEvent );
+
+	$parent[ 0 ].removeEventListener( "click", neverCallMe );
+	$button.off( "click", neverCallMe );
+} );
+
+
 QUnit.test( "on(), iframes", function( assert ) {
 	assert.expect( 1 );
 


### PR DESCRIPTION
### Summary ###

This PR ensures that `event.stopPropagation()` is respected for event handlers that were registered using the native `element.addEventlistener()` method when the event was triggered by jQuery's `.trigger('click')` method.

This PR fixes #3693.

The ticket was closed at first with the following argument:

> jQuery has never been able to guarantee full interoperability of native-vs-jQuery event handlers.

Nonetheless, the discussion lead me to believe, that this incompatibility between native and jQuery event handling could be fixed and that such a fix is worthwhile.

### Checklist ###

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com