### PR TITLE
CSS: Ensure camel- vs kebab-cased names are not collapsed for CSS vars

### DIFF
--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -1632,10 +1632,12 @@ QUnit.test( "Do not throw on frame elements from css method (#15098)", function(
 		assert.equal( div.css( "--color" ), "red", "Modified CSS custom property using object" );
 
 		div.css( { "--mixedCase": "green" } );
+		div.css( { "--mixed-case": "red" } );
 		assert.equal( div.css( "--mixedCase" ), "green",
 			"Modified CSS custom property with mixed case" );
 
 		div.css( { "--theme-dark": "purple" } );
+		div.css( { "--themeDark": "red" } );
 		assert.equal( div.css( "--theme-dark" ), "purple",
 			"Modified CSS custom property with dashed name" );
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
This PR adds tests to ensure camel- vs kebab-cased names are not collapsed for CSS vars

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
