### PR TITLE
Manipulation: Add support script type module

### DIFF
--- a/src/core/DOMEval.js
+++ b/src/core/DOMEval.js
@@ -9,8 +9,12 @@ define( [
 		var i,
 			script = doc.createElement( "script" );
 		script.text = code;
-		for ( i in { type: true, src: true } ) {
-			script[ i ] = node[ i ];
+		if ( node ) {
+			for ( i in { type: true, src: true } ) {
+				if ( node[ i ] ) {
+					script[ i ] = node[ i ];
+				}
+			}
 		}
 		doc.head.appendChild( script ).parentNode.removeChild( script );
 	}

--- a/src/core/DOMEval.js
+++ b/src/core/DOMEval.js
@@ -3,12 +3,19 @@ define( [
 ], function( document ) {
 	"use strict";
 
-	function DOMEval( code, doc ) {
+	function DOMEval( code, doc, type, src ) {
 		doc = doc || document;
 
 		var script = doc.createElement( "script" );
-
-		script.text = code;
+		if ( code ) {
+			script.text = code;
+		}
+		if ( type === "module" ) {
+			script.type = type;
+		}
+		if ( src ) {
+			script.src = src;
+		}
 		doc.head.appendChild( script ).parentNode.removeChild( script );
 	}
 

--- a/src/core/DOMEval.js
+++ b/src/core/DOMEval.js
@@ -6,19 +6,12 @@ define( [
 	function DOMEval( code, doc, node ) {
 		doc = doc || document;
 
-		var script = doc.createElement( "script" );
-		if ( code ) {
-			script.text = code;
+		var i,
+			script = doc.createElement( "script" );
+		script.text = code;
+		for ( i in { type: true, src: true } ) {
+			script[ i ] = node[ i ];
 		}
-		jQuery.each( [
-			"type",
-			"nomodule",
-			"src"
-		], function() {
-			if ( node[ this ] ) {
-				script[ this ] = node[ this ];
-			}
-		} );
 		doc.head.appendChild( script ).parentNode.removeChild( script );
 	}
 

--- a/src/core/DOMEval.js
+++ b/src/core/DOMEval.js
@@ -3,14 +3,18 @@ define( [
 ], function( document ) {
 	"use strict";
 
-	function DOMEval( code, doc, node ) {
+	var
+
+	preservedScriptAttributes = { type: true, src: true, noModule: true };
+
+		function DOMEval( code, doc, node ) {
 		doc = doc || document;
 
 		var i,
 			script = doc.createElement( "script" );
 		script.text = code;
 		if ( node ) {
-			for ( i in { type: true, src: true } ) {
+			for ( i in preservedScriptAttributes ) {
 				if ( node[ i ] ) {
 					script[ i ] = node[ i ];
 				}

--- a/src/core/DOMEval.js
+++ b/src/core/DOMEval.js
@@ -3,19 +3,22 @@ define( [
 ], function( document ) {
 	"use strict";
 
-	function DOMEval( code, doc, type, src ) {
+	function DOMEval( code, doc, node ) {
 		doc = doc || document;
 
 		var script = doc.createElement( "script" );
 		if ( code ) {
 			script.text = code;
 		}
-		if ( type === "module" ) {
-			script.type = type;
-		}
-		if ( src ) {
-			script.src = src;
-		}
+		jQuery.each( [
+			"type",
+			"nomodule",
+			"src"
+		], function() {
+			if ( node[ this ] ) {
+				script[ this ] = node[ this ];
+			}
+		} );
 		doc.head.appendChild( script ).parentNode.removeChild( script );
 	}
 

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -193,14 +193,19 @@ function domManip( collection, args, callback, ignored ) {
 						!dataPriv.access( node, "globalEval" ) &&
 						jQuery.contains( doc, node ) ) {
 
-						if ( node.src ) {
+						if ( node.src && node.type !== "module" ) {
 
 							// Optional AJAX dependency, but won't run scripts if not present
 							if ( jQuery._evalUrl ) {
 								jQuery._evalUrl( node.src );
 							}
 						} else {
-							DOMEval( node.textContent.replace( rcleanScript, "" ), doc );
+							DOMEval(
+								node.textContent.replace( rcleanScript, "" ),
+								doc,
+								node.type,
+								node.src
+							);
 						}
 					}
 				}

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -193,19 +193,14 @@ function domManip( collection, args, callback, ignored ) {
 						!dataPriv.access( node, "globalEval" ) &&
 						jQuery.contains( doc, node ) ) {
 
-						if ( node.src && node.type !== "module" ) {
+						if ( node.src && !/^module$/i.test( node.type ) ) {
 
 							// Optional AJAX dependency, but won't run scripts if not present
 							if ( jQuery._evalUrl ) {
 								jQuery._evalUrl( node.src );
 							}
 						} else {
-							DOMEval(
-								node.textContent.replace( rcleanScript, "" ),
-								doc,
-								node.type,
-								node.src
-							);
+							DOMEval( node.textContent.replace( rcleanScript, "" ), doc, node );
 						}
 					}
 				}

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -193,7 +193,7 @@ function domManip( collection, args, callback, ignored ) {
 						!dataPriv.access( node, "globalEval" ) &&
 						jQuery.contains( doc, node ) ) {
 
-						if ( node.src && !/^module$/i.test( node.type ) ) {
+						if ( node.src && ( node.type || "" ).toLowerCase()  !== "module" ) {
 
 							// Optional AJAX dependency, but won't run scripts if not present
 							if ( jQuery._evalUrl ) {

--- a/src/manipulation/var/rscriptType.js
+++ b/src/manipulation/var/rscriptType.js
@@ -1,5 +1,5 @@
 define( function() {
 	"use strict";
 
-	return ( /^$|\/(?:java|ecma)script/i );
+	return ( /^$|module|\/(?:java|ecma)script/i );
 } );

--- a/src/manipulation/var/rscriptType.js
+++ b/src/manipulation/var/rscriptType.js
@@ -1,5 +1,5 @@
 define( function() {
 	"use strict";
 
-	return ( /^$|module|\/(?:java|ecma)script/i );
+	return ( /^$|^module$|\/(?:java|ecma)script/i );
 } );

--- a/test/data/inner_module.js
+++ b/test/data/inner_module.js
@@ -1,0 +1,1 @@
+window.ok( true, "evaluated: innert module with src" );

--- a/test/data/module.js
+++ b/test/data/module.js
@@ -1,0 +1,1 @@
+window.ok( true, "evaluated: module with src" );

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -1757,15 +1757,11 @@ function testHtml( valueObj, assert ) {
 			"<script type='something/else'>ok( false, 'evaluated: non-script' );</script>",
 			"<script type='text/javascript'>ok( true, 'evaluated: text/javascript' );</script>",
 			"<script type='text/ecmascript'>ok( true, 'evaluated: text/ecmascript' );</script>",
-			"<script type='module'>ok( true, 'evaluated: module' );</script>",
-			"<script type='module' src='./data/module.js'></script>",
 			"<script>ok( true, 'evaluated: no type' );</script>",
 			"<div>",
 				"<script type='something/else'>ok( false, 'evaluated: inner non-script' );</script>",
 				"<script type='text/javascript'>ok( true, 'evaluated: inner text/javascript' );</script>",
 				"<script type='text/ecmascript'>ok( true, 'evaluated: inner text/ecmascript' );</script>",
-				"<script type='module'>ok( true, 'evaluated: inner module' );</script>",
-				"<script type='module' src='./data/inner_module.js'></script>",
 				"<script>ok( true, 'evaluated: inner no type' );</script>",
 			"</div>"
 		].join( "" ) )
@@ -1799,6 +1795,22 @@ QUnit.test( "html(String|Number)", function( assert ) {
 
 QUnit.test( "html(Function)", function( assert ) {
 	testHtml( manipulationFunctionReturningObj, assert  );
+} );
+
+QUnit.test( "html(script type module)", function( assert ) {
+	assert.expect( 1 );
+	var fixture = jQuery( "#qunit-fixture" ),
+	tmp = fixture.html(
+		[
+			"<script type='module'>ok( true, 'evaluated: module' );</script>",
+			"<script type='module' src='./data/module.js'></script>",
+			"<div>",
+				"<script type='module'>ok( true, 'evaluated: inner module' );</script>",
+				"<script type='module' src='./data/inner_module.js'></script>",
+			"</div>"
+		].join( "" )
+	).find( "script" );
+	assert.equal( tmp.length, 4, "All script tags remain." );
 } );
 
 QUnit.test( "html(Function) with incoming value -- direct selection", function( assert ) {

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -1757,11 +1757,13 @@ function testHtml( valueObj, assert ) {
 			"<script type='something/else'>ok( false, 'evaluated: non-script' );</script>",
 			"<script type='text/javascript'>ok( true, 'evaluated: text/javascript' );</script>",
 			"<script type='text/ecmascript'>ok( true, 'evaluated: text/ecmascript' );</script>",
+			"<script type='module'>ok( true, 'evaluated: module' );</script>",
 			"<script>ok( true, 'evaluated: no type' );</script>",
 			"<div>",
 				"<script type='something/else'>ok( false, 'evaluated: inner non-script' );</script>",
 				"<script type='text/javascript'>ok( true, 'evaluated: inner text/javascript' );</script>",
 				"<script type='text/ecmascript'>ok( true, 'evaluated: inner text/ecmascript' );</script>",
+				"<script type='module'>ok( true, 'evaluated: inner module' );</script>",
 				"<script>ok( true, 'evaluated: inner no type' );</script>",
 			"</div>"
 		].join( "" ) )

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -1758,12 +1758,14 @@ function testHtml( valueObj, assert ) {
 			"<script type='text/javascript'>ok( true, 'evaluated: text/javascript' );</script>",
 			"<script type='text/ecmascript'>ok( true, 'evaluated: text/ecmascript' );</script>",
 			"<script type='module'>ok( true, 'evaluated: module' );</script>",
+			"<script type='module' src='./data/module.js'></script>",
 			"<script>ok( true, 'evaluated: no type' );</script>",
 			"<div>",
 				"<script type='something/else'>ok( false, 'evaluated: inner non-script' );</script>",
 				"<script type='text/javascript'>ok( true, 'evaluated: inner text/javascript' );</script>",
 				"<script type='text/ecmascript'>ok( true, 'evaluated: inner text/ecmascript' );</script>",
 				"<script type='module'>ok( true, 'evaluated: inner module' );</script>",
+				"<script type='module' src='./data/inner_module.js'></script>",
 				"<script>ok( true, 'evaluated: inner no type' );</script>",
 			"</div>"
 		].join( "" ) )


### PR DESCRIPTION
Fixes: #3871
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
For method  
`$('selector').html() `
append support native ECMAScript modules, like that
`<script type="module" scr="PATH/file.js"></script>` 
and like that
```
<script type="module">
  import * as myModule from "PATH/myModule.js";
</script>

```
### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
