### PR TITLE
Core: Remove private copies of push, sort & splice from the jQuery prototype

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -108,13 +108,7 @@ jQuery.fn = jQuery.prototype = {
 
 	end: function() {
 		return this.prevObject || this.constructor();
-	},
-
-	// For internal use only.
-	// Behaves like an Array's method, not like a jQuery method.
-	push: push,
-	sort: arr.sort,
-	splice: arr.splice
+	}
 };
 
 jQuery.extend = jQuery.fn.extend = function() {

--- a/src/selector.js
+++ b/src/selector.js
@@ -190,7 +190,7 @@ function find( selector, context, results, seed ) {
 					// Document context
 					if ( nodeType === 9 ) {
 						if ( ( elem = context.getElementById( m ) ) ) {
-							results.push( elem );
+							push.call( results, elem );
 						}
 						return results;
 
@@ -199,7 +199,7 @@ function find( selector, context, results, seed ) {
 						if ( newContext && ( elem = newContext.getElementById( m ) ) &&
 							jQuery.contains( context, elem ) ) {
 
-							results.push( elem );
+							push.call( results, elem );
 							return results;
 						}
 					}
@@ -1426,7 +1426,7 @@ function matcherFromGroupMatchers( elementMatchers, setMatchers ) {
 					}
 					while ( ( matcher = elementMatchers[ j++ ] ) ) {
 						if ( matcher( elem, context || document, xml ) ) {
-							results.push( elem );
+							push.call( results, elem );
 							break;
 						}
 					}

--- a/src/selector/uniqueSort.js
+++ b/src/selector/uniqueSort.js
@@ -1,7 +1,8 @@
 define( [
 	"../core",
-	"../var/document"
-], function( jQuery, document ) {
+	"../var/document",
+	"../var/sort"
+], function( jQuery, document, sort ) {
 
 "use strict";
 
@@ -61,7 +62,7 @@ jQuery.uniqueSort = function( results ) {
 
 	hasDuplicate = false;
 
-	results.sort( sortOrder );
+	sort.call( results, sortOrder );
 
 	if ( hasDuplicate ) {
 		while ( ( elem = results[ i++ ] ) ) {

--- a/src/var/sort.js
+++ b/src/var/sort.js
@@ -1,0 +1,7 @@
+define( [
+	"./arr"
+], function( arr ) {
+	"use strict";
+
+	return arr.sort;
+} );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Remove private copies of push, sort & splice from the jQuery prototype. Saves 13 bytes.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
