### PR TITLE
Fix retrieving children of `<object>` using `contents()`

### DIFF
--- a/src/traversing.js
+++ b/src/traversing.js
@@ -145,7 +145,7 @@ jQuery.each( {
 		return siblings( elem.firstChild );
 	},
 	contents: function( elem ) {
-		if ( typeof elem.contentDocument !== "undefined" ) {
+		if ( elem.contentDocument != null ) {
 			return elem.contentDocument;
 		}
 

--- a/test/unit/traversing.js
+++ b/test/unit/traversing.js
@@ -808,6 +808,19 @@ QUnit.test( "contents() for <object />", function( assert ) {
 	jQuery( "#qunit-fixture" ).append( svgObject );
 } );
 
+QUnit.test( "contents() for <object /> with children", function( assert ) {
+	assert.expect( 1 );
+
+	var object = "<object type='application/x-shockwave-flash' width='200' height='300' id='penguin'>" +
+		"<param name='movie' value='flash/penguin.swf'>" +
+		"<param name='quality' value='high'>" +
+		"<img src='images/penguin.jpg' width='200' height='300' alt='Penguin'>" +
+	"</object>";
+
+	var contents = jQuery( object ).contents();
+	assert.equal( contents.length, 3, "Check object contents children are correct" );
+} );
+
 QUnit.test( "contents() for <frame />", function( assert ) {
 	assert.expect( 2 );
 


### PR DESCRIPTION
Fix for https://github.com/jquery/jquery/issues/4384

### Summary ###
Since https://github.com/jquery/jquery/commit/0ba8e38d0c4ab4a4fb9054e7a713630be9743aff, using `contents()` to get the children of an `<object>` is not working.

Taking this example HTML

```html
<object type="application/x-shockwave-flash" width="200" height="300" id="penguin">
    <param name="movie" value="flash/penguin.swf">
    <param name="quality" value="high">
    <img src="images/penguin.jpg" width="200" height="300" alt="Penguin">
</object>
```

I'd expect the following to happen

```js
jQuery(objectHtml).contents().length // => 3
```

But what actually happens is:

```js
jQuery(objectHtml).contents().length // => 0
```

Changing the conditional to `elem.contentDocument != null` handles this case and the function returns the correct children.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

