### PR TITLE
Add comment regarding selector module and custom built

### DIFF
--- a/src/selector.js
+++ b/src/selector.js
@@ -1,3 +1,8 @@
+// You should not import this module directly in your custom built.
+// This module has a circular dependency on "./core/init"
+// Consider importing "./core/init" instead.
+// It depends on "./traversing/findFilter" which depends on this module.
+
 define( [ "./selector-sizzle" ], function() {
 	"use strict";
 } );


### PR DESCRIPTION
### Summary ###
The pull request adds a helpful comment, so people save their time by not importing `selector` module in their custom built.  
Related to: https://github.com/jquery/jquery/pull/4315

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
