### PR TITLE
Core: deprecate jQuery.now

### DIFF
--- a/src/ajax/var/nonce.js
+++ b/src/ajax/var/nonce.js
@@ -1,7 +1,5 @@
-define( [
-	"../../core"
-], function( jQuery ) {
+define( function() {
 	"use strict";
 
-	return jQuery.now();
+	return Date.now();
 } );

--- a/src/core.js
+++ b/src/core.js
@@ -440,8 +440,6 @@ jQuery.extend( {
 		return proxy;
 	},
 
-	now: Date.now,
-
 	// jQuery.support is not used in Core but other projects attach their
 	// properties to it so it needs to exist.
 	support: support

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -39,4 +39,6 @@ jQuery.parseJSON = JSON.parse;
 jQuery.nodeName = nodeName;
 jQuery.isWindow = isWindow;
 
+jQuery.now = Date.now;
+
 } );

--- a/src/effects.js
+++ b/src/effects.js
@@ -44,7 +44,7 @@ function createFxNow() {
 	window.setTimeout( function() {
 		fxNow = undefined;
 	} );
-	return ( fxNow = jQuery.now() );
+	return ( fxNow = Date.now() );
 }
 
 // Generate parameters to create a standard animation
@@ -652,7 +652,7 @@ jQuery.fx.tick = function() {
 		i = 0,
 		timers = jQuery.timers;
 
-	fxNow = jQuery.now();
+	fxNow = Date.now();
 
 	for ( ; i < timers.length; i++ ) {
 		timer = timers[ i ];

--- a/src/event.js
+++ b/src/event.js
@@ -553,7 +553,7 @@ jQuery.Event = function( src, props ) {
 	}
 
 	// Create a timestamp if incoming event doesn't have one
-	this.timeStamp = src && src.timeStamp || jQuery.now();
+	this.timeStamp = src && src.timeStamp || Date.now();
 
 	// Mark it as fixed
 	this[ jQuery.expando ] = true;

--- a/test/unit/animation.js
+++ b/test/unit/animation.js
@@ -19,13 +19,11 @@ QUnit.module( "animation", {
 		this._oldInterval = jQuery.fx.interval;
 		jQuery.fx.step = {};
 		jQuery.fx.interval = 10;
-		jQuery.now = Date.now;
 		jQuery.Animation.prefilters = [ defaultPrefilter ];
 		jQuery.Animation.tweeners = { "*": [ defaultTweener ] };
 	},
 	teardown: function() {
 		this.sandbox.restore();
-		jQuery.now = Date.now;
 		jQuery.fx.stop();
 		jQuery.fx.interval = this._oldInterval;
 		window.requestAnimationFrame = oldRaf;

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -190,10 +190,10 @@ QUnit.test( "globalEval execution after script injection (#7862)", function( ass
 
 	script.src = "data/longLoadScript.php?sleep=2";
 
-	now = jQuery.now();
+	now = Date.now();
 	document.body.appendChild( script );
 
-	jQuery.globalEval( "var strictEvalTest = " + jQuery.now() + ";" );
+	jQuery.globalEval( "var strictEvalTest = " + Date.now() + ";" );
 	assert.ok( window.strictEvalTest - now < 500, "Code executed synchronously" );
 } );
 

--- a/test/unit/deprecated.js
+++ b/test/unit/deprecated.js
@@ -183,3 +183,9 @@ QUnit.test( "jQuery.isWindow", function( assert ) {
 	assert.ok( !jQuery.isWindow( /window/ ), "regexp" );
 	assert.ok( !jQuery.isWindow( function() {} ), "function" );
 } );
+
+QUnit.test( "jQuery.now", function( assert ) {
+	assert.expect( 1 );
+
+	assert.ok( typeof jQuery.now() === "number", "jQuery.now is a function" );
+} );

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -19,11 +19,9 @@ QUnit.module( "effects", {
 		this._oldInterval = jQuery.fx.interval;
 		jQuery.fx.step = {};
 		jQuery.fx.interval = 10;
-		jQuery.now = Date.now;
 	},
 	teardown: function() {
 		this.sandbox.restore();
-		jQuery.now = Date.now;
 		jQuery.fx.stop();
 		jQuery.fx.interval = this._oldInterval;
 		window.requestAnimationFrame = oldRaf;

--- a/test/unit/tween.js
+++ b/test/unit/tween.js
@@ -15,11 +15,9 @@ QUnit.module( "tween", {
 		this._oldInterval = jQuery.fx.interval;
 		jQuery.fx.step = {};
 		jQuery.fx.interval = 10;
-		jQuery.now = Date.now;
 	},
 	teardown: function() {
 		this.sandbox.restore();
-		jQuery.now = Date.now;
 		jQuery.fx.stop();
 		jQuery.fx.interval = this._oldInterval;
 		window.requestAnimationFrame = oldRaf;


### PR DESCRIPTION
Fixes gh-2959

### Summary ###
Removes all usage of `jQuery.now` and replaces with `Date.now`. Moves `jQuery.now` to deprecated.js.


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
