### PR TITLE
Core: Preserve CSP nonce on scripts with src attribute (#4323)

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -199,7 +199,9 @@ function domManip( collection, args, callback, ignored ) {
 
 							// Optional AJAX dependency, but won't run scripts if not present
 							if ( jQuery._evalUrl && !node.noModule ) {
-								jQuery._evalUrl( node.src );
+								jQuery._evalUrl( node.src, {
+									nonce: node.nonce || node.getAttribute( "nonce" )
+								} );
 							}
 						} else {
 							DOMEval( node.textContent.replace( rcleanScript, "" ), node, doc );

--- a/src/manipulation/_evalUrl.js
+++ b/src/manipulation/_evalUrl.js
@@ -4,7 +4,7 @@ define( [
 
 "use strict";
 
-jQuery._evalUrl = function( url ) {
+jQuery._evalUrl = function( url, options ) {
 	return jQuery.ajax( {
 		url: url,
 
@@ -22,7 +22,7 @@ jQuery._evalUrl = function( url ) {
 			"text script": function() {}
 		},
 		dataFilter: function( response ) {
-			jQuery.globalEval( response );
+			jQuery.globalEval( response, options );
 		}
 	} );
 };

--- a/test/data/csp-nonce-external.html
+++ b/test/data/csp-nonce-external.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+	<title>CSP nonce via jQuery.globalEval Test Page</title>
+	<script nonce="jquery+hardcoded+nonce" src="../jquery.js"></script>
+	<script nonce="jquery+hardcoded+nonce" src="iframeTest.js"></script>
+	<script nonce="jquery+hardcoded+nonce" src="csp-nonce-external.js"></script>
+</head>
+<body>
+	<p>CSP nonce for external script Test Page</p>
+</body>
+</html>

--- a/test/data/csp-nonce-external.js
+++ b/test/data/csp-nonce-external.js
@@ -1,0 +1,5 @@
+/* global startIframeTest */
+
+jQuery( function() {
+	$( "body" ).append( "<script nonce='jquery+hardcoded+nonce' src='csp-nonce.js'></script>" );
+} );

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -2895,6 +2895,29 @@ testIframe(
 );
 
 testIframe(
+    "Check if CSP nonce is preserved for external scripts with src attribute",
+    "mock.php?action=cspNonce&test=external",
+    function( assert, jQuery, window, document ) {
+        var done = assert.async();
+
+        assert.expect( 1 );
+
+        supportjQuery.get( baseURL + "support/csp.log" ).done( function( data ) {
+            assert.equal( data, "", "No log request should be sent" );
+            supportjQuery.get( baseURL + "mock.php?action=cspClean" ).done( done );
+        } );
+    },
+
+    // Support: Edge 18+, iOS 7-9 only, Android 4.0-4.4 only
+    // Edge doesn't support nonce in non-inline scripts.
+    // See https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/13246371/
+    // Old iOS & Android Browser versions support script-src but not nonce, making this test
+    // impossible to run. Browsers not supporting CSP at all are not a problem as they'll skip
+    // script-src restrictions completely.
+    QUnit[ /\bedge\/|iphone os [789]|android 4\./i.test( navigator.userAgent ) ? "skip" : "test" ]
+);
+
+testIframe(
 	"jQuery.globalEval supports nonce",
 	"mock.php?action=cspNonce&test=globaleval",
 	function( assert, jQuery, window, document ) {


### PR DESCRIPTION
### Summary ###
Fixes https://github.com/jquery/jquery/issues/4323


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
