### PR TITLE
Tests: use width style instead of SVG width attribute

### DIFF
--- a/test/unit/dimensions.js
+++ b/test/unit/dimensions.js
@@ -355,7 +355,7 @@ QUnit.test( "table dimensions", function( assert ) {
 QUnit.test( "SVG dimensions (basic content-box)", function( assert ) {
 	assert.expect( 8 );
 
-	var svg = jQuery( "<svg width='100' height='100'></svg>" ).appendTo( "#qunit-fixture" );
+	var svg = jQuery( "<svg style='width: 100px; height: 100px;'></svg>" ).appendTo( "#qunit-fixture" );
 
 	assert.equal( svg.width(), 100 );
 	assert.equal( svg.height(), 100 );
@@ -375,7 +375,7 @@ QUnit.test( "SVG dimensions (basic content-box)", function( assert ) {
 QUnit.test( "SVG dimensions (content-box)", function( assert ) {
 	assert.expect( 8 );
 
-	var svg = jQuery( "<svg width='100' height='100' style='box-sizing: content-box; border: 1px solid white; padding: 2px; margin: 3px'></svg>" ).appendTo( "#qunit-fixture" );
+	var svg = jQuery( "<svg style='width: 100px; height: 100px; box-sizing: content-box; border: 1px solid white; padding: 2px; margin: 3px'></svg>" ).appendTo( "#qunit-fixture" );
 
 	assert.equal( svg.width(), 100 );
 	assert.equal( svg.height(), 100 );
@@ -395,7 +395,7 @@ QUnit.test( "SVG dimensions (content-box)", function( assert ) {
 QUnit.test( "SVG dimensions (border-box)", function( assert ) {
 	assert.expect( 8 );
 
-	var svg = jQuery( "<svg width='100' height='100' style='box-sizing: border-box; border: 1px solid white; padding: 2px; margin: 3px'></svg>" ).appendTo( "#qunit-fixture" );
+	var svg = jQuery( "<svg style='width: 100px; height: 100px; box-sizing: border-box; border: 1px solid white; padding: 2px; margin: 3px'></svg>" ).appendTo( "#qunit-fixture" );
 
 	assert.equal( svg.width(), 94 );
 	assert.equal( svg.height(), 94 );


### PR DESCRIPTION
### Summary ###
The SVG `width` attribute seems to not support `border-box` in iOS7. This is not really relevant to what the test is for.

Closes gh-4155


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
