### PR TITLE
fix selector dependency on init module

### DIFF
--- a/src/selector-native.js
+++ b/src/selector-native.js
@@ -1,5 +1,5 @@
 define( [
-	"./core",
+	"./core/init",
 	"./var/document",
 	"./var/documentElement",
 	"./var/hasOwn",

--- a/src/selector-sizzle.js
+++ b/src/selector-sizzle.js
@@ -1,5 +1,5 @@
 define( [
-	"./core",
+	"./core/init",
 	"../external/sizzle/dist/sizzle"
 ], function( jQuery, Sizzle ) {
 


### PR DESCRIPTION
### Summary ###
There is no way people would use the selector module without creating jquery elements.  
I end up importing `core/init` everywhere I import `selector`.  
I believe `selector` module should depend on `core/init` instead of just `core`.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure, leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
