### PR TITLE
 Manipulation: Properly detect HTML elements with single-character names

### DIFF
--- a/src/core/var/rsingleTag.js
+++ b/src/core/var/rsingleTag.js
@@ -1,6 +1,7 @@
 define( function() {
 	"use strict";
 
-	// Match a standalone tag
+	// rsingleTag matches a string consisting of a single HTML element with no attributes
+	// and captures the element's name
 	return ( /^<([a-z][^\/\0>:\x20\t\r\n\f]*)[\x20\t\r\n\f]*\/?>(?:<\/\1>|)$/i );
 } );

--- a/src/manipulation/var/rtagName.js
+++ b/src/manipulation/var/rtagName.js
@@ -1,5 +1,8 @@
 define( function() {
 	"use strict";
 
+	// rtagName captures the name from the first start tag in a string of HTML
+	// https://html.spec.whatwg.org/multipage/syntax.html#tag-open-state
+	// https://html.spec.whatwg.org/multipage/syntax.html#tag-name-state
 	return ( /<([a-z][^\/\0>\x20\t\r\n\f]*)/i );
 } );

--- a/src/manipulation/var/rtagName.js
+++ b/src/manipulation/var/rtagName.js
@@ -1,5 +1,5 @@
 define( function() {
 	"use strict";
 
-	return ( /<([a-z][^\/\0>\x20\t\r\n\f]+)/i );
+	return ( /<([a-z][^\/\0>\x20\t\r\n\f]*)/i );
 } );

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -2772,6 +2772,21 @@ QUnit.test( "Make sure tr is not appended to the wrong tbody (gh-3439)", functio
 	assert.strictEqual( htmlOut, htmlExpected );
 } );
 
+QUnit.test( "Make sure tags with single-character names are found (gh-4124)", function( assert ) {
+	assert.expect( 1 );
+
+	var htmlOut,
+		htmlIn = "<p>foo<!--<td>--></p>",
+		$el = jQuery( "<div/>" );
+
+	$el.html( htmlIn );
+
+	// Lowercase and replace spaces to remove possible browser inconsistencies
+	htmlOut = $el[ 0 ].innerHTML.toLowerCase().replace( /\s/g, "" );
+
+	assert.strictEqual( htmlOut, htmlIn );
+} );
+
 QUnit.test( "Insert script with data-URI (gh-1887)", 1, function( assert ) {
 	Globals.register( "testFoo" );
 	Globals.register( "testSrcFoo" );


### PR DESCRIPTION
### Summary ###
Updates `rtagName` to capture elements with single-character names (e.g., `<p>`), which were previously ignored.
Fixes gh-4124

### Checklist ###
* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com