### PR TITLE
Build: Only run browser tests in one Node version on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,12 @@ node_js:
 - "9"
 addons:
   chrome: stable
+env:
+  - NPM_SCRIPT=test:browserless
+matrix:
+  include:
+    # Run browser tests only on one Node.js version to save time.
+    - node_js: "8"
+      env: NPM_SCRIPT=test:browser
+script:
+  - npm run $NPM_SCRIPT

--- a/package.json
+++ b/package.json
@@ -68,8 +68,10 @@
   "scripts": {
     "build": "npm install && grunt",
     "start": "grunt watch",
-    "test": "grunt && grunt test:slow karma:main",
-    "jenkins": "grunt && grunt test:slow",
+    "test:browserless": "grunt && grunt test:slow",
+    "test:browser": "grunt && grunt karma:main",
+    "test": "grunt && grunt test:slow && grunt karma:main",
+    "jenkins": "npm run test:browserless",
     "precommit": "grunt lint:newer qunit_fixture",
     "commitmsg": "node node_modules/commitplease"
   },


### PR DESCRIPTION
Ref gh-3744

### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
Only run browser tests in one Node version on Travis. This reduces the possibility of failure.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
