### PR TITLE
Event: Move event aliases to deprecated

### DIFF
--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -3,7 +3,9 @@ define( [
 	"./core/nodeName",
 	"./core/camelCase",
 	"./var/isWindow",
-	"./var/slice"
+	"./var/slice",
+
+	"./event/alias"
 ], function( jQuery, nodeName, camelCase, isWindow, slice ) {
 
 "use strict";

--- a/src/jquery.js
+++ b/src/jquery.js
@@ -11,7 +11,6 @@ define( [
 	"./queue/delay",
 	"./attributes",
 	"./event",
-	"./event/alias",
 	"./event/focusin",
 	"./manipulation",
 	"./manipulation/_evalUrl",

--- a/test/unit/deprecated.js
+++ b/test/unit/deprecated.js
@@ -41,6 +41,82 @@ QUnit.test( "delegate/undelegate", function( assert ) {
 		.remove();
 } );
 
+if ( jQuery.fn.hover ) {
+	QUnit.test( "hover() mouseenter mouseleave", function( assert ) {
+		assert.expect( 1 );
+
+		var times = 0,
+			handler1 = function() { ++times; },
+			handler2 = function() { ++times; };
+
+		jQuery( "#firstp" )
+			.hover( handler1, handler2 )
+			.mouseenter().mouseleave()
+			.off( "mouseenter", handler1 )
+			.off( "mouseleave", handler2 )
+			.hover( handler1 )
+			.mouseenter().mouseleave()
+			.off( "mouseenter mouseleave", handler1 )
+			.mouseenter().mouseleave();
+
+		assert.equal( times, 4, "hover handlers fired" );
+
+	} );
+}
+
+
+QUnit[ jQuery.fn.click ? "test" : "skip" ]( "trigger() shortcuts", function( assert ) {
+	assert.expect( 5 );
+
+	var counter, clickCounter,
+		elem = jQuery( "<li><a href='#'>Change location</a></li>" ).prependTo( "#firstUL" );
+	elem.find( "a" ).on( "click", function() {
+		var close = jQuery( "spanx", this ); // same with jQuery(this).find("span");
+		assert.equal( close.length, 0, "Context element does not exist, length must be zero" );
+		assert.ok( !close[ 0 ], "Context element does not exist, direct access to element must return undefined" );
+		return false;
+	} ).click();
+
+	// manually clean up detached elements
+	elem.remove();
+
+	jQuery( "#check1" ).click( function() {
+		assert.ok( true, "click event handler for checkbox gets fired twice, see #815" );
+	} ).click();
+
+	counter = 0;
+	jQuery( "#firstp" )[ 0 ].onclick = function() {
+		counter++;
+	};
+	jQuery( "#firstp" ).click();
+	assert.equal( counter, 1, "Check that click, triggers onclick event handler also" );
+
+	clickCounter = 0;
+	jQuery( "#simon1" )[ 0 ].onclick = function() {
+		clickCounter++;
+	};
+	jQuery( "#simon1" ).click();
+	assert.equal( clickCounter, 1, "Check that click, triggers onclick event handler on an a tag also" );
+} );
+
+QUnit[ jQuery.fn.click ? "test" : "skip" ]( "Event aliases", function( assert ) {
+
+	// Explicitly skipping focus/blur events due to their flakiness
+	var	$elem = jQuery( "<div />" ).appendTo( "#qunit-fixture" ),
+		aliases = ( "resize scroll click dblclick mousedown mouseup " +
+			"mousemove mouseover mouseout mouseenter mouseleave change " +
+			"select submit keydown keypress keyup contextmenu" ).split( " " );
+	assert.expect( aliases.length );
+
+	jQuery.each( aliases, function( i, name ) {
+
+		// e.g. $(elem).click(...).click();
+		$elem[ name ]( function( event ) {
+			assert.equal( event.type, name, "triggered " + name );
+		} )[ name ]().off( name );
+	} );
+} );
+
 QUnit.test( "jQuery.parseJSON", function( assert ) {
 	assert.expect( 20 );
 

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -872,29 +872,6 @@ QUnit.test( "off(eventObject)", function( assert ) {
 	check( 0 );
 } );
 
-if ( jQuery.fn.hover ) {
-	QUnit.test( "hover() mouseenter mouseleave", function( assert ) {
-		assert.expect( 1 );
-
-		var times = 0,
-			handler1 = function() { ++times; },
-			handler2 = function() { ++times; };
-
-		jQuery( "#firstp" )
-			.hover( handler1, handler2 )
-			.mouseenter().mouseleave()
-			.off( "mouseenter", handler1 )
-			.off( "mouseleave", handler2 )
-			.hover( handler1 )
-			.mouseenter().mouseleave()
-			.off( "mouseenter mouseleave", handler1 )
-			.mouseenter().mouseleave();
-
-		assert.equal( times, 4, "hover handlers fired" );
-
-	} );
-}
-
 QUnit.test( "mouseover triggers mouseenter", function( assert ) {
 	assert.expect( 1 );
 
@@ -2434,17 +2411,6 @@ QUnit.test( "checkbox state (#3827)", function( assert ) {
 	jQuery( cb ).triggerHandler( "click" );
 } );
 
-QUnit.test( "hover event no longer special since 1.9", function( assert ) {
-	assert.expect( 1 );
-
-	jQuery( "<div>craft</div>" )
-		.on( "hover", function( e ) {
-			assert.equal( e.type, "hover", "I am hovering!" );
-		} )
-		.trigger( "hover" )
-		.off( "hover" );
-} );
-
 QUnit.test( "event object properties on natively-triggered event", function( assert ) {
 	assert.expect( 3 );
 
@@ -2957,58 +2923,6 @@ QUnit.test( "trigger('click') on radio passes extra params", function( assert ) 
 		} );
 
 	$radio.trigger( "click", [ true ] );
-} );
-
-QUnit[ jQuery.fn.click ? "test" : "skip" ]( "trigger() shortcuts", function( assert ) {
-	assert.expect( 5 );
-
-	var counter, clickCounter,
-		elem = jQuery( "<li><a href='#'>Change location</a></li>" ).prependTo( "#firstUL" );
-	elem.find( "a" ).on( "click", function() {
-		var close = jQuery( "spanx", this ); // same with jQuery(this).find("span");
-		assert.equal( close.length, 0, "Context element does not exist, length must be zero" );
-		assert.ok( !close[ 0 ], "Context element does not exist, direct access to element must return undefined" );
-		return false;
-	} ).click();
-
-	// manually clean up detached elements
-	elem.remove();
-
-	jQuery( "#check1" ).click( function() {
-		assert.ok( true, "click event handler for checkbox gets fired twice, see #815" );
-	} ).click();
-
-	counter = 0;
-	jQuery( "#firstp" )[ 0 ].onclick = function() {
-		counter++;
-	};
-	jQuery( "#firstp" ).click();
-	assert.equal( counter, 1, "Check that click, triggers onclick event handler also" );
-
-	clickCounter = 0;
-	jQuery( "#simon1" )[ 0 ].onclick = function() {
-		clickCounter++;
-	};
-	jQuery( "#simon1" ).click();
-	assert.equal( clickCounter, 1, "Check that click, triggers onclick event handler on an a tag also" );
-} );
-
-QUnit[ jQuery.fn.click ? "test" : "skip" ]( "Event aliases", function( assert ) {
-
-	// Explicitly skipping focus/blur events due to their flakiness
-	var	$elem = jQuery( "<div />" ).appendTo( "#qunit-fixture" ),
-		aliases = ( "resize scroll click dblclick mousedown mouseup " +
-			"mousemove mouseover mouseout mouseenter mouseleave change " +
-			"select submit keydown keypress keyup contextmenu" ).split( " " );
-	assert.expect( aliases.length );
-
-	jQuery.each( aliases, function( i, name ) {
-
-		// e.g. $(elem).click(...).click();
-		$elem[ name ]( function( event ) {
-			assert.equal( event.type, name, "triggered " + name );
-		} )[ name ]().off( name );
-	} );
 } );
 
 // Support: IE <=9 only


### PR DESCRIPTION
Fixes gh-3214

### Summary ###

No functional change to the built file, just moving this to deprecated.js for now. Probably won't be removed in 4.0 either but can be excluded easier this way. Plugins should be discouraged from using shortcuts so that they can work with the slim build.

Still need to review the api docs and create PRs there.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [-] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com


