### PR TITLE
Event: Cleanup leverageNative

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -469,7 +469,7 @@ jQuery.event = {
 				// Claim the first handler
 				// dataPriv.set( el, "focus", ... )
 				leverageNative( el, "focus", function( el ) {
-					return el !== safeActiveElement();
+					return el === safeActiveElement();
 				} );
 
 				// Return false to allow normal processing in the caller
@@ -502,7 +502,7 @@ jQuery.event = {
 				// Claim the first handler
 				// dataPriv.set( el, "blur", ... )
 				leverageNative( el, "blur", function( el ) {
-					return el === safeActiveElement();
+					return el !== safeActiveElement();
 				} );
 
 				// Return false to allow normal processing in the caller
@@ -538,7 +538,7 @@ jQuery.event = {
 					dataPriv.get( el, "click" ) === undefined ) {
 
 					// dataPriv.set( el, "click", ... )
-					leverageNative( el, "click", returnFalse );
+					leverageNative( el, "click", returnTrue );
 				}
 
 				// Return false to allow normal processing in the caller
@@ -590,10 +590,10 @@ jQuery.event = {
 // synthetic events by interrupting progress until reinvoked in response to
 // *native* events that it fires directly, ensuring that state changes have
 // already occurred before other listeners are invoked.
-function leverageNative( el, type, allowAsync ) {
+function leverageNative( el, type, expectSync ) {
 
-	// Missing allowAsync indicates a trigger call, which must force setup through jQuery.event.add
-	if ( !allowAsync ) {
+	// Missing expectSync indicates a trigger call, which must force setup through jQuery.event.add
+	if ( !expectSync ) {
 		jQuery.event.add( el, type, returnTrue );
 		return;
 	}
@@ -603,7 +603,7 @@ function leverageNative( el, type, allowAsync ) {
 	jQuery.event.add( el, type, {
 		namespace: false,
 		handler: function( event ) {
-			var maybeAsync, result,
+			var notAsync, result,
 				saved = dataPriv.get( this, type );
 
 			if ( ( event.isTrigger & 1 ) && this[ type ] ) {
@@ -618,10 +618,10 @@ function leverageNative( el, type, allowAsync ) {
 					// Trigger the native event and capture its result
 					// Support: IE <=9 - 11+
 					// focus() and blur() are asynchronous
-					maybeAsync = allowAsync( this, type );
+					notAsync = expectSync( this, type );
 					this[ type ]();
 					result = dataPriv.get( this, type );
-					if ( saved !== result || !maybeAsync ) {
+					if ( saved !== result || notAsync ) {
 						dataPriv.set( this, type, false );
 					} else {
 						result = undefined;

--- a/src/event.js
+++ b/src/event.js
@@ -605,21 +605,17 @@ function leverageNative( el, type, allowAsync ) {
 					maybeAsync = allowAsync( this, type );
 					this[ type ]();
 					result = dataPriv.get( this, type );
-					if ( result !== saved ) {
+					if ( saved !== result || !maybeAsync ) {
 						dataPriv.set( this, type, false );
+					} else {
+						result = undefined;
+					}
+					if ( saved !== result ) {
 
 						// Cancel the outer synthetic event
 						event.stopImmediatePropagation();
 						event.preventDefault();
 						return result;
-					} else if ( maybeAsync ) {
-
-						// Cancel the outer synthetic event in expectation of a followup
-						event.stopImmediatePropagation();
-						event.preventDefault();
-						return;
-					} else {
-						dataPriv.set( this, type, false );
 					}
 
 				// If this is an inner synthetic event for an event with a bubbling surrogate

--- a/src/event.js
+++ b/src/event.js
@@ -464,7 +464,7 @@ jQuery.event = {
 
 				// Claim the first handler
 				// dataPriv.set( this, "focus", ... )
-				leverageNative( this, "focus", false, function( el ) {
+				leverageNative( this, "focus", function( el ) {
 					return el !== safeActiveElement();
 				} );
 
@@ -474,7 +474,7 @@ jQuery.event = {
 			trigger: function() {
 
 				// Force setup before trigger
-				leverageNative( this, "focus", returnTrue );
+				leverageNative( this, "focus" );
 
 				// Return non-false to allow normal event-path propagation
 				return true;
@@ -489,7 +489,7 @@ jQuery.event = {
 
 				// Claim the first handler
 				// dataPriv.set( this, "blur", ... )
-				leverageNative( this, "blur", false, function( el ) {
+				leverageNative( this, "blur", function( el ) {
 					return el === safeActiveElement();
 				} );
 
@@ -499,7 +499,7 @@ jQuery.event = {
 			trigger: function() {
 
 				// Force setup before trigger
-				leverageNative( this, "blur", returnTrue );
+				leverageNative( this, "blur" );
 
 				// Return non-false to allow normal event-path propagation
 				return true;
@@ -522,7 +522,7 @@ jQuery.event = {
 					dataPriv.get( el, "click" ) === undefined ) {
 
 					// dataPriv.set( el, "click", ... )
-					leverageNative( el, "click", false, returnFalse );
+					leverageNative( el, "click", returnFalse );
 				}
 
 				// Return false to allow normal processing in the caller
@@ -539,7 +539,7 @@ jQuery.event = {
 					el.click && nodeName( el, "input" ) &&
 					dataPriv.get( el, "click" ) === undefined ) {
 
-					leverageNative( el, "click", returnTrue );
+					leverageNative( el, "click" );
 				}
 
 				// Return non-false to allow normal event-path propagation
@@ -574,16 +574,16 @@ jQuery.event = {
 // synthetic events by interrupting progress until reinvoked in response to
 // *native* events that it fires directly, ensuring that state changes have
 // already occurred before other listeners are invoked.
-function leverageNative( el, type, forceAdd, allowAsync ) {
+function leverageNative( el, type, allowAsync ) {
 
-	// Setup must go through jQuery.event.add
-	if ( forceAdd ) {
-		jQuery.event.add( el, type, forceAdd );
+	// Missing allowAsync indicates a trigger call, which must force setup through jQuery.event.add
+	if ( !allowAsync ) {
+		jQuery.event.add( el, type, returnTrue );
 		return;
 	}
 
 	// Register the controller as a special universal handler for all event namespaces
-	dataPriv.set( el, type, forceAdd );
+	dataPriv.set( el, type, false );
 	jQuery.event.add( el, type, {
 		namespace: false,
 		handler: function( event ) {

--- a/src/event.js
+++ b/src/event.js
@@ -29,15 +29,19 @@ function returnFalse() {
 	return false;
 }
 
-// Support: IE <=9 only
-// https://bugs.jquery.com/ticket/13393
+// Support: IE <=9 - 11+
+// focus() and blur() are asynchronous, except when they are no-op.
+// So expect focus to be synchronous when the element is already active,
+// and blur to be synchronous when the element is not already active.
+// (focus and blur are always synchronous in other supported browsers,
+// this just defines when we can count on it).
 function expectSync( elem, type ) {
-
-	// Expect focus to be synchronous when the element is already active,
-	// and blur to be synchronous when the element is not already active
-	// (even in IE)
 	return ( elem === safeActiveElement() ) === ( type === "focus" );
 }
+
+// Support: IE <=9 only
+// Accessing document.activeElement can throw unexpectedly
+// https://bugs.jquery.com/ticket/13393
 function safeActiveElement() {
 	try {
 		return document.activeElement;
@@ -578,10 +582,10 @@ function leverageNative( el, type, expectSync ) {
 				// If this is an inner synthetic event for an event with a bubbling surrogate
 				// (focus or blur), assume that the surrogate already propagated from triggering the
 				// native event and prevent that from happening again here.
-				// This technically gets the ordering wrong w.r.t. to `.trigger()`, but that seems
+				// This technically gets the ordering wrong w.r.t. to `.trigger()` (in which the
+				// bubbling surrogate propagates *after* the non-bubbling base), but that seems
 				// less bad than duplication.
 				} else if ( ( jQuery.event.special[ type ] || {} ).delegateType ) {
-
 					event.stopPropagation();
 				}
 

--- a/src/event.js
+++ b/src/event.js
@@ -457,72 +457,6 @@ jQuery.event = {
 			// Prevent triggered image.load events from bubbling to window.load
 			noBubble: true
 		},
-		focus: {
-
-			// Utilize native event if possible so blur/focus sequence is correct
-			setup: function( data ) {
-
-				// For mutual compressibility with click, replace `this` access with a local var.
-				// `|| data` is dead code meant only to preserve the variable through minification.
-				var el = this || data;
-
-				// Claim the first handler
-				// dataPriv.set( el, "focus", ... )
-				leverageNative( el, "focus", function( el ) {
-					return el === safeActiveElement();
-				} );
-
-				// Return false to allow normal processing in the caller
-				return false;
-			},
-			trigger: function( data ) {
-
-				// For mutual compressibility with click, replace `this` access with a local var.
-				// `|| data` is dead code meant only to preserve the variable through minification.
-				var el = this || data;
-
-				// Force setup before trigger
-				leverageNative( el, "focus" );
-
-				// Return non-false to allow normal event-path propagation
-				return true;
-			},
-
-			delegateType: "focusin"
-		},
-		blur: {
-
-			// Utilize native event if possible so blur/focus sequence is correct
-			setup: function( data ) {
-
-				// For mutual compressibility with click, replace `this` access with a local var.
-				// `|| data` is dead code meant only to preserve the variable through minification.
-				var el = this || data;
-
-				// Claim the first handler
-				// dataPriv.set( el, "blur", ... )
-				leverageNative( el, "blur", function( el ) {
-					return el !== safeActiveElement();
-				} );
-
-				// Return false to allow normal processing in the caller
-				return false;
-			},
-			trigger: function( data ) {
-
-				// For mutual compressibility with click, replace `this` access with a local var.
-				// `|| data` is dead code meant only to preserve the variable through minification.
-				var el = this || data;
-
-				// Force setup before trigger
-				leverageNative( el, "blur" );
-
-				// Return non-false to allow normal event-path propagation
-				return true;
-			},
-
-			delegateType: "focusout"
-		},
 		click: {
 
 			// Utilize native event to ensure correct state for checkable inputs
@@ -823,6 +757,43 @@ jQuery.each( {
 		return event.which;
 	}
 }, jQuery.event.addProp );
+
+jQuery.each( { focus: "focusin", blur: "focusout" }, function( type, delegateType ) {
+	jQuery.event.special[ type ] = {
+
+		// Utilize native event if possible so blur/focus sequence is correct
+		setup: function( data ) {
+
+			// For mutual compressibility with click, replace `this` access with a local var.
+			// `|| data` is dead code meant only to preserve the variable through minification.
+			var el = this || data;
+
+			// Claim the first handler
+			// dataPriv.set( el, "focus", ... )
+			// dataPriv.set( el, "blur", ... )
+			leverageNative( el, type, function( el ) {
+				return ( el === safeActiveElement() ) === ( type === "focus" );
+			} );
+
+			// Return false to allow normal processing in the caller
+			return false;
+		},
+		trigger: function( data ) {
+
+			// For mutual compressibility with click, replace `this` access with a local var.
+			// `|| data` is dead code meant only to preserve the variable through minification.
+			var el = this || data;
+
+			// Force setup before trigger
+			leverageNative( el, type );
+
+			// Return non-false to allow normal event-path propagation
+			return true;
+		},
+
+		delegateType: delegateType
+	};
+} );
 
 // Create mouseenter/leave events using mouseover/out and event-time checks
 // so that event delegation works in jQuery.

--- a/src/event.js
+++ b/src/event.js
@@ -762,30 +762,22 @@ jQuery.each( { focus: "focusin", blur: "focusout" }, function( type, delegateTyp
 	jQuery.event.special[ type ] = {
 
 		// Utilize native event if possible so blur/focus sequence is correct
-		setup: function( data ) {
-
-			// For mutual compressibility with click, replace `this` access with a local var.
-			// `|| data` is dead code meant only to preserve the variable through minification.
-			var el = this || data;
+		setup: function() {
 
 			// Claim the first handler
-			// dataPriv.set( el, "focus", ... )
-			// dataPriv.set( el, "blur", ... )
-			leverageNative( el, type, function( el ) {
+			// dataPriv.set( this, "focus", ... )
+			// dataPriv.set( this, "blur", ... )
+			leverageNative( this, type, function( el ) {
 				return ( el === safeActiveElement() ) === ( type === "focus" );
 			} );
 
 			// Return false to allow normal processing in the caller
 			return false;
 		},
-		trigger: function( data ) {
-
-			// For mutual compressibility with click, replace `this` access with a local var.
-			// `|| data` is dead code meant only to preserve the variable through minification.
-			var el = this || data;
+		trigger: function() {
 
 			// Force setup before trigger
-			leverageNative( el, type );
+			leverageNative( this, type );
 
 			// Return non-false to allow normal event-path propagation
 			return true;

--- a/src/event.js
+++ b/src/event.js
@@ -460,21 +460,29 @@ jQuery.event = {
 		focus: {
 
 			// Utilize native event if possible so blur/focus sequence is correct
-			setup: function() {
+			setup: function( data ) {
+
+				// For mutual compressibility with click, replace `this` access with a local var.
+				// `|| data` is dead code meant only to preserve the variable through minification.
+				var el = this || data;
 
 				// Claim the first handler
-				// dataPriv.set( this, "focus", ... )
-				leverageNative( this, "focus", function( el ) {
+				// dataPriv.set( el, "focus", ... )
+				leverageNative( el, "focus", function( el ) {
 					return el !== safeActiveElement();
 				} );
 
 				// Return false to allow normal processing in the caller
 				return false;
 			},
-			trigger: function() {
+			trigger: function( data ) {
+
+				// For mutual compressibility with click, replace `this` access with a local var.
+				// `|| data` is dead code meant only to preserve the variable through minification.
+				var el = this || data;
 
 				// Force setup before trigger
-				leverageNative( this, "focus" );
+				leverageNative( el, "focus" );
 
 				// Return non-false to allow normal event-path propagation
 				return true;
@@ -485,21 +493,29 @@ jQuery.event = {
 		blur: {
 
 			// Utilize native event if possible so blur/focus sequence is correct
-			setup: function() {
+			setup: function( data ) {
+
+				// For mutual compressibility with click, replace `this` access with a local var.
+				// `|| data` is dead code meant only to preserve the variable through minification.
+				var el = this || data;
 
 				// Claim the first handler
-				// dataPriv.set( this, "blur", ... )
-				leverageNative( this, "blur", function( el ) {
+				// dataPriv.set( el, "blur", ... )
+				leverageNative( el, "blur", function( el ) {
 					return el === safeActiveElement();
 				} );
 
 				// Return false to allow normal processing in the caller
 				return false;
 			},
-			trigger: function() {
+			trigger: function( data ) {
+
+				// For mutual compressibility with click, replace `this` access with a local var.
+				// `|| data` is dead code meant only to preserve the variable through minification.
+				var el = this || data;
 
 				// Force setup before trigger
-				leverageNative( this, "blur" );
+				leverageNative( el, "blur" );
 
 				// Return non-false to allow normal event-path propagation
 				return true;

--- a/src/event.js
+++ b/src/event.js
@@ -30,7 +30,14 @@ function returnFalse() {
 }
 
 // Support: IE <=9 only
-// See #13393 for more info
+// https://bugs.jquery.com/ticket/13393
+function expectSync( elem, type ) {
+
+	// Expect focus to be synchronous when the element is already active,
+	// and blur to be synchronous when the element is not already active
+	// (even in IE)
+	return ( elem === safeActiveElement() ) === ( type === "focus" );
+}
 function safeActiveElement() {
 	try {
 		return document.activeElement;
@@ -767,9 +774,7 @@ jQuery.each( { focus: "focusin", blur: "focusout" }, function( type, delegateTyp
 			// Claim the first handler
 			// dataPriv.set( this, "focus", ... )
 			// dataPriv.set( this, "blur", ... )
-			leverageNative( this, type, function( el ) {
-				return ( el === safeActiveElement() ) === ( type === "focus" );
-			} );
+			leverageNative( this, type, expectSync );
 
 			// Return false to allow normal processing in the caller
 			return false;

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -2956,11 +2956,7 @@ QUnit.test( "Check order of focusin/focusout events", function( assert ) {
 		.on( "focus", function() {
 			focus = true;
 		} )
-
-		// PR gh-4279 fixed a lot of `focus`-related issues but made `focusin` fire twice.
-		// We've decided to accept this drawback for now. If it's fixed, change `one` to `on`
-		// in the following line:
-		.one( "focusin", function() {
+		.on( "focusin", function() {
 			assert.ok( !focus, "Focusin event should fire before focus does" );
 			focus = true;
 		} )


### PR DESCRIPTION
One commit to restore the test, one to fix it, and the rest to reduce size.

### Summary ###
Ref 669f720edc4f557dfef986db747c09ebfaa16ef5
* Restore the no-duplication logic in focusin/focusout testing
* Reduce size

```
   raw     gz Sizes
279073  82883 dist/jquery.js
 88068  30594 dist/jquery.min.js

   raw     gz Compared to master @ 669f720edc4f557dfef986db747c09ebfaa16ef5
   +89   +209 dist/jquery.js
  -113    -28 dist/jquery.min.js
```

### Checklist ###
* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~