### PR TITLE
fix $(document).offset() error

### DIFF
--- a/src/offset.js
+++ b/src/offset.js
@@ -84,7 +84,7 @@ jQuery.fn.extend( {
 		// Support: IE <=11+
 		// Running getBoundingClientRect on a
 		// disconnected node in IE throws an error
-		if ( !elem.getClientRects().length ) {
+		if ( !elem.getClientRects || !elem.getClientRects().length ) {
 			return { top: 0, left: 0 };
 		}
 


### PR DESCRIPTION
the document didn't have getClientRects, 
we should check whether the getClientRects is undefined before use it

### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
