### PR TITLE
Attributes: allow array param in add/remove/toggleClass

### DIFF
--- a/src/attributes/classes.js
+++ b/src/attributes/classes.js
@@ -12,6 +12,16 @@ function getClass( elem ) {
 	return elem.getAttribute && elem.getAttribute( "class" ) || "";
 }
 
+function classesToArray( value ) {
+	if ( Array.isArray( value ) ) {
+		return value;
+	}
+	if ( typeof value === "string" ) {
+		return value.match( rnothtmlwhite ) || [];
+	}
+	return [];
+}
+
 jQuery.fn.extend( {
 	addClass: function( value ) {
 		var classes, elem, cur, curValue, clazz, j, finalValue,
@@ -23,9 +33,9 @@ jQuery.fn.extend( {
 			} );
 		}
 
-		if ( typeof value === "string" && value ) {
-			classes = value.match( rnothtmlwhite ) || [];
+		classes = classesToArray( value );
 
+		if ( classes.length ) {
 			while ( ( elem = this[ i++ ] ) ) {
 				curValue = getClass( elem );
 				cur = elem.nodeType === 1 && ( " " + stripAndCollapse( curValue ) + " " );
@@ -64,9 +74,9 @@ jQuery.fn.extend( {
 			return this.attr( "class", "" );
 		}
 
-		if ( typeof value === "string" && value ) {
-			classes = value.match( rnothtmlwhite ) || [];
+		classes = classesToArray( value );
 
+		if ( classes.length ) {
 			while ( ( elem = this[ i++ ] ) ) {
 				curValue = getClass( elem );
 
@@ -96,9 +106,10 @@ jQuery.fn.extend( {
 	},
 
 	toggleClass: function( value, stateVal ) {
-		var type = typeof value;
+		var type = typeof value,
+			isValidValue = type === "string" || Array.isArray( value );
 
-		if ( typeof stateVal === "boolean" && type === "string" ) {
+		if ( typeof stateVal === "boolean" && isValidValue ) {
 			return stateVal ? this.addClass( value ) : this.removeClass( value );
 		}
 
@@ -114,12 +125,12 @@ jQuery.fn.extend( {
 		return this.each( function() {
 			var className, i, self, classNames;
 
-			if ( type === "string" ) {
+			if ( isValidValue ) {
 
 				// Toggle individual class names
 				i = 0;
 				self = jQuery( this );
-				classNames = value.match( rnothtmlwhite ) || [];
+				classNames = classesToArray( value );
 
 				while ( ( className = classNames[ i++ ] ) ) {
 

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -12,6 +12,10 @@ function functionReturningObj( value ) {
 	};
 }
 
+function arrayFromString( value ) {
+	return value ? value.split( " " ) : [];
+}
+
 /*
 	======== local reference =======
 	bareObj and functionReturningObj can be used to test passing functions to setters
@@ -1261,6 +1265,10 @@ QUnit.test( "addClass(Function)", function( assert ) {
 	testAddClass( functionReturningObj, assert );
 } );
 
+QUnit.test( "addClass(Array)", function( assert ) {
+	testAddClass( arrayFromString, assert );
+} );
+
 QUnit.test( "addClass(Function) with incoming value", function( assert ) {
 	assert.expect( 52 );
 	var pass, i,
@@ -1332,6 +1340,10 @@ QUnit.test( "removeClass(String) - simple", function( assert ) {
 
 QUnit.test( "removeClass(Function) - simple", function( assert ) {
 	testRemoveClass( functionReturningObj, assert );
+} );
+
+QUnit.test( "removeClass(Array) - simple", function( assert ) {
+	testRemoveClass( arrayFromString, assert );
 } );
 
 QUnit.test( "removeClass(Function) with incoming value", function( assert ) {
@@ -1430,6 +1442,10 @@ QUnit.test( "toggleClass(String|boolean|undefined[, boolean])", function( assert
 
 QUnit.test( "toggleClass(Function[, boolean])", function( assert ) {
 	testToggleClass( functionReturningObj, assert );
+} );
+
+QUnit.test( "toggleClass(Array[, boolean])", function( assert ) {
+	testToggleClass( arrayFromString, assert );
 } );
 
 QUnit.test( "toggleClass(Function[, boolean]) with incoming value", function( assert ) {
@@ -1565,6 +1581,36 @@ QUnit.test( "addClass, removeClass, hasClass on many elements", function( assert
 
 	assert.ok( !jQuery( "<p class='hi0'>p0</p><p class='hi1'>p1</p><p class='hi2'>p2</p>" ).hasClass( "hi" ),
 		"Did not find a class when not present" );
+} );
+
+QUnit.test( "addClass, removeClass, hasClass on many elements - Array", function( assert ) {
+	assert.expect( 14 );
+
+	var elem = jQuery( "<p>p0</p><p>p1</p><p>p2</p>" );
+
+	elem.addClass( [ "hi" ] );
+	assert.equal( elem[ 0 ].className, "hi", "Check single added class" );
+	assert.equal( elem[ 1 ].className, "hi", "Check single added class" );
+	assert.equal( elem[ 2 ].className, "hi", "Check single added class" );
+
+	elem.addClass( [ "foo",  "bar" ] );
+	assert.equal( elem[ 0 ].className, "hi foo bar", "Check more added classes" );
+	assert.equal( elem[ 1 ].className, "hi foo bar", "Check more added classes" );
+	assert.equal( elem[ 2 ].className, "hi foo bar", "Check more added classes" );
+
+	elem.removeClass();
+	assert.equal( elem[ 0 ].className, "", "Remove all classes" );
+	assert.equal( elem[ 1 ].className, "", "Remove all classes" );
+	assert.equal( elem[ 2 ].className, "", "Remove all classes" );
+
+	elem.addClass( [ "hi", "foo", "bar" ] );
+	elem.removeClass( [ "foo" ] );
+	assert.equal( elem[ 0 ].className, "hi bar", "Check removal of one class" );
+	assert.equal( elem[ 1 ].className, "hi bar", "Check removal of one class" );
+	assert.equal( elem[ 2 ].className, "hi bar", "Check removal of one class" );
+
+	assert.ok( elem.hasClass( "hi" ), "Check has1" );
+	assert.ok( elem.hasClass( "bar" ), "Check has2" );
 } );
 
 QUnit.test( "addClass, removeClass, hasClass on elements with classes with non-HTML whitespace (gh-3072, gh-3003)", function( assert ) {


### PR DESCRIPTION
+30 bytes instead of +182

Thanks to @faisaliyk for the first pass on this feature.

See https://github.com/jquery/api.jquery.com/issues/1073 for docs issue.

Fixes gh-3532

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
