### PR TITLE
Ajax: Simplify jQuery.ajaxSettings.xhr

### DIFF
--- a/src/ajax/xhr.js
+++ b/src/ajax/xhr.js
@@ -6,9 +6,7 @@ define( [
 "use strict";
 
 jQuery.ajaxSettings.xhr = function() {
-	try {
-		return new window.XMLHttpRequest();
-	} catch ( e ) {}
+	return new window.XMLHttpRequest();
 };
 
 var xhrSuccessStatus = {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Previously, jQuery.ajaxSettings.xhr, contents were wrapped in a try-catch
as we defined jQuery.support.ajax & jQuery.support.cors executed during the
jQuery load and we didn't want to crash if IE had native XHR disabled (which
is possible). While jQuery hasn't supported the ActiveX-based XHR since 2.0,
jQuery with XHR disabled could still be used for its other features in such
a crippled browser.

Since gh-4347, jQuery.support.ajax & jQuery.support.cors no longer exist, so
we don't need the try-catch anymore.

Fixes gh-1967
Ref gh-4347

-8 bytes

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
