### PR TITLE
Traversing: Fix `contents()` on `<object>`s with children in IE

### DIFF
--- a/src/traversing.js
+++ b/src/traversing.js
@@ -1,5 +1,6 @@
 define( [
 	"./core",
+	"./var/getProto",
 	"./var/indexOf",
 	"./traversing/var/dir",
 	"./traversing/var/siblings",
@@ -9,7 +10,7 @@ define( [
 	"./core/init",
 	"./traversing/findFilter",
 	"./selector"
-], function( jQuery, indexOf, dir, siblings, rneedsContext, nodeName ) {
+], function( jQuery, getProto, indexOf, dir, siblings, rneedsContext, nodeName ) {
 
 "use strict";
 
@@ -145,7 +146,13 @@ jQuery.each( {
 		return siblings( elem.firstChild );
 	},
 	contents: function( elem ) {
-		if ( elem.contentDocument != null ) {
+		if ( elem.contentDocument != null &&
+
+			// Support: IE 11+
+			// <object> elements with no `data` attribute has an object
+			// `contentDocument` with a `null` prototype.
+			getProto( elem.contentDocument ) ) {
+
 			return elem.contentDocument;
 		}
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The original fix didn't account for the fact that in IE `<object>` elements
with no `data` attribute have an object `contentDocument`. The fix leverages
the fact that this special object has a null prototype.

Ref gh-4384
Ref gh-4385

+9 bytes. I tested it in IE this time.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~ Existing tests were failing before this PR.
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
