### PR TITLE
Build: Enable ESLint one-var rule for var declarations in browser code

### DIFF
--- a/.eslintrc-browser.json
+++ b/.eslintrc-browser.json
@@ -19,6 +19,7 @@
 	},
 
 	"rules": {
+		"one-var": ["error", {"var": "always"}],
 		"strict": ["error", "function"]
 	}
 }

--- a/dist/.eslintrc.json
+++ b/dist/.eslintrc.json
@@ -19,7 +19,8 @@
 
 			"rules": {
 				// That is okay for the built version
-				"no-multiple-empty-lines": "off"
+				"no-multiple-empty-lines": "off",
+				"one-var": "off"
 			}
 		}
 	]

--- a/src/css/support.js
+++ b/src/css/support.js
@@ -8,7 +8,7 @@ var reliableTrDimensionsVal;
 // IE/Edge misreport `getComputedStyle` of table rows with width/height
 // set in CSS while `offset*` properties report correct values.
 support.reliableTrDimensions = function() {
-	var table, tr, trChild;
+	var table, tr, trChild, trStyle;
 	if ( reliableTrDimensionsVal == null ) {
 		table = document.createElement( "table" );
 		tr = document.createElement( "tr" );
@@ -23,7 +23,7 @@ support.reliableTrDimensions = function() {
 			.appendChild( tr )
 			.appendChild( trChild );
 
-		var trStyle = window.getComputedStyle( tr );
+		trStyle = window.getComputedStyle( tr );
 		reliableTrDimensionsVal = parseInt( trStyle.height ) > 3;
 
 		documentElement.removeChild( table );

--- a/src/event.js
+++ b/src/event.js
@@ -288,11 +288,12 @@ jQuery.event = {
 
 	dispatch: function( nativeEvent ) {
 
-		// Make a writable jQuery.Event from the native event object
-		var event = jQuery.event.fix( nativeEvent );
-
 		var i, j, ret, matched, handleObj, handlerQueue,
 			args = new Array( arguments.length ),
+
+			// Make a writable jQuery.Event from the native event object
+			event = jQuery.event.fix( nativeEvent ),
+
 			handlers = ( dataPriv.get( this, "events" ) || {} )[ event.type ] || [],
 			special = jQuery.event.special[ event.type ] || {};
 

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -47,6 +47,7 @@
 		"brace-style": "off",
 		"key-spacing": "off",
 		"camelcase": "off",
+		"one-var": "off",
 		"strict": "off",
 
 		// Not really too many - waiting for autofix features for these rules


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Node.js code is written more & more commonly in ES6+ so it doesn't make sense
to enable it there. There are many violations in test code so it's disabled
there as well.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
