### PR TITLE
Misc: Update license prolog/epilog to placate Github checker

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,14 +1,5 @@
 Copyright JS Foundation and other contributors, https://js.foundation/
 
-This software consists of voluntary contributions made by many
-individuals. For exact contribution history, see the revision history
-available at https://github.com/jquery/jquery
-
-The following license applies to all parts of this software except as
-documented below:
-
-====
-
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
 "Software"), to deal in the Software without restriction, including
@@ -27,10 +18,3 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-====
-
-All files located in the node_modules and external directories are
-externally maintained libraries used by this software which have their
-own licenses; we recommend you read them, as their terms may differ from
-the terms above.


### PR DESCRIPTION
### Summary ###
Per gh-4039, the Github license identification algorithm is confused by our prolog and epilog to the MIT license. Although the license is defined as MIT in the `package.json` that doesn't seem to be enough of a hint. If this is okay with JSF legal I'd like to do it as the path of least resistance. Otherwise we'll need to lobby Github to be smarter with their license checker or just ignore it.

### Checklist ###

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* [ ] ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
