### PR TITLE
Build: Require extensions for ES6 imports, prevent import cycles

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "commitplease": "3.2.0",
     "core-js-bundle": "3.0.0",
     "eslint-config-jquery": "2.0.0",
+    "eslint-plugin-import": "2.18.2",
     "grunt": "1.0.4",
     "grunt-babel": "8.0.0",
     "grunt-cli": "1.3.2",

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -11,7 +11,8 @@
 	"plugins": [ "import" ],
 
 	"rules": {
-		"import/extensions": [ "error", "always" ]
+		"import/extensions": [ "error", "always" ],
+		"import/no-cycle": "error"
 	},
 
 	"overrides": [

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -8,6 +8,12 @@
 		"sourceType": "module"
 	},
 
+	"plugins": [ "import" ],
+
+	"rules": {
+		"import/extensions": [ "error", "always" ]
+	},
+
 	"overrides": [
 		{
 			"files": "wrapper.js",


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

jQuery source is now authored in ECMAScript modules. Native browser support for
them requires full file names including extensions. Rollup works even if import
paths don't specify extensions, though, so one import slipped through without
such an extension, breaking native browser import of src/jquery.js.

A new ESLint rule using eslint-plugin-import prevents us from regressing on that
front.

Ref gh-4541
Ref 075320149ae30a5c593c06b2fb015bdf033e0acf

EDIT: Also, make sure we don't have import cycles in src/

eslint-plugin-import's no-cycle rule is used for cycle detection.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
