### PR TITLE
[wip] Do not include some dev files and `src` directory into npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,8 @@
+.babelrc
 .eslintignore
 .eslintrc.json
+.eslint-browser.json
+.eslint-node.json
 
 /.editorconfig
 /.gitattributes
@@ -11,6 +14,11 @@
 /test
 /Gruntfile.js
 
+/external/npo
 /external/qunit
+/external/qunit-assert-step
 /external/requirejs
 /external/sinon
+
+/.github
+/src


### PR DESCRIPTION
### Summary ###
Implementing #3719

Some development-related files and `src` directory are added into `.npmignore` file to reduce size of final package. Size of `tgz` package after this PR is 256kb instead of 328kb and size of installed package is 863kb instead of 1.5mb



### Checklist ###
* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com