### PR TITLE
Tests: Make the support tests pass on Firefox 4x/5x/60

### DIFF
--- a/test/unit/support.js
+++ b/test/unit/support.js
@@ -307,7 +307,7 @@ testIframe(
 		expected = expectedMap.chrome;
 	} else if ( /\b(?:9|10)\.\d+(\.\d+)* safari/i.test( userAgent ) ) {
 		expected = expectedMap.safari_9_10;
-	} else if ( /firefox\/(?:52|60)/i.test( userAgent ) ) {
+	} else if ( /firefox\/(?:4\d|5\d|60)/i.test( userAgent ) ) {
 		expected = expectedMap.firefox_60;
 	} else if ( /firefox/i.test( userAgent ) ) {
 		expected = expectedMap.firefox;


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The check for old Firefox versions with different support test result only
checked for Firefox 52 or 60. It now checks for 4x/5x/60 to understand more
versions.

This is needed for our unofficial Firefox 48 testing on `3.x-stable`.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
