### PR TITLE
Core: Make isAttached work with iOS 10.0-10.2

### DIFF
--- a/src/core/isAttached.js
+++ b/src/core/isAttached.js
@@ -10,8 +10,12 @@ define( [
 		},
 		composed = { composed: true };
 
+	// Support: IE 9 - 11+, Edge 12 - 18+, iOS 10.0 - 10.2 only
 	// Check attachment across shadow DOM boundaries when possible (gh-3504)
-	if ( documentElement.attachShadow ) {
+	// Support: iOS 10.0-10.2 only
+	// Early iOS 10 versions support `attachShadow` but not `getRootNode`,
+	// leading to errors. We need to check for `getRootNode`.
+	if ( documentElement.getRootNode ) {
 		isAttached = function( elem ) {
 			return jQuery.contains( elem.ownerDocument, elem ) ||
 				elem.getRootNode( composed ) === elem.ownerDocument;

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -641,7 +641,11 @@ QUnit.test( "show/hide detached nodes", function( assert ) {
 	span.remove();
 } );
 
-QUnit[ document.body.attachShadow ? "test" : "skip" ]( "show/hide shadow child nodes", function( assert ) {
+QUnit[
+	document.body.attachShadow && document.body.getRootNode ?
+		"test" :
+		"skip"
+	]( "show/hide shadow child nodes", function( assert ) {
 	assert.expect( 28 );
 	jQuery( "<div id='shadowHost'></div>" ).appendTo( "#qunit-fixture" );
 	var shadowHost = document.querySelector( "#shadowHost" );
@@ -1023,7 +1027,11 @@ QUnit[ jQuery.find.compile && jQuery.fn.toggle ? "test" : "skip" ]( "detached to
 		"cascade-hidden element in detached tree" );
 } );
 
-QUnit[ jQuery.find.compile && jQuery.fn.toggle && document.body.attachShadow ? "test" : "skip" ]( "shadow toggle()", function( assert ) {
+QUnit[ jQuery.find.compile && jQuery.fn.toggle &&
+	document.body.attachShadow && document.body.getRootNode ?
+		"test" :
+		"skip"
+]( "shadow toggle()", function( assert ) {
 	assert.expect( 4 );
 	jQuery( "<div id='shadowHost'></div>" ).appendTo( "#qunit-fixture" );
 	var shadowHost = document.querySelector( "#shadowHost" );

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -221,8 +221,11 @@ supportjQuery.each( hideOptions, function( type, setup ) {
 		assert.expectJqData( this, $span, "olddisplay" );
 	} );
 
-	QUnit[ document.body.attachShadow ? "test" : "skip" ](
-		"Persist correct display value - " + type + " hidden, shadow child", function( assert ) {
+	QUnit[
+		document.body.attachShadow && document.body.getRootNode ?
+			"test" :
+			"skip"
+		]( "Persist correct display value - " + type + " hidden, shadow child", function( assert ) {
 		assert.expect( 3 );
 
 		jQuery( "<div id='shadowHost'></div>" ).appendTo( "#qunit-fixture" );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The test for Shadow DOM v1 support has been changed to rely on the presence of
`documentElement.getRootNode` as iOS 10.0-10.2 supports `attachShadow` but
doesn't support `getRootNode`.

No new test is necessary - iOS 10.0 fails lots of our test suite because of
this bug.

Fixes gh-4356

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
