### PR TITLE
Rename variable name from "final" to "_final"

### DIFF
--- a/src/css/finalPropName.js
+++ b/src/css/finalPropName.js
@@ -25,10 +25,10 @@ function vendorPropName( name ) {
 
 // Return a potentially-mapped vendor prefixed property
 function finalPropName( name ) {
-	var final = vendorProps[ name ];
+	var _final = vendorProps[ name ];
 
-	if ( final ) {
-		return final;
+	if ( _final ) {
+		return _final;
 	}
 	if ( name in emptyStyle ) {
 		return name;


### PR DESCRIPTION
"final" is a reserved word, some tool doesn't support it as identifier.
closure-compiler report "ERROR - Parse error. identifier is a reserved word".

### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
