### PR TITLE
Event: remove jQuery.event.global

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -101,8 +101,6 @@ function on( elem, types, selector, data, fn, one ) {
  */
 jQuery.event = {
 
-	global: {},
-
 	add: function( elem, types, handler, data, selector ) {
 
 		var handleObjIn, eventHandle, tmp,
@@ -210,9 +208,6 @@ jQuery.event = {
 			} else {
 				handlers.push( handleObj );
 			}
-
-			// Keep track of which events have ever been used, for event optimization
-			jQuery.event.global[ type ] = true;
 		}
 
 	},

--- a/test/data/testrunner.js
+++ b/test/data/testrunner.js
@@ -80,7 +80,6 @@ QUnit.testDone( function() {
 	supportjQuery( "#qunit-fixture-iframe" ).remove();
 
 	// Reset internal jQuery state
-	jQuery.event.global = {};
 	if ( ajaxSettings ) {
 		jQuery.ajaxSettings = jQuery.extend( true, {}, ajaxSettings );
 	} else {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

jQuery.event.global has been write-only in the jQuery source for the past few
years; reading from it was removed in c2d6847de09a52496f78baebc04f317e11ece6d2
when fixing the trac-12989 bug.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
