### PR TITLE
Tests: Pass a number of necessary done() calls to assert.async()

### DIFF
--- a/test/unit/basic.js
+++ b/test/unit/basic.js
@@ -4,14 +4,14 @@ if ( jQuery.ajax ) {
 QUnit.test( "ajax", function( assert ) {
 	assert.expect( 4 );
 
-	var done = jQuery.map( new Array( 3 ), function() { return assert.async(); } );
+	var done = assert.async( 3 );
 
 	jQuery.ajax( {
 		type: "GET",
 		url: url( "mock.php?action=name&name=foo" ),
 		success: function( msg ) {
 			assert.strictEqual( msg, "bar", "Check for GET" );
-			done.pop()();
+			done();
 		}
 	} );
 
@@ -21,14 +21,14 @@ QUnit.test( "ajax", function( assert ) {
 		data: "name=peter",
 		success: function( msg ) {
 			assert.strictEqual( msg, "pan", "Check for POST" );
-			done.pop()();
+			done();
 		}
 	} );
 
 	jQuery( "#first" ).load( url( "name.html" ), function() {
 		assert.ok( /^ERROR/.test( jQuery( "#first" ).text() ),
 			"Check if content was injected into the DOM" );
-		done.pop()();
+		done();
 	} );
 } );
 }

--- a/test/unit/ready.js
+++ b/test/unit/ready.js
@@ -107,31 +107,31 @@ QUnit.module( "ready" );
 
 	QUnit[ jQuery.when ? "test" : "skip" ]( "jQuery.when(jQuery.ready)", function( assert ) {
 		assert.expect( 2 );
-		var done = jQuery.map( new Array( 2 ), function() { return assert.async(); } );
+		var done = assert.async( 2 );
 
 		whenified.then( function() {
 			assert.ok( jQuery.isReady, "jQuery.when Deferred resolved" );
-			done.pop()();
+			done();
 		} );
 
 		jQuery.when( jQuery.ready ).then( function() {
 			assert.ok( jQuery.isReady, "jQuery.when Deferred resolved" );
-			done.pop()();
+			done();
 		} );
 	} );
 
 	QUnit.test( "Promise.resolve(jQuery.ready)", function( assert ) {
 		assert.expect( 2 );
-		var done = jQuery.map( new Array( 2 ), function() { return assert.async(); } );
+		var done = assert.async( 2 );
 
 		promisified.then( function() {
 			assert.ok( jQuery.isReady, "Native promised resolved" );
-			done.pop()();
+			done();
 		} );
 
 		Promise.resolve( jQuery.ready ).then( function() {
 			assert.ok( jQuery.isReady, "Native promised resolved" );
-			done.pop()();
+			done();
 		} );
 	} );
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

It is no longer needed to create `done` wrappers in tests that require multiple
async operations to complete.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
