### PR TITLE
Build: Enable reportUnusedDisableDirectives in ESLint

### DIFF
--- a/.eslintrc-browser.json
+++ b/.eslintrc-browser.json
@@ -3,6 +3,8 @@
 
 	"extends": "jquery",
 
+	"reportUnusedDisableDirectives": true,
+
 	"parserOptions": {
 		"ecmaVersion": 5
 	},

--- a/.eslintrc-node.json
+++ b/.eslintrc-node.json
@@ -3,6 +3,8 @@
 
 	"extends": "jquery",
 
+	"reportUnusedDisableDirectives": true,
+
 	"parserOptions": {
 		"ecmaVersion": 2018
 	},

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -79,7 +79,8 @@ module.exports = function( grunt ) {
 			options: {
 
 				// See https://github.com/sindresorhus/grunt-eslint/issues/119
-				quiet: true
+				quiet: true,
+				reportUnusedDisableDirectives: true
 			},
 
 			// We have to explicitly declare "src" property otherwise "newer"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -79,8 +79,7 @@ module.exports = function( grunt ) {
 			options: {
 
 				// See https://github.com/sindresorhus/grunt-eslint/issues/119
-				quiet: true,
-				reportUnusedDisableDirectives: true
+				quiet: true
 			},
 
 			// We have to explicitly declare "src" property otherwise "newer"


### PR DESCRIPTION
### Summary ###
The reportUnusedDisableDirectives option in ESLint will report an error when in inline disable directive is no longer required, such as what happened gh-4095.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
