### PR TITLE
Ajax: Support an alternative completeCallback API for transports

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -713,8 +713,19 @@ jQuery.extend( {
 
 		// Callback for when everything is done
 		function done( status, nativeStatusText, responses, headers ) {
-			var isSuccess, success, error, response, modified,
-				statusText = nativeStatusText;
+			var isSuccess, success, error, response, modified, statusText;
+
+			if ( typeof status === "object" ) {
+
+				// The new, object-based API
+				nativeStatusText = status.statusText;
+				responses = status.responses;
+				headers = status.headers;
+
+				status = status.status;
+			}
+
+			statusText = nativeStatusText;
 
 			// Ignore repeat invocations
 			if ( completed ) {

--- a/src/ajax/xhr.js
+++ b/src/ajax/xhr.js
@@ -64,12 +64,9 @@ jQuery.ajaxTransport( function( options ) {
 						if ( type === "abort" ) {
 							xhr.abort();
 						} else if ( type === "error" ) {
-							complete( {
 
-								// File: protocol always yields status 0; see #8605, #14207
-								status: xhr.status,
-								statusText: xhr.statusText
-							} );
+							// File: protocol always yields status 0; see #8605, #14207
+							complete( xhr );
 						} else {
 							complete( {
 								status: xhrSuccessStatus[ xhr.status ] || xhr.status,

--- a/src/ajax/xhr.js
+++ b/src/ajax/xhr.js
@@ -64,23 +64,23 @@ jQuery.ajaxTransport( function( options ) {
 						if ( type === "abort" ) {
 							xhr.abort();
 						} else if ( type === "error" ) {
-							complete(
+							complete( {
 
 								// File: protocol always yields status 0; see #8605, #14207
-								xhr.status,
-								xhr.statusText
-							);
+								status: xhr.status,
+								statusText: xhr.statusText
+							} );
 						} else {
-							complete(
-								xhrSuccessStatus[ xhr.status ] || xhr.status,
-								xhr.statusText,
+							complete( {
+								status: xhrSuccessStatus[ xhr.status ] || xhr.status,
+								statusText: xhr.statusText,
 
 								// For XHR2 non-text, let the caller handle it (gh-2498)
-								( xhr.responseType || "text" ) === "text" ?
+								responses: ( xhr.responseType || "text" ) === "text" ?
 									{ text: xhr.responseText } :
 									{ binary: xhr.response },
-								xhr.getAllResponseHeaders()
-							);
+								headers: xhr.getAllResponseHeaders()
+							} );
 						}
 					}
 				};


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Apart from the existing API:

```js
function( status, statusText, responses, headers ) {}
```
a new API is now available:
```js
function( { status, statusText, responses, headers } ) {}
```

This makes it possible to add new parameters in the future without relying on
their order among parameters and being able to provide them selectively.

Ref gh-4405

+37 bytes. Not changing existing transports would make that smaller but we'll need to change the XHR one anyway to land #4405 and then the build gets smaller if we update it in all the places I modified in the PR.

*Note:* This still needs tests. That said, we don't have any direct tests for [`jQuery.ajaxTransport`](https://api.jquery.com/jQuery.ajaxTransport/), its only implicitly tested by the virtue of two core transports using this API. Therefore, before landing this I'd like to write a few tests for the API first. I'm opening this draft PR now to gain feedback whether this is a direction in which we'd like to go.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
