### PR TITLE
Tests: Skip module tests in Edge

### DIFF
--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -1797,7 +1797,13 @@ QUnit.test( "html(Function)", function( assert ) {
 	testHtml( manipulationFunctionReturningObj, assert  );
 } );
 
-QUnit[ QUnit.moduleTypeSupported ? "test" : "skip" ]( "html(script type module)", function( assert ) {
+QUnit[
+	// Support: Edge 16-17
+	// Edge sometimes doesn't execute module scripts so skip the test there.
+	( QUnit.moduleTypeSupported && !/edge\//i.test( navigator.userAgent ) ) ?
+		"test" :
+		"skip"
+]( "html(script type module)", function( assert ) {
 	assert.expect( 4 );
 	var done = assert.async(),
 		$fixture = jQuery( "#qunit-fixture" );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
Edge sometimes doesn't execute module scripts. It needs to be investigated why
but for now we're skipping the test to make our tests more stable.



### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
