### PR TITLE
Ajax: Allow custom attributes when script transport is used

### DIFF
--- a/src/ajax/script.js
+++ b/src/ajax/script.js
@@ -48,19 +48,16 @@ jQuery.ajaxTransport( "script", function( s ) {
 		var script, callback;
 		return {
 			send: function( _, complete ) {
-				script = jQuery( "<script>" ).prop( {
-					charset: s.scriptCharset,
-					src: s.url
-				} ).attr( s.scriptAttrs || {} ).on(
-					"load error",
-					callback = function( evt ) {
+				script = jQuery( "<script>" )
+					.attr( s.scriptAttrs || {} )
+					.prop( { charset: s.scriptCharset, src: s.url } )
+					.on( "load error", callback = function( evt ) {
 						script.remove();
 						callback = null;
 						if ( evt ) {
 							complete( evt.type === "error" ? 404 : 200, evt.type );
 						}
-					}
-				);
+					} );
 
 				// Use native DOM manipulation to avoid our domManip AJAX trickery
 				document.head.appendChild( script[ 0 ] );

--- a/src/ajax/script.js
+++ b/src/ajax/script.js
@@ -43,15 +43,15 @@ jQuery.ajaxPrefilter( "script", function( s ) {
 // Bind script tag hack transport
 jQuery.ajaxTransport( "script", function( s ) {
 
-	// This transport only deals with cross domain requests
-	if ( s.crossDomain ) {
+	// This transport only deals with cross domain or forced-by-attrs requests
+	if ( s.crossDomain || s.scriptAttrs ) {
 		var script, callback;
 		return {
 			send: function( _, complete ) {
 				script = jQuery( "<script>" ).prop( {
 					charset: s.scriptCharset,
 					src: s.url
-				} ).on(
+				} ).attr( s.scriptAttrs || {} ).on(
 					"load error",
 					callback = function( evt ) {
 						script.remove();

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -89,6 +89,29 @@ QUnit.module( "ajax", {
 		}
 	);
 
+	ajaxTest( "jQuery.ajax() - custom attributes for script tag", 4,
+		function( assert ) {
+			var nonceValue = "0123456789";
+			return {
+				create: function( options ) {
+					var xhr;
+					options.dataType = "script";
+					options.scriptAttrs = { id: "jquery-ajax-test", nonce: nonceValue };
+					xhr = jQuery.ajax( url( "data/script.php?header=ecma" ), options );
+					// Ensure the script tag has the nonce attr on it
+					assert.ok( nonceValue === jQuery( "#jquery-ajax-test" ).attr( "nonce" ), "nonce value" );
+					return xhr;
+				},
+				success: function() {
+					assert.ok( true, "success" );
+				},
+				complete: function() {
+					assert.ok( true, "complete" );
+				}
+			};
+		}
+	);
+
 	ajaxTest( "jQuery.ajax() - do not execute js (crossOrigin)", 2, function( assert ) {
 		return {
 			create: function( options ) {

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -91,15 +91,13 @@ QUnit.module( "ajax", {
 
 	ajaxTest( "jQuery.ajax() - custom attributes for script tag", 4,
 		function( assert ) {
-			var nonceValue = "0123456789";
 			return {
 				create: function( options ) {
 					var xhr;
 					options.dataType = "script";
-					options.scriptAttrs = { id: "jquery-ajax-test", nonce: nonceValue };
-					xhr = jQuery.ajax( url( "data/script.php?header=ecma" ), options );
-					// Ensure the script tag has the nonce attr on it
-					assert.ok( nonceValue === jQuery( "#jquery-ajax-test" ).attr( "nonce" ), "nonce value" );
+					options.scriptAttrs = { id: "jquery-ajax-test", async: "async" };
+					xhr = jQuery.ajax( url( "mock.php?action=script" ), options );
+					assert.equal( jQuery( "#jquery-ajax-test" ).attr( "async" ), "async", "attr value" );
 					return xhr;
 				},
 				success: function() {


### PR DESCRIPTION
Fixes gh-3028
Ref gh-2612

### Summary ###

We've gotten a couple of tickets asking for a way to set attributes on script tags when they're injected as part of a `jQuery.ajax` request. Rather than defining a bunch of custom new ajax settings I thought it might be easier to just let the caller set any attribute on the script tag.  This would be useful, for example, to add `nonce`, `integrity`, or `crossorigin` attributes so that [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) will be appeased.

Possible todos that aren't in here yet, mainly because I wanted feedback:

- Add a `jQuery.getScript` signature
- I'm debating whether to assume crossDomain when attrs are given.

### Checklist ###

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com (will be needed)

