### PR TITLE
Prevent negative getWidthOrHeight

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -83,10 +83,11 @@ function boxModelAdjustment( elem, dimension, box, isBorderBox, styles, computed
 		// If we get here with a border-box (content + padding + border), we're seeking "content" or
 		// "padding" or "margin"
 		} else {
+
 			// For "content", subtract padding
 			if ( box === "content" ) {
 				var padding = jQuery.css( elem, "padding" + cssExpand[ i ], true, styles );
-				if(delta > padding) {
+				if ( delta > padding ) {
 					delta -= padding;
 				} else {
 					delta = 0;
@@ -95,9 +96,9 @@ function boxModelAdjustment( elem, dimension, box, isBorderBox, styles, computed
 
 			// For "content" or "padding", subtract border
 			if ( box !== "margin" ) {
-				var borderWidth = jQuery.css( elem, "border" + cssExpand[ i ] + "Width", true, styles );
-				if(delta > borderWidth) {
-					delta -= borderWidth;
+				var width = jQuery.css( elem, "border" + cssExpand[ i ] + "Width", true, styles );
+				if ( delta > width ) {
+					delta -= width;
 				} else {
 					delta = 0;
 				}

--- a/src/css.js
+++ b/src/css.js
@@ -86,22 +86,12 @@ function boxModelAdjustment( elem, dimension, box, isBorderBox, styles, computed
 
 			// For "content", subtract padding
 			if ( box === "content" ) {
-				var padding = jQuery.css( elem, "padding" + cssExpand[ i ], true, styles );
-				if ( delta > padding ) {
-					delta -= padding;
-				} else {
-					delta = 0;
-				}
+				delta -= jQuery.css( elem, "padding" + cssExpand[ i ], true, styles );
 			}
 
 			// For "content" or "padding", subtract border
 			if ( box !== "margin" ) {
-				var width = jQuery.css( elem, "border" + cssExpand[ i ] + "Width", true, styles );
-				if ( delta > width ) {
-					delta -= width;
-				} else {
-					delta = 0;
-				}
+				delta -= jQuery.css( elem, "border" + cssExpand[ i ] + "Width", true, styles );
 			}
 		}
 	}
@@ -123,7 +113,7 @@ function boxModelAdjustment( elem, dimension, box, isBorderBox, styles, computed
 		) ) || 0;
 	}
 
-	return delta;
+	return Math.max( 0, delta );
 }
 
 function getWidthOrHeight( elem, dimension, extra ) {

--- a/src/css.js
+++ b/src/css.js
@@ -83,15 +83,24 @@ function boxModelAdjustment( elem, dimension, box, isBorderBox, styles, computed
 		// If we get here with a border-box (content + padding + border), we're seeking "content" or
 		// "padding" or "margin"
 		} else {
-
 			// For "content", subtract padding
 			if ( box === "content" ) {
-				delta -= jQuery.css( elem, "padding" + cssExpand[ i ], true, styles );
+				var padding = jQuery.css( elem, "padding" + cssExpand[ i ], true, styles );
+				if(delta > padding) {
+					delta -= padding;
+				} else {
+					delta = 0;
+				}
 			}
 
 			// For "content" or "padding", subtract border
 			if ( box !== "margin" ) {
-				delta -= jQuery.css( elem, "border" + cssExpand[ i ] + "Width", true, styles );
+				var borderWidth = jQuery.css( elem, "border" + cssExpand[ i ] + "Width", true, styles );
+				if(delta > borderWidth) {
+					delta -= borderWidth;
+				} else {
+					delta = 0;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Summary ###
This change prevents negative height and width.
fixes #4145

### Checklist ###

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
