### PR TITLE
Traversing: $.fn.contents() support for object

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -209,7 +209,7 @@ module.exports = function( grunt ) {
 					{ pattern: "dist/*.map", included: false, served: true },
 					{ pattern: "external/qunit/qunit.css", included: false, served: true },
 					{
-						pattern: "test/**/*.@(js|css|jpg|html|xml)",
+						pattern: "test/**/*.@(js|css|jpg|html|xml|svg)",
 						included: false,
 						served: true
 					}

--- a/src/traversing.js
+++ b/src/traversing.js
@@ -145,7 +145,7 @@ jQuery.each( {
 		return siblings( elem.firstChild );
 	},
 	contents: function( elem ) {
-        if ( nodeName( elem, "iframe" ) ) {
+        if ( nodeName( elem, "iframe" ) || nodeName( elem, "object" ) ) {
             return elem.contentDocument;
         }
 

--- a/src/traversing.js
+++ b/src/traversing.js
@@ -145,7 +145,7 @@ jQuery.each( {
 		return siblings( elem.firstChild );
 	},
 	contents: function( elem ) {
-        if ( nodeName( elem, "iframe" ) || nodeName( elem, "object" ) ) {
+				if ( typeof elem.contentDocument !== "undefined" ) {
             return elem.contentDocument;
         }
 

--- a/src/traversing.js
+++ b/src/traversing.js
@@ -145,18 +145,18 @@ jQuery.each( {
 		return siblings( elem.firstChild );
 	},
 	contents: function( elem ) {
-				if ( typeof elem.contentDocument !== "undefined" ) {
-            return elem.contentDocument;
-        }
+		if ( typeof elem.contentDocument !== "undefined" ) {
+			return elem.contentDocument;
+		}
 
-        // Support: IE 9 - 11 only, iOS 7 only, Android Browser <=4.3 only
-        // Treat the template element as a regular one in browsers that
-        // don't support it.
-        if ( nodeName( elem, "template" ) ) {
-            elem = elem.content || elem;
-        }
+		// Support: IE 9 - 11 only, iOS 7 only, Android Browser <=4.3 only
+		// Treat the template element as a regular one in browsers that
+		// don't support it.
+		if ( nodeName( elem, "template" ) ) {
+			elem = elem.content || elem;
+		}
 
-        return jQuery.merge( [], elem.childNodes );
+		return jQuery.merge( [], elem.childNodes );
 	}
 }, function( name, fn ) {
 	jQuery.fn[ name ] = function( until, selector ) {

--- a/test/data/1x1.svg
+++ b/test/data/1x1.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 20010904//EN" 
+	"http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+<svg width="1px" height="1px"
+	xmlns="http://www.w3.org/2000/svg">
+</svg>

--- a/test/data/frame.html
+++ b/test/data/frame.html
@@ -1,0 +1,9 @@
+<html>
+	<head>
+		<title>frame</title>
+	</head>
+	<frameset cols="20%, 80%">
+		<frame id="test-frame" src="iframe.html">
+		<frame src="iframe.html">
+	</frameset>
+</html>

--- a/test/unit/traversing.js
+++ b/test/unit/traversing.js
@@ -795,6 +795,22 @@ QUnit[ "content" in document.createElement( "template" ) ? "test" : "skip" ](
 	}
 );
 
+QUnit.test( "contents() for <object />", function( assert ) {
+	assert.expect( 2 );
+
+	var svgObject = jQuery( "<object id='svg-object' data='" + baseURL + "1x1.svg'></object>" );
+	var done = assert.async();
+
+	svgObject.on( "load", function() {
+		var contents = jQuery( "#svg-object" ).contents();
+		assert.equal( contents.length, 1, "Check object contents" );
+		assert.equal( contents.find( "svg" ).length, 1, "Find svg within object" );
+		done();
+	} );
+
+	jQuery( "#qunit-fixture" ).append( svgObject );
+} );
+
 QUnit.test( "sort direction", function( assert ) {
 	assert.expect( 12 );
 

--- a/test/unit/traversing.js
+++ b/test/unit/traversing.js
@@ -744,56 +744,53 @@ QUnit.test( "contents()", function( assert ) {
 } );
 
 QUnit.test( "contents() for <template />", function( assert ) {
-    assert.expect( 4 );
+	assert.expect( 4 );
 
-    jQuery( "#qunit-fixture" ).append(
-        "<template id='template'>" +
-        "    <div id='template-div0'>" +
-        "        <span>Hello, Web Component!</span>" +
-        "    </div>" +
-        "    <div id='template-div1'></div>" +
-        "    <div id='template-div2'></div>" +
-        "</template>"
-    );
+	jQuery( "#qunit-fixture" ).append(
+		"<template id='template'>" +
+		"    <div id='template-div0'>" +
+		"        <span>Hello, Web Component!</span>" +
+		"    </div>" +
+		"    <div id='template-div1'></div>" +
+		"    <div id='template-div2'></div>" +
+		"</template>"
+	);
 
-    var contents = jQuery( "#template" ).contents();
-    assert.equal( contents.length, 6, "Check template element contents" );
+	var contents = jQuery( "#template" ).contents();
+	assert.equal( contents.length, 6, "Check template element contents" );
 
-    assert.equal( contents.find( "span" ).text(), "Hello, Web Component!", "Find span in template and check its text" );
+	assert.equal( contents.find( "span" ).text(), "Hello, Web Component!", "Find span in template and check its text" );
 
-    jQuery( "<div id='templateTest' />" ).append(
-        jQuery( jQuery.map( contents, function( node ) {
-            return document.importNode( node, true );
-        } ) )
-    ).appendTo( "#qunit-fixture" );
+	jQuery( "<div id='templateTest' />" ).append(
+			jQuery( jQuery.map( contents, function( node ) {
+					return document.importNode( node, true );
+			} ) )
+	).appendTo( "#qunit-fixture" );
 
-    contents = jQuery( "#templateTest" ).contents();
-    assert.equal( contents.length, 6, "Check cloned nodes of template element contents" );
+	contents = jQuery( "#templateTest" ).contents();
+	assert.equal( contents.length, 6, "Check cloned nodes of template element contents" );
 
-    assert.equal( contents.filter( "div" ).length, 3, "Count cloned elements from template" );
+	assert.equal( contents.filter( "div" ).length, 3, "Count cloned elements from template" );
 } );
 
-QUnit[ "content" in document.createElement( "template" ) ? "test" : "skip" ](
-	"contents() for <template /> remains inert",
-	function( assert ) {
-        assert.expect( 2 );
+QUnit[ "content" in document.createElement( "template" ) ? "test" : "skip" ]( "contents() for <template /> remains inert", function( assert ) {
+	assert.expect( 2 );
 
-		Globals.register( "testScript" );
-		Globals.register( "testImgOnload" );
+	Globals.register( "testScript" );
+	Globals.register( "testImgOnload" );
 
-        jQuery( "#qunit-fixture" ).append(
-            "<template id='template'>" +
-            "    <script>testScript = 1;</script>" +
-            "    <img src='" + baseURL + "1x1.jpg' onload='testImgOnload = 1' >" +
-            "</template>"
-        );
+	jQuery( "#qunit-fixture" ).append(
+		"<template id='template'>" +
+		"    <script>testScript = 1;</script>" +
+		"    <img src='" + baseURL + "1x1.jpg' onload='testImgOnload = 1' >" +
+		"</template>"
+	);
 
-        var content = jQuery( "#template" ).contents();
+	var content = jQuery( "#template" ).contents();
 
-        assert.strictEqual( window.testScript, true, "script in template isn't executed" );
-        assert.strictEqual( window.testImgOnload, true, "onload of image in template isn't executed" );
-	}
-);
+	assert.strictEqual( window.testScript, true, "script in template isn't executed" );
+	assert.strictEqual( window.testImgOnload, true, "onload of image in template isn't executed" );
+} );
 
 QUnit.test( "contents() for <object />", function( assert ) {
 	assert.expect( 2 );

--- a/test/unit/traversing.js
+++ b/test/unit/traversing.js
@@ -811,6 +811,23 @@ QUnit.test( "contents() for <object />", function( assert ) {
 	jQuery( "#qunit-fixture" ).append( svgObject );
 } );
 
+QUnit.test( "contents() for <frame />", function( assert ) {
+	assert.expect( 2 );
+
+	var iframe = jQuery( "<iframe id='frame-contents' src='" + baseURL + "frame.html'></iframe>" );
+	var done = assert.async();
+
+	iframe.on( "load", function() {
+		var container = jQuery( "#frame-contents" ).contents();
+		var contents = container.find( "#test-frame" ).contents();
+		assert.equal( contents.length, 1, "Check frame contents" );
+		assert.equal( contents.find( "body" ).length, 1, "Find body within frame" );
+		done();
+	} );
+
+	jQuery( "#qunit-fixture" ).append( iframe );
+} );
+
 QUnit.test( "sort direction", function( assert ) {
 	assert.expect( 12 );
 


### PR DESCRIPTION
Fixes gh-4045

### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

As described in gh-4045, this PR allows `<object>`  document content to be accessed again using `contents()` function.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
