### PR TITLE
Manipulation: Always make _evalUrl requests as dataType: script

### DIFF
--- a/src/manipulation/_evalUrl.js
+++ b/src/manipulation/_evalUrl.js
@@ -16,6 +16,8 @@ jQuery._evalUrl = function( url ) {
 		global: false,
 
 		// Only evaluate the response if it is successful (gh-4126)
+		// dataFilter is not invoked for failure responses, so using it instead
+		// of the default converter is kludgy but it works.
 		converters: {
 			"text script": function() {}
 		},

--- a/src/manipulation/_evalUrl.js
+++ b/src/manipulation/_evalUrl.js
@@ -10,15 +10,17 @@ jQuery._evalUrl = function( url ) {
 
 		// Make this explicit, since user can override this through ajaxSetup (#11264)
 		type: "GET",
-		dataType: "text",
+		dataType: "script",
 		cache: true,
 		async: false,
 		global: false,
-		"throws": true,
 
 		// Only evaluate the response if it is successful (gh-4126)
-		success: function( text ) {
-			jQuery.globalEval( text );
+		converters: {
+			"text script": function() {}
+		},
+		dataFilter: function( response ) {
+			jQuery.globalEval( response );
 		}
 	} );
 };


### PR DESCRIPTION
IE and iOS \<10 XHR transport does not succeed on data: URIs
Ref gh-4243
Ref gh-4126