### PR TITLE
Attributes: Refactor val(): don't strip carriage return, isolate IE workarounds

### DIFF
--- a/src/attributes/val.js
+++ b/src/attributes/val.js
@@ -1,10 +1,9 @@
 import jQuery from "../core.js";
+import isIE from "../var/isIE.js";
 import stripAndCollapse from "../core/stripAndCollapse.js";
 import nodeName from "../core/nodeName.js";
 
 import "../core/init.js";
-
-var rreturn = /\r/g;
 
 jQuery.fn.extend( {
 	val: function( value ) {
@@ -24,11 +23,6 @@ jQuery.fn.extend( {
 				}
 
 				ret = elem.value;
-
-				// Handle most common string cases
-				if ( typeof ret === "string" ) {
-					return ret.replace( rreturn, "" );
-				}
 
 				// Handle cases where value is null/undef or number
 				return ret == null ? "" : ret;
@@ -77,20 +71,6 @@ jQuery.fn.extend( {
 
 jQuery.extend( {
 	valHooks: {
-		option: {
-			get: function( elem ) {
-
-				var val = elem.getAttribute( "value" );
-				return val != null ?
-					val :
-
-					// Support: IE <=10 - 11+
-					// option.text throws exceptions (#14686, #14858)
-					// Strip and collapse whitespace
-					// https://html.spec.whatwg.org/#strip-and-collapse-whitespace
-					stripAndCollapse( jQuery.text( elem ) );
-			}
-		},
 		select: {
 			get: function( elem ) {
 				var value, option, i,
@@ -144,7 +124,7 @@ jQuery.extend( {
 					option = options[ i ];
 
 					if ( ( option.selected =
-						jQuery.inArray( jQuery.valHooks.option.get( option ), values ) > -1
+						jQuery.inArray( jQuery( option ).val(), values ) > -1
 					) ) {
 						optionSet = true;
 					}
@@ -159,6 +139,23 @@ jQuery.extend( {
 		}
 	}
 } );
+
+if ( isIE ) {
+	jQuery.valHooks.option = {
+		get: function( elem ) {
+
+			var val = elem.getAttribute( "value" );
+			return val != null ?
+				val :
+
+				// Support: IE <=10 - 11+
+				// option.text throws exceptions (#14686, #14858)
+				// Strip and collapse whitespace
+				// https://html.spec.whatwg.org/#strip-and-collapse-whitespace
+				stripAndCollapse( jQuery.text( elem ) );
+		}
+	};
+}
 
 // Radios and checkboxes getter/setter
 jQuery.each( [ "radio", "checkbox" ], function() {

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -1196,6 +1196,57 @@ QUnit.test( "select.val(space characters) (gh-2978)", function( assert ) {
 	} );
 } );
 
+QUnit.test( "radio.val(space characters)", function( assert ) {
+	assert.expect( 42 );
+
+	var radio = jQuery( "<input type='radio'/>" ).appendTo( "#qunit-fixture" ),
+		spaces = {
+			"\\t": {
+				html: "&#09;",
+				val: "\t"
+			},
+			"\\n": {
+				html: "&#10;",
+				val: "\n"
+			},
+			"\\r": {
+				html: "&#13;",
+				val: "\r"
+			},
+			"\\f": "\f",
+			"space": " ",
+			"\\u00a0": "\u00a0",
+			"\\u1680": "\u1680"
+		};
+
+	jQuery.each( spaces, function( key, obj ) {
+		var val = obj.val || obj;
+
+		radio.val( "attr" + val );
+		assert.equal( radio.val(), "attr" + val, "Value ending with space character (" + key + ") returned (set via val())" );
+
+		radio.val( "at" + val + "tr" );
+		assert.equal( radio.val(), "at" + val + "tr", "Value with space character (" + key + ") in the middle returned (set via val())" );
+
+		radio.val( val + "attr" );
+		assert.equal( radio.val(), val + "attr", "Value starting with space character (" + key + ") returned (set via val())" );
+	} );
+
+	jQuery.each( spaces, function( key, obj ) {
+		var val = obj.val || obj,
+			htmlVal = obj.html || obj;
+
+		radio = jQuery( "<input type='radio' value='attr" + htmlVal + "'/>" ).appendTo( "#qunit-fixture" );
+		assert.equal( radio.val(), "attr" + val, "Value ending with space character (" + key + ") returned (set via HTML)" );
+
+		radio = jQuery( "<input type='radio' value='at" + htmlVal + "tr'/>" ).appendTo( "#qunit-fixture" );
+		assert.equal( radio.val(), "at" + val + "tr", "Value with space character (" + key + ") in the middle returned (set via HTML)" );
+
+		radio = jQuery( "<input type='radio' value='" + htmlVal + "attr'/>" ).appendTo( "#qunit-fixture" );
+		assert.equal( radio.val(), val + "attr", "Value starting with space character (" + key + ") returned (set via HTML)" );
+	} );
+} );
+
 var testAddClass = function( valueObj, assert ) {
 	assert.expect( 9 );
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Before this change, `val()` was stripping out carriage return characters from
the returned value. No test has relied on that. The logic was different for
option elements as its custom defined hook was omitting this stripping logic.

This commit gets rid of the carriage return removal and isolates the IE-only
select val getter to be skipped in other browsers.

-16 bytes

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
