### PR TITLE
updated sinon to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,11 +59,11 @@
     "qunitjs": "1.23.1",
     "raw-body": "2.3.3",
     "requirejs": "2.3.5",
-    "sinon": "2.3.7",
+    "sinon": "7.1.1",
     "sizzle": "2.3.3",
     "strip-json-comments": "2.0.1",
     "testswarm": "1.1.0",
-    "uglify-js": "3.4.0"
+    "uglify-js": "3.4.9"
   },
   "scripts": {
     "build": "npm install && grunt",

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -1427,8 +1427,7 @@ QUnit[ jQuery.Deferred ? "test" : "skip" ]( "jQuery.readyException (original)", 
 	assert.expect( 1 );
 
 	var message;
-
-	this.sandbox.stub( window, "setTimeout", function( fn ) {
+	this.sandbox.stub( window, "setTimeout" ).callsFake( function( fn ) {
 		try {
 			fn();
 		} catch ( error ) {
@@ -1451,7 +1450,7 @@ QUnit[ jQuery.Deferred ? "test" : "skip" ]( "jQuery.readyException (custom)", fu
 
 	var done = assert.async();
 
-	this.sandbox.stub( jQuery, "readyException", function( error ) {
+	this.sandbox.stub( jQuery, "readyException" ).callsFake( function( error ) {
 		assert.strictEqual(
 			error.message,
 			"Error in jQuery ready",


### PR DESCRIPTION
### Summary ###
This PR updates sinon to v7 and removes the deprecation warnings associated with it
### Checklist ###
* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com