### PR TITLE
Build: ESLint: forbid unused function parameters

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -372,7 +372,7 @@ module.exports = function( grunt ) {
 
 		// Ask for permission the first time
 		if ( insight.optOut === undefined ) {
-			insight.askPermission( null, function( error, result ) {
+			insight.askPermission( null, function( _error, result ) {
 				exec( result );
 			} );
 		} else {

--- a/dist/.eslintrc.json
+++ b/dist/.eslintrc.json
@@ -7,9 +7,10 @@
 		// That is okay for the built version
 		"no-multiple-empty-lines": "off",
 
-		// Because sizzle is not compatible to jquery code style
+		// Sizzle is not compatible with jQuery code style
 		"no-nested-ternary": "off",
 		"no-unused-expressions": "off",
+		"no-unused-vars": "off",
 		"lines-around-comment": "off",
 		"space-in-parens": "off",
 		"camelcase": "off",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@babel/plugin-transform-for-of": "7.4.3",
     "commitplease": "3.2.0",
     "core-js-bundle": "3.0.0",
-    "eslint-config-jquery": "1.0.1",
+    "eslint-config-jquery": "2.0.0",
     "grunt": "1.0.4",
     "grunt-babel": "8.0.0",
     "grunt-cli": "1.3.2",

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -838,7 +838,7 @@ jQuery.extend( {
 	}
 } );
 
-jQuery.each( [ "get", "post" ], function( i, method ) {
+jQuery.each( [ "get", "post" ], function( _i, method ) {
 	jQuery[ method ] = function( url, data, callback, type ) {
 
 		// Shift arguments if data argument was omitted

--- a/src/attributes/attr.js
+++ b/src/attributes/attr.js
@@ -119,7 +119,7 @@ boolHook = {
 	}
 };
 
-jQuery.each( jQuery.expr.match.bool.source.match( /\w+/g ), function( i, name ) {
+jQuery.each( jQuery.expr.match.bool.source.match( /\w+/g ), function( _i, name ) {
 	var getter = attrHandle[ name ] || jQuery.find.attr;
 
 	attrHandle[ name ] = function( elem, name, isXML ) {

--- a/src/core.js
+++ b/src/core.js
@@ -4,7 +4,6 @@
 
 define( [
 	"./var/arr",
-	"./var/document",
 	"./var/getProto",
 	"./var/slice",
 	"./var/concat",
@@ -20,7 +19,7 @@ define( [
 	"./var/isWindow",
 	"./core/DOMEval",
 	"./core/toType"
-], function( arr, document, getProto, slice, concat, push, indexOf,
+], function( arr, getProto, slice, concat, push, indexOf,
 	class2type, toString, hasOwn, fnToString, ObjectFunctionString,
 	trim, support, isWindow, DOMEval, toType ) {
 
@@ -365,7 +364,7 @@ if ( typeof Symbol === "function" ) {
 
 // Populate the class2type map
 jQuery.each( "Boolean Number String Function Array Date RegExp Object Error Symbol".split( " " ),
-function( i, name ) {
+function( _i, name ) {
 	class2type[ "[object " + name + "]" ] = name.toLowerCase();
 } );
 

--- a/src/core/access.js
+++ b/src/core/access.js
@@ -37,7 +37,7 @@ var access = function( elems, fn, key, value, chainable, emptyGet, raw ) {
 			// ...except when executing function values
 			} else {
 				bulk = fn;
-				fn = function( elem, key, value ) {
+				fn = function( elem, _key, value ) {
 					return bulk.call( jQuery( elem ), value );
 				};
 			}

--- a/src/core/camelCase.js
+++ b/src/core/camelCase.js
@@ -6,7 +6,7 @@ define( [], function() {
 var rdashAlpha = /-([a-z])/g;
 
 // Used by camelCase as callback to replace()
-function fcamelCase( all, letter ) {
+function fcamelCase( _all, letter ) {
 	return letter.toUpperCase();
 }
 

--- a/src/css.js
+++ b/src/css.js
@@ -34,7 +34,7 @@ var
 		fontWeight: "400"
 	};
 
-function setPositiveNumber( elem, value, subtract ) {
+function setPositiveNumber( _elem, value, subtract ) {
 
 	// Any relative (+/-) values have already been
 	// normalized at this point
@@ -311,7 +311,7 @@ jQuery.extend( {
 	}
 } );
 
-jQuery.each( [ "height", "width" ], function( i, dimension ) {
+jQuery.each( [ "height", "width" ], function( _i, dimension ) {
 	jQuery.cssHooks[ dimension ] = {
 		get: function( elem, computed, extra ) {
 			if ( computed ) {

--- a/src/css/var/swap.js
+++ b/src/css/var/swap.js
@@ -3,7 +3,7 @@ define( function() {
 "use strict";
 
 // A method for quickly swapping in/out CSS properties to get correct calculations.
-return function( elem, options, callback, args ) {
+return function( elem, options, callback ) {
 	var ret, name,
 		old = {};
 
@@ -13,7 +13,7 @@ return function( elem, options, callback, args ) {
 		elem.style[ name ] = options[ name ];
 	}
 
-	ret = callback.apply( elem, args || [] );
+	ret = callback.call( elem );
 
 	// Revert the old values
 	for ( name in options ) {

--- a/src/deferred.js
+++ b/src/deferred.js
@@ -75,7 +75,7 @@ jQuery.extend( {
 					var fns = arguments;
 
 					return jQuery.Deferred( function( newDefer ) {
-						jQuery.each( tuples, function( i, tuple ) {
+						jQuery.each( tuples, function( _i, tuple ) {
 
 							// Map tuples (progress, done, fail) to arguments (done, fail, progress)
 							var fn = typeof fns[ tuple[ 4 ] ] === "function" &&

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -1,13 +1,9 @@
 define( [
 	"./core",
-	"./core/nodeName",
-	"./core/toType",
-	"./css/cssCamelCase",
-	"./var/isWindow",
 	"./var/slice",
 
 	"./event/alias"
-], function( jQuery, nodeName, toType, cssCamelCase, isWindow, slice ) {
+], function( jQuery, slice ) {
 
 "use strict";
 

--- a/src/effects.js
+++ b/src/effects.js
@@ -5,7 +5,6 @@ define( [
 	"./var/rnothtmlwhite",
 	"./css/var/cssExpand",
 	"./css/var/isHiddenWithinTree",
-	"./css/var/swap",
 	"./css/adjustCSS",
 	"./css/cssCamelCase",
 	"./data/var/dataPriv",
@@ -19,7 +18,7 @@ define( [
 	"./css",
 	"./effects/Tween"
 ], function( jQuery, document, rcssNum, rnothtmlwhite, cssExpand,
-	isHiddenWithinTree, swap, adjustCSS, cssCamelCase, dataPriv, showHide ) {
+	isHiddenWithinTree, adjustCSS, cssCamelCase, dataPriv, showHide ) {
 
 "use strict";
 
@@ -621,7 +620,7 @@ jQuery.fn.extend( {
 	}
 } );
 
-jQuery.each( [ "toggle", "show", "hide" ], function( i, name ) {
+jQuery.each( [ "toggle", "show", "hide" ], function( _i, name ) {
 	var cssFn = jQuery.fn[ name ];
 	jQuery.fn[ name ] = function( speed, easing, callback ) {
 		return speed == null || typeof speed === "boolean" ?

--- a/src/event/ajax.js
+++ b/src/event/ajax.js
@@ -13,7 +13,7 @@ jQuery.each( [
 	"ajaxError",
 	"ajaxSuccess",
 	"ajaxSend"
-], function( i, type ) {
+], function( _i, type ) {
 	jQuery.fn[ type ] = function( fn ) {
 		return this.on( type, fn );
 	};

--- a/src/event/alias.js
+++ b/src/event/alias.js
@@ -10,7 +10,7 @@ define( [
 jQuery.each( ( "blur focus focusin focusout resize scroll click dblclick " +
 	"mousedown mouseup mousemove mouseover mouseout mouseenter mouseleave " +
 	"change select submit keydown keypress keyup contextmenu" ).split( " " ),
-	function( i, name ) {
+	function( _i, name ) {
 
 	// Handle event binding
 	jQuery.fn[ name ] = function( data, fn ) {

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -4,7 +4,6 @@ define( [
 	"./var/concat",
 	"./var/isIE",
 	"./var/push",
-	"./var/rcheckableType",
 	"./core/access",
 	"./manipulation/var/rtagName",
 	"./manipulation/var/rscriptType",
@@ -23,9 +22,8 @@ define( [
 	"./traversing",
 	"./selector",
 	"./event"
-], function( jQuery, isAttached, concat, isIE, push,
-	rcheckableType, access, rtagName, rscriptType,
-	wrapMap, getAll, setGlobalEval, buildFragment,
+], function( jQuery, isAttached, concat, isIE, push, access, rtagName,
+	rscriptType, wrapMap, getAll, setGlobalEval, buildFragment,
 	dataPriv, dataUser, acceptData, DOMEval, nodeName ) {
 
 "use strict";

--- a/src/offset.js
+++ b/src/offset.js
@@ -1,15 +1,12 @@
 define( [
 	"./core",
 	"./core/access",
-	"./var/document",
 	"./var/documentElement",
-	"./css/var/rnumnonpx",
-	"./css/curCSS",
 	"./var/isWindow",
 	"./core/init",
 	"./css",
 	"./selector" // contains
-], function( jQuery, access, document, documentElement, rnumnonpx, curCSS, isWindow ) {
+], function( jQuery, access, documentElement, isWindow ) {
 
 "use strict";
 

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -113,7 +113,7 @@ jQuery.fn.extend( {
 				rsubmittable.test( this.nodeName ) && !rsubmitterTypes.test( type ) &&
 				( this.checked || !rcheckableType.test( type ) );
 		} )
-		.map( function( i, elem ) {
+		.map( function( _i, elem ) {
 			var val = jQuery( this ).val();
 
 			if ( val == null ) {

--- a/src/traversing.js
+++ b/src/traversing.js
@@ -118,7 +118,7 @@ jQuery.each( {
 	parents: function( elem ) {
 		return dir( elem, "parentNode" );
 	},
-	parentsUntil: function( elem, i, until ) {
+	parentsUntil: function( elem, _i, until ) {
 		return dir( elem, "parentNode", until );
 	},
 	next: function( elem ) {
@@ -133,10 +133,10 @@ jQuery.each( {
 	prevAll: function( elem ) {
 		return dir( elem, "previousSibling" );
 	},
-	nextUntil: function( elem, i, until ) {
+	nextUntil: function( elem, _i, until ) {
 		return dir( elem, "nextSibling", until );
 	},
-	prevUntil: function( elem, i, until ) {
+	prevUntil: function( elem, _i, until ) {
 		return dir( elem, "previousSibling", until );
 	},
 	siblings: function( elem ) {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

This commit requires all function parameters to be used, not just the last one.
In cases where that's not possible as we need to match an external API, there's
an escape hatch of prefixing an unused argument with `_`.

This change makes it easier to catch unused AMD dependencies and unused
parameters in internal functions the API of which we may change at will, among
other things.

Unused AMD dependencies have been removed as part of this commit.

What do you think? If you agree this change is worthwhile, should we add that rule to `eslint-config-jquery`?

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
