### PR TITLE
Fix getResponseHeader(key) for IE11

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -461,7 +461,7 @@ jQuery.extend( {
 							while ( ( match = rheaders.exec( responseHeadersString ) ) ) {
 								responseHeaders[ match[ 1 ].toLowerCase() + " " ] =
 									( responseHeaders[ match[ 1 ].toLowerCase() + " " ] || [] )
-									.concat( match[ 2 ] );
+										.concat( match[ 2 ] );
 							}
 						}
 						match = responseHeaders[ key.toLowerCase() + " " ];

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -454,14 +454,14 @@ jQuery.extend( {
 
 				// Builds headers hashtable if needed
 				getResponseHeader: function( key ) {
-					var match, existingHeaderValues, headerValues;
+					var match;
 					if ( completed ) {
 						if ( !responseHeaders ) {
 							responseHeaders = {};
 							while ( ( match = rheaders.exec( responseHeadersString ) ) ) {
-								existingHeaderValues = responseHeaders[ match[ 1 ].toLowerCase() ];
-								headerValues = ( existingHeaderValues || [] ).concat( match[ 2 ] );
-								responseHeaders[ match[ 1 ].toLowerCase() ] = headerValues;
+								responseHeaders[ match[ 1 ].toLowerCase() ] =
+									( responseHeaders[ match[ 1 ].toLowerCase() ] || [] )
+									.concat( match[ 2 ] );
 							}
 						}
 						match = responseHeaders[ key.toLowerCase() ];

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -454,17 +454,19 @@ jQuery.extend( {
 
 				// Builds headers hashtable if needed
 				getResponseHeader: function( key ) {
-					var match;
+					var match, existingHeaderValues, headerValues;
 					if ( completed ) {
 						if ( !responseHeaders ) {
 							responseHeaders = {};
 							while ( ( match = rheaders.exec( responseHeadersString ) ) ) {
-								responseHeaders[ match[ 1 ].toLowerCase() ] = (responseHeaders[ match[ 1 ].toLowerCase() ] || []).concat(match[ 2 ]);
+								existingHeaderValues = responseHeaders[ match[ 1 ].toLowerCase() ];
+								headerValues = ( existingHeaderValues || [] ).concat( match[ 2 ] );
+								responseHeaders[ match[ 1 ].toLowerCase() ] = headerValues;
 							}
 						}
 						match = responseHeaders[ key.toLowerCase() ];
 					}
-					return match == null ? null : match.join(", ");
+					return match == null ? null : match.join( ", " );
 				},
 
 				// Raw string

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -459,12 +459,12 @@ jQuery.extend( {
 						if ( !responseHeaders ) {
 							responseHeaders = {};
 							while ( ( match = rheaders.exec( responseHeadersString ) ) ) {
-								responseHeaders[ match[ 1 ].toLowerCase() ] = match[ 2 ];
+								responseHeaders[ match[ 1 ].toLowerCase() ] = (responseHeaders[ match[ 1 ].toLowerCase() ] || []).concat(match[ 2 ]);
 							}
 						}
 						match = responseHeaders[ key.toLowerCase() ];
 					}
-					return match == null ? null : match;
+					return match == null ? null : match.join(", ");
 				},
 
 				// Raw string

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -459,12 +459,12 @@ jQuery.extend( {
 						if ( !responseHeaders ) {
 							responseHeaders = {};
 							while ( ( match = rheaders.exec( responseHeadersString ) ) ) {
-								responseHeaders[ match[ 1 ].toLowerCase() ] =
-									( responseHeaders[ match[ 1 ].toLowerCase() ] || [] )
+								responseHeaders[ match[ 1 ].toLowerCase() + " " ] =
+									( responseHeaders[ match[ 1 ].toLowerCase() + " " ] || [] )
 									.concat( match[ 2 ] );
 							}
 						}
-						match = responseHeaders[ key.toLowerCase() ];
+						match = responseHeaders[ key.toLowerCase() + " " ];
 					}
 					return match == null ? null : match.join( ", " );
 				},

--- a/test/data/mock.php
+++ b/test/data/mock.php
@@ -116,8 +116,7 @@ ok( true, "mock executed");';
 		header( 'Sample-Header2: Hello World 2' );
 		header( 'List-Header: Item 1' );
 		header( 'list-header: Item 2' );
-		header( 'Constructor: prototype collision (constructor)' );
-		header( '__Proto__: prototype collision (__proto__)' );
+		header( 'constructor: prototype collision (constructor)' );
 
 		foreach ( explode( '|' , $req->query[ 'keys' ] ) as $key ) {
 			// Only echo if key exists in the header

--- a/test/data/mock.php
+++ b/test/data/mock.php
@@ -114,6 +114,8 @@ ok( true, "mock executed");';
 		header( 'Sample-Header: Hello World' );
 		header( 'Empty-Header: ' );
 		header( 'Sample-Header2: Hello World 2' );
+		header( 'List-Header: Item 1' );
+		header( 'list-header: Item 2' );
 
 		foreach ( explode( '|' , $req->query[ 'keys' ] ) as $key ) {
 			// Only echo if key exists in the header

--- a/test/data/mock.php
+++ b/test/data/mock.php
@@ -116,6 +116,8 @@ ok( true, "mock executed");';
 		header( 'Sample-Header2: Hello World 2' );
 		header( 'List-Header: Item 1' );
 		header( 'list-header: Item 2' );
+		header( 'Constructor: prototype collision (constructor)' );
+		header( '__Proto__: prototype collision (__proto__)' );
 
 		foreach ( explode( '|' , $req->query[ 'keys' ] ) as $key ) {
 			// Only echo if key exists in the header

--- a/test/middleware-mockserver.js
+++ b/test/middleware-mockserver.js
@@ -135,8 +135,7 @@ var mocks = {
 			"Sample-Header2": "Hello World 2",
 			"List-Header": "Item 1",
 			"list-header": "Item 2",
-			"Constructor": "prototype collision (constructor)",
-			"__Proto__": "prototype collision (__proto__)"
+			"constructor": "prototype collision (constructor)"
 		} );
 		req.query.keys.split( "|" ).forEach( function( key ) {
 			if ( req.headers[ key.toLowerCase() ] ) {

--- a/test/middleware-mockserver.js
+++ b/test/middleware-mockserver.js
@@ -134,7 +134,9 @@ var mocks = {
 			"Empty-Header": "",
 			"Sample-Header2": "Hello World 2",
 			"List-Header": "Item 1",
-			"list-header": "Item 2"
+			"list-header": "Item 2",
+			"Constructor": "prototype collision (constructor)",
+			"__Proto__": "prototype collision (__proto__)"
 		} );
 		req.query.keys.split( "|" ).forEach( function( key ) {
 			if ( req.headers[ key.toLowerCase() ] ) {

--- a/test/middleware-mockserver.js
+++ b/test/middleware-mockserver.js
@@ -132,7 +132,9 @@ var mocks = {
 		resp.writeHead( 200, {
 			"Sample-Header": "Hello World",
 			"Empty-Header": "",
-			"Sample-Header2": "Hello World 2"
+			"Sample-Header2": "Hello World 2",
+			"List-Header": "Item 1",
+			"list-header": "Item 2"
 		} );
 		req.query.keys.split( "|" ).forEach( function( key ) {
 			if ( req.headers[ key.toLowerCase() ] ) {

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -252,7 +252,7 @@ QUnit.module( "ajax", {
 		} );
 	} );
 
-	ajaxTest( "jQuery.ajax() - headers", 5, function( assert ) {
+	ajaxTest( "jQuery.ajax() - headers", 6, function( assert ) {
 		return {
 			setup: function() {
 				jQuery( document ).ajaxSend( function( evt, xhr ) {
@@ -293,6 +293,7 @@ QUnit.module( "ajax", {
 					assert.strictEqual( emptyHeader, "", "Empty header received" );
 				}
 				assert.strictEqual( xhr.getResponseHeader( "Sample-Header2" ), "Hello World 2", "Second sample header received" );
+				assert.strictEqual( xhr.getResponseHeader( "List-Header" ), "Item 1, Item 2", "List header received" );
 			}
 		};
 	} );

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -252,7 +252,7 @@ QUnit.module( "ajax", {
 		} );
 	} );
 
-	ajaxTest( "jQuery.ajax() - headers", 6, function( assert ) {
+	ajaxTest( "jQuery.ajax() - headers", 8, function( assert ) {
 		return {
 			setup: function() {
 				jQuery( document ).ajaxSend( function( evt, xhr ) {
@@ -294,6 +294,8 @@ QUnit.module( "ajax", {
 				}
 				assert.strictEqual( xhr.getResponseHeader( "Sample-Header2" ), "Hello World 2", "Second sample header received" );
 				assert.strictEqual( xhr.getResponseHeader( "List-Header" ), "Item 1, Item 2", "List header received" );
+				assert.strictEqual( xhr.getResponseHeader( "constructor" ), "prototype collision (constructor)", "constructor header received" );
+				assert.strictEqual( xhr.getResponseHeader( "__proto__" ), "prototype collision (__proto__)", "__proto__ header received" );
 			}
 		};
 	} );

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -295,7 +295,7 @@ QUnit.module( "ajax", {
 				assert.strictEqual( xhr.getResponseHeader( "Sample-Header2" ), "Hello World 2", "Second sample header received" );
 				assert.strictEqual( xhr.getResponseHeader( "List-Header" ), "Item 1, Item 2", "List header received" );
 				assert.strictEqual( xhr.getResponseHeader( "constructor" ), "prototype collision (constructor)", "constructor header received" );
-				assert.strictEqual( xhr.getResponseHeader( "__proto__" ), "prototype collision (__proto__)", "__proto__ header received" );
+				assert.strictEqual( xhr.getResponseHeader( "__proto__" ), null, "Undefined __proto__ header not received" );
 			}
 		};
 	} );


### PR DESCRIPTION
### Summary ###

This issue is described in more depth by #3403.

getResponseHeader(key) combines all header values for the provided key into a
single result where values are concatenated by ', '. This does not happen for
IE11 since multiple values for the same header are returned on separate lines.
This makes the function only return the last value of the header for IE11.

### Checklist ###

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com