### PR TITLE
Core: Implement .even() & .odd() to replace POS :even & :odd

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -100,6 +100,18 @@ jQuery.fn = jQuery.prototype = {
 		return this.eq( -1 );
 	},
 
+	even: function() {
+		return this.filter( function( i ) {
+			return ( i + 1 ) % 2;
+		} );
+	},
+
+	odd: function() {
+		return this.filter( function( i ) {
+			return i % 2;
+		} );
+	},
+
 	eq: function( i ) {
 		var len = this.length,
 			j = +i + ( i < 0 ? len : 0 );

--- a/src/core.js
+++ b/src/core.js
@@ -101,15 +101,15 @@ jQuery.fn = jQuery.prototype = {
 	},
 
 	even: function() {
-		return this.filter( function( i ) {
+		return this.pushStack( jQuery.grep( this, function( _elem, i ) {
 			return ( i + 1 ) % 2;
-		} );
+		} ) );
 	},
 
 	odd: function() {
-		return this.filter( function( i ) {
+		return this.pushStack( jQuery.grep( this, function( _elem, i ) {
 			return i % 2;
-		} );
+		} ) );
 	},
 
 	eq: function( i ) {

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -648,6 +648,18 @@ QUnit.test( "first()/last()", function( assert ) {
 	assert.deepEqual( $none.last().get(), [], "last() none" );
 } );
 
+QUnit.test( "even()/odd()", function( assert ) {
+	assert.expect( 4 );
+
+	var $links = jQuery( "#ap a" ), $none = jQuery( "asdf" );
+
+	assert.deepEqual( $links.even().get(), q( "google", "anchor1" ), "even()" );
+	assert.deepEqual( $links.odd().get(), q( "groups", "mark" ), "odd()" );
+
+	assert.deepEqual( $none.even().get(), [], "even() none" );
+	assert.deepEqual( $none.odd().get(), [], "odd() none" );
+} );
+
 QUnit.test( "map()", function( assert ) {
 	assert.expect( 2 );
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Implement .even() & .odd() to replace POS :even & :odd. The current version adds 28 bytes; it'd be slightly smaller (+25 bytes) to rely on `.filter()` but that'd make `core` depend on `traversing/findFilter`.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
