### PR TITLE
Deprecate jQuery.isWindow (3629)

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -16,10 +16,11 @@ define( [
 	"./var/fnToString",
 	"./var/ObjectFunctionString",
 	"./var/support",
+	"./var/isWindow",
 	"./core/DOMEval"
 ], function( arr, document, getProto, slice, concat, push, indexOf,
 	class2type, toString, hasOwn, fnToString, ObjectFunctionString,
-	support, DOMEval ) {
+	support, isWindow, DOMEval ) {
 
 "use strict";
 
@@ -218,10 +219,6 @@ jQuery.extend( {
 		// (i.e., `typeof document.createElement( "object" ) === "function"`).
 		// We don't want to classify *any* DOM node as a function.
 		return typeof obj === "function" && typeof obj.nodeType !== "number";
-	},
-
-	isWindow: function( obj ) {
-		return obj != null && obj === obj.window;
 	},
 
 	isNumeric: function( obj ) {
@@ -469,7 +466,7 @@ function isArrayLike( obj ) {
 	var length = !!obj && "length" in obj && obj.length,
 		type = jQuery.type( obj );
 
-	if ( jQuery.isFunction( obj ) || jQuery.isWindow( obj ) ) {
+	if ( jQuery.isFunction( obj ) || isWindow( obj ) ) {
 		return false;
 	}
 

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -1,7 +1,8 @@
 define( [
 	"./core",
-	"./core/nodeName"
-], function( jQuery, nodeName ) {
+	"./core/nodeName",
+	"./var/isWindow"
+], function( jQuery, nodeName, isWindow ) {
 
 "use strict";
 
@@ -36,5 +37,6 @@ jQuery.holdReady = function( hold ) {
 jQuery.isArray = Array.isArray;
 jQuery.parseJSON = JSON.parse;
 jQuery.nodeName = nodeName;
+jQuery.isWindow = isWindow;
 
 } );

--- a/src/dimensions.js
+++ b/src/dimensions.js
@@ -1,8 +1,8 @@
 define( [
 	"./core",
 	"./core/access",
-	"./css",
-	"./var/isWindow"
+	"./var/isWindow",
+	"./css"
 ], function( jQuery, access, isWindow ) {
 
 "use strict";

--- a/src/dimensions.js
+++ b/src/dimensions.js
@@ -1,8 +1,9 @@
 define( [
 	"./core",
 	"./core/access",
-	"./css"
-], function( jQuery, access ) {
+	"./css",
+	"./var/isWindow"
+], function( jQuery, access, isWindow ) {
 
 "use strict";
 
@@ -19,7 +20,7 @@ jQuery.each( { Height: "height", Width: "width" }, function( name, type ) {
 			return access( this, function( elem, type, value ) {
 				var doc;
 
-				if ( jQuery.isWindow( elem ) ) {
+				if ( isWindow( elem ) ) {
 
 					// $( window ).outerWidth/Height return w/h including scrollbars (gh-1729)
 					return funcName.indexOf( "outer" ) === 0 ?

--- a/src/event/trigger.js
+++ b/src/event/trigger.js
@@ -6,7 +6,7 @@ define( [
 	"../var/hasOwn",
 	"../var/isWindow",
 	"../event"
-], function( jQuery, document, dataPriv, acceptData, isWindow, hasOwn ) {
+], function( jQuery, document, dataPriv, acceptData, hasOwn, isWindow ) {
 
 "use strict";
 

--- a/src/event/trigger.js
+++ b/src/event/trigger.js
@@ -4,9 +4,9 @@ define( [
 	"../data/var/dataPriv",
 	"../data/var/acceptData",
 	"../var/hasOwn",
-
+	"../var/isWindow",
 	"../event"
-], function( jQuery, document, dataPriv, acceptData, hasOwn ) {
+], function( jQuery, document, dataPriv, acceptData, isWindow, hasOwn ) {
 
 "use strict";
 
@@ -73,7 +73,7 @@ jQuery.extend( jQuery.event, {
 
 		// Determine event propagation path in advance, per W3C events spec (#9951)
 		// Bubble up to document, then to window; watch for a global ownerDocument var (#9724)
-		if ( !onlyHandlers && !special.noBubble && !jQuery.isWindow( elem ) ) {
+		if ( !onlyHandlers && !special.noBubble && !isWindow( elem ) ) {
 
 			bubbleType = special.delegateType || type;
 			if ( !rfocusMorph.test( bubbleType + type ) ) {
@@ -125,7 +125,7 @@ jQuery.extend( jQuery.event, {
 
 				// Call a native DOM method on the target with the same name as the event.
 				// Don't do default actions on window, that's where global variables be (#6170)
-				if ( ontype && jQuery.isFunction( elem[ type ] ) && !jQuery.isWindow( elem ) ) {
+				if ( ontype && jQuery.isFunction( elem[ type ] ) && !isWindow( elem ) ) {
 
 					// Don't re-trigger an onFOO event when we call its FOO() method
 					tmp = elem[ ontype ];

--- a/src/offset.js
+++ b/src/offset.js
@@ -7,12 +7,12 @@ define( [
 	"./css/curCSS",
 	"./css/addGetHookIf",
 	"./css/support",
-
+	"./var/isWindow",
 	"./core/init",
 	"./css",
 	"./selector" // contains
 ], function( jQuery, access, document, documentElement, rnumnonpx,
-             curCSS, addGetHookIf, support ) {
+             curCSS, addGetHookIf, support, isWindow ) {
 
 "use strict";
 
@@ -186,7 +186,7 @@ jQuery.each( { scrollLeft: "pageXOffset", scrollTop: "pageYOffset" }, function( 
 
 			// Coalesce documents and windows
 			var win;
-			if ( jQuery.isWindow( elem ) ) {
+			if ( isWindow( elem ) ) {
 				win = elem;
 			} else if ( elem.nodeType === 9 ) {
 				win = elem.defaultView;

--- a/src/var/isWindow.js
+++ b/src/var/isWindow.js
@@ -2,7 +2,7 @@ define( function() {
 	"use strict";
 
 	return function isWindow( obj ) {
-		return obj !== null && typeof obj !== "undefined" && obj === obj.window;
+		return obj != null && obj === obj.window;
 	};
 
 } );

--- a/src/var/isWindow.js
+++ b/src/var/isWindow.js
@@ -1,0 +1,8 @@
+define( function() {
+	"use strict";
+
+	return function isWindow( obj ) {
+		return obj !== null && obj === obj.window;
+	};
+
+} );

--- a/src/var/isWindow.js
+++ b/src/var/isWindow.js
@@ -2,7 +2,7 @@ define( function() {
 	"use strict";
 
 	return function isWindow( obj ) {
-		return obj !== null && obj === obj.window;
+		return obj !== null && typeof obj !== "undefined" && obj === obj.window;
 	};
 
 } );

--- a/test/unit/basic.js
+++ b/test/unit/basic.js
@@ -100,9 +100,6 @@ QUnit.test( "core", function( assert ) {
 		"<?xml version='1.0' encoding='UTF-8'?><foo bar='baz'></foo>"
 	) ), "jQuery.isXMLDoc" );
 
-	assert.ok( jQuery.isWindow( window ), "jQuery.isWindow(window)" );
-	assert.ok( !jQuery.isWindow( 2 ), "jQuery.isWindow(Number)" );
-
 	assert.strictEqual( jQuery.inArray( 3, [ "a", 6, false, 3, {} ] ), 3, "jQuery.inArray - true" );
 	assert.strictEqual(
 		jQuery.inArray( 3, [ "a", 6, false, "3", {} ] ),

--- a/test/unit/basic.js
+++ b/test/unit/basic.js
@@ -76,7 +76,7 @@ QUnit.test( "show/hide", function( assert ) {
 }
 
 QUnit.test( "core", function( assert ) {
-	assert.expect( 27 );
+	assert.expect( 25 );
 
 	var elem = jQuery( "<div></div><span></span>" );
 

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -680,25 +680,6 @@ QUnit.test( "isXMLDoc - XML", function( assert ) {
 	assert.ok( jQuery.isXMLDoc( jQuery( "tab", xml )[ 0 ] ), "XML Tab Element" );
 } );
 
-QUnit.test( "isWindow", function( assert ) {
-	assert.expect( 14 );
-
-	assert.ok( jQuery.isWindow( window ), "window" );
-	assert.ok( jQuery.isWindow( document.getElementsByTagName( "iframe" )[ 0 ].contentWindow ), "iframe.contentWindow" );
-	assert.ok( !jQuery.isWindow(), "empty" );
-	assert.ok( !jQuery.isWindow( null ), "null" );
-	assert.ok( !jQuery.isWindow( undefined ), "undefined" );
-	assert.ok( !jQuery.isWindow( document ), "document" );
-	assert.ok( !jQuery.isWindow( document.documentElement ), "documentElement" );
-	assert.ok( !jQuery.isWindow( "" ), "string" );
-	assert.ok( !jQuery.isWindow( 1 ), "number" );
-	assert.ok( !jQuery.isWindow( true ), "boolean" );
-	assert.ok( !jQuery.isWindow( {} ), "object" );
-	assert.ok( !jQuery.isWindow( { setInterval: function() {} } ), "fake window" );
-	assert.ok( !jQuery.isWindow( /window/ ), "regexp" );
-	assert.ok( !jQuery.isWindow( function() {} ), "function" );
-} );
-
 QUnit.test( "jQuery('html')", function( assert ) {
 	assert.expect( 18 );
 

--- a/test/unit/deprecated.js
+++ b/test/unit/deprecated.js
@@ -165,7 +165,7 @@ QUnit.test( "jQuery.nodeName", function( assert ) {
 	);
 } );
 
-QUnit.test( "isWindow", function( assert ) {
+QUnit.test( "jQuery.isWindow", function( assert ) {
 	assert.expect( 14 );
 
 	assert.ok( jQuery.isWindow( window ), "window" );

--- a/test/unit/deprecated.js
+++ b/test/unit/deprecated.js
@@ -164,3 +164,22 @@ QUnit.test( "jQuery.nodeName", function( assert ) {
 		"Works on custom elements (true)"
 	);
 } );
+
+QUnit.test( "isWindow", function( assert ) {
+	assert.expect( 14 );
+
+	assert.ok( jQuery.isWindow( window ), "window" );
+	assert.ok( jQuery.isWindow( document.getElementsByTagName( "iframe" )[ 0 ].contentWindow ), "iframe.contentWindow" );
+	assert.ok( !jQuery.isWindow(), "empty" );
+	assert.ok( !jQuery.isWindow( null ), "null" );
+	assert.ok( !jQuery.isWindow( undefined ), "undefined" );
+	assert.ok( !jQuery.isWindow( document ), "document" );
+	assert.ok( !jQuery.isWindow( document.documentElement ), "documentElement" );
+	assert.ok( !jQuery.isWindow( "" ), "string" );
+	assert.ok( !jQuery.isWindow( 1 ), "number" );
+	assert.ok( !jQuery.isWindow( true ), "boolean" );
+	assert.ok( !jQuery.isWindow( {} ), "object" );
+	assert.ok( !jQuery.isWindow( { setInterval: function() {} } ), "fake window" );
+	assert.ok( !jQuery.isWindow( /window/ ), "regexp" );
+	assert.ok( !jQuery.isWindow( function() {} ), "function" );
+} );


### PR DESCRIPTION
### Summary ###
Fix for issue #3629
Removed occurances of isWindow

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
