### PR TITLE
Selector: Use shallow document comparisons in uniqueSort

### DIFF
--- a/src/selector/uniqueSort.js
+++ b/src/selector/uniqueSort.js
@@ -24,7 +24,11 @@ function sortOrder( a, b ) {
 	}
 
 	// Calculate position if both inputs belong to the same document
-	compare = ( a.ownerDocument || a ) === ( b.ownerDocument || b ) ?
+	// Support: IE 11+, Edge 17 - 18+
+	// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
+	// two documents; shallow comparisons work.
+	// eslint-disable-next-line eqeqeq
+	compare = ( a.ownerDocument || a ) == ( b.ownerDocument || b ) ?
 		a.compareDocumentPosition( b ) :
 
 		// Otherwise we know they are disconnected
@@ -34,11 +38,20 @@ function sortOrder( a, b ) {
 	if ( compare & 1 ) {
 
 		// Choose the first element that is related to the document
-		if ( a === document || a.ownerDocument === document &&
+		// Support: IE 11+, Edge 17 - 18+
+		// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
+		// two documents; shallow comparisons work.
+		// eslint-disable-next-line eqeqeq
+		if ( a == document || a.ownerDocument == document &&
 			jQuery.contains( document, a ) ) {
 			return -1;
 		}
-		if ( b === document || b.ownerDocument === document &&
+
+		// Support: IE 11+, Edge 17 - 18+
+		// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
+		// two documents; shallow comparisons work.
+		// eslint-disable-next-line eqeqeq
+		if ( b == document || b.ownerDocument == document &&
 			jQuery.contains( document, b ) ) {
 			return 1;
 		}


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

IE/Edge sometimes crash when comparing documents between frames using the strict
equality operator (`===` & `!==`). Funnily enough, shallow comparisons
(`==` & `!=`) work without crashing.

The change to shallow comparisons in `src/selector.js` was done in gh-4471 but
relevant changes in `src/selector/uniqueSort.js` were missed. Those changes
have landed in Sizzle in jquery/sizzle#459.

+1 byte

Fixes gh-4441
Ref gh-4471
Ref jquery/sizzle#459

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
