### PR TITLE
Build: Fix UglifyJS output in Android 4.0

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -165,6 +165,11 @@ module.exports = function( grunt ) {
 					output: {
 						"ascii_only": true
 					},
+
+					// Support: Android 4.0 only
+					// UglifyJS 3 breaks Android 4.0 if this option is not enabled.
+					ie8: true,
+
 					banner: "/*! jQuery v<%= pkg.version %> | " +
 						"(c) JS Foundation and other contributors | jquery.org/license */",
 					compress: {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
Enabling the ie8 option makes Android 4.0 run tests properly. Before that it
wasn't rendering anything in the QUnit iframe.

Fixes gh-3743

I don't know what exactly causes the issue without the setting. At first sight I only see unescaped `throws` property and `void 0` instead of `undefined` but just using those two doesn't fail the parsing in Android 4.0: http://jsbin.com/zageloz/edit?html,css,js,console

It'd be worth to investigate longer the real reason for the breakage (perhaps by) but I don't have a lot of time right now. This PR adds 52 bytes to the minified gzipped build which is quite a lot. But even if we don't land this, this PR shows in which direction to look for the real issue.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
