### PR TITLE
Fixing warning message in firefox version 56.0.1 - 'The getPreventDef…

### DIFF
--- a/test/data/jquery-1.9.1.js
+++ b/test/data/jquery-1.9.1.js
@@ -3443,7 +3443,7 @@ jQuery.Event = function( src, props ) {
 		// Events bubbling up the document may have been marked as prevented
 		// by a handler lower down the tree; reflect the correct value.
 		this.isDefaultPrevented = ( src.defaultPrevented || src.returnValue === false ||
-			src.getPreventDefault && src.getPreventDefault() ) ? returnTrue : returnFalse;
+			src.defaultPrevented && src.getPreventDefault() ) ? returnTrue : returnFalse;
 
 	// Event type
 	} else {


### PR DESCRIPTION
### Summary ###
<!--
Fixing warning message in firefox version 56.0.1 The getPreventDefault () method should no longer be used. Instead, use defaultPrevented
Warning reproduced here - https://jsbin.com/foyihaj/edit?html,js,output (Look through the browser's console) 
-->

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
