### PR TITLE
Core: deprecate jQuery.type

### DIFF
--- a/src/callbacks.js
+++ b/src/callbacks.js
@@ -1,8 +1,9 @@
 define( [
 	"./core",
+	"./core/toType",
 	"./var/isFunction",
 	"./var/rnothtmlwhite"
-], function( jQuery, isFunction, rnothtmlwhite ) {
+], function( jQuery, toType, isFunction, rnothtmlwhite ) {
 
 "use strict";
 
@@ -130,7 +131,7 @@ jQuery.Callbacks = function( options ) {
 								if ( !options.unique || !self.has( arg ) ) {
 									list.push( arg );
 								}
-							} else if ( arg && arg.length && jQuery.type( arg ) !== "string" ) {
+							} else if ( arg && arg.length && toType( arg ) !== "string" ) {
 
 								// Inspect recursively
 								add( arg );

--- a/src/core.js
+++ b/src/core.js
@@ -18,10 +18,11 @@ define( [
 	"./var/support",
 	"./var/isFunction",
 	"./var/isWindow",
-	"./core/DOMEval"
+	"./core/DOMEval",
+	"./core/toType"
 ], function( arr, document, getProto, slice, concat, push, indexOf,
 	class2type, toString, hasOwn, fnToString, ObjectFunctionString,
-	support, isFunction, isWindow, DOMEval ) {
+	support, isFunction, isWindow, DOMEval, toType ) {
 
 "use strict";
 
@@ -237,17 +238,6 @@ jQuery.extend( {
 		return true;
 	},
 
-	type: function( obj ) {
-		if ( obj == null ) {
-			return obj + "";
-		}
-
-		// Support: Android <=2.3 only (functionish RegExp)
-		return typeof obj === "object" || typeof obj === "function" ?
-			class2type[ toString.call( obj ) ] || "object" :
-			typeof obj;
-	},
-
 	// Evaluates a script in a global context
 	globalEval: function( code ) {
 		DOMEval( code );
@@ -395,7 +385,7 @@ function isArrayLike( obj ) {
 	// hasOwn isn't used here due to false negatives
 	// regarding Nodelist length in IE
 	var length = !!obj && "length" in obj && obj.length,
-		type = jQuery.type( obj );
+		type = toType( obj );
 
 	if ( isFunction( obj ) || isWindow( obj ) ) {
 		return false;

--- a/src/core/access.js
+++ b/src/core/access.js
@@ -1,7 +1,8 @@
 define( [
 	"../core",
+	"../core/toType",
 	"../var/isFunction"
-], function( jQuery, isFunction ) {
+], function( jQuery, toType, isFunction ) {
 
 "use strict";
 
@@ -13,7 +14,7 @@ var access = function( elems, fn, key, value, chainable, emptyGet, raw ) {
 		bulk = key == null;
 
 	// Sets many values
-	if ( jQuery.type( key ) === "object" ) {
+	if ( toType( key ) === "object" ) {
 		chainable = true;
 		for ( i in key ) {
 			access( elems, fn, i, key[ i ], true, emptyGet, raw );

--- a/src/core/toType.js
+++ b/src/core/toType.js
@@ -1,0 +1,20 @@
+define( [
+	"../var/class2type",
+	"../var/toString"
+], function( class2type, toString ) {
+
+"use strict";
+
+function toType( obj ) {
+	if ( obj == null ) {
+		return obj + "";
+	}
+
+	// Support: Android <=2.3 only (functionish RegExp)
+	return typeof obj === "object" || typeof obj === "function" ?
+		class2type[ toString.call( obj ) ] || "object" :
+		typeof obj;
+}
+
+return toType;
+} );

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -2,12 +2,13 @@ define( [
 	"./core",
 	"./core/nodeName",
 	"./core/camelCase",
+	"./core/toType",
 	"./var/isFunction",
 	"./var/isWindow",
 	"./var/slice",
 
 	"./event/alias"
-], function( jQuery, nodeName, camelCase, isFunction, isWindow, slice ) {
+], function( jQuery, nodeName, camelCase, toType, isFunction, isWindow, slice ) {
 
 "use strict";
 
@@ -76,6 +77,7 @@ jQuery.nodeName = nodeName;
 jQuery.isFunction = isFunction;
 jQuery.isWindow = isWindow;
 jQuery.camelCase = camelCase;
+jQuery.type = toType;
 
 jQuery.now = Date.now;
 

--- a/src/manipulation/buildFragment.js
+++ b/src/manipulation/buildFragment.js
@@ -1,11 +1,12 @@
 define( [
 	"../core",
+	"../core/toType",
 	"./var/rtagName",
 	"./var/rscriptType",
 	"./wrapMap",
 	"./getAll",
 	"./setGlobalEval"
-], function( jQuery, rtagName, rscriptType, wrapMap, getAll, setGlobalEval ) {
+], function( jQuery, toType, rtagName, rscriptType, wrapMap, getAll, setGlobalEval ) {
 
 "use strict";
 
@@ -24,7 +25,7 @@ function buildFragment( elems, context, scripts, selection, ignored ) {
 		if ( elem || elem === 0 ) {
 
 			// Add nodes directly
-			if ( jQuery.type( elem ) === "object" ) {
+			if ( toType( elem ) === "object" ) {
 
 				// Support: Android <=4.0 only, PhantomJS 1 only
 				// push.apply(_, arraylike) throws on ancient WebKit

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -1,11 +1,12 @@
 define( [
 	"./core",
+	"./core/toType",
 	"./manipulation/var/rcheckableType",
 	"./var/isFunction",
 	"./core/init",
 	"./traversing", // filter
 	"./attributes/prop"
-], function( jQuery, rcheckableType, isFunction ) {
+], function( jQuery, toType, rcheckableType, isFunction ) {
 
 "use strict";
 
@@ -39,7 +40,7 @@ function buildParams( prefix, obj, traditional, add ) {
 			}
 		} );
 
-	} else if ( !traditional && jQuery.type( obj ) === "object" ) {
+	} else if ( !traditional && toType( obj ) === "object" ) {
 
 		// Serialize object item.
 		for ( name in obj ) {

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -937,7 +937,7 @@ QUnit.module( "ajax", {
 					dataType: "jsonp",
 					crossDomain: crossDomain,
 					success: function( data ) {
-						assert.strictEqual( jQuery.type( data ), "array", "JSON results returned (GET, REST-like with param)" );
+						assert.ok( Array.isArray( data ), "JSON results returned (GET, REST-like with param)" );
 					}
 				}
 			];

--- a/test/unit/basic.js
+++ b/test/unit/basic.js
@@ -76,16 +76,12 @@ QUnit.test( "show/hide", function( assert ) {
 }
 
 QUnit.test( "core", function( assert ) {
-	assert.expect( 21 );
+	assert.expect( 17 );
 
 	var elem = jQuery( "<div></div><span></span>" );
 
 	assert.strictEqual( elem.length, 2, "Correct number of elements" );
 	assert.strictEqual( jQuery.trim( "  hello   " ), "hello", "jQuery.trim" );
-
-	assert.strictEqual( jQuery.type( null ), "null", "jQuery.type(null)" );
-	assert.strictEqual( jQuery.type( undefined ), "undefined", "jQuery.type(undefined)" );
-	assert.strictEqual( jQuery.type( "a" ), "string", "jQuery.type(String)" );
 
 	assert.ok( jQuery.isPlainObject( { "a": 2 } ), "jQuery.isPlainObject(object)" );
 	assert.ok( !jQuery.isPlainObject( "foo" ), "jQuery.isPlainObject(String)" );

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -238,58 +238,6 @@ QUnit.test( "trim", function( assert ) {
 	assert.equal( jQuery.trim( "\uFEFF \xA0! | \uFEFF" ), "! |", "leading/trailing should be trimmed" );
 } );
 
-QUnit.test( "type", function( assert ) {
-	assert.expect( 28 );
-
-	assert.equal( jQuery.type( null ), "null", "null" );
-	assert.equal( jQuery.type( undefined ), "undefined", "undefined" );
-	assert.equal( jQuery.type( true ), "boolean", "Boolean" );
-	assert.equal( jQuery.type( false ), "boolean", "Boolean" );
-	assert.equal( jQuery.type( Boolean( true ) ), "boolean", "Boolean" );
-	assert.equal( jQuery.type( 0 ), "number", "Number" );
-	assert.equal( jQuery.type( 1 ), "number", "Number" );
-	assert.equal( jQuery.type( Number( 1 ) ), "number", "Number" );
-	assert.equal( jQuery.type( "" ), "string", "String" );
-	assert.equal( jQuery.type( "a" ), "string", "String" );
-	assert.equal( jQuery.type( String( "a" ) ), "string", "String" );
-	assert.equal( jQuery.type( {} ), "object", "Object" );
-	assert.equal( jQuery.type( /foo/ ), "regexp", "RegExp" );
-	assert.equal( jQuery.type( new RegExp( "asdf" ) ), "regexp", "RegExp" );
-	assert.equal( jQuery.type( [ 1 ] ), "array", "Array" );
-	assert.equal( jQuery.type( new Date() ), "date", "Date" );
-	assert.equal( jQuery.type( new Function( "return;" ) ), "function", "Function" );
-	assert.equal( jQuery.type( function() {} ), "function", "Function" );
-	assert.equal( jQuery.type( new Error() ), "error", "Error" );
-	assert.equal( jQuery.type( window ), "object", "Window" );
-	assert.equal( jQuery.type( document ), "object", "Document" );
-	assert.equal( jQuery.type( document.body ), "object", "Element" );
-	assert.equal( jQuery.type( document.createTextNode( "foo" ) ), "object", "TextNode" );
-	assert.equal( jQuery.type( document.getElementsByTagName( "*" ) ), "object", "NodeList" );
-
-	// Avoid Lint complaints
-	var MyString = String,
-		MyNumber = Number,
-		MyBoolean = Boolean,
-		MyObject = Object;
-	assert.equal( jQuery.type( new MyBoolean( true ) ), "boolean", "Boolean" );
-	assert.equal( jQuery.type( new MyNumber( 1 ) ), "number", "Number" );
-	assert.equal( jQuery.type( new MyString( "a" ) ), "string", "String" );
-	assert.equal( jQuery.type( new MyObject() ), "object", "Object" );
-} );
-
-QUnit.test( "type for `Symbol`", function( assert ) {
-	// Prevent reference errors
-	if ( typeof Symbol !== "function" ) {
-		assert.expect( 0 );
-		return;
-	}
-
-	assert.expect( 2 );
-
-	assert.equal( jQuery.type( Symbol() ), "symbol", "Symbol" );
-	assert.equal( jQuery.type( Object( Symbol() ) ), "symbol", "Symbol" );
-} );
-
 QUnit.asyncTest( "isPlainObject", function( assert ) {
 
 	assert.expect( 23 );
@@ -1328,7 +1276,7 @@ QUnit.test( "jQuery.parseHTML", function( assert ) {
 
 	nodes = jQuery.parseHTML( jQuery( "body" )[ 0 ].innerHTML );
 	assert.ok( nodes.length > 4, "Parse a large html string" );
-	assert.equal( jQuery.type( nodes ), "array", "parseHTML returns an array rather than a nodelist" );
+	assert.ok( Array.isArray( nodes ), "parseHTML returns an array rather than a nodelist" );
 
 	html = "<script>undefined()</script>";
 	assert.equal( jQuery.parseHTML( html ).length, 0, "Ignore scripts by default" );

--- a/test/unit/deferred.js
+++ b/test/unit/deferred.js
@@ -50,7 +50,7 @@ jQuery.each( [ "", " - new operator" ], function( _, withNew ) {
 			assert.strictEqual( funcPromise, func, "non objects get extended" );
 			jQuery.each( promise, function( key ) {
 				if ( typeof promise[ key ] !== "function" ) {
-					assert.ok( false, key + " is a function (" + jQuery.type( promise[ key ] ) + ")" );
+					assert.ok( false, key + " is a function (" + typeof( promise[ key ] ) + ")" );
 				}
 				if ( promise[ key ] !== func[ key ] ) {
 					assert.strictEqual( func[ key ], promise[ key ], key + " is the same" );

--- a/test/unit/deprecated.js
+++ b/test/unit/deprecated.js
@@ -242,11 +242,56 @@ QUnit.test( "jQuery.nodeName", function( assert ) {
 } );
 
 
-QUnit.test( "core", function( assert ) {
+QUnit.test( "type", function( assert ) {
+	assert.expect( 28 );
+
+	assert.equal( jQuery.type( null ), "null", "null" );
+	assert.equal( jQuery.type( undefined ), "undefined", "undefined" );
+	assert.equal( jQuery.type( true ), "boolean", "Boolean" );
+	assert.equal( jQuery.type( false ), "boolean", "Boolean" );
+	assert.equal( jQuery.type( Boolean( true ) ), "boolean", "Boolean" );
+	assert.equal( jQuery.type( 0 ), "number", "Number" );
+	assert.equal( jQuery.type( 1 ), "number", "Number" );
+	assert.equal( jQuery.type( Number( 1 ) ), "number", "Number" );
+	assert.equal( jQuery.type( "" ), "string", "String" );
+	assert.equal( jQuery.type( "a" ), "string", "String" );
+	assert.equal( jQuery.type( String( "a" ) ), "string", "String" );
+	assert.equal( jQuery.type( {} ), "object", "Object" );
+	assert.equal( jQuery.type( /foo/ ), "regexp", "RegExp" );
+	assert.equal( jQuery.type( new RegExp( "asdf" ) ), "regexp", "RegExp" );
+	assert.equal( jQuery.type( [ 1 ] ), "array", "Array" );
+	assert.equal( jQuery.type( new Date() ), "date", "Date" );
+	assert.equal( jQuery.type( new Function( "return;" ) ), "function", "Function" );
+	assert.equal( jQuery.type( function() {} ), "function", "Function" );
+	assert.equal( jQuery.type( new Error() ), "error", "Error" );
+	assert.equal( jQuery.type( window ), "object", "Window" );
+	assert.equal( jQuery.type( document ), "object", "Document" );
+	assert.equal( jQuery.type( document.body ), "object", "Element" );
+	assert.equal( jQuery.type( document.createTextNode( "foo" ) ), "object", "TextNode" );
+	assert.equal( jQuery.type( document.getElementsByTagName( "*" ) ), "object", "NodeList" );
+
+	// Avoid Lint complaints
+	var MyString = String,
+		MyNumber = Number,
+		MyBoolean = Boolean,
+		MyObject = Object;
+	assert.equal( jQuery.type( new MyBoolean( true ) ), "boolean", "Boolean" );
+	assert.equal( jQuery.type( new MyNumber( 1 ) ), "number", "Number" );
+	assert.equal( jQuery.type( new MyString( "a" ) ), "string", "String" );
+	assert.equal( jQuery.type( new MyObject() ), "object", "Object" );
+} );
+
+QUnit.test( "type for `Symbol`", function( assert ) {
+	// Prevent reference errors
+	if ( typeof Symbol !== "function" ) {
+		assert.expect( 0 );
+		return;
+	}
+
 	assert.expect( 2 );
 
-	assert.ok( jQuery.isFunction( jQuery.noop ), "jQuery.isFunction(jQuery.noop)" );
-	assert.ok( !jQuery.isFunction( 2 ), "jQuery.isFunction(Number)" );
+	assert.equal( jQuery.type( Symbol() ), "symbol", "Symbol" );
+	assert.equal( jQuery.type( Object( Symbol() ) ), "symbol", "Symbol" );
 } );
 
 


### PR DESCRIPTION
Fixes gh-3605

### Summary ###
Deprecates `type`, renames the internal one to `toType`.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
