### PR TITLE
Core: Deprecate jQuery.trim

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -14,14 +14,13 @@ define( [
 	"./var/hasOwn",
 	"./var/fnToString",
 	"./var/ObjectFunctionString",
-	"./var/trim",
 	"./var/support",
 	"./var/isWindow",
 	"./core/DOMEval",
 	"./core/toType"
 ], function( arr, getProto, slice, concat, push, indexOf,
 	class2type, toString, hasOwn, fnToString, ObjectFunctionString,
-	trim, support, isWindow, DOMEval, toType ) {
+	support, isWindow, DOMEval, toType ) {
 
 "use strict";
 
@@ -298,9 +297,6 @@ jQuery.extend( {
 		return ret;
 	},
 
-	trim: function( text ) {
-		return text == null ? "" : trim.call( text );
-	},
 
 	// results is for internal usage only
 	makeArray: function( arr, results ) {

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -1,9 +1,9 @@
 define( [
 	"./core",
 	"./var/slice",
-
+	"./var/trim",
 	"./event/alias"
-], function( jQuery, slice ) {
+], function( jQuery, trim, slice ) {
 
 "use strict";
 
@@ -65,5 +65,9 @@ jQuery.holdReady = function( hold ) {
 	} else {
 		jQuery.ready( true );
 	}
+};
+
+jQuery.trim = function( text ) {
+	return text == null ? "" : trim.call( text );
 };
 } );

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -70,4 +70,5 @@ jQuery.holdReady = function( hold ) {
 jQuery.trim = function( text ) {
 	return text == null ? "" : trim.call( text );
 };
+
 } );

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -70,5 +70,4 @@ jQuery.holdReady = function( hold ) {
 jQuery.trim = function( text ) {
 	return text == null ? "" : trim.call( text );
 };
-
 } );

--- a/test/unit/basic.js
+++ b/test/unit/basic.js
@@ -76,7 +76,7 @@ QUnit.test( "show/hide", function( assert ) {
 }
 
 QUnit.test( "core", function( assert ) {
-	assert.expect( 18 );
+	assert.expect( 17 );
 
 	var elem = jQuery( "<div></div><span></span>" );
 

--- a/test/unit/basic.js
+++ b/test/unit/basic.js
@@ -81,7 +81,6 @@ QUnit.test( "core", function( assert ) {
 	var elem = jQuery( "<div></div><span></span>" );
 
 	assert.strictEqual( elem.length, 2, "Correct number of elements" );
-	assert.strictEqual( jQuery.trim( "  hello   " ), "hello", "jQuery.trim" );
 
 	assert.ok( jQuery.isPlainObject( { "a": 2 } ), "jQuery.isPlainObject(object)" );
 	assert.ok( !jQuery.isPlainObject( "foo" ), "jQuery.isPlainObject(String)" );

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -216,28 +216,6 @@ QUnit.test( "noConflict", function( assert ) {
 	window[ "jQuery" ] = jQuery = $$;
 } );
 
-QUnit.test( "trim", function( assert ) {
-	assert.expect( 13 );
-
-	var nbsp = String.fromCharCode( 160 );
-
-	assert.equal( jQuery.trim( "hello  " ), "hello", "trailing space" );
-	assert.equal( jQuery.trim( "  hello" ), "hello", "leading space" );
-	assert.equal( jQuery.trim( "  hello   " ), "hello", "space on both sides" );
-	assert.equal( jQuery.trim( "  " + nbsp + "hello  " + nbsp + " " ), "hello", "&nbsp;" );
-
-	assert.equal( jQuery.trim(), "", "Nothing in." );
-	assert.equal( jQuery.trim( undefined ), "", "Undefined" );
-	assert.equal( jQuery.trim( null ), "", "Null" );
-	assert.equal( jQuery.trim( 5 ), "5", "Number" );
-	assert.equal( jQuery.trim( false ), "false", "Boolean" );
-
-	assert.equal( jQuery.trim( " " ), "", "space should be trimmed" );
-	assert.equal( jQuery.trim( "ipad\xA0" ), "ipad", "nbsp should be trimmed" );
-	assert.equal( jQuery.trim( "\uFEFF" ), "", "zwsp should be trimmed" );
-	assert.equal( jQuery.trim( "\uFEFF \xA0! | \uFEFF" ), "! |", "leading/trailing should be trimmed" );
-} );
-
 QUnit.test( "isPlainObject", function( assert ) {
 	var done = assert.async();
 

--- a/test/unit/deprecated.js
+++ b/test/unit/deprecated.js
@@ -160,3 +160,25 @@ QUnit.test( "jQuery.proxy", function( assert ) {
 	cb = jQuery.proxy( fn, null, "arg1", "arg2" );
 	cb.call( thisObject, "arg3" );
 } );
+
+QUnit.test( "trim", function( assert ) {
+	assert.expect( 13 );
+
+	var nbsp = String.fromCharCode( 160 );
+
+	assert.equal( jQuery.trim( "hello  " ), "hello", "trailing space" );
+	assert.equal( jQuery.trim( "  hello" ), "hello", "leading space" );
+	assert.equal( jQuery.trim( "  hello   " ), "hello", "space on both sides" );
+	assert.equal( jQuery.trim( "  " + nbsp + "hello  " + nbsp + " " ), "hello", "&nbsp;" );
+
+	assert.equal( jQuery.trim(), "", "Nothing in." );
+	assert.equal( jQuery.trim( undefined ), "", "Undefined" );
+	assert.equal( jQuery.trim( null ), "", "Null" );
+	assert.equal( jQuery.trim( 5 ), "5", "Number" );
+	assert.equal( jQuery.trim( false ), "false", "Boolean" );
+
+	assert.equal( jQuery.trim( " " ), "", "space should be trimmed" );
+	assert.equal( jQuery.trim( "ipad\xA0" ), "ipad", "nbsp should be trimmed" );
+	assert.equal( jQuery.trim( "\uFEFF" ), "", "zwsp should be trimmed" );
+	assert.equal( jQuery.trim( "\uFEFF \xA0! | \uFEFF" ), "! |", "leading/trailing should be trimmed" );
+} );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Component: Core
 
- Moved `jQuery.trim()` from the `core.js` file into the `deprecated.js` file
- Moved corresponding unit test from `test/unit/core.js` to `test/unit/deprecated.js`
 
Fixes #4363

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
