### PR TITLE
Tests: Make support tests accept Safari 13 & newer

### DIFF
--- a/test/unit/support.js
+++ b/test/unit/support.js
@@ -292,22 +292,22 @@ testIframe(
 		// Catches Chrome on Android as well (i.e. the default
 		// Android browser on Android >= 4.4).
 		expected = expectedMap.chrome;
-	} else if ( /\b(?:11|12)\.\d(\.\d+)* safari/i.test( userAgent ) ) {
-		expected = expectedMap.safari;
-	} else if ( /\b(?:9|10)\.\d(\.\d+)* safari/i.test( userAgent ) ) {
+	} else if ( /\b(?:9|10)\.\d+(\.\d+)* safari/i.test( userAgent ) ) {
 		expected = expectedMap.safari_9_10;
+	} else if ( /\b\d+(\.\d+)+ safari/i.test( userAgent ) ) {
+		expected = expectedMap.safari;
 	} else if ( /firefox\/(?:52|60)/i.test( userAgent ) ) {
 		expected = expectedMap.firefox_60;
 	} else if ( /firefox/i.test( userAgent ) ) {
 		expected = expectedMap.firefox;
-	} else if ( /(?:iphone|ipad);.*(?:iphone)? os (?:11|12)_/i.test( userAgent ) ) {
-		expected = expectedMap.ios;
 	} else if ( /iphone os (?:9|10)_/i.test( userAgent ) ) {
 		expected = expectedMap.ios_9_10;
 	} else if ( /iphone os 8_/i.test( userAgent ) ) {
 		expected = expectedMap.ios_8;
 	} else if ( /iphone os 7_/i.test( userAgent ) ) {
 		expected = expectedMap.ios_7;
+	} else if ( /(?:iphone|ipad);.*(?:iphone)? os \d+_/i.test( userAgent ) ) {
+		expected = expectedMap.ios;
 	} else if ( /android 4\.[0-3]/i.test( userAgent ) ) {
 		expected = expectedMap.android;
 	}


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The regexes detecting browsers with their versions have been updated for iOS
and Safari so that all iOS >=11 & all Safari (desktop) >= 11 are recognized.
This is required to make Safari 13 & iOS 13 pass support tests but it'll also
make tests forward-compatible with future Safari/iOS versions.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
