### PR TITLE
Core: Use isAttached to check for attachment of element

### DIFF
--- a/src/css/curCSS.js
+++ b/src/css/curCSS.js
@@ -1,11 +1,11 @@
 define( [
 	"../core",
+	"../var/isAttached",
 	"./var/rboxStyle",
 	"./var/rnumnonpx",
 	"./var/getStyles",
-	"./support",
-	"../selector" // Get jQuery.contains
-], function( jQuery, rboxStyle, rnumnonpx, getStyles, support ) {
+	"./support"
+], function( jQuery, isAttached, rboxStyle, rnumnonpx, getStyles, support ) {
 
 "use strict";
 
@@ -26,7 +26,7 @@ function curCSS( elem, name, computed ) {
 	if ( computed ) {
 		ret = computed.getPropertyValue( name ) || computed[ name ];
 
-		if ( ret === "" && !jQuery.contains( elem.ownerDocument, elem ) ) {
+		if ( ret === "" && !isAttached( elem ) ) {
 			ret = jQuery.style( elem, name );
 		}
 

--- a/src/css/var/isHiddenWithinTree.js
+++ b/src/css/var/isHiddenWithinTree.js
@@ -1,9 +1,9 @@
 define( [
 	"../../core",
-	"../../selector"
+	"../../var/isAttached"
 
 	// css is assumed
-], function( jQuery ) {
+], function( jQuery, isAttached ) {
 	"use strict";
 
 	// isHiddenWithinTree reports if an element has a non-"none" display style (inline and/or
@@ -27,7 +27,7 @@ define( [
 			// Support: Firefox <=43 - 45
 			// Disconnected elements can have computed display: none, so first confirm that elem is
 			// in the document.
-			jQuery.contains( elem.ownerDocument, elem ) &&
+			isAttached( elem ) &&
 
 			jQuery.css( elem, "display" ) === "none";
 	};

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -1,5 +1,6 @@
 define( [
 	"./core",
+	"./var/isAttached",
 	"./var/concat",
 	"./var/isFunction",
 	"./var/push",
@@ -23,7 +24,7 @@ define( [
 	"./traversing",
 	"./selector",
 	"./event"
-], function( jQuery, concat, isFunction, push, access,
+], function( jQuery, isAttached, concat, isFunction, push, access,
 	rcheckableType, rtagName, rscriptType,
 	wrapMap, getAll, setGlobalEval, buildFragment, support,
 	dataPriv, dataUser, acceptData, DOMEval, nodeName ) {
@@ -223,7 +224,7 @@ function remove( elem, selector, keepData ) {
 		}
 
 		if ( node.parentNode ) {
-			if ( keepData && jQuery.contains( node.ownerDocument, node ) ) {
+			if ( keepData && isAttached( node ) ) {
 				setGlobalEval( getAll( node, "script" ) );
 			}
 			node.parentNode.removeChild( node );
@@ -241,7 +242,7 @@ jQuery.extend( {
 	clone: function( elem, dataAndEvents, deepDataAndEvents ) {
 		var i, l, srcElements, destElements,
 			clone = elem.cloneNode( true ),
-			inPage = jQuery.contains( elem.ownerDocument, elem );
+			inPage = isAttached( elem );
 
 		// Fix IE cloning issues
 		if ( !support.noCloneChecked && ( elem.nodeType === 1 || elem.nodeType === 11 ) &&

--- a/src/manipulation/buildFragment.js
+++ b/src/manipulation/buildFragment.js
@@ -1,19 +1,20 @@
 define( [
 	"../core",
 	"../core/toType",
+	"../var/isAttached",
 	"./var/rtagName",
 	"./var/rscriptType",
 	"./wrapMap",
 	"./getAll",
 	"./setGlobalEval"
-], function( jQuery, toType, rtagName, rscriptType, wrapMap, getAll, setGlobalEval ) {
+], function( jQuery, toType, isAttached, rtagName, rscriptType, wrapMap, getAll, setGlobalEval ) {
 
 "use strict";
 
 var rhtml = /<|&#?\w+;/;
 
 function buildFragment( elems, context, scripts, selection, ignored ) {
-	var elem, tmp, tag, wrap, contains, j,
+	var elem, tmp, tag, wrap, attached, j,
 		fragment = context.createDocumentFragment(),
 		nodes = [],
 		i = 0,
@@ -77,13 +78,13 @@ function buildFragment( elems, context, scripts, selection, ignored ) {
 			continue;
 		}
 
-		contains = jQuery.contains( elem.ownerDocument, elem );
+		attached = isAttached( elem );
 
 		// Append to fragment
 		tmp = getAll( fragment.appendChild( elem ), "script" );
 
 		// Preserve script evaluation history
-		if ( contains ) {
+		if ( attached ) {
 			setGlobalEval( tmp );
 		}
 

--- a/src/var/isAttached.js
+++ b/src/var/isAttached.js
@@ -1,0 +1,11 @@
+define( [
+	"../core",
+	"../selector" // Get jQuery.contains
+], function( jQuery ) {
+	"use strict";
+
+	return function isAttached( obj ) {
+		return jQuery.contains( obj.ownerDocument, obj );
+	};
+
+} );


### PR DESCRIPTION
### Summary ###
This change replaces the use of `jQuery.contains` to check for attachment of DOM
by `isAttached` function to better communicate what is being done.

Ref gh-3504

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] Grunt build and unit tests pass locally with these changes

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
