### PR TITLE
Build: Make Promises/A+ tests use the dot reporter instead of the default

### DIFF
--- a/build/tasks/promises_aplus_tests.js
+++ b/build/tasks/promises_aplus_tests.js
@@ -1,9 +1,8 @@
-module.exports = function( grunt ) {
+"use strict";
 
-	"use strict";
-
-	var timeout = 2000,
-		spawnTest = require( "./lib/spawn_test.js" );
+module.exports = grunt => {
+	const timeout = 2000;
+	const spawnTest = require( "./lib/spawn_test.js" );
 
 	grunt.registerTask( "promises_aplus_tests",
 		[ "promises_aplus_tests:deferred", "promises_aplus_tests:when" ] );
@@ -12,6 +11,7 @@ module.exports = function( grunt ) {
 		spawnTest( this.async(),
 			"\"" + __dirname + "/../../node_modules/.bin/promises-aplus-tests\"" +
 				" test/promises_aplus_adapters/deferred.js" +
+				" --reporter dot" +
 				" --timeout " + timeout
 		);
 	} );
@@ -20,6 +20,7 @@ module.exports = function( grunt ) {
 		spawnTest( this.async(),
 			"\"" + __dirname + "/../../node_modules/.bin/promises-aplus-tests\"" +
 				" test/promises_aplus_adapters/when.js" +
+				" --reporter dot" +
 				" --timeout " + timeout
 		);
 	} );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The default reporter is very verbose as it prints all the test names it
encounters. We already use the dot reporter for Karma tests.

This PR makes the Promises/A+ tests also use the dot reporter.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
