### PR TITLE
Build: use child_process.spawn shell option, increase timeout in Promises/A+ tests 10 times

### DIFF
--- a/build/tasks/lib/spawn_test.js
+++ b/build/tasks/lib/spawn_test.js
@@ -3,11 +3,13 @@
 // Run Node with provided parameters: the first one being the Grunt
 // done function and latter ones being files to be tested.
 // See the comment in ../node_smoke_tests.js for more information.
-module.exports = function spawnTest( done ) {
-	var testPaths = [].slice.call( arguments, 1 ),
-		spawn = require( "cross-spawn" );
+module.exports = function spawnTest( done, command ) {
+	var spawn = require( "child_process" ).spawn;
 
-	spawn( "node", testPaths, { stdio: "inherit" } )
+	spawn( command, {
+		stdio: "inherit",
+		shell: true
+	} )
 		.on( "close", function( code ) {
 			done( code === 0 );
 		} );

--- a/build/tasks/node_smoke_tests.js
+++ b/build/tasks/node_smoke_tests.js
@@ -22,7 +22,7 @@ module.exports = function( grunt ) {
 			var taskName = "node_" + testFilePath.replace( /\.js$/, "" );
 
 			grunt.registerTask( taskName, function() {
-				spawnTest( this.async(), "test/node_smoke_tests/" + testFilePath );
+				spawnTest( this.async(), "node test/node_smoke_tests/" + testFilePath );
 			} );
 
 			nodeSmokeTests.push( taskName );

--- a/build/tasks/promises_aplus_tests.js
+++ b/build/tasks/promises_aplus_tests.js
@@ -9,15 +9,15 @@ module.exports = function( grunt ) {
 
 	grunt.registerTask( "promises_aplus_tests:deferred", function() {
 		spawnTest( this.async(),
-			"./node_modules/.bin/promises-aplus-tests",
-			"test/promises_aplus_adapters/deferred.js"
+			__dirname + "/../../node_modules/.bin/promises-aplus-tests" +
+				" test/promises_aplus_adapters/deferred.js"
 		);
 	} );
 
 	grunt.registerTask( "promises_aplus_tests:when", function() {
 		spawnTest( this.async(),
-			"./node_modules/.bin/promises-aplus-tests",
-			"test/promises_aplus_adapters/when.js"
+			__dirname + "/../../node_modules/.bin/promises-aplus-tests" +
+				" test/promises_aplus_adapters/when.js"
 		);
 	} );
 };

--- a/build/tasks/promises_aplus_tests.js
+++ b/build/tasks/promises_aplus_tests.js
@@ -2,7 +2,8 @@ module.exports = function( grunt ) {
 
 	"use strict";
 
-	var spawnTest = require( "./lib/spawn_test.js" );
+	var timeout = 2000,
+		spawnTest = require( "./lib/spawn_test.js" );
 
 	grunt.registerTask( "promises_aplus_tests",
 		[ "promises_aplus_tests:deferred", "promises_aplus_tests:when" ] );
@@ -10,14 +11,16 @@ module.exports = function( grunt ) {
 	grunt.registerTask( "promises_aplus_tests:deferred", function() {
 		spawnTest( this.async(),
 			__dirname + "/../../node_modules/.bin/promises-aplus-tests" +
-				" test/promises_aplus_adapters/deferred.js"
+				" test/promises_aplus_adapters/deferred.js" +
+				" --timeout " + timeout
 		);
 	} );
 
 	grunt.registerTask( "promises_aplus_tests:when", function() {
 		spawnTest( this.async(),
 			__dirname + "/../../node_modules/.bin/promises-aplus-tests" +
-				" test/promises_aplus_adapters/when.js"
+				" test/promises_aplus_adapters/when.js" +
+				" --timeout " + timeout
 		);
 	} );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -986,17 +986,6 @@
       "integrity": "sha1-etIg1v/c0Rn5/BJ6d3LKzqOQpLo=",
       "dev": true
     },
-    "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "dev": true,
-      "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.2.14"
-      }
-    },
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
@@ -3998,16 +3987,6 @@
         "signal-exit": "3.0.2"
       }
     },
-    "lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-      "dev": true,
-      "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
-      }
-    },
     "map-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
@@ -4657,12 +4636,6 @@
         }
       }
     },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
-    },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -5073,21 +5046,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-      "dev": true
-    },
-    "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
-      "requires": {
-        "shebang-regex": "1.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
     "sigmund": {
@@ -5660,12 +5618,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
-    },
-    "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "babel-plugin-transform-es2015-for-of": "7.0.0-beta.0",
     "commitplease": "2.7.10",
     "core-js": "2.4.1",
-    "cross-spawn": "5.1.0",
     "eslint-config-jquery": "1.0.1",
     "grunt": "1.0.1",
     "grunt-babel": "7.0.0",


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
The first commit drops `cross-spawn` & uses the `child_process.spawn` shell option.

The second one increases the timeout used for Promises/A+ tests from 200 ms to 2 seconds. This should help with Jenkins failures.

I'd like to land it as two commits (unsquashed) as those are two separate changes, it was just easier to do the second one after the initial refactor.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
