### PR TITLE
Core: Exclude callbacks & deferred modules in the slim build as well

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -306,7 +306,7 @@ module.exports = function( grunt ) {
 				// the official slim build
 				.reduce( ( acc, elem ) => acc.concat(
 					elem === "slim" ?
-						[ "-ajax", "-effects" ] :
+						[ "-ajax", "-callbacks", "-deferred", "-effects" ] :
 						[ elem ]
 				), [] )
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

So far, the slim build only excluded ajax & effects modules. As many web apps
right now rely on native Promises, often with a polyfill for legacy browsers,
deferred & callbacks modules are not that useful for sites that already exclude
ajax & effects modules.

This decreases the gzipped minified size of the slim module by 1758 bytes,
to 19656 bytes (below 20k!).

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
