### PR TITLE
ESLint: Fix comment typo

### DIFF
--- a/dist/.eslintrc.json
+++ b/dist/.eslintrc.json
@@ -7,7 +7,7 @@
 		// That is okay for the built version
 		"no-multiple-empty-lines": "off",
 
-		// Because sizze is not compatible to jquery code style
+		// Because sizzle is not compatible to jquery code style
 		"no-nested-ternary": "off",
 		"no-unused-expressions": "off",
 		"lines-around-comment": "off",


### PR DESCRIPTION
### Summary ###
This fixes a small typo where "sizzle" is misspelled as "sizze" in a comment in an eslint config.


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
