### PR TITLE
Docs: Change OS X to macOS in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To build jQuery, you need to have the latest Node.js/npm and git 1.7 or later. E
 
 For Windows, you have to download and install [git](https://git-scm.com/downloads) and [Node.js](https://nodejs.org/en/download/).
 
-OS X users should install [Homebrew](https://brew.sh/). Once Homebrew is installed, run `brew install git` to install git,
+MacOS users should install [Homebrew](https://brew.sh/). Once Homebrew is installed, run `brew install git` to install git,
 and `brew install node` to install Node.js.
 
 Linux/BSD users should use their appropriate package managers to install git and Node.js, or build from source

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To build jQuery, you need to have the latest Node.js/npm and git 1.7 or later. E
 
 For Windows, you have to download and install [git](https://git-scm.com/downloads) and [Node.js](https://nodejs.org/en/download/).
 
-MacOS users should install [Homebrew](https://brew.sh/). Once Homebrew is installed, run `brew install git` to install git,
+macOS users should install [Homebrew](https://brew.sh/). Once Homebrew is installed, run `brew install git` to install git,
 and `brew install node` to install Node.js.
 
 Linux/BSD users should use their appropriate package managers to install git and Node.js, or build from source


### PR DESCRIPTION
MacOS has been around for long enough to update the naming here.

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
