### PR TITLE
Fixed IE bug: SCRIPT438: Object doesn't support property or method 'getRootNode'

### DIFF
--- a/src/core/isAttached.js
+++ b/src/core/isAttached.js
@@ -15,7 +15,7 @@ define( [
 	if ( documentElement.getRootNode ) {
 		isAttached = function( elem ) {
 			return jQuery.contains( elem.ownerDocument, elem ) ||
-				elem.getRootNode( composed ) === elem.ownerDocument;
+				(elem.getRootNode && elem.getRootNode( composed ) === elem.ownerDocument);
 		};
 	}
 

--- a/src/core/isAttached.js
+++ b/src/core/isAttached.js
@@ -15,7 +15,7 @@ define( [
 	if ( documentElement.getRootNode ) {
 		isAttached = function( elem ) {
 			return jQuery.contains( elem.ownerDocument, elem ) ||
-				(elem.getRootNode && elem.getRootNode( composed ) === elem.ownerDocument);
+				( elem.getRootNode && elem.getRootNode( composed ) === elem.ownerDocument );
 		};
 	}
 


### PR DESCRIPTION
### Summary ###
This PR fixes a bug which I have in Internet Explorer 11.678.17763.0 / 11.0.140. (and in general some Internet Explorers)

The browser is set to IE 11 mode. (via F12 developer tools)
And even via meta tag: `<meta http-equiv="X-UA-Compatible" content="IE=edge"/>`

The console says:
```
SCRIPT438: Object doesn't support property or method 'getRootNode'
app.js (4992,4)
```

![image](https://user-images.githubusercontent.com/15617021/64069852-4bf1cb00-cc53-11e9-9468-a22668318d54.png)

After fixing this issue I not getting this error anymore and everything works fine.

When I put a `console.log(elem.getRootNode)` there I can see a lot of `function(a){return a&&a.composed?d(this):b(this)}`.
Then there is an `undefined` and then the error message is appearing.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com