### PR TITLE
Fix the width calculation of border-box due to browser zoom

### DIFF
--- a/src/css/support.js
+++ b/src/css/support.js
@@ -30,16 +30,16 @@ define( [
 		pixelPositionVal = divStyle.top !== "1%";
 
 		// Support: Android 4.0 - 4.3 only, Firefox <=3 - 44
-		reliableMarginLeftVal = divStyle.marginLeft === "12px";
+		reliableMarginLeftVal = roundPixelMeasures( divStyle.marginLeft ) === 12;
 
 		// Support: Android 4.0 - 4.3 only, Safari <=9.1 - 10.1, iOS <=7.0 - 9.3
 		// Some styles come back with percentage values, even though they shouldn't
 		div.style.right = "60%";
-		pixelBoxStylesVal = divStyle.right === "36px";
+		pixelBoxStylesVal = roundPixelMeasures( divStyle.right ) === 36;
 
 		// Support: IE 9 - 11 only
 		// Detect misreporting of content dimensions for box-sizing:border-box elements
-		boxSizingReliableVal = divStyle.width === "36px";
+		boxSizingReliableVal = roundPixelMeasures( divStyle.width ) === 36;
 
 		// Support: IE 9 only
 		// Detect overflow:scroll screwiness (gh-3699)
@@ -51,6 +51,10 @@ define( [
 		// Nullify the div so it wouldn't be stored in the memory and
 		// it will also be a sign that checks already performed
 		div = null;
+	}
+
+	function roundPixelMeasures( measure ) {
+		return Math.round( parseFloat( measure ) );
 	}
 
 	var pixelPositionVal, boxSizingReliableVal, scrollboxSizeVal, pixelBoxStylesVal,

--- a/test/data/css/cssWidthBrowserZoom.html
+++ b/test/data/css/cssWidthBrowserZoom.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style>
+		html {
+			zoom: 1.1;
+		}
+		#test {
+			width: 100px;
+			height: 100px;
+			padding: 10px;
+			border: 1px solid pink;
+			box-sizing: border-box;
+		}
+	</style>
+</head>
+<body>
+<div id="test"></div>
+<script src="../../jquery.js"></script>
+<script src="../iframeTest.js"></script>
+<script>
+	startIframeTest( jQuery( "#test" ).css( 'width' ) );
+</script>
+</body>
+</html>

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -1164,6 +1164,15 @@ testIframe(
 	}
 );
 
+testIframe(
+	"css('width') should work correctly with browser zooming",
+	"css/cssWidthBrowserZoom.html",
+	function( assert, jQuery, window, document, cssWidthBrowserZoom ) {
+		assert.expect( 1 );
+		assert.strictEqual( cssWidthBrowserZoom, "100px", "elem.css('width') works correctly with browser zoom" );
+	}
+);
+
 ( function() {
 	var supportsFractionalGBCR,
 		qunitFixture = document.getElementById( "qunit-fixture" ),


### PR DESCRIPTION
### Summary ###
The pull request mainly has two tasks done:
- Test for the issue (#3808 )
- Fixing the issue by rounding off the measure to unit place.

However the test for the issue isn't working. I used an iframe test to check for the border-box width at `html {zoom: 1.1}`. Though opening the html file separately recreates the issue, but via the unittest code, it doesn't. 

Some help in fixing the unittest will be really helpful.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
