### PR TITLE
Build: Fix AMD dependencies in curCSS

### DIFF
--- a/src/css/curCSS.js
+++ b/src/css/curCSS.js
@@ -2,7 +2,7 @@ define( [
 	"../core",
 	"../core/isAttached",
 	"./var/getStyles"
-], function( jQuery, isAttached, rboxStyle, getStyles ) {
+], function( jQuery, isAttached, getStyles ) {
 
 "use strict";
 

--- a/src/css/var/rboxStyle.js
+++ b/src/css/var/rboxStyle.js
@@ -1,7 +1,0 @@
-define( [
-	"./cssExpand"
-], function( cssExpand ) {
-	"use strict";
-
-	return new RegExp( cssExpand.join( "|" ), "i" );
-} );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

A leftover `rboxStyle` was left in the wrapper parameters but not in the
dependency array, causing `getStyles` to be undefined in AMD mode.

Since `rboxStyle` is no longer used, it's now removed.

Ref gh-4347

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
