### PR TITLE
CSS: Don't auto-append "px" to CSS variables

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -246,7 +246,9 @@ jQuery.extend( {
 			}
 
 			// If a number was passed in, add the unit (except for certain CSS properties)
-			if ( type === "number" ) {
+			// The isCustomProp check can be removed in jQuery 4.0 when we only auto-append
+			// "px" to a few hardcoded values.
+			if ( type === "number" && !isCustomProp ) {
 				value += ret && ret[ 3 ] || ( jQuery.cssNumber[ origName ] ? "" : "px" );
 			}
 

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -1658,6 +1658,21 @@ QUnit.test( "Do not throw on frame elements from css method (#15098)", function(
 			assert.equal( $elem.css( "--prop5" ), "'val5'", "Works with single quotes" );
 		}
 	} );
+
+	QUnit[ supportsCssVars ? "test" : "skip" ]( "Don't append px to CSS vars", function( assert ) {
+		assert.expect( 3 );
+
+		var $div = jQuery( "<div>" ).appendTo( "#qunit-fixture" );
+
+		$div
+			.css( "--a", 3 )
+			.css( "--line-height", 4 )
+			.css( "--lineHeight", 5 );
+
+		assert.equal( $div.css( "--a" ), "3", "--a: 3" );
+		assert.equal( $div.css( "--line-height" ), "4", "--line-height: 4" );
+		assert.equal( $div.css( "--lineHeight" ), "5", "--lineHeight: 5" );
+	} );
 } )();
 
 }


### PR DESCRIPTION
Fixes gh-4063

### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
Fixes gh-4063

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
