### PR TITLE
Tests: Make Node tests work for paths with spaces in them

### DIFF
--- a/build/tasks/node_smoke_tests.js
+++ b/build/tasks/node_smoke_tests.js
@@ -22,7 +22,7 @@ module.exports = function( grunt ) {
 			var taskName = "node_" + testFilePath.replace( /\.js$/, "" );
 
 			grunt.registerTask( taskName, function() {
-				spawnTest( this.async(), "node test/node_smoke_tests/" + testFilePath );
+				spawnTest( this.async(), "node \"test/node_smoke_tests/" + testFilePath + "\"" );
 			} );
 
 			nodeSmokeTests.push( taskName );

--- a/build/tasks/promises_aplus_tests.js
+++ b/build/tasks/promises_aplus_tests.js
@@ -10,7 +10,7 @@ module.exports = function( grunt ) {
 
 	grunt.registerTask( "promises_aplus_tests:deferred", function() {
 		spawnTest( this.async(),
-			__dirname + "/../../node_modules/.bin/promises-aplus-tests" +
+			"\"" + __dirname + "/../../node_modules/.bin/promises-aplus-tests\"" +
 				" test/promises_aplus_adapters/deferred.js" +
 				" --timeout " + timeout
 		);
@@ -18,7 +18,7 @@ module.exports = function( grunt ) {
 
 	grunt.registerTask( "promises_aplus_tests:when", function() {
 		spawnTest( this.async(),
-			__dirname + "/../../node_modules/.bin/promises-aplus-tests" +
+			"\"" + __dirname + "/../../node_modules/.bin/promises-aplus-tests\"" +
 				" test/promises_aplus_adapters/when.js" +
 				" --timeout " + timeout
 		);


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

This PR makes Node tests work for paths with spaces in them. Without this patch Jenkins tests fail as jQuery job names there contain spaces,
e.g. "jQuery Core".

I verified it works on Jenkins with this PR again.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
