### PR TITLE
Prefer eslint-disable-next-line to eslint-disable

### DIFF
--- a/src/attributes/val.js
+++ b/src/attributes/val.js
@@ -147,15 +147,12 @@ jQuery.extend( {
 				while ( i-- ) {
 					option = options[ i ];
 
-					/* eslint-disable no-cond-assign */
-
+					// eslint-disable-next-line no-cond-assign
 					if ( option.selected =
 						jQuery.inArray( jQuery.valHooks.option.get( option ), values ) > -1
 					) {
 						optionSet = true;
 					}
-
-					/* eslint-enable no-cond-assign */
 				}
 
 				// Force browsers to behave consistently when non-matching value is set

--- a/src/effects.js
+++ b/src/effects.js
@@ -225,11 +225,8 @@ function defaultPrefilter( elem, props, opts ) {
 				showHide( [ elem ], true );
 			}
 
-			/* eslint-disable no-loop-func */
-
+			// eslint-disable-next-line no-loop-func
 			anim.done( function() {
-
-			/* eslint-enable no-loop-func */
 
 				// The final step of a "hide" animation is actually hiding the element
 				if ( !hidden ) {

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars*/
 /*!
  * jQuery JavaScript Library v@VERSION
  * https://jquery.com/
@@ -35,6 +34,7 @@
 	}
 
 // Pass this if window is not defined yet
+// eslint-disable-next-line no-unused-vars
 } )( typeof window !== "undefined" ? window : this, function( window, noGlobal ) {
 
 "use strict";


### PR DESCRIPTION
More targetted directives result in fewer incorrectly suppressed errors.

### Summary ###
Replaces `/* eslint-disable */ ... /* eslint-enable */` blocks, or open-ended `/* eslint-disable */` whole-files directives with more targetted `// eslint-disable-next-line` comments.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
