### PR TITLE
Tests: fix karma debug tasks, no jQuery global is available

### DIFF
--- a/test/data/testrunner.js
+++ b/test/data/testrunner.js
@@ -4,12 +4,16 @@
 
 // Store the old counts so that we only assert on tests that have actually leaked,
 // instead of asserting every time a test has leaked sometime in the past
-var oldCacheLength = 0,
+var ajaxSettings,
+	oldCacheLength = 0,
 	oldActive = 0,
 
 	expectedDataKeys = {},
-	splice = [].splice,
+	splice = [].splice;
+
+if ( window.jQuery ) {
 	ajaxSettings = jQuery.ajaxSettings;
+}
 
 /**
  * QUnit configuration


### PR DESCRIPTION
### Summary ###

In the process of testing another PR, I noticed that the debug tasks (not `karma:main`) were all broken because testrunner expected a jQuery global, which is removed with `noConflict` in testinit. I'm not sure how `karma:main` was even working unless another jQuery somehow leaked into the globals there.

### Checklist ###

* [x] Grunt build and unit tests pass locally with these changes
