### PR TITLE
Event: Only attach events to objects that accept data - for real

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -4,6 +4,7 @@ import documentElement from "./var/documentElement.js";
 import rnothtmlwhite from "./var/rnothtmlwhite.js";
 import rcheckableType from "./var/rcheckableType.js";
 import slice from "./var/slice.js";
+import acceptData from "./data/var/acceptData.js";
 import dataPriv from "./data/var/dataPriv.js";
 import nodeName from "./core/nodeName.js";
 
@@ -109,8 +110,8 @@ jQuery.event = {
 			special, handlers, type, namespaces, origType,
 			elemData = dataPriv.get( elem );
 
-		// Don't attach events to noData or text/comment nodes (but allow plain objects)
-		if ( !elemData ) {
+		// Only attach events to objects that accept data
+		if ( !acceptData( elem ) ) {
 			return;
 		}
 

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -2811,6 +2811,15 @@ QUnit.test( "preventDefault() on focusin does not throw exception", function( as
 	}, QUnit.config.testTimeout / 4 || 1000 );
 } );
 
+QUnit.test( ".on('focus', fn) on a text node doesn't throw", function( assert ) {
+	assert.expect( 1 );
+
+	jQuery( document.createTextNode( "text" ) )
+		.on( "focus", function() {} );
+
+	assert.ok( true, "No crash" );
+} );
+
 QUnit.test( "Donor event interference", function( assert ) {
 	assert.expect( 8 );
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

There was a check in jQuery.event.add that was supposed to make it a noop
for objects that don't accept data like text or comment nodes. The problem was
the check was incorrect: it assumed `dataPriv.get( elem )` returns a falsy
value for an `elem` that doesn't accept data but that's not the case - we get
an empty object then. The check was changed to use `acceptData` directly.

Fixes gh-4397

It's funny that this has been the behavior for at least the past few years so this code has been wrong for a long time. 😱 

We'll also need to CP that to `3.x-stable`

+2 bytes

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
