### PR TITLE
Manipulation: Respect script nomodule attribute in DOM manipulation

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -198,7 +198,7 @@ function domManip( collection, args, callback, ignored ) {
 						if ( node.src && ( node.type || "" ).toLowerCase()  !== "module" ) {
 
 							// Optional AJAX dependency, but won't run scripts if not present
-							if ( jQuery._evalUrl ) {
+							if ( jQuery._evalUrl && !node.noModule ) {
 								jQuery._evalUrl( node.src );
 							}
 						} else {

--- a/test/data/inner_nomodule.js
+++ b/test/data/inner_nomodule.js
@@ -1,0 +1,1 @@
+window.ok( !QUnit.moduleTypeSupported, "evaluated: inner nomodule script with src" );

--- a/test/data/nomodule.js
+++ b/test/data/nomodule.js
@@ -1,0 +1,1 @@
+window.ok( !QUnit.moduleTypeSupported, "evaluated: nomodule script with src" );

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -1798,7 +1798,7 @@ QUnit.test( "html(Function)", function( assert ) {
 } );
 
 QUnit[
-	// Support: Edge 16-17
+	// Support: Edge 16-18+
 	// Edge sometimes doesn't execute module scripts so skip the test there.
 	( QUnit.moduleTypeSupported && !/edge\//i.test( navigator.userAgent ) ) ?
 		"test" :
@@ -1815,6 +1815,36 @@ QUnit[
 			"<div>",
 				"<script type='module'>ok( true, 'evaluated: inner module' );</script>",
 				"<script type='module' src='" + url( "inner_module.js" ) + "'></script>",
+			"</div>"
+		].join( "" )
+	);
+
+	// Allow asynchronous script execution to generate assertions
+	setTimeout( function() {
+		done();
+	}, 1000 );
+} );
+
+QUnit[
+	// Support: IE 9-11 only, Android 4.0-4.4 only, iOS 7-10 only
+	// `nomodule` scripts should be executed by legacy browsers only.
+	// iOS 10 supports `<script type="module">` but doesn't support the nomodule attribute
+	// so let's skip it here; sites supporting it must handle `nomodule` in a custom way anyway.
+	!/iphone os 10_/i.test( navigator.userAgent ) ?
+		"test" :
+		"skip"
+]( "html(script nomodule)", function( assert ) {
+	assert.expect( QUnit.moduleTypeSupported ? 0 : 4 );
+	var done = assert.async(),
+		$fixture = jQuery( "#qunit-fixture" );
+
+	$fixture.html(
+		[
+			"<script nomodule>ok( !QUnit.moduleTypeSupported, 'evaluated: nomodule script' );</script>",
+			"<script nomodule src='" + url( "nomodule.js" ) + "'></script>",
+			"<div>",
+				"<script nomodule>ok( !QUnit.moduleTypeSupported, 'evaluated: inner nomodule script' );</script>",
+				"<script nomodule src='" + url( "inner_nomodule.js" ) + "'></script>",
 			"</div>"
 		].join( "" )
 	);


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

PR #3869 added support for `<script type="module">` & some support for
the `nomodule` attribute but with no tests for `nomodule` and with the
attribute only respected on inline scripts. This commit adds support for
source-based scripts as well. It also adds tests for `nomodule`, including
making sure legacy browsers execute such scripts as they'd natively do - that's
the whole point of `nomodule` scripts, after all.

Fixes gh-4281
Ref gh-3871
Ref gh-3869

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~ - I don't think that's needed here.

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
