### PR TITLE
Fix native offsetParent difference

### DIFF
--- a/src/offset.js
+++ b/src/offset.js
@@ -131,6 +131,9 @@ jQuery.fn.extend( {
 			// when a statically positioned element is identified
 			doc = elem.ownerDocument;
 			offsetParent = elem.offsetParent || doc.documentElement;
+			while ((offsetParent.nodeName == "TD" || offsetParent.nodeName == "TABLE") && 
+			       jQuery.css(offsetParent, "position") === "static")
+				offsetParent = offsetParent.offsetParent || doc.documentElement;
 			while ( offsetParent &&
 				( offsetParent === doc.body || offsetParent === doc.documentElement ) &&
 				jQuery.css( offsetParent, "position" ) === "static" ) {


### PR DESCRIPTION
### Summary ###
When using native offsetParent method so according to https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent TD and TABLE are returned even non-positioned at all.
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] New tests have been added to show the fix or feature works
* [ ] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
