### PR TITLE
Build: Fix the regex parsing AMD var-modules

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -65,7 +65,7 @@ module.exports = function( grunt ) {
 		if ( /.\/var\//.test( path.replace( process.cwd(), "" ) ) ) {
 			contents = contents
 				.replace(
-					/define\([\w\W]*?return/,
+					/define\(\s*(["'])[\w\W]*?\1[\w\W]*?return/,
 					"var " +
 					( /var\/([\w-]+)/.exec( name )[ 1 ] ) +
 					" ="


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Fix the regex parsing AMD var-modules.

The previous regex caused the final jQuery binary to have syntax errors for
var-modules with names starting with "return". For example, the following module
wouldn't work when the file is named `returnTrue.js`:

```js
define( function() {
	"use strict";
	return function returnTrue() {
		return true;
	};
} );
```


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~ N/A
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~ N/A

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
