### PR TITLE
Build: Create a `grunt custom:slim` alias for the Slim build

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,11 @@ Exclude a bunch of modules:
 grunt custom:-ajax,-css,-deprecated,-dimensions,-effects,-event/alias,-offset,-wrap
 ```
 
+There is also a special alias to generate a build with the same configuration as the official jQuery Slim build is generated:
+```bash
+grunt custom:slim
+```
+
 For questions or requests regarding custom builds, please start a thread on the [Developing jQuery Core](https://forum.jquery.com/developing-jquery-core) section of the forum. Due to the combinatorics and custom nature of these builds, they are not regularly tested in jQuery's unit test process.
 
 Running the Unit Tests

--- a/build/release.js
+++ b/build/release.js
@@ -50,7 +50,7 @@ module.exports = function( Release ) {
 		generateArtifacts: function( callback ) {
 			Release.exec( "grunt", "Grunt command failed" );
 			Release.exec(
-				"grunt custom:-ajax,-effects --filename=jquery.slim.js && " +
+				"grunt custom:slim --filename=jquery.slim.js && " +
 					"grunt remove_map_comment --filename=jquery.slim.js",
 				"Grunt custom failed"
 			);

--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -291,9 +291,27 @@ module.exports = function( grunt ) {
 	// Becomes:
 	//
 	//   grunt build:*:*:+ajax:-dimensions:-effects:-offset
+	//
+	// There's also a special "slim" alias that resolves to the jQuery Slim build
+	// configuration:
+	//
+	//   grunt custom:slim
 	grunt.registerTask( "custom", function() {
 		const args = this.args;
-		const modules = args.length ? args[ 0 ].replace( /,/g, ":" ) : "";
+		const modules = args.length ?
+			args[ 0 ]
+				.split( "," )
+
+				// Replace "slim" with respective exclusions meant for
+				// the official slim build
+				.reduce( ( acc, elem ) => acc.concat(
+					elem === "slim" ?
+						[ "-ajax", "-effects" ] :
+						[ elem ]
+				), [] )
+
+				.join( ":" ) :
+			"";
 		const done = this.async();
 		const insight = new Insight( {
 			trackingCode: "UA-1076265-4",


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

This PR adds a custom `slim` alias for the official Slim build. It will allow to achieve the same build locally in an easier way and will also de-duplicate the slim build configuration in changes like #4577, making us sure we really test the slim build even after its definition changes.

This PR interferes with #4577 so whichever one lands first, the other one will need to get updated (e.g. if #4577 lands first, this PR will need to modify the new Travis config to use the new alias).

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
