### PR TITLE
Tests: Remove obsolete jQuery data tests

### DIFF
--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -1411,10 +1411,6 @@ var testToggleClass = function( valueObj, assert ) {
 	e.toggleClass( false );
 	e.toggleClass();
 	assert.ok( e.is( ".testD.testE" ), "Assert class present (restored from data)" );
-
-	// Cleanup
-	e.removeClass( "testD" );
-	assert.expectJqData( this, e[ 0 ], "__className__" );
 };
 
 QUnit.test( "toggleClass(String|boolean|undefined[, boolean])", function( assert ) {

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -132,11 +132,6 @@ QUnit.test( "jQuery.data(div)", function( assert ) {
 	var div = document.createElement( "div" );
 
 	dataTests( div, assert );
-
-	// We stored one key in the private data
-	// assert that nothing else was put in there, and that that
-	// one stayed there.
-	assert.expectJqData( this, div, "foo" );
 } );
 
 QUnit.test( "jQuery.data({})", function( assert ) {
@@ -159,8 +154,6 @@ QUnit.test( "jQuery.data(document)", function( assert ) {
 	assert.expect( 25 );
 
 	dataTests( document, assert );
-
-	assert.expectJqData( this, document, "foo" );
 } );
 
 QUnit.test( "jQuery.data(<embed>)", function( assert ) {

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -90,9 +90,6 @@ QUnit.test( "show()", function( assert ) {
 		assert.ok( pass, "Show with " + name + " does not call animate callback" );
 	} );
 
-	// Tolerate data from show()/hide()
-	assert.expectJqData( this, div, "olddisplay" );
-
 	jQuery(
 		"<div id='show-tests'>" +
 		"<div><p><a href='#'></a></p><code></code><pre></pre><span></span></div>" +
@@ -217,8 +214,6 @@ supportjQuery.each( hideOptions, function( type, setup ) {
 		} );
 
 		clock.tick( 300 );
-
-		assert.expectJqData( this, $span, "olddisplay" );
 	} );
 
 	// Support: IE 11+, Edge 12 - 18+
@@ -251,8 +246,6 @@ supportjQuery.each( hideOptions, function( type, setup ) {
 		} );
 
 		clock.tick( 300 );
-
-		assert.expectJqData( this, $shadowChild, "olddisplay" );
 	} );
 } );
 
@@ -1161,9 +1154,6 @@ QUnit.test( "interrupt toggle", function( assert ) {
 
 			// Save original property value for comparison
 			jQuery.data( this, "startVal", jQuery( this ).css( prop ) );
-
-			// Expect olddisplay data from our .hide() call below
-			assert.expectJqData( env, this, "olddisplay" );
 		} );
 
 		// Interrupt a hiding toggle
@@ -1612,8 +1602,6 @@ QUnit.test( "animate should set display for disconnected nodes", function( asser
 		"show() should change display if it already set to none" );
 	assert.strictEqual( $divInline.show()[ 0 ].style.display, "inline",
 		"show() should not change display if it already set" );
-
-	assert.expectJqData( env, $divNone[ 0 ], "olddisplay" );
 
 	jQuery.each( showMethods, function( name, opt ) {
 		jQuery.fn[ name ].apply( jQuery( "<div/>" ), opt.concat( [ function() {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Remove obsolete jQuery data tests.

The tests relied on `jQuery.cache` so they only ever worked in jQuery 1.x.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
