### PR TITLE
Selector: Leverage the :scope pseudo-class where possible

### DIFF
--- a/src/selector.js
+++ b/src/selector.js
@@ -154,7 +154,7 @@ function selectorError( msg ) {
 }
 
 function find( selector, context, results, seed ) {
-	var m, i, elem, nid, match, groups, newSelector, canUseScope,
+	var m, i, elem, nid, match, groups, newSelector,
 		newContext = context && context.ownerDocument,
 
 		// nodeType defaults to 9, since context defaults to document
@@ -237,10 +237,9 @@ function find( selector, context, results, seed ) {
 
 					// We can use :scope instead of the ID hack if the browser
 					// supports it & if we're not changing the context.
-					canUseScope = newContext === context && support.scope;
+					if ( newContext !== context || !support.scope ) {
 
-					// Capture the context ID, setting it first if necessary
-					if ( !canUseScope ) {
+						// Capture the context ID, setting it first if necessary
 						if ( ( nid = context.getAttribute( "id" ) ) ) {
 							nid = jQuery.escapeSelector( nid );
 						} else {
@@ -252,7 +251,7 @@ function find( selector, context, results, seed ) {
 					groups = tokenize( selector );
 					i = groups.length;
 					while ( i-- ) {
-						groups[ i ] = ( canUseScope || "#" + nid ) + " " +
+						groups[ i ] = ( nid ? "#" + nid : ":scope" ) + " " +
 							toSelector( groups[ i ] );
 					}
 					newSelector = groups.join( "," );

--- a/src/selector/support.js
+++ b/src/selector/support.js
@@ -1,0 +1,17 @@
+define( [
+	"../var/document",
+	"../var/support"
+], function( document, support ) {
+
+	"use strict";
+
+	// Support: IE 9 - 11+, Edge 12 - 18+
+	// IE/Edge don't support the :scope pseudo-class.
+	try {
+		document.querySelectorAll( ":scope" );
+		support.scope = ":scope";
+	} catch ( e ) {}
+
+	return support;
+
+} );

--- a/src/selector/support.js
+++ b/src/selector/support.js
@@ -3,15 +3,15 @@ define( [
 	"../var/support"
 ], function( document, support ) {
 
-	"use strict";
+"use strict";
 
-	// Support: IE 9 - 11+, Edge 12 - 18+
-	// IE/Edge don't support the :scope pseudo-class.
-	try {
-		document.querySelectorAll( ":scope" );
-		support.scope = true;
-	} catch ( e ) {}
+// Support: IE 9 - 11+, Edge 12 - 18+
+// IE/Edge don't support the :scope pseudo-class.
+try {
+	document.querySelectorAll( ":scope" );
+	support.scope = true;
+} catch ( e ) {}
 
-	return support;
+return support;
 
 } );

--- a/src/selector/support.js
+++ b/src/selector/support.js
@@ -9,7 +9,7 @@ define( [
 	// IE/Edge don't support the :scope pseudo-class.
 	try {
 		document.querySelectorAll( ":scope" );
-		support.scope = ":scope";
+		support.scope = true;
 	} catch ( e ) {}
 
 	return support;

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -1631,6 +1631,41 @@ QUnit.test( "context", function( assert ) {
 	}
 } );
 
+// Support: IE 11+, Edge 12 - 18+
+// IE/Edge don't support the :scope pseudo-class so they will trigger MutationObservers.
+// The test is skipped there.
+QUnit[
+	( QUnit.isIE || /edge\//i.test( navigator.userAgent ) ) ?
+		"skip" :
+		"test"
+	]( "selectors maintaining context don't trigger mutation observers", function( assert ) {
+	assert.expect( 1 );
+
+	var timeout,
+		done = assert.async(),
+		container = jQuery( "<div/>" ),
+		child = jQuery( "<div/>" );
+
+	child.appendTo( container );
+	container.appendTo( "#qunit-fixture" );
+
+	var observer = new MutationObserver(  function() {
+		clearTimeout( timeout );
+		observer.disconnect();
+		assert.ok( false, "Mutation observer fired during selection" );
+		done();
+	} );
+	observer.observe( container[ 0 ], { attributes: true } );
+
+	container.find( "div div" );
+
+	timeout = setTimeout( function() {
+		observer.disconnect();
+		assert.ok( true, "Mutation observer didn't fire during selection" );
+		done();
+	} );
+} );
+
 QUnit.test( "caching does not introduce bugs", function( assert ) {
 	assert.expect( 3 );
 

--- a/test/unit/support.js
+++ b/test/unit/support.js
@@ -65,16 +65,16 @@ testIframe(
 				scope: undefined
 			},
 			chrome: {
-				scope: ":scope"
+				scope: true
 			},
 			safari: {
-				scope: ":scope"
+				scope: true
 			},
 			firefox: {
-				scope: ":scope"
+				scope: true
 			},
 			ios: {
-				scope: ":scope"
+				scope: true
 			}
 		};
 

--- a/test/unit/support.js
+++ b/test/unit/support.js
@@ -58,12 +58,24 @@ testIframe(
 	var expected,
 		userAgent = window.navigator.userAgent,
 		expectedMap = {
-			edge: {},
-			ie_11: {},
-			chrome: {},
-			safari: {},
-			firefox: {},
-			ios: {}
+			edge: {
+				scope: undefined
+			},
+			ie_11: {
+				scope: undefined
+			},
+			chrome: {
+				scope: ":scope"
+			},
+			safari: {
+				scope: ":scope"
+			},
+			firefox: {
+				scope: ":scope"
+			},
+			ios: {
+				scope: ":scope"
+			}
 		};
 
 	if ( /edge\//i.test( userAgent ) ) {
@@ -95,6 +107,15 @@ testIframe(
 			j++;
 		}
 
+		// Add an assertion per undefined support prop as it may
+		// not even exist on computedSupport but we still want to run
+		// the check.
+		for ( prop in expected ) {
+			if ( expected[ prop ] === undefined ) {
+				j++;
+			}
+		}
+
 		assert.expect( j );
 
 		for ( i in expected ) {
@@ -116,6 +137,15 @@ testIframe(
 			i++;
 		}
 
+		// Add an assertion per undefined support prop as it may
+		// not even exist on computedSupport but we still want to run
+		// the check.
+		for ( prop in expected ) {
+			if ( expected[ prop ] === undefined ) {
+				i++;
+			}
+		}
+
 		assert.expect( i );
 
 		// Record all support props and the failing ones and ensure every test
@@ -123,7 +153,7 @@ testIframe(
 		for ( browserKey in expectedMap ) {
 			for ( supportTestName in expectedMap[ browserKey ] ) {
 				supportProps[ supportTestName ] = true;
-				if ( expectedMap[ browserKey ][ supportTestName ] !== true ) {
+				if ( !expectedMap[ browserKey ][ supportTestName ] ) {
 					failingSupportProps[ supportTestName ] = true;
 				}
 			}


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The [`:scope` pseudo-class][1] has surprisingly good browser support: Chrome,
Firefox & Safari have supported if for a long time; only IE & Edge lack support.
This commit leverages this pseudo-class to get rid of the ID hack in most cases.
Adding a temporary ID may cause layout thrashing which was reported a few times
in [the past.

We can't completely eliminate the ID hack in modern browses as sibling selectors
require us to change context to the parent and then `:scope` stops applying to
what we'd like. But it'd still improve performance in the vast majority of
cases.

[1]: https://developer.mozilla.org/en-US/docs/Web/CSS/:scope

Fixes gh-4453
Ref gh-4332
Ref jquery/sizzle#405

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
