### PR TITLE
Event: Fix handling of multiple async focus events

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -556,7 +556,7 @@ function leverageNative( el, type, expectSync ) {
 				// Interrupt processing of the outer synthetic .trigger()ed event
 				// Saved data should be false in such cases, but might be a leftover capture object
 				// from an async native handler (gh-4350)
-				if ( !( saved.length >= 0 ) ) {
+				if ( !saved.length ) {
 
 					// Store arguments for use when handling the inner native event
 					saved = slice.call( arguments );
@@ -593,15 +593,15 @@ function leverageNative( el, type, expectSync ) {
 
 			// If this is a native event triggered above, everything is now in order
 			// Fire an inner synthetic event with the original arguments
-			} else if ( saved.length >= 0 ) {
+			} else if ( saved.length ) {
 
 				// ...and capture the result
 				dataPriv.set( this, type, { value: jQuery.event.trigger(
 
 					// Support: IE <=9 - 11+
 					// Extend with the prototype to reset the above stopImmediatePropagation()
-					jQuery.extend( saved.shift(), jQuery.Event.prototype ),
-					saved,
+					jQuery.extend( saved[ 0 ], jQuery.Event.prototype ),
+					saved.slice( 1 ),
 					this
 				) } );
 

--- a/src/event.js
+++ b/src/event.js
@@ -559,6 +559,8 @@ function leverageNative( el, type, expectSync ) {
 				if ( !saved.length ) {
 
 					// Store arguments for use when handling the inner native event
+					// There will always be at least one argument (an event object), so this array
+					// will not be confused with a leftover capture object.
 					saved = slice.call( arguments );
 					dataPriv.set( this, type, saved );
 
@@ -596,14 +598,16 @@ function leverageNative( el, type, expectSync ) {
 			} else if ( saved.length ) {
 
 				// ...and capture the result
-				dataPriv.set( this, type, { value: jQuery.event.trigger(
+				dataPriv.set( this, type, {
+					value: jQuery.event.trigger(
 
-					// Support: IE <=9 - 11+
-					// Extend with the prototype to reset the above stopImmediatePropagation()
-					jQuery.extend( saved[ 0 ], jQuery.Event.prototype ),
-					saved.slice( 1 ),
-					this
-				) } );
+						// Support: IE <=9 - 11+
+						// Extend with the prototype to reset the above stopImmediatePropagation()
+						jQuery.extend( saved[ 0 ], jQuery.Event.prototype ),
+						saved.slice( 1 ),
+						this
+					)
+				} );
 
 				// Abort handling of the native event
 				event.stopImmediatePropagation();

--- a/src/event.js
+++ b/src/event.js
@@ -554,7 +554,9 @@ function leverageNative( el, type, expectSync ) {
 			if ( ( event.isTrigger & 1 ) && this[ type ] ) {
 
 				// Interrupt processing of the outer synthetic .trigger()ed event
-				if ( !saved ) {
+				// Saved data should be false in such cases, but might be a leftover capture object
+				// from an async native handler (gh-4350)
+				if ( !( saved.length >= 0 ) ) {
 
 					// Store arguments for use when handling the inner native event
 					saved = slice.call( arguments );
@@ -569,14 +571,14 @@ function leverageNative( el, type, expectSync ) {
 					if ( saved !== result || notAsync ) {
 						dataPriv.set( this, type, false );
 					} else {
-						result = undefined;
+						result = {};
 					}
 					if ( saved !== result ) {
 
 						// Cancel the outer synthetic event
 						event.stopImmediatePropagation();
 						event.preventDefault();
-						return result;
+						return result.value;
 					}
 
 				// If this is an inner synthetic event for an event with a bubbling surrogate
@@ -591,17 +593,17 @@ function leverageNative( el, type, expectSync ) {
 
 			// If this is a native event triggered above, everything is now in order
 			// Fire an inner synthetic event with the original arguments
-			} else if ( saved ) {
+			} else if ( saved.length >= 0 ) {
 
 				// ...and capture the result
-				dataPriv.set( this, type, jQuery.event.trigger(
+				dataPriv.set( this, type, { value: jQuery.event.trigger(
 
 					// Support: IE <=9 - 11+
 					// Extend with the prototype to reset the above stopImmediatePropagation()
 					jQuery.extend( saved.shift(), jQuery.Event.prototype ),
 					saved,
 					this
-				) );
+				) } );
 
 				// Abort handling of the native event
 				event.stopImmediatePropagation();

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -3073,7 +3073,7 @@ QUnit.test( "Event handling works with multiple async focus events (gh-4350)", f
 
 	// DOM focus is unreliable in TestSwarm
 	setTimeout( function() {
-		if ( remaining === 3 ) {
+		if ( QUnit.isSwarm && remaining === 3 ) {
 			assert.ok( true, "GAP: Could not observe focus change" );
 			assert.ok( true, "GAP: Could not observe focus change" );
 			assert.ok( true, "GAP: Could not observe focus change" );

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -3041,6 +3041,49 @@ QUnit.test( "focus-blur order (#12868)", function( assert ) {
 	}, 50 );
 } );
 
+QUnit.test( "Event handling works with multiple async focus events (gh-4350)", function( assert ) {
+	assert.expect( 3 );
+
+	var remaining = 3,
+		input = jQuery( "#name" ),
+
+		// Support: IE <=9 - 11+
+		// focus and blur events are asynchronous; this is the resulting mess.
+		// The browser window must be topmost for this to work properly!!
+		done = assert.async();
+
+	input
+		.on( "focus", function() {
+			remaining--;
+			assert.ok( true, "received focus event, expecting " + remaining + " more" );
+			if ( remaining > 0 ) {
+				input.trigger( "blur" );
+			} else {
+				done();
+			}
+		} )
+		.on( "blur", function() {
+			setTimeout( function() {
+				input.trigger( "focus" );
+			} );
+		} );
+
+	// gain focus
+	input.trigger( "focus" );
+
+	// DOM focus is unreliable in TestSwarm
+	setTimeout( function() {
+		if ( remaining === 3 ) {
+			assert.ok( true, "GAP: Could not observe focus change" );
+			assert.ok( true, "GAP: Could not observe focus change" );
+			assert.ok( true, "GAP: Could not observe focus change" );
+			setTimeout( function() {
+				done();
+			} );
+		}
+	} );
+} );
+
 QUnit.test( "native-backed events preserve trigger data (gh-1741, gh-4139)", function( assert ) {
 	assert.expect( 17 );
 


### PR DESCRIPTION
### Summary ###
Prevent leftover saved data from async focus/blur from overriding outermost trigger handling.

Fixes gh-4350

### Checklist ###
* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~