### PR TITLE
Issue #3964 outerWidth of svg yields NaNpx

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -102,7 +102,7 @@ function boxModelAdjustment( elem, dimension, box, isBorderBox, styles, computed
 		// offsetWidth/offsetHeight is a rounded sum of content, padding, scroll gutter, and border
 		// Assuming integer scroll gutter, subtract the rest and round down
 		delta += Math.max( 0, Math.ceil(
-			elem[ "offset" + dimension[ 0 ].toUpperCase() + dimension.slice( 1 ) ] -
+			( elem[ "offset" + dimension[ 0 ].toUpperCase() + dimension.slice( 1 ) ] || 0 ) -
 			computedVal -
 			delta -
 			extra -

--- a/test/unit/dimensions.js
+++ b/test/unit/dimensions.js
@@ -236,6 +236,12 @@ QUnit.test( "outerWidth()", function( assert ) {
 	// Temporarily require 0 for backwards compat - should be auto
 	assert.equal( div.outerWidth(), 0, "Make sure that disconnected nodes are handled." );
 
+	// SVG outerWidth test
+	div = jQuery( "<svg width=\"100\" height=\"100\" style=\"padding: 2px;\"></svg>" );
+
+	// Check outerWide returns 100 + 2 + 2 = 104 px
+	assert.equal( div.outerWidth(), 104, "Make sure that SVG nodes are handled." );
+
 	div.remove();
 } );
 


### PR DESCRIPTION
### Summary ###

fix for issue 3964 that allows boxModelAdjustment() to handle svg element without offsetWidth or offsetHeight

[Issue 3964](https://github.com/jquery/jquery/issues/3964)


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
