### PR TITLE
Tests: Skip a "width/height on a table row with phantom borders" test in Firefox

### DIFF
--- a/test/unit/dimensions.js
+++ b/test/unit/dimensions.js
@@ -627,7 +627,14 @@ QUnit.test( "width/height on an inline element with percentage dimensions (gh-36
 	}
 );
 
-QUnit.test( "width/height on a table row with phantom borders (gh-3698)", function( assert ) {
+// Support: Firefox 70+
+// Firefox 70 & newer fail this test but the issue there is more profound - Firefox doesn't
+// subtract borders from table row computed widths.
+// See https://github.com/jquery/jquery/issues/4529
+// See https://bugzilla.mozilla.org/show_bug.cgi?id=1590837
+// See https://github.com/w3c/csswg-drafts/issues/4444
+QUnit[ /firefox/i.test( navigator.userAgent ) ? "skip" : "test" ](
+	"width/height on a table row with phantom borders (gh-3698)", function( assert ) {
 	assert.expect( 4 );
 
 	jQuery( "<table id='gh3698' style='border-collapse: separate; border-spacing: 0;'><tbody>" +


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Tests: Skip a "width/height on a table row with phantom borders" test in Firefox

Firefox 70 & newer fail this test but the issue there is more profound - Firefox
doesn't subtract borders from table row computed widths.

Ref jquery/jquery#4529
Ref https://bugzilla.mozilla.org/show_bug.cgi?id=1590837
Ref w3c/csswg-drafts#4444

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
