### PR TITLE
CSS: use setProperty to support !important

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -264,7 +264,7 @@ jQuery.extend( {
 			// If a hook was provided, use that value, otherwise just set the specified value
 			if ( !hooks || !( "set" in hooks ) ||
 				( value = hooks.set( elem, value, extra ) ) !== undefined ) {
-				if ( typeof value === "string" && value.includes( "!important" ) ) {
+				if ( typeof value === "string" && value.indexOf( "!important" ) !== -1 ) {
 
 					// Support !important priority (gh-3713).
 					var splitValue = value.split( "!" );

--- a/src/css.js
+++ b/src/css.js
@@ -264,7 +264,7 @@ jQuery.extend( {
 			// If a hook was provided, use that value, otherwise just set the specified value
 			if ( !hooks || !( "set" in hooks ) ||
 				( value = hooks.set( elem, value, extra ) ) !== undefined ) {
-				if ( value.indexOf( "!" ) !== -1 ) {
+				if ( typeof value === "string" && value.includes( "!important" ) ) {
 
 					// Support !important priority (gh-3713).
 					var splitValue = value.split( "!" );

--- a/src/css.js
+++ b/src/css.js
@@ -217,6 +217,7 @@ jQuery.extend( {
 
 		// Make sure that we're working with the right name
 		var ret, type, hooks,
+			argName = name,
 			origName = camelCase( name ),
 			isCustomProp = rcustomProp.test( name ),
 			style = elem.style;
@@ -263,14 +264,13 @@ jQuery.extend( {
 			// If a hook was provided, use that value, otherwise just set the specified value
 			if ( !hooks || !( "set" in hooks ) ||
 				( value = hooks.set( elem, value, extra ) ) !== undefined ) {
+				if ( value.indexOf( "!" ) !== -1 ) {
 
-				if ( isCustomProp ) {
-					style.setProperty( name, value );
-				} else if ( value.indexOf( "!important" !== -1 ) ) {
-
-					//Added else if to resolve #3713
+					// Support !important priority (gh-3713).
 					var splitValue = value.split( "!" );
-					style.setProperty( name,  splitValue[ 0 ], splitValue[ 1 ] );
+					style.setProperty( argName,  splitValue[ 0 ], splitValue[ 1 ] );
+				} else if ( isCustomProp ) {
+					style.setProperty( name, value );
 				} else {
 					style[ name ] = value;
 				}

--- a/src/css.js
+++ b/src/css.js
@@ -266,6 +266,11 @@ jQuery.extend( {
 
 				if ( isCustomProp ) {
 					style.setProperty( name, value );
+				} else if ( value.indexOf( "!important" !== -1 ) ) {
+
+					//Added else if to resolve #3713
+					var splitValue = value.split( "!" );
+					style.setProperty( name,  splitValue[ 0 ], splitValue[ 1 ] );
 				} else {
 					style[ name ] = value;
 				}


### PR DESCRIPTION
### Summary ###
Resolution to issue #3713, where !important was not taken when css property was been set using $.css method.

Please review and let me know if any changes are required.


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
