### PR TITLE
Added application/javascript content-type header to jsonp test script

### DIFF
--- a/test/data/jsonp.php
+++ b/test/data/jsonp.php
@@ -1,5 +1,6 @@
 <?php
 error_reporting(0);
+header("Content-Type: application/javascript");
 $callback = $_REQUEST['callback'];
 if ( ! $callback ) {
 	$callback = explode("?",end(explode("/",$_SERVER['REQUEST_URI'])));


### PR DESCRIPTION
### Summary ###
A fix for issue #3767

As mentioned in the issue: although this file is intended only to be used for test purposes, several sites on the web seem to have deployed jquery by cloning the entire repository, inadvertently making them vulnerable to XSS.

This fix is intended to prevent the same thing happening to more sites.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
