### PR TITLE
Position: Fixes typo in position() logic to retrieve offsetParent

### DIFF
--- a/src/offset.js
+++ b/src/offset.js
@@ -131,7 +131,7 @@ jQuery.fn.extend( {
 			doc = elem.ownerDocument;
 			offsetParent = elem.offsetParent || doc.documentElement;
 			while ( offsetParent &&
-				( offsetParent === doc.body || offsetParent === doc.documentElement ) &&
+				( offsetParent !== doc.body || offsetParent !== doc.documentElement ) &&
 				jQuery.css( offsetParent, "position" ) === "static" ) {
 
 				offsetParent = offsetParent.parentNode;

--- a/src/offset.js
+++ b/src/offset.js
@@ -131,7 +131,7 @@ jQuery.fn.extend( {
 			doc = elem.ownerDocument;
 			offsetParent = elem.offsetParent || doc.documentElement;
 			while ( offsetParent &&
-				( offsetParent !== doc.body || offsetParent !== doc.documentElement ) &&
+				(offsetParent !== doc && offsetParent !== doc.body && offsetParent !== doc.documentElement ) &&
 				jQuery.css( offsetParent, "position" ) === "static" ) {
 
 				offsetParent = offsetParent.parentNode;

--- a/src/offset.js
+++ b/src/offset.js
@@ -131,7 +131,8 @@ jQuery.fn.extend( {
 			doc = elem.ownerDocument;
 			offsetParent = elem.offsetParent || doc.documentElement;
 			while ( offsetParent &&
-				(offsetParent !== doc && offsetParent !== doc.body && offsetParent !== doc.documentElement ) &&
+				offsetParent !== doc &&
+				( offsetParent !== doc.body && offsetParent !== doc.documentElement ) &&
 				jQuery.css( offsetParent, "position" ) === "static" ) {
 
 				offsetParent = offsetParent.parentNode;


### PR DESCRIPTION
There's a typo in position. The while statement should be walking up the DOM tree finding the first element with position static. 

Currently the loop that finds the `offsetParent` it is exiting immediately because the first parent node isnt document root or body. 

The while loop should check to ensure each iteration of getting `parentNode` doesn't reach the top of the document, instead of checking that each iteration `===` the document.

Related issues 
#3080 #3107  #3096 #3487 
Related code in issue https://github.com/jquery/jquery/issues/1765#issuecomment-69847034 

### Summary ###
Bug was introduced in 1d2df772b4d6e5dbf91df6e75f4a1809f7879ab0

The logic for finding `offsetParent` was modified in position, but the while has incorrect exit conditions which would cause it to exit immediately. 