### PR TITLE
Ajax: Create correct URLs for jQuery.ajax() with cache: false

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -19,7 +19,9 @@ define( [
 var
 	r20 = /%20/g,
 	rhash = /#.*$/,
-	rantiCache = /([?&])_=[^&]*/,
+	rantiCacheParam = /^([^?]*(?=\?)(.(.*(?=&)|)|).)_=\d*&?/,
+	rqueryParameterPrefix = /^([^?]*(?=\?)(.(.*(?=&).|)$|))/,
+
 	rheaders = /^(.*?):[ \t]*([^\r\n]*)$/mg,
 
 	// #7653, #8125, #8152: local protocol detection
@@ -609,8 +611,19 @@ jQuery.extend( {
 
 			// Add or update anti-cache param if needed
 			if ( s.cache === false ) {
-				cacheURL = cacheURL.replace( rantiCache, "$1" );
-				uncached = ( rquery.test( cacheURL ) ? "&" : "?" ) + "_=" + ( nonce++ ) + uncached;
+				cacheURL = cacheURL.replace( rantiCacheParam, "$1" );
+				uncached = ( "?&".replace(
+
+					// If there is a "?", remove all characters before the first one,
+					// and additionally remove the entire query if it is safe to append a naked "name=value".
+					// Then consider the first remaining character:
+					// * "?" for a nonempty query not terminated with "&" (parameter prefix needed: "&")
+					// * nonexistent for a terminated or empty query (parameter prefix needed: "")
+					// * a path character otherwise (parameter prefix needed: "?")
+
+					cacheURL.replace( rqueryParameterPrefix, "" )[ 0 ] || "?&",
+					""
+				)[ 0 ] || "" ) + "_=" + ( nonce++ ) + uncached;
 			}
 
 			// Put hash and anti-cache on the URL that will be requested (gh-1732)


### PR DESCRIPTION
Component: Ajax

Correctly creates the URL for calls to jQuery.ajax() when the "cache" option is set to false.
Based upon discussion on this pull request (it's been a while, so I restarted from scratch): https://github.com/jquery/jquery/pull/3902

Adds 43 characters to .min.js.gz, so I'll "soon-ish" prepare an alternate approach which does not cover all cases, but adds less code.

Fixes gh-3682.

### Summary ###
Correctly creates the URL for calls to jQuery.ajax() when the "cache" option is set to false. Fixes gh-3682.

### Checklist ###
* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com
