### PR TITLE
Core: Remove unnecessary check for type when checking for numeric values

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -226,13 +226,13 @@ jQuery.extend( {
 		// As of jQuery 3.0, isNumeric is limited to
 		// strings and numbers (primitives or objects)
 		// that can be coerced to finite numbers (gh-2662)
-		var type = jQuery.type( obj );
-		return ( type === "number" || type === "string" ) &&
+		return (
 
 			// parseFloat NaNs numeric-cast false positives ("")
 			// ...but misinterprets leading-number strings, particularly hex literals ("0x...")
-			// subtraction forces infinities to NaN
-			!isNaN( obj - parseFloat( obj ) );
+			// subtraction eliminates false positives and forces infinities to NaN
+			!isNaN( Number( obj ) - parseFloat( obj ) )
+		);
 	},
 
 	isPlainObject: function( obj ) {


### PR DESCRIPTION
### Summary ###
Checking for the type of the passed value here is an unnecessary step.
Converting the value to number with `Number(obj)` (was done implicitly, I made it explicit) and `parseFloat(obj)` eliminates all possible false-positives, and subtraction eliminates infinities.


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
