### PR TITLE
Serialize: jQuery.param: return empty string when given null/undefined

### DIFF
--- a/src/serialize.js
+++ b/src/serialize.js
@@ -70,6 +70,10 @@ jQuery.param = function( a, traditional ) {
 				encodeURIComponent( value == null ? "" : value );
 		};
 
+	if ( a == null ) {
+		return "";
+	}
+
 	// If an array was passed in, assume that it is an array of form elements.
 	if ( Array.isArray( a ) || ( a.jquery && !jQuery.isPlainObject( a ) ) ) {
 

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -1,7 +1,7 @@
 QUnit.module( "serialize", { teardown: moduleTeardown } );
 
 QUnit.test( "jQuery.param()", function( assert ) {
-	assert.expect( 23 );
+	assert.expect( 24 );
 
 	var params;
 
@@ -72,6 +72,9 @@ QUnit.test( "jQuery.param()", function( assert ) {
 
 	params = { "test": [ 1, 2, null ] };
 	assert.equal( jQuery.param( params ), "test%5B%5D=1&test%5B%5D=2&test%5B%5D=", "object with array property with null value" );
+
+	params = undefined;
+	assert.equal( jQuery.param( params ), "", "jQuery.param( undefined ) === empty string" );
 } );
 
 QUnit.test( "jQuery.param() not affected by ajaxSettings", function( assert ) {


### PR DESCRIPTION
### Summary ###
Fixes https://github.com/jquery/jquery/issues/2633


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
