### PR TITLE
Build: Run Karma browser tests on Node.js 10 instead of 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
 matrix:
   include:
     # Run browser tests only on one Node.js version to save time.
-    - node_js: "8"
+    - node_js: "10"
       env: NPM_SCRIPT=test:browser
 script:
   - npm run $NPM_SCRIPT


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Node.js 10 has been in Active LTS since 2018-04-24 and Node.js 8 is now in
maintenance mode.

See https://github.com/nodejs/Release for more details.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
