### PR TITLE
Build: Don't require sudo on Travis, use sandboxless headless Chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: node_js
-# Temporary workaround.
-# Karma can't access the binaries on travis
-# without root access.
-# See https://github.com/travis-ci/travis-ci/issues/8836
-sudo: required
+sudo: false
 node_js:
 - "4"
 - "6"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,7 +13,8 @@ module.exports = function( grunt ) {
 	}
 
 	var fs = require( "fs" ),
-		gzip = require( "gzip-js" );
+		gzip = require( "gzip-js" ),
+		isTravis = process.env.TRAVIS;
 
 	if ( !grunt.option( "filename" ) ) {
 		grunt.option( "filename", "jquery.js" );
@@ -151,6 +152,12 @@ module.exports = function( grunt ) {
 			options: {
 				customContextFile: "test/karma.context.html",
 				customDebugFile: "test/karma.debug.html",
+				customLaunchers: {
+					ChromeHeadlessNoSandbox: {
+						base: "ChromeHeadless",
+						flags: [ "--no-sandbox" ]
+					}
+				},
 				frameworks: [ "qunit" ],
 				middleware: [ "mockserver" ],
 				plugins: [
@@ -214,7 +221,9 @@ module.exports = function( grunt ) {
 				singleRun: true
 			},
 			main: {
-				browsers: [ "ChromeHeadless" ]
+
+				// The Chrome sandbox doesn't work on Travis.
+				browsers: [ isTravis ? "ChromeHeadlessNoSandbox" : "ChromeHeadless" ]
 			},
 
 			// To debug tests with Karma:


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The Chrome sandbox doesn't work on Travis unless sudo is enabled. Instead,
we're disabling the Chrome sandbox.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
