### PR TITLE
Effect: Fix a unnecessary conditional statement in .stop()

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -542,7 +542,7 @@ jQuery.fn.extend( {
 			clearQueue = type;
 			type = undefined;
 		}
-		if ( clearQueue && type !== false ) {
+		if ( clearQueue ) {
 			this.queue( type || "fx", [] );
 		}
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Because of the above conditional, the 'type' variable has a value of type 'string' or undefined.
Therefore, boolean comparisons for 'type' variable is always unnecessary because it return true.
The patch removed the unnecessary conditional statement.

Fixes https://github.com/jquery/jquery/issues/4372


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [X] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [X] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
