### PR TITLE
Avoid reading outside of collection bounds

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -285,9 +285,11 @@ jQuery.extend( {
 	cleanData: function( elems ) {
 		var data, elem, type,
 			special = jQuery.event.special,
+			length = elems.length,
 			i = 0;
 
-		for ( ; ( elem = elems[ i ] ) !== undefined; i++ ) {
+		for ( ; i < length; i++ ) {
+			elem = elems[ i ];
 			if ( acceptData( elem ) ) {
 				if ( ( data = elem[ dataPriv.expando ] ) ) {
 					if ( data.events ) {

--- a/src/manipulation/buildFragment.js
+++ b/src/manipulation/buildFragment.js
@@ -66,7 +66,9 @@ function buildFragment( elems, context, scripts, selection, ignored ) {
 	fragment.textContent = "";
 
 	i = 0;
-	while ( ( elem = nodes[ i++ ] ) ) {
+	l = nodes.length;
+	for ( ; i < l; i++ ) {
+		elem = nodes[ i ];
 
 		// Skip elements already in the context collection (trac-4087)
 		if ( selection && jQuery.inArray( elem, selection ) > -1 ) {


### PR DESCRIPTION
### Summary ###

Consider the following collection:

```js
const array = ['a', 'b', 'c'];
```

Retrieving `array[0]` can be done relatively quickly. However, when the property doesn’t exist on the receiver, JavaScript engines must continue to look up the prototype chain until either the property is found or the chain ends. This is inherently slower than *not* doing any prototype chain lookups. Retrieving an out-of-bounds index, e.g. `array[3]`, triggers this scenario, resulting in decreased performance.

This patch changes the way the `cleanData` loop is written to avoid running into the slow case unnecessarily.

A more in-depth explanation can be found here: https://ripsawridge.github.io/articles/blink-mysterium/

### Checklist ###

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works: **N/A**
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com: **N/A**

----

Similar patch for Sizzle: https://github.com/jquery/sizzle/pull/407