### PR TITLE
Core: Fire iframe script in its context, add doc param in globalEval

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -231,9 +231,10 @@ jQuery.extend( {
 		return true;
 	},
 
-	// Evaluates a script in a global context
-	globalEval: function( code, options ) {
-		DOMEval( code, { nonce: options && options.nonce } );
+	// Evaluates a script in a provided context; falls back to the global one
+	// if not specified.
+	globalEval: function( code, options, doc ) {
+		DOMEval( code, { nonce: options && options.nonce }, doc );
 	},
 
 	each: function( obj, callback ) {

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -163,7 +163,7 @@ function domManip( collection, args, callback, ignored ) {
 							if ( jQuery._evalUrl && !node.noModule ) {
 								jQuery._evalUrl( node.src, {
 									nonce: node.nonce || node.getAttribute( "nonce" )
-								} );
+								}, doc );
 							}
 						} else {
 							DOMEval( node.textContent.replace( rcleanScript, "" ), node, doc );

--- a/src/manipulation/_evalUrl.js
+++ b/src/manipulation/_evalUrl.js
@@ -1,6 +1,6 @@
 import jQuery from "../ajax.js";
 
-jQuery._evalUrl = function( url, options ) {
+jQuery._evalUrl = function( url, options, doc ) {
 	return jQuery.ajax( {
 		url: url,
 
@@ -18,7 +18,7 @@ jQuery._evalUrl = function( url, options ) {
 			"text script": function() {}
 		},
 		dataFilter: function( response ) {
-			jQuery.globalEval( response, options );
+			jQuery.globalEval( response, options, doc );
 		}
 	} );
 };

--- a/test/data/core/globaleval-context.html
+++ b/test/data/core/globaleval-context.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset=utf-8 />
+		<title>body</title>
+	</head>
+	<body>
+		<div id="qunit-fixture"></div>
+		<script src="../../jquery.js"></script>
+		<script src="../iframeTest.js"></script>
+		<script>
+			startIframeTest();
+		</script>
+	</body>
+</html>

--- a/test/data/manipulation/set-global-scripttest.js
+++ b/test/data/manipulation/set-global-scripttest.js
@@ -1,0 +1,2 @@
+window.scriptTest = true;
+parent.finishTest();

--- a/test/data/testinit.js
+++ b/test/data/testinit.js
@@ -254,12 +254,24 @@ this.testIframe = function( title, fileName, func, wrapper ) {
 			args.unshift( assert );
 
 			setTimeout( function() {
+				var result;
+
 				this.iframeCallback = undefined;
 
-				func.apply( this, args );
-				func = function() {};
-				$iframe.remove();
-				done();
+				result = func.apply( this, args );
+
+				function finish() {
+					func = function() {};
+					$iframe.remove();
+					done();
+				}
+
+				// Wait for promises returned by `func`.
+				if ( result && result.then ) {
+					result.then( finish );
+				} else {
+					finish();
+				}
 			} );
 		};
 

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -197,6 +197,19 @@ QUnit.test( "globalEval execution after script injection (#7862)", function( ass
 	assert.ok( window.strictEvalTest - now < 500, "Code executed synchronously" );
 } );
 
+testIframe(
+	"globalEval with custom document context",
+	"core/globaleval-context.html",
+	function( assert, framejQuery, frameWindow, frameDocument ) {
+		assert.expect( 2 );
+
+		jQuery.globalEval( "window.scriptTest = true;", {}, frameDocument );
+		assert.ok( !window.scriptTest, "script executed in iframe context" );
+		assert.ok( frameWindow.scriptTest, "script executed in iframe context" );
+	}
+);
+
+
 QUnit.test( "noConflict", function( assert ) {
 	assert.expect( 7 );
 

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -2274,6 +2274,27 @@ testIframe(
 	}
 );
 
+testIframe(
+	"domManip executes external scripts in iframes in the iframes' context",
+	"manipulation/scripts-context.html",
+	function( assert, framejQuery, frameWindow, frameDocument ) {
+		assert.expect( 2 );
+
+		Globals.register( "finishTest" );
+
+		return new Promise( function( resolve ) {
+			window.finishTest = resolve;
+			jQuery( frameDocument.body ).append(
+				"<script src='" + url( "manipulation/set-global-scripttest.js" ) + "'></script>" );
+			assert.ok( !window.scriptTest, "script executed in iframe context" );
+			assert.ok( frameWindow.scriptTest, "script executed in iframe context" );
+		} );
+	},
+
+	// The AJAX module is needed for jQuery._evalUrl.
+	QUnit[ jQuery.ajax ? "test" : "skip" ]
+);
+
 QUnit.test( "jQuery.clone - no exceptions for object elements #9587", function( assert ) {
 
 	assert.expect( 1 );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

1. Support passing custom document to jQuery.globalEval; the script will be
   invoked in the context of this document.
2. Fire external scripts appended to iframe contents in that iframe context;
   this was already supported & tested for inline scripts but not for external
   ones.

Fixes gh-4518

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
