### PR TITLE
Build: Fix unresolved jQuery reference in finalPropName

### DIFF
--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -3,7 +3,12 @@
 
 	"extends": "../.eslintrc-browser.json",
 
-	"globals": {
-		"jQuery": true
-	}
+	"overrides": [
+		{
+			"files": "wrapper.js",
+			"globals": {
+				"jQuery": false
+			}
+		}
+	]
 }

--- a/src/css/finalPropName.js
+++ b/src/css/finalPropName.js
@@ -1,4 +1,7 @@
-define( [ "../var/document" ], function( document ) {
+define( [
+	"../var/document",
+	"../core"
+], function( document, jQuery ) {
 
 "use strict";
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Also, prevent further similar breakages by changing our ESLint configuration
to disallow relying on a global jQuery object in AMD modules.

Fixes gh-4358

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works (@mgol: the "test" here is the ESLint config change)
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
