### PR TITLE
Manipulation: Reduce size by eliminating single-use variable

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -45,7 +45,6 @@ var
 
 	// checked="checked" or checked
 	rchecked = /checked\s*(?:[^=]|=\s*.checked.)/i,
-	rscriptTypeMasked = /^true\/(.*)/,
 	rcleanScript = /^\s*<!(?:\[CDATA\[|--)|(?:\]\]|--)>\s*$/g;
 
 // Prefer a tbody over its parent table for containing new rows
@@ -65,10 +64,8 @@ function disableScript( elem ) {
 	return elem;
 }
 function restoreScript( elem ) {
-	var match = rscriptTypeMasked.exec( elem.type );
-
-	if ( match ) {
-		elem.type = match[ 1 ];
+	if ( ( elem.type || "" ).slice( 0, 5 ) === "true/" ) {
+		elem.type = elem.type.slice( 5 );
 	} else {
 		elem.removeAttribute( "type" );
 	}


### PR DESCRIPTION
### Summary ###
Noticed in passing while investigating #3834.
```
   raw     gz Sizes
271549  80440 dist/jquery.js
 87285  30171 dist/jquery.min.js

   raw     gz Compared to master @ 3e902a812014e8a6980e08599c4840b1cb969f7c
   -37    -13 dist/jquery.js
    +3     -6 dist/jquery.min.js
```

### Checklist ###
* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* [x] ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~