### PR TITLE
Release: Use an in-repository dist README fixture

### DIFF
--- a/build/fixtures/README.md
+++ b/build/fixtures/README.md
@@ -1,0 +1,62 @@
+# jQuery
+
+> jQuery is a fast, small, and feature-rich JavaScript library.
+
+For information on how to get started and how to use jQuery, please see [jQuery's documentation](http://api.jquery.com/).
+For source files and issues, please visit the [jQuery repo](https://github.com/jquery/jquery).
+
+If upgrading, please see the [blog post for @VERSION](@BLOG_POST_LINK). This includes notable differences from the previous version and a more readable changelog.
+
+## Including jQuery
+
+Below are some of the most common ways to include jQuery.
+
+### Browser
+
+#### Script tag
+
+```html
+<script src="https://code.jquery.com/jquery-@VERSION.min.js"></script>
+```
+
+#### Babel
+
+[Babel](http://babeljs.io/) is a next generation JavaScript compiler. One of the features is the ability to use ES6/ES2015 modules now, even though browsers do not yet support this feature natively.
+
+```js
+import $ from "jquery";
+```
+
+#### Browserify/Webpack
+
+There are several ways to use [Browserify](http://browserify.org/) and [Webpack](https://webpack.github.io/). For more information on using these tools, please refer to the corresponding project's documention. In the script, including jQuery will usually look like this...
+
+```js
+var $ = require( "jquery" );
+```
+
+#### AMD (Asynchronous Module Definition)
+
+AMD is a module format built for the browser. For more information, we recommend [require.js' documentation](http://requirejs.org/docs/whyamd.html).
+
+```js
+define( [ "jquery" ], function( $ ) {
+
+} );
+```
+
+### Node
+
+To include jQuery in [Node](nodejs.org), first install with npm.
+
+```sh
+npm install jquery
+```
+
+For jQuery to work in Node, a window with a document is required. Since no such window exists natively in Node, one can be mocked by tools such as [jsdom](https://github.com/tmpvar/jsdom). This can be useful for testing purposes.
+
+```js
+const { JSDOM } = require( "jsdom" );
+const { window } = new JSDOM( "" );
+const $ = require( "jquery" )( window );
+```

--- a/build/release.js
+++ b/build/release.js
@@ -85,6 +85,7 @@ module.exports = function( Release ) {
 module.exports.dependencies = [
 	"archiver@1.3.0",
 	"shelljs@0.7.7",
+	"inquirer@7.0.4",
 	"npm@4.4.1",
 	"chalk@1.1.3"
 ];

--- a/build/release.js
+++ b/build/release.js
@@ -4,23 +4,22 @@ var fs = require( "fs" );
 
 module.exports = function( Release ) {
 
-	var
-		distFiles = [
-			"dist/jquery.js",
-			"dist/jquery.min.js",
-			"dist/jquery.min.map",
-			"dist/jquery.slim.js",
-			"dist/jquery.slim.min.js",
-			"dist/jquery.slim.min.map"
-		],
-		filesToCommit = [
-			...distFiles,
-			"src/core.js"
-		],
-		cdn = require( "./release/cdn" ),
-		dist = require( "./release/dist" ),
+	const distFiles = [
+		"dist/jquery.js",
+		"dist/jquery.min.js",
+		"dist/jquery.min.map",
+		"dist/jquery.slim.js",
+		"dist/jquery.slim.min.js",
+		"dist/jquery.slim.min.map"
+	];
+	const filesToCommit = [
+		...distFiles,
+		"src/core.js"
+	];
+	const cdn = require( "./release/cdn" );
+	const dist = require( "./release/dist" );
 
-		npmTags = Release.npmTags;
+	const npmTags = Release.npmTags;
 
 	function setSrcVersion( filepath ) {
 		var contents = fs.readFileSync( filepath, "utf8" );

--- a/build/release/dist.js
+++ b/build/release/dist.js
@@ -2,33 +2,33 @@
 
 module.exports = function( Release, files, complete ) {
 
-	var
-		fs = require( "fs" ),
-		shell = require( "shelljs" ),
-		pkg = require( Release.dir.repo + "/package.json" ),
-		distRemote = Release.remote
+	const fs = require( "fs" ).promises;
+	const shell = require( "shelljs" );
+	const inquirer = require( "inquirer" );
+	const pkg = require( `${ Release.dir.repo }/package.json` );
+	const distRemote = Release.remote
 
-			// For local and github dists
-			.replace( /jquery(\.git|$)/, "jquery-dist$1" ),
+		// For local and github dists
+		.replace( /jquery(\.git|$)/, "jquery-dist$1" );
 
-		// These files are included with the distribution
-		extras = [
-			"amd",
-			"src",
-			"LICENSE.txt",
-			"AUTHORS.txt",
-			"package.json"
-		];
+	// These files are included with the distribution
+	const extras = [
+		"amd",
+		"src",
+		"LICENSE.txt",
+		"AUTHORS.txt",
+		"package.json"
+	];
 
 	/**
 	 * Clone the distribution repo
 	 */
 	function clone() {
 		Release.chdir( Release.dir.base );
-		Release.dir.dist = Release.dir.base + "/dist";
+		Release.dir.dist = `${ Release.dir.base }/dist`;
 
 		console.log( "Using distribution repo: ", distRemote );
-		Release.exec( "git clone " + distRemote + " " + Release.dir.dist,
+		Release.exec( `git clone ${ distRemote } ${ Release.dir.dist }`,
 			"Error cloning repo." );
 
 		// Distribution always works on master
@@ -64,44 +64,45 @@ module.exports = function( Release, files, complete ) {
 	/**
 	 * Copy necessary files over to the dist repo
 	 */
-	function copy() {
+	async function copy() {
 
 		// Copy dist files
-		var distFolder = Release.dir.dist + "/dist",
-			readme = fs.readFileSync( Release.dir.dist + "/README.md", "utf8" ),
-			rmIgnore = files
-				.concat( [
-					"README.md",
-					"node_modules"
-				] )
-				.map( function( file ) {
-					return Release.dir.dist + "/" + file;
-				} );
+		const distFolder = `${ Release.dir.dist }/dist`;
+		const readme = await fs.readFile(
+			`${ Release.dir.dist }/README.md`, "utf8" );
+		const rmIgnore =
+			[
+				...files,
+				"README.md",
+				"node_modules"
+			]
+			.map( file => `${ Release.dir.dist }/${ file }` );
 
 		shell.config.globOptions = {
 			ignore: rmIgnore
 		};
 
 		// Remove extraneous files before copy
-		shell.rm( "-rf", Release.dir.dist + "/**/*" );
+		shell.rm( "-rf", `${ Release.dir.dist }/**/*` );
 
 		shell.mkdir( "-p", distFolder );
 		files.forEach( function( file ) {
-			shell.cp( "-f", Release.dir.repo + "/" + file, distFolder );
+			shell.cp( "-f", `${ Release.dir.repo }/${ file }`, distFolder );
 		} );
 
 		// Copy other files
 		extras.forEach( function( file ) {
-			shell.cp( "-rf", Release.dir.repo + "/" + file, Release.dir.dist );
+			shell.cp( "-rf", `${ Release.dir.repo }/${ file }`, Release.dir.dist );
 		} );
 
 		// Remove the wrapper from the dist repo
-		shell.rm( "-f", Release.dir.dist + "/src/wrapper.js" );
+		shell.rm( "-f", `${ Release.dir.dist }/src/wrapper.js` );
 
 		// Write generated bower file
-		fs.writeFileSync( Release.dir.dist + "/bower.json", generateBower() );
+		await fs.writeFile( `${ Release.dir.dist }/bower.json`, generateBower() );
 
-		fs.writeFileSync( Release.dir.dist + "/README.md", editReadme( readme ) );
+		await fs.writeFile( `${ Release.dir.dist }/README.md`,
+			editReadme( readme, blogPostLink ) );
 
 		console.log( "Files ready to add." );
 		console.log( "Edit the dist README.md to include the latest blog post link." );
@@ -114,14 +115,14 @@ module.exports = function( Release, files, complete ) {
 		console.log( "Adding files to dist..." );
 		Release.exec( "git add -A", "Error adding files." );
 		Release.exec(
-			"git commit -m \"Release " + Release.newVersion + "\"",
+			`git commit -m "Release ${ Release.newVersion }"`,
 			"Error committing files."
 		);
 		console.log();
 
 		console.log( "Tagging release on dist..." );
-		Release.exec( "git tag " + Release.newVersion,
-			"Error tagging " + Release.newVersion + " on dist repo." );
+		Release.exec( `git tag ${ Release.newVersion }`,
+			`Error tagging ${ Release.newVersion } on dist repo.` );
 		Release.tagTime = Release.exec( "git log -1 --format=\"%ad\"",
 			"Error getting tag timestamp." ).trim();
 	}
@@ -133,9 +134,12 @@ module.exports = function( Release, files, complete ) {
 		Release.chdir( Release.dir.dist );
 
 		console.log( "Pushing release to dist repo..." );
-		Release.exec( "git push " + ( Release.isTest ? " --dry-run " : "" ) +
-			distRemote + " master --tags",
-			"Error pushing master and tags to git repo." );
+		Release.exec(
+			`git push ${
+				Release.isTest ? " --dry-run" : ""
+			} ${ distRemote } master --tags`,
+			"Error pushing master and tags to git repo."
+		);
 
 		// Set repo for npm publish
 		Release.dir.origRepo = Release.dir.repo;


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Use a dist README fixture kept in the jQuery repository instead of modifying
an existing one. This makes the jQuery repository the single source of truth
when it comes to jQuery releases and it makes it easier to make changes to
README without worrying how it will affect older jQuery lines.

https://github.com/jquery/jquery-release/pull/103 is a pre-requisite to make this PR work.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
