### PR TITLE
Selector: Remove the "a:enabled" workaround for Chrome <=77

### DIFF
--- a/src/selector/rbuggyQSA.js
+++ b/src/selector/rbuggyQSA.js
@@ -6,15 +6,6 @@ var rbuggyQSA = [],
 	testEl = document.createElement( "div" ),
 	input = document.createElement( "input" );
 
-testEl.innerHTML = "<a href=''></a>";
-
-// Support: Chrome 38 - 77 only
-// Chrome considers anchor elements with href to match ":enabled"
-// See https://bugs.chromium.org/p/chromium/issues/detail?id=993387
-if ( testEl.querySelectorAll( ":enabled" ).length ) {
-	rbuggyQSA.push( ":enabled" );
-}
-
 // Support: IE 9 - 11+
 // IE's :disabled selector does not pick up the children of disabled fieldsets
 if ( isIE ) {

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -2,8 +2,6 @@ QUnit.module( "selector", {
 	beforeEach: function() {
 		this.safari = /\bsafari\b/i.test( navigator.userAgent ) &&
 			!/\bchrome\b/i.test( navigator.userAgent );
-		this.chrome = /\bchrome\b/i.test( navigator.userAgent ) &&
-			!/\bedge\b/i.test( navigator.userAgent );
 	},
 	afterEach: moduleTeardown
 } );
@@ -1379,9 +1377,7 @@ QUnit.test( "pseudo - :(dis|en)abled, explicitly disabled", function( assert ) {
 			"disabled-select", "disabled-optgroup", "disabled-option" ]
 	);
 
-	if ( QUnit.jQuerySelectors || !this.chrome ) {
-		// Support: Chrome 75+
-		// Chrome recognizes anchor elements as enabled.
+	if ( QUnit.jQuerySelectors ) {
 		assert.t(
 			"Enabled elements",
 			"#enabled-fieldset :enabled",


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Remove the workaround for a broken `:enabled` pseudo-class on anchor elements
in Chrome <=77. These versions of Chrome considers anchor elements with the
`href` attribute as matching `:enabled`.

-23 bytes gzipped

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~ (this is already tested)
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
