### PR TITLE
Tests: update path calculation to split at last occurence of "test"

### DIFF
--- a/test/jquery.js
+++ b/test/jquery.js
@@ -2,7 +2,7 @@
 ( function() {
 	/* global loadTests: false */
 
-	var path = window.location.pathname.split( "test" )[ 0 ],
+	var path = window.location.pathname.substring(0, window.location.pathname.lastIndexOf("test")),
 		QUnit = window.QUnit || parent.QUnit,
 		require = window.require || parent.require,
 

--- a/test/jquery.js
+++ b/test/jquery.js
@@ -2,7 +2,7 @@
 ( function() {
 	/* global loadTests: false */
 
-	var path = window.location.pathname.substring(0, window.location.pathname.lastIndexOf("test")),
+	var path = window.location.pathname.substring( 0, window.location.pathname.lastIndexOf( "test" ) ),
 		QUnit = window.QUnit || parent.QUnit,
 		require = window.require || parent.require,
 

--- a/test/jquery.js
+++ b/test/jquery.js
@@ -2,7 +2,8 @@
 ( function() {
 	/* global loadTests: false */
 
-	var path = window.location.pathname.substring( 0, window.location.pathname.lastIndexOf( "test" ) ),
+	var pathname = window.location.pathname,
+		path = pathname.slice( 0, pathname.lastIndexOf( "test" ) ),
 		QUnit = window.QUnit || parent.QUnit,
 		require = window.require || parent.require,
 


### PR DESCRIPTION
### Summary ###
Fixes #3756 by switching the path calculation from splitting at the first instance of "test", to finding its last index in the pathname, and then taking the substring from from the beginning until that index

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
