### PR TITLE
Ajax: Don't process data property on no-entity-body requests

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -596,8 +596,8 @@ jQuery.extend( {
 			// Remember the hash so we can put it back
 			uncached = s.url.slice( cacheURL.length );
 
-			// If data is available, append data to url
-			if ( s.data ) {
+			// If data is available and should be processed, append data to url
+			if ( s.data && s.processData ) {
 				cacheURL += ( rquery.test( cacheURL ) ? "&" : "?" ) + s.data;
 
 				// #9682: remove data so that it's not used in an eventual retry

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -597,7 +597,7 @@ jQuery.extend( {
 			uncached = s.url.slice( cacheURL.length );
 
 			// If data is available and should be processed, append data to url
-			if ( s.data && s.processData ) {
+			if ( s.data && ( s.processData || typeof s.data === "string" ) ) {
 				cacheURL += ( rquery.test( cacheURL ) ? "&" : "?" ) + s.data;
 
 				// #9682: remove data so that it's not used in an eventual retry

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -1273,12 +1273,27 @@ QUnit.module( "ajax", {
 		};
 	} );
 
-	ajaxTest( "jQuery.ajax() - data - no processing ", 1, function( assert ) {
+	ajaxTest( "jQuery.ajax() - data - no processing POST", 1, function( assert ) {
 		return {
 			url: "bogus.html",
 			data: { devo: "A Beautiful World" },
 			type: "post",
 			contentType: "x-special-sauce",
+			processData: false,
+			beforeSend: function( _, s ) {
+				assert.deepEqual( s.data, { devo: "A Beautiful World" }, "data is not processed" );
+				return false;
+			},
+			error: true
+		};
+	} );
+
+	ajaxTest( "jQuery.ajax() - data - no processing GET", 1, function( assert ) {
+		return {
+			url: "bogus.html",
+			data: { devo: "A Beautiful World" },
+			type: "get",
+			contentType: "x-something-else",
 			processData: false,
 			beforeSend: function( _, s ) {
 				assert.deepEqual( s.data, { devo: "A Beautiful World" }, "data is not processed" );

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -1303,6 +1303,22 @@ QUnit.module( "ajax", {
 		};
 	} );
 
+		ajaxTest( "jQuery.ajax() - data - process string with GET", 2, function( assert ) {
+		return {
+			url: "bogus.html",
+			data: "a=1&b=2",
+			type: "get",
+			contentType: "x-something-else",
+			processData: false,
+			beforeSend: function( _, s ) {
+				assert.equal( s.url, "bogus.html?a=1&b=2", "added data to url" );
+				assert.equal( s.data, undefined, "removed data from settings" );
+				return false;
+			},
+			error: true
+		};
+	} );
+
 	var ifModifiedNow = new Date();
 
 	jQuery.each(


### PR DESCRIPTION
Fixes gh-3438

### Summary ###
The description in gh-3438 is pretty detailed. Basically, don't process `settings.data` if `settings.processData` is `false`. This allows a `settings.beforeSend` hook to have its way with the original data and, for example, serialize it to JSON on the URL.

I'd consider this a long-standing bug and the current documentation would imply it should have worked this way all along. It should be safe to include in a minor release.

### Checklist ###

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [-] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

