### PR TITLE
Misc: Add config for lockbot

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,13 @@
+# Configuration for lock-threads - https://github.com/dessant/lock-threads
+
+# Number of days of inactivity before a closed issue or pull request is locked
+daysUntilLock: 180
+
+# Issues and pull requests with these labels will not be locked. Set to `[]` to disable
+exemptLabels: []
+
+# Label to add before locking, such as `outdated`. Set to `false` to disable
+lockLabel: false
+
+# Comment to post before locking. Set to `false` to disable
+lockComment: false


### PR DESCRIPTION
### Summary ###
Adds configuration for the bot described in https://github.com/apps/lock and gh-4069. In addition we'll need to add the bot to the repo's config.

I didn't add a close message because the bot will go through all the closed issues/PRs and lock them. If we add it now we'll get spammed with hundreds of messages. It would be possible to add some message after the bot has caught up, but be aware that all repo subscribers will see them.

### Checklist ###

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* [ ] ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~
