### PR TITLE
Build: Lint the minified jQuery file as well - a Gruntfile fix

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -85,7 +85,7 @@ module.exports = function( grunt ) {
 			// We have to explicitly declare "src" property otherwise "newer"
 			// task wouldn't work properly :/
 			dist: {
-				src: "dist/jquery.js"
+				src: [ "dist/jquery.js", "dist/jquery.min.js" ]
 			},
 			dev: {
 				src: [ "src/**/*.js", "Gruntfile.js", "test/**/*.js", "build/**/*.js" ]


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Code in gh-4594 configured ESLint properly but didn't change the Gruntfile.js
config to actually lint the minified file. This has now been fixed.

Fixes gh-3075
Ref gh-4594

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
