### PR TITLE
Tests: only run ontimeout test if ontimeout exists

### DIFF
--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -524,22 +524,25 @@ QUnit.module( "ajax", {
 		};
 	} );
 
-	ajaxTest( "jQuery.ajax() - native timeout", 2, function( assert ) {
-		return {
-			url: url( "mock.php?action=wait&wait=1" ),
-			xhr: function() {
-				var xhr = new window.XMLHttpRequest();
-				xhr.timeout = 1;
-				return xhr;
-			},
-			error: function( xhr, msg ) {
-				assert.strictEqual( msg, "error", "Native timeout triggers error callback" );
-			},
-			complete: function() {
-				assert.ok( true, "complete" );
-			}
-		};
-	} );
+	// Android 4.0-4.3 does not have ontimeout on an xhr
+	if ( "ontimeout" in new window.XMLHttpRequest() ) {
+		ajaxTest( "jQuery.ajax() - native timeout", 2, function( assert ) {
+			return {
+				url: url( "mock.php?action=wait&wait=1" ),
+				xhr: function() {
+					var xhr = new window.XMLHttpRequest();
+					xhr.timeout = 1;
+					return xhr;
+				},
+				error: function( xhr, msg ) {
+					assert.strictEqual( msg, "error", "Native timeout triggers error callback" );
+				},
+				complete: function() {
+					assert.ok( true, "complete" );
+				}
+			};
+		} );
+	}
 
 	ajaxTest( "jQuery.ajax() - events with context", 12, function( assert ) {
 		var context = document.createElement( "div" );

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -524,6 +524,7 @@ QUnit.module( "ajax", {
 		};
 	} );
 
+	// Support: Android <= 4.0 - 4.3 only
 	// Android 4.0-4.3 does not have ontimeout on an xhr
 	if ( "ontimeout" in new window.XMLHttpRequest() ) {
 		ajaxTest( "jQuery.ajax() - native timeout", 2, function( assert ) {


### PR DESCRIPTION
Fixes gh-3742

### Summary ###
Android 4.0-4.3 never call the ontimeout handler. It seems ontimeout wasn't implemented yet. Rather than a convoluted workaround for an outdated browser, we're bypassing this test where ontimeout does not exist.


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
