### PR TITLE
Let default file for browsers be minified for bundlers and services relying on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "JavaScript library for DOM operations",
   "version": "3.2.2-pre",
   "main": "dist/jquery.js",
+  "browser": "dist/jquery.min.js",
   "homepage": "https://jquery.com",
   "author": {
     "name": "JS Foundation and other contributors",


### PR DESCRIPTION
When serving to browsers the default file should (as default) be minified. It, therefore, makes sense to use the `browser` field ([see specs](https://github.com/defunctzombie/package-browser-field-spec)) in `package.json` to indicate that `jquery.min.js` should be the default choice when targeting browsers for bundlers or services relying on jQuery from npm.
 
**Example:** At the moment including something like `<script src="//unpkg.com/jquery"></script>` on your website will fetch the original JS. With this PR the minified file will be served. For version 3.2.1 that represents going from 268.039 bytes to 86.659 bytes. Sure, I can just change the script to `<script src="//unpkg.com/jquery@3/dist/jquery.min.js"></script>`. I will argue that too many people are too lazy (or does not know better) to care about the extra 181.380 bytes this will add to the load for each person fetching the file. 



### Checklist ###
* [X] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jquery/jquery/3870)
<!-- Reviewable:end -->
