### PR TITLE
Docs: Add cloning command for HTTPS connection in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,13 @@ if you swing that way. Easy-peasy.
 How to build your own jQuery
 ----------------------------
 
-Clone a copy of the main jQuery git repo by running:
+Clone a copy of the main jQuery git repo by cloning:
 
+Using HTTPS connection
+```bash
+git clone https://github.com/jquery/jquery.git
+```
+Or using the SSH connection
 ```bash
 git clone git://github.com/jquery/jquery.git
 ```


### PR DESCRIPTION
HTTPS connection URL has been added along with SSH connection URL to clone the jQuery repository

Fixes #4556 

### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
