### PR TITLE
Dimensions: avoid fetching boxSizing when setting width/height

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -378,7 +378,12 @@ jQuery.each( [ "height", "width" ], function( i, dimension ) {
 		set: function( elem, value, extra ) {
 			var matches,
 				styles = getStyles( elem ),
-				isBorderBox = jQuery.css( elem, "boxSizing", false, styles ) === "border-box",
+				scrollBoxSize = support.scrollboxSize() === styles.position,
+
+				// To avoid forcing a reflow, only fetch boxSizing if we need it (gh-3991)
+				boxSizingNeeded = scrollBoxSize || extra,
+				isBorderBox = boxSizingNeeded &&
+					jQuery.css( elem, "boxSizing", false, styles ) === "border-box",
 				subtract = extra && boxModelAdjustment(
 					elem,
 					dimension,
@@ -389,7 +394,7 @@ jQuery.each( [ "height", "width" ], function( i, dimension ) {
 
 			// Account for unreliable border-box dimensions by comparing offset* to computed and
 			// faking a content-box to get border and padding (gh-3699)
-			if ( isBorderBox && support.scrollboxSize() === styles.position ) {
+			if ( isBorderBox && scrollBoxSize ) {
 				subtract -= Math.ceil(
 					elem[ "offset" + dimension[ 0 ].toUpperCase() + dimension.slice( 1 ) ] -
 					parseFloat( styles[ dimension ] ) -


### PR DESCRIPTION
- this avoids forcing a reflow in some cases

Fixes #3991

```
 raw     gz Compared to 3991 @ 625e19cd9be4898939a7c40dbeb2b17e40df9d54
+147    +63 dist/jquery.js
 +12    +12 dist/jquery.min.js
```

Adds a bit of size but I think it's worth it...