### PR TITLE
Core: Support passing nonce through jQuery.globalEval

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -238,8 +238,8 @@ jQuery.extend( {
 	},
 
 	// Evaluates a script in a global context
-	globalEval: function( code ) {
-		DOMEval( code );
+	globalEval: function( code, options ) {
+		DOMEval( code, { nonce: options && options.nonce } );
 	},
 
 	each: function( obj, callback ) {

--- a/src/core/DOMEval.js
+++ b/src/core/DOMEval.js
@@ -10,26 +10,29 @@ define( [
 		noModule: true
 	};
 
-	function DOMEval( code, doc, node ) {
+	function DOMEval( code, node, doc ) {
 		doc = doc || document;
 
-		var i,
+		var i, val,
 			script = doc.createElement( "script" );
 
 		script.text = code;
 		if ( node ) {
 			for ( i in preservedScriptAttributes ) {
-				if ( node[ i ] ) {
-					script[ i ] = node[ i ];
-				} else if ( node.getAttribute( i ) ) {
 
-					// Support: Firefox 64+, Edge 18+
-					// Some browsers don't support the "nonce" property on scripts.
-					// On the other hand, just using `setAttribute` & `getAttribute`
-					// is not enough as `nonce` is no longer exposed as an attribute
-					// in the latest standard.
-					// See https://github.com/whatwg/html/issues/2369
-					script.setAttribute( i, node.getAttribute( i ) );
+				// Support: Firefox 64+, Edge 18+
+				// Some browsers don't support the "nonce" property on scripts.
+				// On the other hand, just using `getAttribute` is not enough as
+				// the `nonce` attribute is reset to an empty string whenever it
+				// becomes browsing-context connected.
+				// See https://github.com/whatwg/html/issues/2369
+				// See https://html.spec.whatwg.org/#nonce-attributes
+				// The `node.getAttribute` check was added for the sake of
+				// `jQuery.globalEval` so that it can fake a nonce-containing node
+				// via an object.
+				val = node[ i ] || node.getAttribute && node.getAttribute( i );
+				if ( val ) {
+					script.setAttribute( i, val );
 				}
 			}
 		}

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -202,7 +202,7 @@ function domManip( collection, args, callback, ignored ) {
 								jQuery._evalUrl( node.src );
 							}
 						} else {
-							DOMEval( node.textContent.replace( rcleanScript, "" ), doc, node );
+							DOMEval( node.textContent.replace( rcleanScript, "" ), node, doc );
 						}
 					}
 				}

--- a/test/data/csp-nonce-globaleval.html
+++ b/test/data/csp-nonce-globaleval.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+	<title>CSP nonce via jQuery.globalEval Test Page</title>
+	<script nonce="jquery+hardcoded+nonce" src="../jquery.js"></script>
+	<script nonce="jquery+hardcoded+nonce" src="iframeTest.js"></script>
+	<script nonce="jquery+hardcoded+nonce" src="csp-nonce-globaleval.js"></script>
+</head>
+<body>
+	<p>CSP nonce via jQuery.globalEval Test Page</p>
+</body>
+</html>

--- a/test/data/csp-nonce-globaleval.js
+++ b/test/data/csp-nonce-globaleval.js
@@ -1,0 +1,5 @@
+/* global startIframeTest */
+
+jQuery( function() {
+	$.globalEval( "startIframeTest()", { nonce: "jquery+hardcoded+nonce" } );
+} );

--- a/test/data/mock.php
+++ b/test/data/mock.php
@@ -201,9 +201,10 @@ ok( true, "mock executed");';
 	protected function cspNonce( $req ) {
 		// This is CSP only for browsers with "Content-Security-Policy" header support
 		// i.e. no old WebKit or old Firefox
+		$test = $req->query['test'] ? '-' . $req->query['test'] : '';
 		header( "Content-Security-Policy: script-src 'nonce-jquery+hardcoded+nonce'; report-uri ./mock.php?action=cspLog" );
 		header( 'Content-type: text/html' );
-		echo file_get_contents( __DIR__ . '/csp-nonce.html' );
+		echo file_get_contents( __DIR__ . '/csp-nonce' . $test . '.html' );
 	}
 
 	protected function cspLog( $req ) {

--- a/test/middleware-mockserver.js
+++ b/test/middleware-mockserver.js
@@ -208,11 +208,13 @@ var mocks = {
 		resp.end( body );
 	},
 	cspNonce: function( req, resp ) {
+		var testParam = req.query.test ? "-" + req.query.test : "";
 		resp.writeHead( 200, {
 			"Content-Type": "text/html",
 			"Content-Security-Policy": "script-src 'nonce-jquery+hardcoded+nonce'; report-uri /base/test/data/mock.php?action=cspLog"
 		} );
-		var body = fs.readFileSync( __dirname + "/data/csp-nonce.html" ).toString();
+		var body = fs.readFileSync(
+			__dirname + "/data/csp-nonce" + testParam + ".html" ).toString();
 		resp.end( body );
 	},
 	cspLog: function( req, resp ) {

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -2858,3 +2858,26 @@ testIframe(
 	// script-src restrictions completely.
 	QUnit[ /\bedge\/|iphone os [789]|android 4\./i.test( navigator.userAgent ) ? "skip" : "test" ]
 );
+
+testIframe(
+	"jQuery.globalEval supports nonce",
+	"mock.php?action=cspNonce&test=globaleval",
+	function( assert, jQuery, window, document ) {
+		var done = assert.async();
+
+		assert.expect( 1 );
+
+		supportjQuery.get( baseURL + "support/csp.log" ).done( function( data ) {
+			assert.equal( data, "", "No log request should be sent" );
+			supportjQuery.get( baseURL + "mock.php?action=cspClean" ).done( done );
+		} );
+	},
+
+	// Support: Edge 18+, iOS 7-9 only, Android 4.0-4.4 only
+	// Edge doesn't support nonce in non-inline scripts.
+	// See https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/13246371/
+	// Old iOS & Android Browser versions support script-src but not nonce, making this test
+	// impossible to run. Browsers not supporting CSP at all are not a problem as they'll skip
+	// script-src restrictions completely.
+	QUnit[ /\bedge\/|iphone os [789]|android 4\./i.test( navigator.userAgent ) ? "skip" : "test" ]
+);


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Support passing nonce through jQuery.globalEval:

```js
jQuery.globalEval( code, nonceValue );
```

Fixes gh-4278
Ref gh-3541
Ref gh-4269



### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

Docs issue: https://github.com/jquery/api.jquery.com/issues/1123

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
