### PR TITLE
Offset: Send px-ed strings to .css()

### DIFF
--- a/src/offset.js
+++ b/src/offset.js
@@ -64,6 +64,12 @@ jQuery.offset = {
 			options.using.call( elem, props );
 
 		} else {
+			if ( typeof props.top === "number" ) {
+				props.top += "px";
+			}
+			if ( typeof props.left === "number" ) {
+				props.left += "px";
+			}
 			curElem.css( props );
 		}
 	}


### PR DESCRIPTION
An upcoming release of Migrate will generate warnings for calls to `.css()` that pass numbers rather than strings, see https://github.com/jquery/jquery-migrate/issues/296 . At the moment, core's `.offset()` setter passes numbers rather than `px` strings so it would throw warnings.

This is the dumbest possible implementation I could think of (and `+18`)  but there are several concerns I have with trying to optimize this code. First, there is an undocumented `using` option that is used by jQuery UI. Second, it's possible for options other than `top` and `left` to be passed through to `.css()` even though that's also undocumented; I don't know if anyone does that.

For the purposes of removing this warning for 3.x I want to just fix it so that Migrate can avoid spurious warnings, and not cause any other problems. For 4.x we could try something fancier.