### PR TITLE
Tests: Exclude Android 4.x from repeated header names test

### DIFF
--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -273,6 +273,7 @@ QUnit.module( "ajax", {
 			},
 			success: function( data, _, xhr ) {
 				var i, emptyHeader,
+					isAndroid = /android 4\.[0-3]/i.test( navigator.userAgent ),
 					requestHeaders = jQuery.extend( this.headers, {
 						"ajax-send": "test"
 					} ),
@@ -293,7 +294,16 @@ QUnit.module( "ajax", {
 					assert.strictEqual( emptyHeader, "", "Empty header received" );
 				}
 				assert.strictEqual( xhr.getResponseHeader( "Sample-Header2" ), "Hello World 2", "Second sample header received" );
-				assert.strictEqual( xhr.getResponseHeader( "List-Header" ), "Item 1, Item 2", "List header received" );
+
+				if ( isAndroid ) {
+					// Support: Android 4.0-4.3 only
+					// Android Browser only returns the last value for each header
+					// so there's no way for jQuery get all parts.
+					assert.ok( true, "Android doesn't support repeated header names" );
+				} else {
+					assert.strictEqual( xhr.getResponseHeader( "List-Header" ), "Item 1, Item 2", "List header received" );
+				}
+
 				assert.strictEqual( xhr.getResponseHeader( "constructor" ), "prototype collision (constructor)", "constructor header received" );
 				assert.strictEqual( xhr.getResponseHeader( "__proto__" ), null, "Undefined __proto__ header not received" );
 			}


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Android Browser only returns the last value for each header so there's no way
for jQuery get all parts.

This commit skips the relevant assertion in Android Browser.

Ref gh-3403
Ref gh-4173

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
