### PR TITLE
Build: Remove CRLF line endings to fix builds on Windows

### DIFF
--- a/build/tasks/qunit_fixture.js
+++ b/build/tasks/qunit_fixture.js
@@ -11,7 +11,7 @@ module.exports = function( grunt ) {
 				fs.readFileSync(
 					"./test/data/qunit-fixture.html",
 					"utf8"
-				).toString()
+				).toString().replace( /\r\n/g, "\n" )
 			) +
 			";\n" +
 			"// Compat with QUnit 1.x:\n" +


### PR DESCRIPTION
### Summary ###

On Windows, the QUnit fixture HTML file has `\r\n` (CRLF) line endings when it's checked out into the directory by Git. This causes the built file to have CRLF as well, which generates spurious file diffs. I'm just removing the extra CRs in the file.

### Checklist ###

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [-] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [-] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
