### PR TITLE
Ajax: fix equivalent operator

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -463,7 +463,7 @@ jQuery.extend( {
 						}
 						match = responseHeaders[ key.toLowerCase() ];
 					}
-					return match == null ? null : match;
+					return match === null ? null : match;
 				},
 
 				// Raw string


### PR DESCRIPTION
### Summary ###
I think I should use the equivalent operator in this part.
You can use === because variables are already declared before.


### Checklist ###
* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com