### PR TITLE
Manipulation: Only evaluate HTTP-successful script src

### DIFF
--- a/src/manipulation/_evalUrl.js
+++ b/src/manipulation/_evalUrl.js
@@ -10,11 +10,16 @@ jQuery._evalUrl = function( url ) {
 
 		// Make this explicit, since user can override this through ajaxSetup (#11264)
 		type: "GET",
-		dataType: "script",
+		dataType: "text",
 		cache: true,
 		async: false,
 		global: false,
-		"throws": true
+		"throws": true,
+
+		// Only evaluate the response if it is successful (gh-4126)
+		success: function( text ) {
+			jQuery.globalEval( text );
+		}
 	} );
 };
 

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -2818,3 +2818,20 @@ QUnit.test( "Insert script with data-URI (gh-1887)", 1, function( assert ) {
 		done();
 	}, 100 );
 } );
+
+QUnit.test( "Ignore content from unsuccessful responses (gh-4126)", 1, function( assert ) {
+	var globalEval = jQuery.globalEval;
+	jQuery.globalEval = function( code ) {
+		assert.ok( false, "no attempt to evaluate code from an unsuccessful response" );
+	};
+
+	try {
+		jQuery( "#qunit-fixture" ).append(
+			"<script src='" + url( "mock.php?action=error" ) + "'/>" );
+		assert.ok( true, "no error thrown from embedding script with unsuccessful-response src" );
+	} catch ( e ) {
+		throw e;
+	} finally {
+		jQuery.globalEval = globalEval;
+	}
+} );


### PR DESCRIPTION
Fixes gh-4126

### Checklist ###
* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~