### PR TITLE
Data:Event:Manipulation: Prevent collisions with Object.prototype properties

### DIFF
--- a/src/data/Data.js
+++ b/src/data/Data.js
@@ -18,7 +18,7 @@ Data.prototype = {
 
 		// If not, create one
 		if ( !value ) {
-			value = {};
+			value = Object.create( null );
 
 			// We can accept data for non-element nodes in modern browsers,
 			// but we should not, see #8335.

--- a/src/event.js
+++ b/src/event.js
@@ -133,7 +133,7 @@ jQuery.event = {
 
 		// Init the element's event structure and main handler, if this is the first
 		if ( !( events = elemData.events ) ) {
-			events = elemData.events = {};
+			events = elemData.events = Object.create( null );
 		}
 		if ( !( eventHandle = elemData.handle ) ) {
 			eventHandle = elemData.handle = function( e ) {
@@ -294,7 +294,9 @@ jQuery.event = {
 			// Make a writable jQuery.Event from the native event object
 			event = jQuery.event.fix( nativeEvent ),
 
-			handlers = ( dataPriv.get( this, "events" ) || {} )[ event.type ] || [],
+			handlers = (
+					dataPriv.get( this, "events" ) || Object.create( null )
+				)[ event.type ] || [],
 			special = jQuery.event.special[ event.type ] || {};
 
 		// Use the fix-ed jQuery.Event rather than the (read-only) native event

--- a/src/event/trigger.js
+++ b/src/event/trigger.js
@@ -99,7 +99,9 @@ jQuery.extend( jQuery.event, {
 				special.bindType || type;
 
 			// jQuery handler
-			handle = ( dataPriv.get( cur, "events" ) || {} )[ event.type ] &&
+			handle = (
+					dataPriv.get( cur, "events" ) || Object.create( null )
+				)[ event.type ] &&
 				dataPriv.get( cur, "handle" );
 			if ( handle ) {
 				handle.apply( cur, data );

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -60,7 +60,7 @@ function restoreScript( elem ) {
 }
 
 function cloneCopyEvent( src, dest ) {
-	var i, l, type, pdataOld, pdataCur, udataOld, udataCur, events;
+	var i, l, type, pdataOld, udataOld, udataCur, events;
 
 	if ( dest.nodeType !== 1 ) {
 		return;
@@ -68,13 +68,11 @@ function cloneCopyEvent( src, dest ) {
 
 	// 1. Copy private data: events, handlers, etc.
 	if ( dataPriv.hasData( src ) ) {
-		pdataOld = dataPriv.access( src );
-		pdataCur = dataPriv.set( dest, pdataOld );
+		pdataOld = dataPriv.get( src );
 		events = pdataOld.events;
 
 		if ( events ) {
-			delete pdataCur.handle;
-			pdataCur.events = {};
+			dataPriv.remove( dest, "handle events" );
 
 			for ( type in events ) {
 				for ( i = 0, l = events[ type ].length; i < l; i++ ) {

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -998,3 +998,18 @@ QUnit.test( ".data(prop) does not create expando", function( assert ) {
 		}
 	}
 } );
+
+QUnit.test( "keys matching Object.prototype properties  (gh-3256)", function( assert ) {
+	assert.expect( 2 );
+
+	var div = jQuery( "<div/>" );
+
+	assert.strictEqual( div.data( "hasOwnProperty" ), undefined,
+		"hasOwnProperty not matched (before forced data creation)" );
+
+	// Force the creation of a data object for this element.
+	div.data( { foo: "bar" } );
+
+	assert.strictEqual( div.data( "hasOwnProperty" ), undefined,
+		"hasOwnProperty not matched (after forced data creation)" );
+} );

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -1796,6 +1796,49 @@ QUnit.test( "jQuery.off using dispatched jQuery.Event", function( assert ) {
 		.remove();
 } );
 
+QUnit.test( "events with type matching an Object.prototype property (gh-3256)", function( assert ) {
+	assert.expect( 1 );
+
+	var elem = jQuery( "<div/>" ),
+		eventFired = false;
+
+	elem.appendTo( "#qunit-fixture" );
+
+	try {
+		elem
+			.one( "hasOwnProperty", function() {
+				eventFired = true;
+			} )
+			.trigger( "hasOwnProperty" );
+	} finally {
+		assert.strictEqual( eventFired, true, "trigger fired without crashing" );
+	}
+} );
+
+QUnit.test( "events with type matching an Object.prototype property, cloned element (gh-3256)",
+	function( assert ) {
+	assert.expect( 1 );
+
+	var elem = jQuery( "<div/>" ),
+		eventFired = false;
+
+	elem.appendTo( "#qunit-fixture" );
+
+	try {
+		// Make sure the original element has some event data.
+		elem.on( "click", function() {} );
+
+		elem
+			.clone( true )
+			.one( "hasOwnProperty", function() {
+				eventFired = true;
+			} )
+			.trigger( "hasOwnProperty" );
+	} finally {
+		assert.strictEqual( eventFired, true, "trigger fired without crashing" );
+	}
+} );
+
 // selector-native does not support scope-fixing in delegation
 QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "delegated event with delegateTarget-relative selector", function( assert ) {
 	assert.expect( 3 );


### PR DESCRIPTION
## Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Make sure events & data keys matching Object.prototype properties work.
A separate fix for such events on cloned elements was added as well.

The commit also removes two unnecessary checks:
1. A check for `events` in private data in `.trigger()` - only the `handle`
   key is needed.
2. A fallback of the `events` private data to an empty object in
   `jQuery.event.dispatch` because that method is called from the `handle`
   function in element's private data and both `events` & `handle` are set and
   removed at the same time.

Fixes gh-3256

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
