### PR TITLE
Build: Require strict mode in Node.js scripts via ESLint

### DIFF
--- a/.eslintrc-node.json
+++ b/.eslintrc-node.json
@@ -10,5 +10,9 @@
 	"env": {
 		"es6": true,
 		"node": true
+	},
+
+	"rules": {
+		"strict": ["error", "global"]
 	}
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,6 @@
-module.exports = function( grunt ) {
-	"use strict";
+"use strict";
 
+module.exports = function( grunt ) {
 	function readOptionalJSON( filepath ) {
 		var stripJSONComments = require( "strip-json-comments" ),
 			data = {};

--- a/build/release.js
+++ b/build/release.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var fs = require( "fs" );
 
 module.exports = function( Release ) {

--- a/build/release/cdn.js
+++ b/build/release/cdn.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var
 	fs = require( "fs" ),
 	shell = require( "shelljs" ),

--- a/build/release/dist.js
+++ b/build/release/dist.js
@@ -1,3 +1,5 @@
+"use strict";
+
 module.exports = function( Release, files, complete ) {
 
 	var

--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -4,10 +4,9 @@
  * and includes/excludes specified modules
  */
 
+"use strict";
+
 module.exports = function( grunt ) {
-
-	"use strict";
-
 	var fs = require( "fs" ),
 		requirejs = require( "requirejs" ),
 		Insight = require( "insight" ),

--- a/build/tasks/dist.js
+++ b/build/tasks/dist.js
@@ -1,7 +1,6 @@
+"use strict";
+
 module.exports = function( grunt ) {
-
-	"use strict";
-
 	var	fs = require( "fs" ),
 		filename = grunt.option( "filename" ),
 		distpaths = [

--- a/build/tasks/node_smoke_tests.js
+++ b/build/tasks/node_smoke_tests.js
@@ -1,7 +1,6 @@
+"use strict";
+
 module.exports = ( grunt ) => {
-
-	"use strict";
-
 	const fs = require( "fs" );
 	const spawnTest = require( "./lib/spawn_test.js" );
 	const testsDir = "./test/node_smoke_tests/";

--- a/build/tasks/qunit_fixture.js
+++ b/build/tasks/qunit_fixture.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var fs = require( "fs" );
 
 module.exports = function( grunt ) {

--- a/build/tasks/sourcemap.js
+++ b/build/tasks/sourcemap.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var fs = require( "fs" );
 
 module.exports = function( grunt ) {

--- a/build/tasks/testswarm.js
+++ b/build/tasks/testswarm.js
@@ -1,7 +1,6 @@
+"use strict";
+
 module.exports = function( grunt ) {
-
-	"use strict";
-
 	grunt.registerTask( "testswarm", function( commit, configFile, projectName, browserSets,
 			timeout, testMode ) {
 		var jobName, config, tests,


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

So far, only browser-based JS files were required to be in strict mode (in the
function form). This commit adds such a requirement to Node.js scripts where
the global form is preferred. All Node.js scripts in sloppy mode were
converted to strict mode.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
