### PR TITLE
Ajax: More checks before replacing %20 to + in data

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -422,6 +422,9 @@ jQuery.extend( {
 			// uncached part of the url
 			uncached,
 
+			// real content-type, .headers member wins
+			realContentType,
+
 			// Create the final options object
 			s = jQuery.ajaxSetup( {}, options ),
 
@@ -615,9 +618,18 @@ jQuery.extend( {
 			s.url = cacheURL + uncached;
 
 		// Change '%20' to '+' if this is encoded form body content (gh-2658)
-		} else if ( s.data && s.processData &&
-			( s.contentType || "" ).indexOf( "application/x-www-form-urlencoded" ) === 0 ) {
-			s.data = s.data.replace( r20, "+" );
+		} else if ( s.data && s.processData ) {
+
+			// Build content-type from opts and headers section (gh-4119)
+			realContentType = s.contentType || "";
+			for ( i in s.headers ) {
+				if ( i.toLowerCase() === "content-type" ) {
+					realContentType = s.headers[ i ] || "";
+				}
+			}
+			if ( realContentType.indexOf( "application/x-www-form-urlencoded" ) === 0 ) {
+				s.data = s.data.replace( r20, "+" );
+			}
 		}
 
 		// Set the If-Modified-Since and/or If-None-Match header, if in ifModified mode.


### PR DESCRIPTION
### Summary ###
Before $.ajax replaces `%20` to `+` in POST-ed data,  `opts.headers['content-type']` is now checked as well as `opts.contentType`, and explicit header wins if present. Replacement only takes place if resulting content type starts with `application/x-www-form-urlencoded`.

Fixes #4119.

### Checklist ###
* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

