### PR TITLE
Tests: Don't test synchronous XHR on unload in Chrome

### DIFF
--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -2001,14 +2001,19 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 		};
 	} );
 
-	testIframe(
-		"#14379 - jQuery.ajax() on unload",
-		"ajax/onunload.html",
-		function( assert, jQuery, window, document, status ) {
-			assert.expect( 1 );
-			assert.strictEqual( status, "success", "Request completed" );
-		}
-	);
+	// Chrome 78 dropped support for synchronous XHR requests inside of
+	// beforeunload, unload, pagehide, and visibilitychange event handlers.
+	// See https://bugs.chromium.org/p/chromium/issues/detail?id=952452
+	if ( !/chrome/i.test( navigator.userAgent ) ) {
+		testIframe(
+			"#14379 - jQuery.ajax() on unload",
+			"ajax/onunload.html",
+			function( assert, jQuery, window, document, status ) {
+				assert.expect( 1 );
+				assert.strictEqual( status, "success", "Request completed" );
+			}
+		);
+	}
 
 	ajaxTest( "#14683 - jQuery.ajax() - Exceptions thrown synchronously by xhr.send should be caught", 4, function( assert ) {
 		return [ {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Chrome 78 dropped support for synchronous XHR requests inside of beforeunload, unload, pagehide, and visibilitychange event handlers. This made an AJAX test checking exactly that fail in Chrome.
See https://bugs.chromium.org/p/chromium/issues/detail?id=952452

BTW, I can't reliably reproduce the failure in Chrome on macOS when tested via the PHP setup. It does fail in Chrome 78 via Karma & in Edge Chromium in all ways, though. It also reliably fails in TestSwarm. Therefore, we need to drop that test in Chrome.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
