### PR TITLE
Ajax: Create correct URLs for jQuery.ajax() with cache: false

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -5,20 +5,23 @@ define( [
 	"./ajax/var/location",
 	"./ajax/var/nonce",
 	"./ajax/var/rquery",
-
+	"./ajax/var/rqueryend",
+	"./ajax/var/rampersandstart",
 	"./core/init",
 	"./ajax/parseXML",
 	"./event/trigger",
 	"./deferred",
 	"./serialize" // jQuery.param
-], function( jQuery, document, rnothtmlwhite, location, nonce, rquery ) {
+], function( jQuery, document, rnothtmlwhite, location, nonce, rquery, rqueryend, 
+	rampersandstart ) {
 
 "use strict";
 
 var
 	r20 = /%20/g,
 	rhash = /#.*$/,
-	rantiCache = /([?&])_=[^&]*/,
+	rantiCacheQuery = /\?_=[^&]*(&?)/,
+	rantiCacheFragment = /&_=[^&]*(&?)/,
 	rheaders = /^(.*?):[ \t]*([^\r\n]*)$/mg,
 
 	// #7653, #8125, #8152: local protocol detection
@@ -606,12 +609,15 @@ jQuery.extend( {
 
 			// Add or update anti-cache param if needed
 			if ( s.cache === false ) {
-				cacheURL = cacheURL.replace( rantiCache, "$1" );
+				cacheURL = cacheURL.replace( rantiCacheQuery, "?" )
+					.replace( rantiCacheFragment, "$1" );
 				uncached = ( rquery.test( cacheURL ) ? "&" : "?" ) + "_=" + ( nonce++ ) + uncached;
 			}
 
 			// Put hash and anti-cache on the URL that will be requested (gh-1732)
-			s.url = cacheURL + uncached;
+			// Make sure to remove extra ampersand if cacheURL ends with ? (gh-3682)
+			s.url = ( rqueryend.test( cacheURL ) && rampersandstart.test( uncached ) ) ?
+				cacheURL + uncached.substring( 1 ) : cacheURL + uncached;
 
 		// Change '%20' to '+' if this is encoded form body content (gh-2658)
 		} else if ( s.data && s.processData &&

--- a/src/ajax/var/rampersandstart.js
+++ b/src/ajax/var/rampersandstart.js
@@ -1,0 +1,5 @@
+define( function() {
+	"use strict";
+
+	return ( /^&/ );
+} );

--- a/src/ajax/var/rqueryend.js
+++ b/src/ajax/var/rqueryend.js
@@ -1,0 +1,5 @@
+define( function() {
+	"use strict";
+
+	return ( /\?$/ );
+} );


### PR DESCRIPTION
fixes gh-3682

### Summary ###
Correctly creates the URL for calls to jQuery.ajax() when the "cache" option is set to false. Fixes gh-3682.

### Checklist ###
* [X] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [X] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com
