### PR TITLE
Selector: Make selectors with leading combinators use qSA again

### DIFF
--- a/src/selector.js
+++ b/src/selector.js
@@ -226,8 +226,11 @@ function find( selector, context, results, seed ) {
 				// descendant combinators, which is not what we want.
 				// In such cases, we work around the behavior by prefixing every selector in the
 				// list with an ID selector referencing the scope context.
+				// The technique has to be used as well when a leading combinator is used
+				// as such selectors are not recognized by querySelectorAll.
 				// Thanks to Andrew Dupont for this technique.
-				if ( nodeType === 1 && rdescend.test( selector ) ) {
+				if ( nodeType === 1 &&
+					( rdescend.test( selector ) || rcombinators.test( selector ) ) ) {
 
 					// Expand context for sibling selectors
 					newContext = rsibling.test( selector ) && testContext( context.parentNode ) ||


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

An optimization added in jquery/sizzle#431 skips the temporary IDs for selectors
not using child or descendant combinators. For sibling combinators, though, this
pushes a selector with a leading combinator to qSA directly which crashes and
falls back to a slower Sizzle route.

This commit makes selectors with leading combinators not skip the selector
rewriting. Note that after jquery/jquery#4454 & jquery/sizzle#453, all modern
browsers other than Edge leverage the :scope pseudo-class, avoiding temporary
id attributes.

Ref gh-431

+3 bytes

Sizzle PR (for jQuery 3.x): https://github.com/jquery/sizzle/pull/460

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~[ ] New tests have been added to show the fix or feature works~~ (we don't generally if a selector goes through `qSA`)
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
