### PR TITLE
Filter: Use direct filter in winnow

### DIFF
--- a/src/traversing/findFilter.js
+++ b/src/traversing/findFilter.js
@@ -7,8 +7,6 @@ define( [
 
 "use strict";
 
-var risSimple = /^.[^:#\[\.,]*$/;
-
 // Implement the identical functionality for filter and not
 function winnow( elements, qualifier, not ) {
 	if ( jQuery.isFunction( qualifier ) ) {
@@ -31,16 +29,8 @@ function winnow( elements, qualifier, not ) {
 		} );
 	}
 
-	// Simple selector that can be filtered directly, removing non-Elements
-	if ( risSimple.test( qualifier ) ) {
-		return jQuery.filter( qualifier, elements, not );
-	}
-
-	// Complex selector, compare the two sets, removing non-Elements
-	qualifier = jQuery.filter( qualifier, elements );
-	return jQuery.grep( elements, function( elem ) {
-		return ( indexOf.call( qualifier, elem ) > -1 ) !== not && elem.nodeType === 1;
-	} );
+	// Filtered directly for both simple and complex selectors
+	return jQuery.filter( qualifier, elements, not );
 }
 
 jQuery.filter = function( expr, elems, not ) {


### PR DESCRIPTION
For both simple and complex selectors, use direct filter in winnow

### Summary ###
As show [here](https://github.com/jquery/jquery/issues/3272#issuecomment-239574563), the only-intersection implementation has an overall poor performance in all scenarios, and the direct implementation is equal or better than the branching implementation. Also it simplifies the code.
Hence, we can just use the direct filter implementation for both simple and complex selectors.


### Checklist ###

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] Grunt build and unit tests pass locally with these changes
