### PR TITLE
Core: Allow CSP nonce on script

### DIFF
--- a/src/core/DOMEval.js
+++ b/src/core/DOMEval.js
@@ -3,10 +3,13 @@ define( [
 ], function( document ) {
 	"use strict";
 
-	function DOMEval( code, doc ) {
+	function DOMEval( code, doc, nonce ) {
 		doc = doc || document;
-
 		var script = doc.createElement( "script" );
+
+		if ( nonce ) {
+			script.setAttribute( "nonce", nonce );
+		}
 
 		script.text = code;
 		doc.head.appendChild( script ).parentNode.removeChild( script );

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -128,7 +128,7 @@ function domManip( collection, args, callback, ignored ) {
 	// Flatten any nested arrays
 	args = concat.apply( [], args );
 
-	var fragment, first, scripts, hasScripts, node, doc,
+	var fragment, first, scripts, hasScripts, node, doc, nonce,
 		i = 0,
 		l = collection.length,
 		iNoClone = l - 1,
@@ -202,7 +202,10 @@ function domManip( collection, args, callback, ignored ) {
 								jQuery._evalUrl( node.src );
 							}
 						} else {
-							DOMEval( node.textContent.replace( rcleanScript, "" ), doc );
+							if ( node.hasAttribute && node.hasAttribute( "nonce" ) ) {
+								nonce = node.getAttribute( "nonce" );
+							}
+							DOMEval( node.textContent.replace( rcleanScript, "" ), doc, nonce );
 						}
 					}
 				}

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -640,7 +640,7 @@ QUnit.test( "isWindow", function( assert ) {
 } );
 
 QUnit.test( "jQuery('html')", function( assert ) {
-	assert.expect( 18 );
+	assert.expect( 19 );
 
 	var s, div, j;
 
@@ -662,6 +662,9 @@ QUnit.test( "jQuery('html')", function( assert ) {
 	assert.ok( jQuery( "<link rel='stylesheet'/>" )[ 0 ], "Creating a link" );
 
 	assert.ok( !jQuery( "<script/>" )[ 0 ].parentNode, "Create a script" );
+
+	jQuery( "body" ).append( "<script nonce='test' id='nonceCreatedTest' />" );
+	assert.equal( jQuery( "#nonceCreatedTest" ).attr( "nonce" ), "test", "Ensure the nonce attribute is preserved for CSP" );
 
 	assert.ok( jQuery( "<input/>" ).attr( "type", "hidden" ), "Create an input and set the type." );
 


### PR DESCRIPTION
Fixed CSP nonce attributes being stripped on dynamically created script tags

Fixes: [#3541](https://github.com/jquery/jquery/issues/3541)

### Summary ###

The PR allows CSP nonce attributes to remain on dynamically added script tags. Previously jQuery would strip such attributes causing dynamically inserted scripts with a valid nonce to cause a CSP violation.

Note: from memory build was fine but I ran into some issues with the commit scripts and had to force something despite following guide lines as closely as possible as it was a while ago I don't recall specifically what the issue was sorry! If this is a problem let me know and I'll try and sort it asap :)



### Checklist ###

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com
