### PR TITLE
Dimensions: fall back to offsetWidth/Height for border-box in IE

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -239,6 +239,10 @@ module.exports = function( grunt ) {
 			"firefox-debug": {
 				browsers: [ "Firefox" ],
 				singleRun: false
+			},
+			"ie-debug": {
+				browsers: [ "IE" ],
+				singleRun: false
 			}
 		},
 		watch: {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "karma-browserstack-launcher": "1.3.0",
     "karma-chrome-launcher": "2.2.0",
     "karma-firefox-launcher": "1.1.0",
+    "karma-ie-launcher": "1.0.0",
     "karma-qunit": "1.2.1",
     "load-grunt-tasks": "4.0.0",
     "native-promise-only": "0.8.1",

--- a/src/css.js
+++ b/src/css.js
@@ -117,7 +117,9 @@ function boxModelAdjustment( elem, dimension, box, isBorderBox, styles, computed
 function getWidthOrHeight( elem, dimension, extra ) {
 
 	// Start with computed style
-	var isBorderBox, valueIsBorderBox, offsetProp, offsetVal,
+	var isBorderBox = jQuery.css( elem, "boxSizing", false, styles ) === "border-box",
+		valueIsBorderBox = isBorderBox && support.boxSizingReliable(),
+		offsetProp = "offset" + dimension[ 0 ].toUpperCase() + dimension.slice( 1 ),
 		styles = getStyles( elem ),
 		val = curCSS( elem, dimension, styles );
 
@@ -130,9 +132,6 @@ function getWidthOrHeight( elem, dimension, extra ) {
 		val = "auto";
 	}
 
-	isBorderBox = jQuery.css( elem, "boxSizing", false, styles ) === "border-box";
-	valueIsBorderBox = isBorderBox && support.boxSizingReliable();
-	offsetProp = "offset" + dimension[ 0 ].toUpperCase() + dimension.slice( 1 );
 
 	// Fall back to offsetWidth/offsetHeight when value is "auto"
 	// This happens for inline elements with no explicit setting (gh-3571)
@@ -141,21 +140,19 @@ function getWidthOrHeight( elem, dimension, extra ) {
 	// Support: IE 9-11 only
 	// Also use offsetWidth/offsetHeight for when box sizing is unreliable
 	// Do not use offset for elements that don't have it (e.g. SVG)
-	if ( typeof elem[ offsetProp ] !== "undefined" &&
-		( val === "auto" || ( isBorderBox && !valueIsBorderBox ) ||
+	// Computed value for SVG elements does not respect border-box in IE 9-11
+	// so valueIsBorderBox should be false there
+	if ( elem.hasOwnProperty( offsetProp ) &&
+		( val === "auto" || ( isBorderBox !== valueIsBorderBox ) ||
 			!parseFloat( val ) && jQuery.css( elem, "display", false, styles ) === "inline" ) ) {
 
-		offsetVal = elem[ offsetProp ];
-
 		// Support: IE 9-11 only
-		// offsetWidth/offsetHeight is zero for disconnect elements
+		// offsetWidth/offsetHeight is zero for disconnected elements
 		// and children of hidden elements
-		if ( offsetVal || !parseFloat( val ) ) {
-			val = offsetVal;
-		}
+		val = elem[ offsetProp ] || val;
 
 		// offsetWidth/offsetHeight provide border-box values
-		// In the case where val is not set,
+		// In the case where val remains unchanged,
 		// computed value can then be trusted to be border-box
 		valueIsBorderBox = true;
 	}

--- a/src/css.js
+++ b/src/css.js
@@ -117,11 +117,11 @@ function boxModelAdjustment( elem, dimension, box, isBorderBox, styles, computed
 function getWidthOrHeight( elem, dimension, extra ) {
 
 	// Start with computed style
-	var isBorderBox = jQuery.css( elem, "boxSizing", false, styles ) === "border-box",
+	var styles = getStyles( elem ),
+		val = curCSS( elem, dimension, styles ),
+		isBorderBox = jQuery.css( elem, "boxSizing", false, styles ) === "border-box",
 		valueIsBorderBox = isBorderBox && support.boxSizingReliable(),
-		offsetProp = "offset" + dimension[ 0 ].toUpperCase() + dimension.slice( 1 ),
-		styles = getStyles( elem ),
-		val = curCSS( elem, dimension, styles );
+		offsetProp = "offset" + dimension[ 0 ].toUpperCase() + dimension.slice( 1 );
 
 	// Support: Firefox <=54
 	// Return a confounding non-pixel value or feign ignorance, as appropriate.
@@ -142,9 +142,9 @@ function getWidthOrHeight( elem, dimension, extra ) {
 	// Do not use offset for elements that don't have it (e.g. SVG)
 	// Computed value for SVG elements does not respect border-box in IE 9-11
 	// so valueIsBorderBox should be false there
-	if ( elem.hasOwnProperty( offsetProp ) &&
-		( val === "auto" || ( isBorderBox !== valueIsBorderBox ) ||
-			!parseFloat( val ) && jQuery.css( elem, "display", false, styles ) === "inline" ) ) {
+	if ( ( val === "auto" || ( isBorderBox !== valueIsBorderBox ) ||
+			!parseFloat( val ) && jQuery.css( elem, "display", false, styles ) === "inline" ) &&
+			typeof elem[ offsetProp ] !== "undefined" ) {
 
 		// Support: IE 9-11 only
 		// offsetWidth/offsetHeight is zero for disconnected elements

--- a/src/css.js
+++ b/src/css.js
@@ -144,7 +144,7 @@ function getWidthOrHeight( elem, dimension, extra ) {
 	// so valueIsBorderBox should be false there
 	if ( ( val === "auto" || ( isBorderBox !== valueIsBorderBox ) ||
 			!parseFloat( val ) && jQuery.css( elem, "display", false, styles ) === "inline" ) &&
-			typeof elem[ offsetProp ] !== "undefined" ) {
+			offsetProp in elem ) {
 
 		// Support: IE 9-11 only
 		// offsetWidth/offsetHeight is zero for disconnected elements

--- a/test/data/testsuite.css
+++ b/test/data/testsuite.css
@@ -142,3 +142,7 @@ section { background:#f0f; display:block; }
 	padding: 0;
 	margin: 0;
 }
+
+.border-box, .border-box * {
+	box-sizing: border-box;
+}

--- a/test/unit/dimensions.js
+++ b/test/unit/dimensions.js
@@ -696,13 +696,6 @@ QUnit.test( "interaction with scrollbars (gh-3589)", function( assert ) {
 			borderBox.clone().css( { overflow: "auto" } ).appendTo( parent )[ 0 ].offsetWidth -
 			borderBox[ 0 ].offsetWidth;
 
-	if ( borderBoxLoss > 0 ) {
-		borderBox.css( {
-			width: ( size + borderBoxLoss ) + "px",
-			height: ( size + borderBoxLoss ) + "px"
-		} );
-	}
-
 	for ( i = 0; i < 3; i++ ) {
 		if ( i === 1 ) {
 			suffix = " after increasing inner* by " + i;
@@ -732,13 +725,13 @@ QUnit.test( "interaction with scrollbars (gh-3589)", function( assert ) {
 		assert.equal( contentBox.outerHeight(), size + 2 * padding + 2 * borderWidth,
 			"content-box outerHeight includes scroll gutter" + suffix );
 
-		assert.equal( borderBox.innerWidth(), size - 2 * borderWidth,
+		assert.equal( borderBox.innerWidth() + borderBoxLoss, size - 2 * borderWidth,
 			"border-box innerWidth includes scroll gutter" + suffix );
-		assert.equal( borderBox.innerHeight(), size - 2 * borderWidth,
+		assert.equal( borderBox.innerHeight() + borderBoxLoss, size - 2 * borderWidth,
 			"border-box innerHeight includes scroll gutter" + suffix );
-		assert.equal( borderBox.outerWidth(), size,
+		assert.equal( borderBox.outerWidth() + borderBoxLoss, size,
 			"border-box outerWidth includes scroll gutter" + suffix );
-		assert.equal( borderBox.outerHeight(), size,
+		assert.equal( borderBox.outerHeight() + borderBoxLoss, size,
 			"border-box outerHeight includes scroll gutter" + suffix );
 
 		assert.equal( relativeBorderBox.innerWidth(), size - 2 * borderWidth,

--- a/test/unit/dimensions.js
+++ b/test/unit/dimensions.js
@@ -696,6 +696,11 @@ QUnit.test( "interaction with scrollbars (gh-3589)", function( assert ) {
 			borderBox.clone().css( { overflow: "auto" } ).appendTo( parent )[ 0 ].offsetWidth -
 			borderBox[ 0 ].offsetWidth;
 
+	if ( borderBoxLoss > 0 ) {
+		borderBox[ 0 ].style.width = ( size + borderBoxLoss ) + "px";
+		borderBox[ 0 ].style.height = ( size + borderBoxLoss ) + "px";
+	}
+
 	for ( i = 0; i < 3; i++ ) {
 		if ( i === 1 ) {
 			suffix = " after increasing inner* by " + i;
@@ -725,13 +730,13 @@ QUnit.test( "interaction with scrollbars (gh-3589)", function( assert ) {
 		assert.equal( contentBox.outerHeight(), size + 2 * padding + 2 * borderWidth,
 			"content-box outerHeight includes scroll gutter" + suffix );
 
-		assert.equal( borderBox.innerWidth() + borderBoxLoss, size - 2 * borderWidth,
+		assert.equal( borderBox.innerWidth(), size - 2 * borderWidth,
 			"border-box innerWidth includes scroll gutter" + suffix );
-		assert.equal( borderBox.innerHeight() + borderBoxLoss, size - 2 * borderWidth,
+		assert.equal( borderBox.innerHeight(), size - 2 * borderWidth,
 			"border-box innerHeight includes scroll gutter" + suffix );
-		assert.equal( borderBox.outerWidth() + borderBoxLoss, size,
+		assert.equal( borderBox.outerWidth(), size,
 			"border-box outerWidth includes scroll gutter" + suffix );
-		assert.equal( borderBox.outerHeight() + borderBoxLoss, size,
+		assert.equal( borderBox.outerHeight(), size,
 			"border-box outerHeight includes scroll gutter" + suffix );
 
 		assert.equal( relativeBorderBox.innerWidth(), size - 2 * borderWidth,

--- a/test/unit/dimensions.js
+++ b/test/unit/dimensions.js
@@ -646,7 +646,9 @@ QUnit.test( "width/height on a table row with phantom borders (gh-3698)", functi
 	} );
 } );
 
-QUnit.test( "interaction with scrollbars (gh-3589)", function( assert ) {
+// Because we fallback to offsetWidth/offsetHeight,
+// IE9-11 does not report fractional values
+QUnit[ jQuery.support.boxSizingReliable() ? "test" : "skip" ]( "interaction with scrollbars (gh-3589)", function( assert ) {
 	assert.expect( 48 );
 
 	var i,
@@ -748,6 +750,28 @@ QUnit.test( "interaction with scrollbars (gh-3589)", function( assert ) {
 		assert.equal( relativeBorderBox.outerHeight(), size,
 			"relative border-box outerHeight includes scroll gutter" + suffix );
 	}
+} );
+
+QUnit.test( "outerWidth/Height for table cells and textarea with border-box in IE 11 (gh-4102)", function( assert ) {
+	assert.expect( 5 );
+	var $table = jQuery( "<table class='border-box' style='border-collapse: separate' />" ).appendTo( "#qunit-fixture" ),
+		$thead = jQuery( "<thead />" ).appendTo( $table ),
+		$firstTh = jQuery( "<th style='width: 200px;padding: 5px' />" ),
+		$secondTh = jQuery( "<th style='width: 190px;padding: 5px' />" ),
+		$thirdTh = jQuery( "<th style='width: 180px;padding: 5px' />" ),
+		$td = jQuery( "<td style='height: 20px;padding: 5px;border: 1px solid'>text</td>" ),
+		$tbody = jQuery( "<tbody />" ).appendTo( $table ),
+		$textarea = jQuery( "<textarea style='height: 0;padding: 2px;border: 1px solid;box-sizing: border-box' />" ).appendTo( "#qunit-fixture" );
+	jQuery( "<tr />" ).appendTo( $thead ).append( $firstTh );
+	jQuery( "<tr />" ).appendTo( $thead ).append( $secondTh );
+	jQuery( "<tr />" ).appendTo( $thead ).append( $thirdTh );
+	jQuery( "<tr><td></td></tr>" ).appendTo( $tbody ).append( $td );
+
+	assert.strictEqual( $firstTh.outerWidth(), 200, "First th has outerWidth 200." );
+	assert.strictEqual( $secondTh.outerWidth(), 200, "Second th has outerWidth 200." );
+	assert.strictEqual( $thirdTh.outerWidth(), 200, "Third th has outerWidth 200." );
+	assert.strictEqual( $td.outerHeight(), 30, "outerHeight of td with border-box should include padding." );
+	assert.strictEqual( $textarea.outerHeight(), 6, "outerHeight of textarea with border-box should include padding and border." );
 } );
 
 } )();

--- a/test/unit/dimensions.js
+++ b/test/unit/dimensions.js
@@ -646,9 +646,7 @@ QUnit.test( "width/height on a table row with phantom borders (gh-3698)", functi
 	} );
 } );
 
-// Because we fallback to offsetWidth/offsetHeight,
-// IE9-11 does not report fractional values
-QUnit[ jQuery.support.boxSizingReliable() ? "test" : "skip" ]( "interaction with scrollbars (gh-3589)", function( assert ) {
+QUnit.test( "interaction with scrollbars (gh-3589)", function( assert ) {
 	assert.expect( 48 );
 
 	var i,
@@ -661,7 +659,9 @@ QUnit[ jQuery.support.boxSizingReliable() ? "test" : "skip" ]( "interaction with
 		parent = jQuery( "<div/>" )
 			.css( { position: "absolute", width: "1000px", height: "1000px" } )
 			.appendTo( "#qunit-fixture" ),
-		fraction = jQuery( "<div style='width:4.5px;'/>" ).appendTo( parent ).width() % 1,
+		fraction = jQuery.support.boxSizingReliable() ?
+			jQuery( "<div style='width:4.5px;'/>" ).appendTo( parent ).width() % 1 :
+			0,
 		borderWidth = 1,
 		padding = 2,
 		size = 100 + fraction,


### PR DESCRIPTION
### Summary ###
Fixes gh-4102

If box-sizing is unreliable and box-sizing is border-box, we can use offsetWidth and offsetHeight in most situations. In the situations we can't, box-sizing seems to be reliable and we can use computed CSS. Specifically, in these cases:

- Child of hidden element
- Disconnected element

`valueIsBorderBox` should be `false` for SVG in IE9-11.

The downside here is that we lose fractional values for border-box dimensions in IE9-11. I can live with that, but open to review.

- I first added a commit to include the IE launcher for debugging IE issues on Windows machines, which came in handy for this.
- Also removed a couple unused variables.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->

With @gibson042's help, got it down to +9.