### PR TITLE
Tests: Fix a comment in testinit.js

### DIFF
--- a/test/data/testinit.js
+++ b/test/data/testinit.js
@@ -283,7 +283,6 @@ QUnit.basicTests = ( QUnit.urlParams.module + "" ) === "basic";
 // Says whether jQuery positional selector extensions are supported.
 // A full selector engine is required to support them as they need to be evaluated
 // left-to-right. Remove that property when support for positional selectors is dropped.
-// if your custom jQuery versions relies more on native qSA.
 QUnit.jQuerySelectorsPos = true;
 
 // Says whether jQuery selector extensions are supported. Change that to `false`


### PR DESCRIPTION
#1435 # Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

A copied comment line was accidentally left out above the line defining
`QUnit.jQuerySelectorsPos`, making the sentence nonsense. This commit removes
that line.

If there are more small fixes like that needed in various test files, we could wait with this PR to land them all in one batch.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
