### PR TITLE
replaced unmaintained gzip-js with pako

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,7 +13,7 @@ module.exports = function( grunt ) {
 	}
 
 	var fs = require( "fs" ),
-		gzip = require( "gzip-js" ),
+		gzip = require( "pako" ).gzip,
 		isTravis = process.env.TRAVIS;
 
 	if ( !grunt.option( "filename" ) ) {
@@ -28,7 +28,7 @@ module.exports = function( grunt ) {
 			options: {
 				compress: {
 					gz: function( contents ) {
-						return gzip.zip( contents, {} ).length;
+						return gzip( contents, {} ).length;
 					}
 				},
 				cache: "build/.sizecache.json"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "grunt-karma": "2.0.0",
     "grunt-newer": "1.3.0",
     "grunt-npmcopy": "0.1.0",
-    "gzip-js": "0.3.2",
+    "pako": "1.0.6",
     "husky": "0.14.3",
     "insight": "0.10.1",
     "jsdom": "5.6.1",


### PR DESCRIPTION
### Summary ###
This PR replaces gzip-js with pako (https://github.com/nodeca/pako) because the former is not maintained any more
### Checklist ###
* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com
