### PR TITLE
Tests: Add support test results for Firefox 61+

### DIFF
--- a/test/unit/support.js
+++ b/test/unit/support.js
@@ -160,7 +160,7 @@ testIframe(
 				"reliableMarginLeft": true,
 				"scrollboxSize": true
 			},
-			firefox: {
+			firefox_60: {
 				"ajax": true,
 				"boxSizingReliable": true,
 				"checkClone": true,
@@ -175,6 +175,23 @@ testIframe(
 				"pixelPosition": true,
 				"radioValue": true,
 				"reliableMarginLeft": false,
+				"scrollboxSize": true
+			},
+			firefox: {
+				"ajax": true,
+				"boxSizingReliable": true,
+				"checkClone": true,
+				"checkOn": true,
+				"clearCloneStyle": true,
+				"cors": true,
+				"createHTMLDocument": true,
+				"focusin": false,
+				"noCloneChecked": true,
+				"optSelected": true,
+				"pixelBoxStyles": true,
+				"pixelPosition": true,
+				"radioValue": true,
+				"reliableMarginLeft": true,
 				"scrollboxSize": true
 			},
 			ios_11: {
@@ -279,6 +296,8 @@ testIframe(
 		expected = expectedMap.safari_11;
 	} else if ( /\b(?:9|10)\.\d(\.\d+)* safari/i.test( userAgent ) ) {
 		expected = expectedMap.safari_9_10;
+	} else if ( /firefox\/60/i.test( userAgent ) ) {
+		expected = expectedMap.firefox_60;
 	} else if ( /firefox/i.test( userAgent ) ) {
 		expected = expectedMap.firefox;
 	} else if ( /iphone os 11_/i.test( userAgent ) ) {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Firefox 61 now passes the reliableMarginLeft test. This made our support tests fail.


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
