### PR TITLE
Core:Ajax: Align nonce & global with master, fix an AMD issue

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -610,7 +610,8 @@ jQuery.extend( {
 			// Add or update anti-cache param if needed
 			if ( s.cache === false ) {
 				cacheURL = cacheURL.replace( rantiCache, "$1" );
-				uncached = ( rquery.test( cacheURL ) ? "&" : "?" ) + "_=" + ( nonce++ ) + uncached;
+				uncached = ( rquery.test( cacheURL ) ? "&" : "?" ) + "_=" + ( nonce.guid++ ) +
+					uncached;
 			}
 
 			// Put hash and anti-cache on the URL that will be requested (gh-1732)

--- a/src/ajax/jsonp.js
+++ b/src/ajax/jsonp.js
@@ -15,7 +15,7 @@ var oldCallbacks = [],
 jQuery.ajaxSetup( {
 	jsonp: "callback",
 	jsonpCallback: function() {
-		var callback = oldCallbacks.pop() || ( jQuery.expando + "_" + ( nonce++ ) );
+		var callback = oldCallbacks.pop() || ( jQuery.expando + "_" + ( nonce.guid++ ) );
 		this[ callback ] = true;
 		return callback;
 	}

--- a/src/ajax/var/nonce.js
+++ b/src/ajax/var/nonce.js
@@ -1,5 +1,5 @@
 define( function() {
 	"use strict";
 
-	return Date.now();
+	return { guid: Date.now() };
 } );

--- a/src/exports/global.js
+++ b/src/exports/global.js
@@ -1,6 +1,6 @@
 define( [
 	"../core"
-], function( jQuery, noGlobal ) {
+], function( jQuery ) {
 
 "use strict";
 
@@ -27,7 +27,7 @@ jQuery.noConflict = function( deep ) {
 // Expose jQuery and $ identifiers, even in AMD
 // (#7102#comment:10, https://github.com/jquery/jquery/pull/557)
 // and CommonJS for browser emulators (#13566)
-if ( !noGlobal ) {
+if ( typeof noGlobal === "undefined" ) {
 	window.jQuery = window.$ = jQuery;
 }
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

This PR aligns the `3.x-stable` branch with `master` in two aspects:
1. It migrates the nonce module to return an object instead of a primitive
variable. This had to be changed on `master` as in ES modules you export
live read-only bindings to variables, meaning you can't increment the nonce
directly. Also, the way it was done so far was working differently in AMD & the
single built file - in the built file one nonce variable was declared, accessed
and incremented. In AMD mode separate instances were create for each module
that depend on the nonce module, creating unintended nonce clashes.
2. Whether the `noGlobal` parameter was set to `true` is now checked using the
typeof operator to align with `master`.

+8 bytes

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
