### PR TITLE
Offset: fixed error

### DIFF
--- a/src/offset.js
+++ b/src/offset.js
@@ -52,6 +52,8 @@ jQuery.offset = {
 			options = options.call( elem, i, jQuery.extend( {}, curOffset ) );
 		}
 
+		if ( !options ) return this;
+
 		if ( options.top != null ) {
 			props.top = ( options.top - curOffset.top ) + curTop;
 		}


### PR DESCRIPTION
- handle when options value (from function returned) is undefined

### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
When I invoke `offset` method, if arguments was function that return `undefined`. I can see the error like this "_Uncaught TypeError: Cannot read property 'top' of undefined_". So I solved this error by insert condition statement into line 9922. Please check PR and feedback for me.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
