### PR TITLE
Build: Fix UglifyJS output in Android 4.0; update uglify

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -246,7 +246,12 @@ module.exports = function( grunt ) {
 						"dist/<%= grunt.option('filename').replace('.js', '.min.map') %>",
 					report: "min",
 					output: {
-						"ascii_only": true
+						"ascii_only": true,
+
+						// Support: Android 4.0 only
+						// UglifyJS 3 breaks Android 4.0 if this option is not enabled.
+						// This is in lieu of setting ie8 for all of mangle, compress, and output
+						"ie8": true
 					},
 					banner: "/*! jQuery v<%= pkg.version %> | " +
 						"(c) JS Foundation and other contributors | jquery.org/license */",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "sizzle": "2.3.3",
     "strip-json-comments": "2.0.1",
     "testswarm": "1.1.0",
-    "uglify-js": "3.0.24"
+    "uglify-js": "3.3.4"
   },
   "scripts": {
     "build": "npm install && grunt",


### PR DESCRIPTION
Fixes gh-3743

### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

+13 bytes instead of +52

I've tried to dig deeper into the differences here, but the only ones I noticed were the replacement of undefined with `void 0` and stringifying some reserved words like "catch", "throws", and "char", all of which I tested separately in Android 4.0 and didn't find issues. That said, we don't seem to need to use ie8: true for `mangle`, `compress`, and `output` options, just `output`.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->

  
  