### PR TITLE
Core: Fixes Safari 5.1 bugs

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -384,6 +384,14 @@ function isArrayLike( obj ) {
 	var length = !!obj && "length" in obj && obj.length,
 		type = toType( obj );
 
+    // Support: Safari 5.1
+    // Safari returns HTMLCollections and NodeLists that have
+    // typeof === "function"
+    if ( obj instanceof window.HTMLCollection ||
+         obj instanceof window.NodeList ) {
+        return true;
+    }
+
 	if ( isFunction( obj ) || isWindow( obj ) ) {
 		return false;
 	}


### PR DESCRIPTION
### Summary ###

This change broke Safari 5.1:

https://github.com/jquery/jquery/commit/a16339b8933f115da3661f3d3f64854c3fa60bdc

Safari 5.1 (and other old browsers) return `HTMLCollection` and `NodeList` variables that are functions. This breaks isArrayLike. This fix ensures that all `HTMLCollection` and `NodeList` variables are treated like arrays.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
