### PR TITLE
You cannot send a request when AJAX passes in a Json object

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -564,6 +564,11 @@ jQuery.extend( {
 				s.crossDomain = true;
 			}
 		}
+	
+		//You cannot send a request when AJAX passes in a Json object
+		if(typeof(s.data) == "object" && Object.prototype.toString.call(s.data).toLowerCase() == "[object object]" && !s.data.length){
+			s.data = JSON.stringify(s.data);
+		}
 
 		// Convert data if not already a string
 		if ( s.data && s.processData && typeof s.data !== "string" ) {


### PR DESCRIPTION
### Summary ###
<!--
You cannot send a request when AJAX passes in a Json object
-->


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
