### PR TITLE
Selector: Add a test for throwing on post-comma invalid selectors

### DIFF
--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -179,7 +179,7 @@ QUnit.test( "XML Document Selectors", function( assert ) {
 } );
 
 QUnit.test( "broken selectors throw", function( assert ) {
-	assert.expect( 32 );
+	assert.expect( 33 );
 
 	function broken( name, selector ) {
 		assert.throws( function() {
@@ -197,6 +197,7 @@ QUnit.test( "broken selectors throw", function( assert ) {
 	broken( "Broken Selector", "," );
 	broken( "Broken Selector", ",a" );
 	broken( "Broken Selector", "a," );
+	broken( "Post-comma invalid selector", "*,:x" );
 	broken( "Identifier with bad escape", "foo\\\fbaz" );
 	broken( "Broken Selector", "[id=012345678901234567890123456789" );
 	broken( "Doesn't exist", ":visble" );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Sizzle's PR jquery/sizzle#456 introduced a test catching not throwing on
badly-escaped identifiers by Firefox 3.6-5. Unfortunately, it was placed just
before a test Opera 10-11 failed, making Opera fail quicker and not adding
a post-comma invalid selector to rbuggyQSA.

The issue was fixed in jquery/sizzle#463. This jQuery commit backports the test
that Sizzle PR added as no workarounds are needed in browsers jQuery supports.

Ref jquery/sizzle#456
Ref jquery/sizzle#463

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
