### PR TITLE
Build: Make dev mode work in Karma again, serve source files from disk

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -158,14 +158,31 @@ module.exports = function( grunt ) {
 
 					"test/jquery.js",
 
-					{ pattern: "dist/jquery.*", included: false, served: true },
-					{ pattern: "src/**", type: "module", included: false, served: true },
-					{ pattern: "amd/**", included: false, served: true },
+					{
+						pattern: "dist/jquery.*",
+						included: false,
+						served: true,
+						nocache: true
+					},
+					{
+						pattern: "src/**",
+						type: "module",
+						included: false,
+						served: true,
+						nocache: true
+					},
+					{
+						pattern: "amd/**",
+						included: false,
+						served: true,
+						nocache: true
+					},
 					{ pattern: "node_modules/**", included: false, served: true },
 					{
 						pattern: "test/**/*.@(js|css|jpg|html|xml|svg)",
 						included: false,
-						served: true
+						served: true,
+						nocache: true
 					}
 				],
 				reporters: [ "dots" ],


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

PR gh-4550 added support for running ES modules & AMD tests via Karma. This
required reading the `esmodules` & `amd` props from both `QUnit.config` &
`QUnit.urlParams`. By picking these two properties manually, the `dev` one
stopped being respected while ones handled directly by QUnit were fine (like
`hidepassed`). Instead of maintaining the full list of options, the code now
iterates over QUnit URL config and handles the fallbacks in a more generic way.

Apart from that, all jQuery source & test files are now read directly from disk
instead of being cached by Karma so that one can run `grunt karma:chrome-debug`
& work on a fix without restarting that Karma run after each change. A similar
effect could have been achieved by setting `autoWatch` to `true` but then the
main Karma page runs tests in an iframe by default when
`grunt karma:chrome-debug` is run instead of relying on the current debug flow.

Ref gh-4550

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
