### PR TITLE
Test: enable a spec testing CSS whitespace preserving in Edge 17

### DIFF
--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -1348,11 +1348,11 @@ QUnit.test( "Keep the last style if the new one isn't recognized by the browser 
 	assert.equal( el.css( "position" ), "absolute", "The old style is kept when setting an unrecognized value" );
 } );
 
-// Support: Edge 14 - 15
+// Support: Edge 14 - 16 only
 // Edge collapses whitespace-only values when setting a style property and
 // there is no easy way for us to work around it. Just skip the test there
 // and hope for the better future.
-QUnit[ /\bedge\//i.test( navigator.userAgent ) ? "skip" : "test" ](
+QUnit[ /\bedge\/16\./i.test( navigator.userAgent ) ? "skip" : "test" ](
 	"Keep the last style if the new one is a non-empty whitespace (gh-3204)",
 	function( assert ) {
 	assert.expect( 1 );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

In Edge 14-16 setting a style property to a whitespace-only value resets it to
the default, forcing us to skip a relevant CSS test in Edge. Now that Edge 17
has fixed the issue we can re-enable this test there.

Ref gh-3204
### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
