### PR TITLE
Make callbacks.fireWith work with non-array arguments

### DIFF
--- a/src/callbacks.js
+++ b/src/callbacks.js
@@ -206,7 +206,12 @@ jQuery.Callbacks = function( options ) {
 			fireWith: function( context, args ) {
 				if ( !locked ) {
 					args = args || [];
-					args = [ context, args.slice ? args.slice() : args ];
+					if ( args.slice && typeof args !== "string" ) {
+						args = args.slice();
+					} else if ( args.toString() !== "[object Arguments]" ) {
+						args = [ args ];
+					}
+					args = [ context, args ];
 					queue.push( args );
 					if ( !firing ) {
 						fire();

--- a/test/unit/callbacks.js
+++ b/test/unit/callbacks.js
@@ -283,6 +283,32 @@ QUnit.test( "jQuery.Callbacks.fireWith - arguments are copied", function( assert
 	} );
 } );
 
+QUnit.test( "jQuery.Callbacks.fireWith - works with number argument", function( assert ) {
+
+	assert.expect( 1 );
+
+	var cb = jQuery.Callbacks( "memory" );
+
+	cb.fireWith( null, 42 );
+
+	cb.add( function( meaning ) {
+		assert.strictEqual( meaning, 42, "works with number argument" );
+	} );
+} );
+
+QUnit.test( "jQuery.Callbacks.fireWith - works with string argument", function( assert ) {
+
+	assert.expect( 1 );
+
+	var cb = jQuery.Callbacks( "memory" );
+
+	cb.fireWith( null, "hello" );
+
+	cb.add( function( hello ) {
+		assert.strictEqual( hello, "hello", "works with string argument" );
+	} );
+} );
+
 QUnit.test( "jQuery.Callbacks.remove - should remove all instances", function( assert ) {
 
 	assert.expect( 1 );


### PR DESCRIPTION
### Summary ###

In jquery/api.jquery.com#1066, I have noticed that a way to call callbacks.fireWith is documented, but doing so doesn't work. This PR fixes that.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
