### PR TITLE
CSS: deprecate jQuery.cssProps

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -5,6 +5,7 @@ define( [
 	"./var/document",
 	"./var/rcssNum",
 	"./css/var/rnumnonpx",
+	"./css/var/cssProps",
 	"./css/var/cssExpand",
 	"./css/var/getStyles",
 	"./css/var/swap",
@@ -16,7 +17,7 @@ define( [
 	"./core/init",
 	"./core/ready",
 	"./selector" // contains
-], function( jQuery, pnum, access, document, rcssNum, rnumnonpx, cssExpand,
+], function( jQuery, pnum, access, document, rcssNum, rnumnonpx, cssProps, cssExpand,
 	getStyles, swap, curCSS, adjustCSS, addGetHookIf, support ) {
 
 "use strict";
@@ -57,12 +58,12 @@ function vendorPropName( name ) {
 	}
 }
 
-// Return a property mapped along what jQuery.cssProps suggests or to
+// Return a property mapped along what cssProps suggests or to
 // a vendor prefixed property.
 function finalPropName( name ) {
-	var ret = jQuery.cssProps[ name ];
+	var ret = cssProps[ name ];
 	if ( !ret ) {
-		ret = jQuery.cssProps[ name ] = vendorPropName( name ) || name;
+		ret = cssProps[ name ] = vendorPropName( name ) || name;
 	}
 	return ret;
 }
@@ -230,10 +231,6 @@ jQuery.extend( {
 		"zIndex": true,
 		"zoom": true
 	},
-
-	// Add in properties whose names you wish to fix before
-	// setting or getting the value
-	cssProps: {},
 
 	// Get and set the style property on a DOM Node
 	style: function( elem, name, value, extra ) {

--- a/src/css/var/cssProps.js
+++ b/src/css/var/cssProps.js
@@ -1,0 +1,8 @@
+define( function() {
+	"use strict";
+
+	// Add in properties whose names you wish to fix before
+	// setting or getting the value
+	// Also used for the vendor prefix cache
+	return {};
+} );

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -1,8 +1,9 @@
 define( [
 	"./core",
 	"./core/nodeName",
-	"./var/isWindow"
-], function( jQuery, nodeName, isWindow ) {
+	"./var/isWindow",
+	"./css/var/cssProps"
+], function( jQuery, nodeName, isWindow, cssProps ) {
 
 "use strict";
 
@@ -38,5 +39,6 @@ jQuery.isArray = Array.isArray;
 jQuery.parseJSON = JSON.parse;
 jQuery.nodeName = nodeName;
 jQuery.isWindow = isWindow;
+jQuery.cssProps = cssProps;
 
 } );

--- a/src/effects/Tween.js
+++ b/src/effects/Tween.js
@@ -1,7 +1,8 @@
 define( [
 	"../core",
+	"../css/var/cssProps",
 	"../css"
-], function( jQuery ) {
+], function( jQuery, cssProps ) {
 
 "use strict";
 
@@ -85,7 +86,7 @@ Tween.propHooks = {
 			if ( jQuery.fx.step[ tween.prop ] ) {
 				jQuery.fx.step[ tween.prop ]( tween );
 			} else if ( tween.elem.nodeType === 1 &&
-				( tween.elem.style[ jQuery.cssProps[ tween.prop ] ] != null ||
+				( tween.elem.style[ cssProps[ tween.prop ] ] != null ||
 					jQuery.cssHooks[ tween.prop ] ) ) {
 				jQuery.style( tween.elem, tween.prop, tween.now + tween.unit );
 			} else {

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -1028,23 +1028,6 @@ QUnit.test( "box model properties incorrectly returning % instead of px, see #10
 	assert.equal( el2.css( "marginLeft" ), "100px", "css('marginLeft') returning incorrect pixel value, see #12088" );
 } );
 
-QUnit.test( "jQuery.cssProps behavior, (bug #8402)", function( assert ) {
-	assert.expect( 2 );
-
-	var div = jQuery( "<div>" ).appendTo( document.body ).css( {
-		"position": "absolute",
-		"top": 0,
-		"left": 10
-	} );
-	jQuery.cssProps.top = "left";
-	assert.equal( div.css( "top" ), "10px", "the fixed property is used when accessing the computed style" );
-	div.css( "top", "100px" );
-	assert.equal( div[ 0 ].style.left, "100px", "the fixed property is used when setting the style" );
-
-	// cleanup jQuery.cssProps
-	jQuery.cssProps.top = undefined;
-} );
-
 QUnit.test( "widows & orphans #8936", function( assert ) {
 
 	var $p = jQuery( "<p>" ).appendTo( "#qunit-fixture" );

--- a/test/unit/deprecated.js
+++ b/test/unit/deprecated.js
@@ -183,3 +183,20 @@ QUnit.test( "jQuery.isWindow", function( assert ) {
 	assert.ok( !jQuery.isWindow( /window/ ), "regexp" );
 	assert.ok( !jQuery.isWindow( function() {} ), "function" );
 } );
+
+QUnit.test( "jQuery.cssProps behavior, (bug #8402)", function( assert ) {
+	assert.expect( 2 );
+
+	var div = jQuery( "<div>" ).appendTo( document.body ).css( {
+		"position": "absolute",
+		"top": 0,
+		"left": 10
+	} );
+	jQuery.cssProps.top = "left";
+	assert.equal( div.css( "top" ), "10px", "the fixed property is used when accessing the computed style" );
+	div.css( "top", "100px" );
+	assert.equal( div[ 0 ].style.left, "100px", "the fixed property is used when setting the style" );
+
+	// cleanup jQuery.cssProps
+	jQuery.cssProps.top = undefined;
+} );


### PR DESCRIPTION
Fixes gh-3653

### Summary ###
Deprecates the now empty jQuery.cssProps. It's still used for the vendor prefix cache, but no longer has any properties to map to different names for each browser.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
