### PR TITLE
Manipulation: Make jQuery.htmlPrefilter an identity function

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -23,9 +23,6 @@ import "./event.js";
 
 var
 
-	// See https://github.com/eslint/eslint/issues/3229
-	rxhtmlTag = /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([a-z][^\/\0>\x20\t\r\n\f]*)[^>]*)\/>/gi,
-
 	// Support: IE <=10 - 11+, Edge 12 - 13 only
 	// In IE/Edge using regex groups here causes severe slowdowns.
 	// See https://connect.microsoft.com/IE/feedback/details/1736512/
@@ -198,7 +195,7 @@ function remove( elem, selector, keepData ) {
 
 jQuery.extend( {
 	htmlPrefilter: function( html ) {
-		return html.replace( rxhtmlTag, "<$1></$2>" );
+		return html;
 	},
 
 	clone: function( elem, dataAndEvents, deepDataAndEvents ) {

--- a/test/data/testinit.js
+++ b/test/data/testinit.js
@@ -243,7 +243,7 @@ this.testIframe = function( title, fileName, func, wrapper ) {
 	}
 	wrapper.call( QUnit, title, function( assert ) {
 		var done = assert.async(),
-			$iframe = supportjQuery( "<iframe/>" )
+			$iframe = supportjQuery( "<iframe></iframe>" )
 				.css( { position: "absolute", top: "0", left: "-600px", width: "500px" } )
 				.attr( { id: "qunit-fixture-iframe", src: url( fileName ) } );
 

--- a/test/localfile.html
+++ b/test/localfile.html
@@ -49,7 +49,7 @@
 	<script>
 		var logUL = jQuery( "#log" );
 		function doLog( message, args ) {
-			jQuery( "<li />").appendTo( logUL ).text( message + ': "' + Array.prototype.join.call( args, '" - "' ) + '"' );
+			jQuery( "<li></li>" ).appendTo( logUL ).text( message + ': "' + Array.prototype.join.call( args, '" - "' ) + '"' );
 		}
 		jQuery.ajax( "./data/badjson.js" , {
 			context: jQuery( "#success" ),

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -2540,7 +2540,7 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 
 		addGlobalEvents( "ajaxStart ajaxStop ajaxSend ajaxComplete ajaxError", assert )();
 		jQuery( document ).on( "ajaxStop", done );
-		jQuery( "<div/>" ).load( baseURL + "404.txt", function() {
+		jQuery( "<div></div>" ).load( baseURL + "404.txt", function() {
 			assert.ok( true, "complete" );
 		} );
 	} );
@@ -2647,7 +2647,7 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 				return "Hello World";
 			}
 		} );
-		jQuery( "<div/>" ).load( url( "name.html" ), function( responseText ) {
+		jQuery( "<div></div>" ).load( url( "name.html" ), function( responseText ) {
 			assert.strictEqual( jQuery( this ).html(), "Hello World", "Test div was filled with filtered data" );
 			assert.strictEqual( responseText, "Hello World", "Test callback receives filtered data" );
 			done();
@@ -2657,7 +2657,7 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 	QUnit.test( "jQuery.fn.load( String, Object, Function )", function( assert ) {
 		assert.expect( 2 );
 		var done = assert.async();
-		jQuery( "<div />" ).load( url( "mock.php?action=echoHtml" ), {
+		jQuery( "<div></div>" ).load( url( "mock.php?action=echoHtml" ), {
 			"bar": "ok"
 		}, function() {
 			var $node = jQuery( this );
@@ -2671,7 +2671,7 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 		assert.expect( 2 );
 		var done = assert.async();
 
-		jQuery( "<div />" ).load( url( "mock.php?action=echoHtml" ), "foo=3&bar=ok", function() {
+		jQuery( "<div></div>" ).load( url( "mock.php?action=echoHtml" ), "foo=3&bar=ok", function() {
 			var $node = jQuery( this );
 			assert.strictEqual( $node.find( "#method" ).text(), "GET", "Check method" );
 			assert.ok( $node.find( "#query" ).text().match( /foo=3&bar=ok/ ), "Check if a string of data is passed correctly" );

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -93,12 +93,12 @@ QUnit.test( "attr(String)", function( assert ) {
 	assert.equal( jQuery( "#area1" ).attr( "maxLength" ), "30", "Check for maxLength attribute" );
 
 	// using innerHTML in IE causes href attribute to be serialized to the full path
-	jQuery( "<a/>" ).attr( {
+	jQuery( "<a></a>" ).attr( {
 		"id": "tAnchor5",
 		"href": "#5"
 	} ).appendTo( "#qunit-fixture" );
 	assert.equal( jQuery( "#tAnchor5" ).attr( "href" ), "#5", "Check for non-absolute href (an anchor)" );
-	jQuery( "<a id='tAnchor6' href='#5' />" ).appendTo( "#qunit-fixture" );
+	jQuery( "<a id='tAnchor6' href='#5'></a>" ).appendTo( "#qunit-fixture" );
 	assert.equal( jQuery( "#tAnchor5" ).prop( "href" ), jQuery( "#tAnchor6" ).prop( "href" ), "Check for absolute href prop on an anchor" );
 
 	jQuery( "<script type='jquery/test' src='#5' id='scriptSrc'></script>" ).appendTo( "#qunit-fixture" );
@@ -136,7 +136,7 @@ QUnit.test( "attr(String)", function( assert ) {
 	assert.equal( $img.attr( "height" ), "53", "Retrieve height attribute on an element with display:none." );
 
 	// Check for style support
-	styleElem = jQuery( "<div/>" ).appendTo( "#qunit-fixture" ).css( {
+	styleElem = jQuery( "<div></div>" ).appendTo( "#qunit-fixture" ).css( {
 		background: "url(UPPERlower.gif)"
 	} );
 	assert.ok( !!~styleElem.attr( "style" ).indexOf( "UPPERlower.gif" ), "Check style attribute getter" );
@@ -158,11 +158,11 @@ QUnit.test( "attr(String)", function( assert ) {
 	$a = jQuery( "<a href='#' onclick='something()'>Click</a>" ).appendTo( "#qunit-fixture" );
 	assert.equal( $a.attr( "onclick" ), "something()", "Retrieve ^on attribute without anonymous function wrapper." );
 
-	assert.ok( jQuery( "<div/>" ).attr( "doesntexist" ) === undefined, "Make sure undefined is returned when no attribute is found." );
-	assert.ok( jQuery( "<div/>" ).attr( "title" ) === undefined, "Make sure undefined is returned when no attribute is found." );
-	assert.equal( jQuery( "<div/>" ).attr( "title", "something" ).attr( "title" ), "something", "Set the title attribute." );
+	assert.ok( jQuery( "<div></div>" ).attr( "doesntexist" ) === undefined, "Make sure undefined is returned when no attribute is found." );
+	assert.ok( jQuery( "<div></div>" ).attr( "title" ) === undefined, "Make sure undefined is returned when no attribute is found." );
+	assert.equal( jQuery( "<div></div>" ).attr( "title", "something" ).attr( "title" ), "something", "Set the title attribute." );
 	assert.ok( jQuery().attr( "doesntexist" ) === undefined, "Make sure undefined is returned when no element is there." );
-	assert.equal( jQuery( "<div/>" ).attr( "value" ), undefined, "An unset value on a div returns undefined." );
+	assert.equal( jQuery( "<div></div>" ).attr( "value" ), undefined, "An unset value on a div returns undefined." );
 	assert.strictEqual( jQuery( "<select><option value='property'></option></select>" ).attr( "value" ), undefined, "An unset value on a select returns undefined." );
 
 	$form = jQuery( "#form" ).attr( "enctype", "multipart/form-data" );
@@ -180,7 +180,7 @@ QUnit.test( "attr(String) on cloned elements, #9646", function( assert ) {
 
 	assert.strictEqual( input.clone( true ).attr( "name", "test" )[ 0 ].name, "test", "Name attribute should be changed on cloned element" );
 
-	div = jQuery( "<div id='tester' />" );
+	div = jQuery( "<div id='tester'></div>" );
 	div.attr( "id" );
 
 	assert.strictEqual( div.clone( true ).attr( "id", "test" )[ 0 ].id, "test", "Id attribute should be changed on cloned element" );
@@ -299,7 +299,7 @@ QUnit.test( "attr(String, Object)", function( assert ) {
 	$input = jQuery( "<input type='checkbox'/>" ).attr( "checked", true );
 	assert.equal( $input.prop( "checked" ), true, "Setting checked updates property (verified by .prop)" );
 	assert.equal( $input[ 0 ].checked, true, "Setting checked updates property (verified by native property)" );
-	$input = jQuery( "<option/>" ).attr( "selected", true );
+	$input = jQuery( "<option></option>" ).attr( "selected", true );
 	assert.equal( $input.prop( "selected" ), true, "Setting selected updates property (verified by .prop)" );
 	assert.equal( $input[ 0 ].selected, true, "Setting selected updates property (verified by native property)" );
 
@@ -569,7 +569,7 @@ QUnit.test( "removeAttr(String)", function( assert ) {
 	assert.expect( 12 );
 	var $first;
 
-	assert.equal( jQuery( "<div class='hello' />" ).removeAttr( "class" ).attr( "class" ), undefined, "remove class" );
+	assert.equal( jQuery( "<div class='hello'></div>" ).removeAttr( "class" ).attr( "class" ), undefined, "remove class" );
 	assert.equal( jQuery( "#form" ).removeAttr( "id" ).attr( "id" ), undefined, "Remove id" );
 	assert.equal( jQuery( "#foo" ).attr( "style", "position:absolute;" ).removeAttr( "style" ).attr( "style" ), undefined, "Check removing style attribute" );
 	assert.equal( jQuery( "#form" ).attr( "style", "position:absolute;" ).removeAttr( "style" ).attr( "style" ), undefined, "Check removing style attribute on a form" );
@@ -669,7 +669,7 @@ QUnit.test( "prop(String, Object)", function( assert ) {
 	assert.equal( jQuery( "#select2" ).prop( "selectedIndex" ), 3, "Check for selectedIndex attribute" );
 	assert.equal( jQuery( "#foo" ).prop( "nodeName" ).toUpperCase(), "DIV", "Check for nodeName attribute" );
 	assert.equal( jQuery( "#foo" ).prop( "tagName" ).toUpperCase(), "DIV", "Check for tagName attribute" );
-	assert.equal( jQuery( "<option/>" ).prop( "selected" ), false, "Check selected attribute on disconnected element." );
+	assert.equal( jQuery( "<option></option>" ).prop( "selected" ), false, "Check selected attribute on disconnected element." );
 
 	assert.equal( jQuery( "#listWithTabIndex" ).prop( "tabindex" ), 5, "Check retrieving tabindex" );
 	jQuery( "#text1" ).prop( "readonly", true );
@@ -814,16 +814,16 @@ QUnit.test( "option.prop('selected', true) affects select.selectedIndex (gh-2732
 
 	function addOptions( $elem ) {
 		return $elem.append(
-			jQuery( "<option/>" ).val( "a" ).text( "One" ),
-			jQuery( "<option/>" ).val( "b" ).text( "Two" ),
-			jQuery( "<option/>" ).val( "c" ).text( "Three" )
+			jQuery( "<option></option>" ).val( "a" ).text( "One" ),
+			jQuery( "<option></option>" ).val( "b" ).text( "Two" ),
+			jQuery( "<option></option>" ).val( "c" ).text( "Three" )
 		)
 		.find( "[value=a]" ).prop( "selected", true ).end()
 		.find( "[value=c]" ).prop( "selected", true ).end();
 	}
 
 	var $optgroup,
-		$select = jQuery( "<select/>" );
+		$select = jQuery( "<select></select>" );
 
 	// Check select with options
 	addOptions( $select ).appendTo( "#qunit-fixture" );
@@ -833,7 +833,7 @@ QUnit.test( "option.prop('selected', true) affects select.selectedIndex (gh-2732
 	$select.empty();
 
 	// Check select with optgroup
-	$optgroup = jQuery( "<optgroup/>" );
+	$optgroup = jQuery( "<optgroup></optgroup>" );
 	addOptions( $optgroup ).appendTo( $select );
 	$select.find( "[value=b]" ).prop( "selected", true );
 
@@ -947,7 +947,7 @@ QUnit.test( "val()", function( assert ) {
 	assert.equal( $button.val(), "foobar", "Value retrieval on a button does not return innerHTML" );
 	assert.equal( $button.val( "baz" ).html(), "text", "Setting the value does not change innerHTML" );
 
-	assert.equal( jQuery( "<option/>" ).val( "test" ).attr( "value" ), "test", "Setting value sets the value attribute" );
+	assert.equal( jQuery( "<option></option>" ).val( "test" ).attr( "value" ), "test", "Setting value sets the value attribute" );
 } );
 
 QUnit.test( "val() with non-matching values on dropdown list", function( assert ) {
@@ -1014,7 +1014,7 @@ var testVal = function( valueObj, assert ) {
 	assert.equal( document.getElementById( "text1" ).value, "", "Check for modified (via val(null)) value of input element" );
 
 	var j,
-		$select = jQuery( "<select multiple><option value='1'/><option value='2'/></select>" ),
+		$select = jQuery( "<select multiple><option value='1'></option><option value='2'></option></select>" ),
 		$select1 = jQuery( "#select1" );
 
 	$select1.val( valueObj( "3" ) );
@@ -1130,7 +1130,7 @@ QUnit.test( "val(select) after form.reset() (Bug #2551)", function( assert ) {
 QUnit.test( "select.val(space characters) (gh-2978)", function( assert ) {
 	assert.expect( 37 );
 
-	var $select = jQuery( "<select/>" ).appendTo( "#qunit-fixture" ),
+	var $select = jQuery( "<select></select>" ).appendTo( "#qunit-fixture" ),
 		spaces = {
 			"\\t": {
 				html: "&#09;",
@@ -1266,7 +1266,7 @@ var testAddClass = function( valueObj, assert ) {
 	j.addClass( valueObj( "asdf" ) );
 	assert.ok( j.hasClass( "asdf" ), "Check node,textnode,comment for addClass" );
 
-	div = jQuery( "<div/>" );
+	div = jQuery( "<div></div>" );
 
 	div.addClass( valueObj( "test" ) );
 	assert.equal( div.attr( "class" ), "test", "Make sure there's no extra whitespace." );
@@ -1697,9 +1697,9 @@ QUnit.test( "coords returns correct values in IE6/IE7, see #10828", function( as
 	assert.expect( 1 );
 
 	var area,
-		map = jQuery( "<map />" );
+		map = jQuery( "<map></map>" );
 
-	area = map.html( "<area shape='rect' coords='0,0,0,0' href='#' alt='a' />" ).find( "area" );
+	area = map.html( "<area shape='rect' coords='0,0,0,0' href='#' alt='a'></area>" ).find( "area" );
 	assert.equal( area.attr( "coords" ), "0,0,0,0", "did not retrieve coords correctly" );
 } );
 
@@ -1707,7 +1707,7 @@ QUnit.test( "should not throw at $(option).val() (#14686)", function( assert ) {
 	assert.expect( 1 );
 
 	try {
-		jQuery( "<option/>" ).val();
+		jQuery( "<option></option>" ).val();
 		assert.ok( true );
 	} catch ( _ ) {
 		assert.ok( false );

--- a/test/unit/basic.js
+++ b/test/unit/basic.js
@@ -36,7 +36,7 @@ QUnit.test( "ajax", function( assert ) {
 QUnit.test( "attributes", function( assert ) {
 	assert.expect( 6 );
 
-	var a = jQuery( "<a/>" ).appendTo( "#qunit-fixture" ),
+	var a = jQuery( "<a></a>" ).appendTo( "#qunit-fixture" ),
 		input = jQuery( "<input/>" ).appendTo( "#qunit-fixture" );
 
 	assert.strictEqual( a.attr( "foo", "bar" ).attr( "foo" ), "bar", ".attr getter/setter" );
@@ -56,7 +56,7 @@ if ( jQuery.css ) {
 QUnit.test( "css", function( assert ) {
 	assert.expect( 1 );
 
-	var div = jQuery( "<div/>" ).appendTo( "#qunit-fixture" );
+	var div = jQuery( "<div></div>" ).appendTo( "#qunit-fixture" );
 
 	assert.strictEqual( div.css( "width", "50px" ).css( "width" ), "50px", ".css getter/setter" );
 } );
@@ -66,7 +66,7 @@ if ( jQuery.fn.show && jQuery.fn.hide ) {
 QUnit.test( "show/hide", function( assert ) {
 	assert.expect( 2 );
 
-	var div = jQuery( "<div/>" ).appendTo( "#qunit-fixture" );
+	var div = jQuery( "<div></div>" ).appendTo( "#qunit-fixture" );
 
 	div.hide();
 	assert.strictEqual( div.css( "display" ), "none", "div hidden" );
@@ -126,7 +126,7 @@ QUnit.test( "core", function( assert ) {
 QUnit.test( "data", function( assert ) {
 	assert.expect( 4 );
 
-	var elem = jQuery( "<div data-c='d'/>" ).appendTo( "#qunit-fixture" );
+	var elem = jQuery( "<div data-c='d'></div>" ).appendTo( "#qunit-fixture" );
 
 	assert.ok( !jQuery.hasData( elem[ 0 ] ), "jQuery.hasData - false" );
 	assert.strictEqual( elem.data( "a", "b" ).data( "a" ), "b", ".data getter/setter" );
@@ -138,7 +138,7 @@ QUnit.test( "dimensions", function( assert ) {
 	assert.expect( 3 );
 
 	var elem = jQuery(
-		"<div style='margin: 10px; padding: 7px; border: 2px solid black;' /> "
+		"<div style='margin: 10px; padding: 7px; border: 2px solid black;'></div> "
 	).appendTo( "#qunit-fixture" );
 
 	assert.strictEqual( elem.width( 50 ).width(), 50, ".width getter/setter" );
@@ -149,7 +149,7 @@ QUnit.test( "dimensions", function( assert ) {
 QUnit.test( "event", function( assert ) {
 	assert.expect( 1 );
 
-	var elem = jQuery( "<div/>" ).appendTo( "#qunit-fixture" );
+	var elem = jQuery( "<div></div>" ).appendTo( "#qunit-fixture" );
 
 	elem
 		.on( "click", function() {
@@ -168,12 +168,12 @@ QUnit.test( "manipulation", function( assert ) {
 
 	var child,
 		elem1 = jQuery( "<div><span></span></div>" ).appendTo( "#qunit-fixture" ),
-		elem2 = jQuery( "<div/>" ).appendTo( "#qunit-fixture" );
+		elem2 = jQuery( "<div></div>" ).appendTo( "#qunit-fixture" );
 
 	assert.strictEqual( elem1.text( "foo" ).text(), "foo", ".html getter/setter" );
 
 	assert.strictEqual(
-		elem1.html( "<span/>" ).html(),
+		elem1.html( "<span></span>" ).html(),
 		"<span></span>",
 		".html getter/setter"
 	);
@@ -186,8 +186,8 @@ QUnit.test( "manipulation", function( assert ) {
 	assert.strictEqual( elem1.prepend( elem2 )[ 0 ].childNodes[ 0 ], elem2[ 0 ], ".prepend" );
 
 	child = elem1.find( "span" );
-	child.after( "<a/>" );
-	child.before( "<b/>" );
+	child.after( "<a></a>" );
+	child.before( "<b></b>" );
 
 	assert.strictEqual(
 		elem1.html(),
@@ -201,8 +201,8 @@ QUnit.test( "manipulation", function( assert ) {
 QUnit[ /jsdom\//.test( navigator.userAgent ) ? "skip" : "test" ]( "offset", function( assert ) {
 	assert.expect( 3 );
 
-	var parent = jQuery( "<div style='position:fixed;top:20px;'/>" ).appendTo( "#qunit-fixture" ),
-		elem = jQuery( "<div style='position:absolute;top:5px;'/>" ).appendTo( parent );
+	var parent = jQuery( "<div style='position:fixed;top:20px;'></div>" ).appendTo( "#qunit-fixture" ),
+		elem = jQuery( "<div style='position:absolute;top:5px;'></div>" ).appendTo( parent );
 
 	assert.strictEqual( elem.offset().top, 25, ".offset getter" );
 	assert.strictEqual( elem.position().top, 5, ".position getter" );

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -23,9 +23,9 @@ QUnit.test( "jQuery()", function( assert ) {
 
 	var elem, i,
 		obj = jQuery( "div" ),
-		code = jQuery( "<code/>" ),
+		code = jQuery( "<code></code>" ),
 		img = jQuery( "<img/>" ),
-		div = jQuery( "<div/><hr/><code/><b/>" ),
+		div = jQuery( "<div></div><hr/><code></code><b/>" ),
 		exec = false,
 		expected = 23,
 		attrObj = {
@@ -113,7 +113,7 @@ QUnit.test( "jQuery()", function( assert ) {
 	elem = jQuery( "\n\n<em>world</em>" )[ 0 ];
 	assert.equal( elem.nodeName.toLowerCase(), "em", "leading newlines" );
 
-	elem = jQuery( "<div/>", attrObj );
+	elem = jQuery( "<div></div>", attrObj );
 
 	if ( jQuery.fn.width ) {
 		assert.equal( elem[ 0 ].style.width, "10px", "jQuery() quick setter width" );
@@ -458,7 +458,7 @@ QUnit.test( "jQuery('html')", function( assert ) {
 
 	assert.ok( jQuery( "<link rel='stylesheet'/>" )[ 0 ], "Creating a link" );
 
-	assert.ok( !jQuery( "<script/>" )[ 0 ].parentNode, "Create a script" );
+	assert.ok( !jQuery( "<script></script>" )[ 0 ].parentNode, "Create a script" );
 
 	assert.ok( jQuery( "<input/>" ).attr( "type", "hidden" ), "Create an input and set the type." );
 
@@ -526,8 +526,8 @@ QUnit.test( "jQuery('massive html #7990')", function( assert ) {
 QUnit.test( "jQuery('html', context)", function( assert ) {
 	assert.expect( 1 );
 
-	var $div = jQuery( "<div/>" )[ 0 ],
-		$span = jQuery( "<span/>", $div );
+	var $div = jQuery( "<div></div>" )[ 0 ],
+		$span = jQuery( "<span></span>", $div );
 	assert.equal( $span.length, 1, "verify a span created with a div context works, #1763" );
 } );
 
@@ -1355,7 +1355,7 @@ QUnit.test( "jQuery.parseHTML", function( assert ) {
 	assert.equal( jQuery.parseHTML( "text" )[ 0 ].nodeType, 3, "Parsing text returns a text node" );
 	assert.equal( jQuery.parseHTML( "\t<div></div>" )[ 0 ].nodeValue, "\t", "Preserve leading whitespace" );
 
-	assert.equal( jQuery.parseHTML( " <div/> " )[ 0 ].nodeType, 3, "Leading spaces are treated as text nodes (#11290)" );
+	assert.equal( jQuery.parseHTML( " <div></div> " )[ 0 ].nodeType, 3, "Leading spaces are treated as text nodes (#11290)" );
 
 	html = jQuery.parseHTML( "<div>test div</div>" );
 

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -13,7 +13,7 @@ QUnit.test( "css(String|Hash)", function( assert ) {
 	assert.notEqual( $child.css( "width" ), "20px", "Retrieving a width percentage on the child of a hidden div returns percentage" );
 	assert.notEqual( $child.css( "height" ), "20px", "Retrieving a height percentage on the child of a hidden div returns percentage" );
 
-	div = jQuery( "<div/>" );
+	div = jQuery( "<div></div>" );
 
 	// These should be "auto" (or some better value)
 	// temporarily provide "0px" for backwards compat
@@ -25,7 +25,7 @@ QUnit.test( "css(String|Hash)", function( assert ) {
 	assert.equal( div.css( "width" ), "4px", "Width on disconnected node." );
 	assert.equal( div.css( "height" ), "4px", "Height on disconnected node." );
 
-	div2 = jQuery( "<div style='display:none;'><input type='text' style='height:20px;'/><textarea style='height:20px;'/><div style='height:20px;'></div></div>" ).appendTo( "body" );
+	div2 = jQuery( "<div style='display:none;'><input type='text' style='height:20px;'/><textarea style='height:20px;'></textarea><div style='height:20px;'></div></div>" ).appendTo( "body" );
 
 	assert.equal( div2.find( "input" ).css( "height" ), "20px", "Height on hidden input." );
 	assert.equal( div2.find( "textarea" ).css( "height" ), "20px", "Height on hidden textarea." );
@@ -42,7 +42,7 @@ QUnit.test( "css(String|Hash)", function( assert ) {
 	assert.equal( parseFloat( jQuery( "#nothiddendiv" ).css( "width" ) ), 0, "Test negative width set to 0" );
 	assert.equal( parseFloat( jQuery( "#nothiddendiv" ).css( "height" ) ), 0, "Test negative height set to 0" );
 
-	assert.equal( jQuery( "<div style='display: none;'/>" ).css( "display" ), "none", "Styles on disconnected nodes" );
+	assert.equal( jQuery( "<div style='display: none;'></div>" ).css( "display" ), "none", "Styles on disconnected nodes" );
 
 	jQuery( "#floatTest" ).css( { "float": "right" } );
 	assert.equal( jQuery( "#floatTest" ).css( "float" ), "right", "Modified CSS float using \"float\": Assert float is right" );
@@ -111,7 +111,7 @@ QUnit.test( "css(String|Hash)", function( assert ) {
 
 	assert.strictEqual( child.css( "x-fake" ), undefined, "Make sure undefined is returned from css(nonexistent)." );
 
-	div = jQuery( "<div/>" ).css( { position: "absolute", "z-index": 1000 } ).appendTo( "#qunit-fixture" );
+	div = jQuery( "<div></div>" ).css( { position: "absolute", "z-index": 1000 } ).appendTo( "#qunit-fixture" );
 	assert.strictEqual( div.css( "z-index" ), "1000",
 		"Make sure that a string z-index is returned from css('z-index') (#14432)." );
 } );
@@ -275,10 +275,10 @@ QUnit.test( "css() mismatched relative values with bounded styles (gh-2144)", fu
 	assert.expect( 1 );
 
 	var right,
-		$container = jQuery( "<div/>" )
+		$container = jQuery( "<div></div>" )
 			.css( { position: "absolute", width: "400px", fontSize: "4px" } )
 			.appendTo( "#qunit-fixture" ),
-		$el = jQuery( "<div/>" )
+		$el = jQuery( "<div></div>" )
 			.css( { position: "absolute", left: "50%", right: "50%" } )
 			.appendTo( $container );
 
@@ -574,7 +574,7 @@ QUnit.test( "show/hide detached nodes", function( assert ) {
 	assert.equal( div.css( "display" ), "none",
 		"A shown-while-detached div inside a visible div can be hidden by the CSS cascade" );
 
-	span = jQuery( "<span class='hidden'/>" );
+	span = jQuery( "<span class='hidden'></span>" );
 	span.show().appendTo( "#qunit-fixture" );
 	assert.equal( span.css( "display" ), "none",
 		"A shown-while-detached span can be hidden by the CSS cascade" );
@@ -588,7 +588,7 @@ QUnit.test( "show/hide detached nodes", function( assert ) {
 		"A shown-while-detached cascade-hidden div is hidden after attachment" );
 	div.remove();
 
-	span = jQuery( "<span class='hidden'/>" );
+	span = jQuery( "<span class='hidden'></span>" );
 	span.appendTo( "#qunit-fixture" ).detach().show().appendTo( "#qunit-fixture" );
 	assert.equal( span.css( "display" ), "none",
 		"A shown-while-detached cascade-hidden span is hidden after attachment" );
@@ -615,7 +615,7 @@ QUnit.test( "show/hide detached nodes", function( assert ) {
 		"A shown-while-detached inline-hidden div inside a visible div has default display " +
 		"after attachment" );
 
-	span = jQuery( "<span style='display: none'/>" );
+	span = jQuery( "<span style='display: none'></span>" );
 	span.show();
 	assert.equal( span[ 0 ].style.display, "",
 		"show() updates inline style of a detached inline-hidden span" );
@@ -623,20 +623,20 @@ QUnit.test( "show/hide detached nodes", function( assert ) {
 	assert.equal( span.css( "display" ), "inline",
 		"A shown-while-detached inline-hidden span has default display after attachment" );
 
-	div = jQuery( "<div style='display: inline'/>" );
+	div = jQuery( "<div style='display: inline'></div>" );
 	div.show().appendTo( "#qunit-fixture" );
 	assert.equal( div.css( "display" ), "inline",
 		"show() does not update inline style of a detached inline-visible div" );
 	div.remove();
 
-	tr = jQuery( "<tr/>" );
+	tr = jQuery( "<tr></tr>" );
 	jQuery( "#table" ).append( tr );
 	tr.detach().hide().show();
 
 	assert.ok( !tr[ 0 ].style.display, "Not-hidden detached tr elements have no inline style" );
 	tr.remove();
 
-	span = jQuery( "<span/>" ).hide().show();
+	span = jQuery( "<span></span>" ).hide().show();
 	assert.ok( !span[ 0 ].style.display, "Not-hidden detached span elements have no inline style" );
 	span.remove();
 } );
@@ -718,7 +718,7 @@ QUnit.test( "hide hidden elements (bug #7141)", function( assert ) {
 QUnit.test( "show() after hide() should always set display to initial value (#14750)", function( assert ) {
 	assert.expect( 1 );
 
-	var div = jQuery( "<div />" ),
+	var div = jQuery( "<div></div>" ),
 		fixture = jQuery( "#qunit-fixture" );
 
 	fixture.append( div );
@@ -732,11 +732,11 @@ QUnit.test( "show/hide 3.0, default display", function( assert ) {
 	assert.expect( 36 );
 
 	var i,
-		$elems = jQuery( "<div/>" )
+		$elems = jQuery( "<div></div>" )
 			.appendTo( "#qunit-fixture" )
-			.html( "<div data-expected-display='block'/>" +
-				"<span data-expected-display='inline'/>" +
-				"<ul><li data-expected-display='list-item'/></ul>" )
+			.html( "<div data-expected-display='block'></div>" +
+				"<span data-expected-display='inline'></span>" +
+				"<ul><li data-expected-display='list-item'></li></ul>" )
 			.find( "[data-expected-display]" );
 
 	$elems.each( function() {
@@ -790,9 +790,9 @@ QUnit.test( "show/hide 3.0, cascade display", function( assert ) {
 	assert.expect( 36 );
 
 	var i,
-		$elems = jQuery( "<div/>" )
+		$elems = jQuery( "<div></div>" )
 			.appendTo( "#qunit-fixture" )
-			.html( "<span class='block'/><div class='inline'/><div class='list-item'/>" )
+			.html( "<span class='block'></span><div class='inline'></div><div class='list-item'></div>" )
 			.children();
 
 	$elems.each( function() {
@@ -829,17 +829,17 @@ QUnit.test( "show/hide 3.0, inline display", function( assert ) {
 	assert.expect( 96 );
 
 	var i,
-		$elems = jQuery( "<div/>" )
+		$elems = jQuery( "<div></div>" )
 			.appendTo( "#qunit-fixture" )
-			.html( "<span data-expected-display='block' style='display:block'/>" +
-				"<span class='list-item' data-expected-display='block' style='display:block'/>" +
-				"<div data-expected-display='inline' style='display:inline'/>" +
-				"<div class='list-item' data-expected-display='inline' style='display:inline'/>" +
+			.html( "<span data-expected-display='block' style='display:block'></span>" +
+				"<span class='list-item' data-expected-display='block' style='display:block'></span>" +
+				"<div data-expected-display='inline' style='display:inline'></div>" +
+				"<div class='list-item' data-expected-display='inline' style='display:inline'></div>" +
 				"<ul>" +
-					"<li data-expected-display='block' style='display:block'/>" +
-					"<li class='inline' data-expected-display='block' style='display:block'/>" +
-					"<li data-expected-display='inline' style='display:inline'/>" +
-					"<li class='block' data-expected-display='inline' style='display:inline'/>" +
+					"<li data-expected-display='block' style='display:block'></li>" +
+					"<li class='inline' data-expected-display='block' style='display:block'></li>" +
+					"<li data-expected-display='inline' style='display:inline'></li>" +
+					"<li class='block' data-expected-display='inline' style='display:inline'></li>" +
 				"</ul>" )
 			.find( "[data-expected-display]" );
 
@@ -878,15 +878,15 @@ QUnit.test( "show/hide 3.0, cascade hidden", function( assert ) {
 	assert.expect( 72 );
 
 	var i,
-		$elems = jQuery( "<div/>" )
+		$elems = jQuery( "<div></div>" )
 			.appendTo( "#qunit-fixture" )
-			.html( "<div class='hidden' data-expected-display='block'/>" +
-				"<div class='hidden' data-expected-display='block' style='display:none'/>" +
-				"<span class='hidden' data-expected-display='inline'/>" +
-				"<span class='hidden' data-expected-display='inline' style='display:none'/>" +
+			.html( "<div class='hidden' data-expected-display='block'></div>" +
+				"<div class='hidden' data-expected-display='block' style='display:none'></div>" +
+				"<span class='hidden' data-expected-display='inline'></span>" +
+				"<span class='hidden' data-expected-display='inline' style='display:none'></span>" +
 				"<ul>" +
-					"<li class='hidden' data-expected-display='list-item'/>" +
-					"<li class='hidden' data-expected-display='list-item' style='display:none'/>" +
+					"<li class='hidden' data-expected-display='list-item'></li>" +
+					"<li class='hidden' data-expected-display='list-item' style='display:none'></li>" +
 				"</ul>" )
 			.find( "[data-expected-display]" );
 
@@ -925,16 +925,16 @@ QUnit.test( "show/hide 3.0, inline hidden", function( assert ) {
 	assert.expect( 84 );
 
 	var i,
-		$elems = jQuery( "<div/>" )
+		$elems = jQuery( "<div></div>" )
 			.appendTo( "#qunit-fixture" )
-			.html( "<span data-expected-display='inline' style='display:none'/>" +
-				"<span class='list-item' data-expected-display='list-item' style='display:none'/>" +
-				"<div data-expected-display='block' style='display:none'/>" +
-				"<div class='list-item' data-expected-display='list-item' style='display:none'/>" +
+			.html( "<span data-expected-display='inline' style='display:none'></span>" +
+				"<span class='list-item' data-expected-display='list-item' style='display:none'></span>" +
+				"<div data-expected-display='block' style='display:none'></div>" +
+				"<div class='list-item' data-expected-display='list-item' style='display:none'></div>" +
 				"<ul>" +
-					"<li data-expected-display='list-item' style='display:none'/>" +
-					"<li class='block' data-expected-display='block' style='display:none'/>" +
-					"<li class='inline' data-expected-display='inline' style='display:none'/>" +
+					"<li data-expected-display='list-item' style='display:none'></li>" +
+					"<li class='block' data-expected-display='block' style='display:none'></li>" +
+					"<li class='inline' data-expected-display='inline' style='display:none'></li>" +
 				"</ul>" )
 			.find( "[data-expected-display]" );
 
@@ -1005,9 +1005,9 @@ QUnit[ QUnit.jQuerySelectors && jQuery.fn.toggle ? "test" : "skip" ]( "toggle()"
 
 QUnit[ QUnit.jQuerySelectors && jQuery.fn.toggle ? "test" : "skip" ]( "detached toggle()", function( assert ) {
 	assert.expect( 6 );
-	var detached = jQuery( "<p><a/><p>" ).find( "*" ).addBack(),
-		hiddenDetached = jQuery( "<p><a/></p>" ).find( "*" ).addBack().css( "display", "none" ),
-		cascadeHiddenDetached = jQuery( "<p><a/></p>" ).find( "*" ).addBack().addClass( "hidden" );
+	var detached = jQuery( "<p><a></a><p>" ).find( "*" ).addBack(),
+		hiddenDetached = jQuery( "<p><a></a></p>" ).find( "*" ).addBack().css( "display", "none" ),
+		cascadeHiddenDetached = jQuery( "<p><a></a></p>" ).find( "*" ).addBack().addClass( "hidden" );
 
 	detached.toggle();
 	detached.appendTo( "#qunit-fixture" );
@@ -1107,9 +1107,9 @@ QUnit.test( "computed margins (trac-3333; gh-2237)", function( assert ) {
 QUnit.test( "box model properties incorrectly returning % instead of px, see #10639 and #12088", function( assert ) {
 	assert.expect( 2 );
 
-	var container = jQuery( "<div/>" ).width( 400 ).appendTo( "#qunit-fixture" ),
-		el = jQuery( "<div/>" ).css( { "width": "50%", "marginRight": "50%" } ).appendTo( container ),
-		el2 = jQuery( "<div/>" ).css( { "width": "50%", "minWidth": "300px", "marginLeft": "25%" } ).appendTo( container );
+	var container = jQuery( "<div></div>" ).width( 400 ).appendTo( "#qunit-fixture" ),
+		el = jQuery( "<div></div>" ).css( { "width": "50%", "marginRight": "50%" } ).appendTo( container ),
+		el2 = jQuery( "<div></div>" ).css( { "width": "50%", "minWidth": "300px", "marginLeft": "25%" } ).appendTo( container );
 
 	assert.equal( el.css( "marginRight" ), "200px", "css('marginRight') returning % instead of px, see #10639" );
 	assert.equal( el2.css( "marginLeft" ), "100px", "css('marginLeft') returning incorrect pixel value, see #12088" );
@@ -1136,10 +1136,10 @@ QUnit.test( "can't get css for disconnected in IE<9, see #10254 and #8388", func
 	assert.expect( 2 );
 	var span, div;
 
-	span = jQuery( "<span/>" ).css( "background-image", "url(" + baseURL + "1x1.jpg)" );
+	span = jQuery( "<span></span>" ).css( "background-image", "url(" + baseURL + "1x1.jpg)" );
 	assert.notEqual( span.css( "background-image" ), null, "can't get background-image in IE<9, see #10254" );
 
-	div = jQuery( "<div/>" ).css( "top", 10 );
+	div = jQuery( "<div></div>" ).css( "top", 10 );
 	assert.equal( div.css( "top" ), "10px", "can't get top in IE<9, see #8388" );
 } );
 
@@ -1154,7 +1154,7 @@ QUnit.test( "Ensure styles are retrieving from parsed html on document fragments
 } );
 
 QUnit.test( "can't get background-position in IE<9, see #10796", function( assert ) {
-	var div = jQuery( "<div/>" ).appendTo( "#qunit-fixture" ),
+	var div = jQuery( "<div></div>" ).appendTo( "#qunit-fixture" ),
 		units = [
 			"0 0",
 			"12px 12px",
@@ -1246,7 +1246,7 @@ QUnit.testUnlessIE( "Do not append px to CSS Grid-related properties (gh-4007)",
 		};
 
 	for ( prop in gridProps ) {
-		$div = jQuery( "<div/>" ).appendTo( "#qunit-fixture" );
+		$div = jQuery( "<div></div>" ).appendTo( "#qunit-fixture" );
 		$div.css( prop, 2 );
 
 		value = gridProps[ prop ];
@@ -1644,7 +1644,7 @@ QUnit.test(
 QUnit.test( "Don't append px to CSS \"order\" value (#14049)", function( assert ) {
 	assert.expect( 1 );
 
-	var $elem = jQuery( "<div/>" );
+	var $elem = jQuery( "<div></div>" );
 
 	$elem.css( "order", 2 );
 	assert.equal( $elem.css( "order" ), "2", "2 on order" );
@@ -1711,7 +1711,7 @@ QUnit.test( "Do not throw on frame elements from css method (#15098)", function(
 
 		assert.expect( !!appearanceName + !!transformName + 1 );
 
-		elem = jQuery( "<div/>" )
+		elem = jQuery( "<div></div>" )
 			.css( {
 				msAppearance: "none",
 				appearance: "none",
@@ -1735,7 +1735,7 @@ QUnit.test( "Do not throw on frame elements from css method (#15098)", function(
 	QUnit.test( "Don't detect fake set properties on a node when caching the prefixed version", function( assert ) {
 		assert.expect( 1 );
 
-		var elem = jQuery( "<div/>" ),
+		var elem = jQuery( "<div></div>" ),
 			style = elem[ 0 ].style;
 		style.MozFakeProperty = "old value";
 		elem.css( "fakeProperty", "new value" );

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -420,7 +420,7 @@ QUnit.test( ".data(Object)", function( assert ) {
 	assert.expect( 4 );
 
 	var obj, jqobj,
-		div = jQuery( "<div/>" );
+		div = jQuery( "<div></div>" );
 
 	div.data( { "test": "in", "test2": "in2" } );
 	assert.equal( div.data( "test" ), "in", "Verify setting an object in data" );
@@ -547,7 +547,7 @@ QUnit.test( ".data should not miss preset data-* w/ hyphenated property names", 
 
 	assert.expect( 2 );
 
-	var div = jQuery( "<div/>", { id: "hyphened" } ).appendTo( "#qunit-fixture" ),
+	var div = jQuery( "<div></div>", { id: "hyphened" } ).appendTo( "#qunit-fixture" ),
 		test = {
 			"camelBar": "camelBar",
 			"hyphen-foo": "hyphen-foo"
@@ -564,7 +564,7 @@ QUnit.test( "jQuery.data should not miss data-* w/ hyphenated property names #14
 
 	assert.expect( 1 );
 
-	var div = jQuery( "<div/>" );
+	var div = jQuery( "<div></div>" );
 
 	div.data( "foo-bar", "baz" );
 
@@ -576,14 +576,14 @@ QUnit.test( ".data should not miss attr() set data-* with hyphenated property na
 
 	var a, b;
 
-	a = jQuery( "<div/>" ).appendTo( "#qunit-fixture" );
+	a = jQuery( "<div></div>" ).appendTo( "#qunit-fixture" );
 
 	a.attr( "data-long-param", "test" );
 	a.data( "long-param", { a: 2 } );
 
 	assert.deepEqual( a.data( "long-param" ), { a: 2 }, "data with property long-param was found, 1" );
 
-	b = jQuery( "<div/>" ).appendTo( "#qunit-fixture" );
+	b = jQuery( "<div></div>" ).appendTo( "#qunit-fixture" );
 
 	b.attr( "data-long-param", "test" );
 	b.data( "long-param" );
@@ -659,7 +659,7 @@ QUnit.test( ".data should not strip more than one hyphen when camelCasing (gh-20
 
 QUnit.test( ".data supports interoperable hyphenated/camelCase get/set of properties with arbitrary non-null|NaN|undefined values", function( assert ) {
 
-	var div = jQuery( "<div/>", { id: "hyphened" } ).appendTo( "#qunit-fixture" ),
+	var div = jQuery( "<div></div>", { id: "hyphened" } ).appendTo( "#qunit-fixture" ),
 		datas = {
 			"non-empty": {
 				key: "nonEmpty",
@@ -745,7 +745,7 @@ QUnit.test( ".data supports interoperable hyphenated/camelCase get/set of proper
 } );
 
 QUnit.test( ".data supports interoperable removal of hyphenated/camelCase properties", function( assert ) {
-	var div = jQuery( "<div/>", { id: "hyphened" } ).appendTo( "#qunit-fixture" ),
+	var div = jQuery( "<div></div>", { id: "hyphened" } ).appendTo( "#qunit-fixture" ),
 		rdashAlpha = /-([a-z])/g,
 		datas = {
 			"non-empty": "a string",
@@ -952,7 +952,7 @@ QUnit.test( "Check that the expando is removed when there's no more data", funct
 	assert.expect( 2 );
 
 	var key,
-		div = jQuery( "<div/>" );
+		div = jQuery( "<div></div>" );
 	div.data( "some", "data" );
 	assert.equal( div.data( "some" ), "data", "Data is added" );
 	div.removeData( "some" );
@@ -986,7 +986,7 @@ QUnit.test( ".data(prop) does not create expando", function( assert ) {
 	assert.expect( 1 );
 
 	var key,
-		div = jQuery( "<div/>" );
+		div = jQuery( "<div></div>" );
 
 	div.data( "foo" );
 	assert.equal( jQuery.hasData( div[ 0 ] ), false, "No data exists after access" );
@@ -1002,7 +1002,7 @@ QUnit.test( ".data(prop) does not create expando", function( assert ) {
 QUnit.test( "keys matching Object.prototype properties  (gh-3256)", function( assert ) {
 	assert.expect( 2 );
 
-	var div = jQuery( "<div/>" );
+	var div = jQuery( "<div></div>" );
 
 	assert.strictEqual( div.data( "hasOwnProperty" ), undefined,
 		"hasOwnProperty not matched (before forced data creation)" );

--- a/test/unit/deprecated.js
+++ b/test/unit/deprecated.js
@@ -137,7 +137,7 @@ if ( jQuery.ajax && jQuery.fn.ajaxSend ) {
 QUnit[ jQuery.fn.click ? "test" : "skip" ]( "Event aliases", function( assert ) {
 
 	// Explicitly skipping focus/blur events due to their flakiness
-	var	$elem = jQuery( "<div />" ).appendTo( "#qunit-fixture" ),
+	var	$elem = jQuery( "<div></div>" ).appendTo( "#qunit-fixture" ),
 		aliases = ( "resize scroll click dblclick mousedown mouseup " +
 			"mousemove mouseover mouseout mouseenter mouseleave change " +
 			"select submit keydown keypress keyup contextmenu" ).split( " " );

--- a/test/unit/dimensions.js
+++ b/test/unit/dimensions.js
@@ -342,7 +342,7 @@ QUnit.test( "getting dimensions shouldn't modify runtimeStyle see #9233", functi
 QUnit.test( "table dimensions", function( assert ) {
 	assert.expect( 2 );
 
-	var table = jQuery( "<table><colgroup><col/><col/></colgroup><tbody><tr><td></td><td>a</td></tr><tr><td></td><td>a</td></tr></tbody></table>" ).appendTo( "#qunit-fixture" ),
+	var table = jQuery( "<table><colgroup><col></col><col></col></colgroup><tbody><tr><td></td><td>a</td></tr><tr><td></td><td>a</td></tr></tbody></table>" ).appendTo( "#qunit-fixture" ),
 		tdElem = table.find( "td" ).first(),
 		colElem = table.find( "col" ).first().width( 300 );
 
@@ -536,7 +536,7 @@ QUnit.test( "allow modification of coordinates argument (gh-1848)", function( as
 	assert.expect( 1 );
 
 	var offsetTop,
-		element = jQuery( "<div/>" ).appendTo( "#qunit-fixture" );
+		element = jQuery( "<div></div>" ).appendTo( "#qunit-fixture" );
 
 	element.offset( function( index, coords ) {
 		coords.top = 100;
@@ -583,7 +583,7 @@ QUnit.test( "width/height on element with transform (gh-3193)", function( assert
 
 	assert.expect( 2 );
 
-	var $elem = jQuery( "<div style='width: 200px; height: 200px; transform: scale(2);' />" )
+	var $elem = jQuery( "<div style='width: 200px; height: 200px; transform: scale(2);'></div>" )
 		.appendTo( "#qunit-fixture" );
 
 	assert.equal( $elem.width(), 200, "Width ignores transforms" );
@@ -663,7 +663,7 @@ QUnit.test( "interaction with scrollbars (gh-3589)", function( assert ) {
 				return old + adjustment;
 			};
 		},
-		parent = jQuery( "<div/>" )
+		parent = jQuery( "<div></div>" )
 			.css( { position: "absolute", width: "1000px", height: "1000px" } )
 			.appendTo( "#qunit-fixture" ),
 
@@ -672,7 +672,7 @@ QUnit.test( "interaction with scrollbars (gh-3589)", function( assert ) {
 		borderWidth = 1,
 		padding = 2,
 		size = 100 + fraction,
-		plainBox = jQuery( "<div />" )
+		plainBox = jQuery( "<div></div>" )
 			.css( {
 				"box-sizing": "content-box",
 				position: "absolute",
@@ -747,23 +747,23 @@ QUnit.test( "interaction with scrollbars (gh-3589)", function( assert ) {
 
 QUnit.test( "outerWidth/Height for table cells and textarea with border-box in IE 11 (gh-4102)", function( assert ) {
 	assert.expect( 5 );
-	var $table = jQuery( "<table class='border-box' style='border-collapse: separate' />" ).appendTo( "#qunit-fixture" ),
-		$thead = jQuery( "<thead />" ).appendTo( $table ),
-		$firstTh = jQuery( "<th style='width: 200px;padding: 5px' />" ),
-		$secondTh = jQuery( "<th style='width: 190px;padding: 5px' />" ),
-		$thirdTh = jQuery( "<th style='width: 180px;padding: 5px' />" ),
+	var $table = jQuery( "<table class='border-box' style='border-collapse: separate'></table>" ).appendTo( "#qunit-fixture" ),
+		$thead = jQuery( "<thead></thead>" ).appendTo( $table ),
+		$firstTh = jQuery( "<th style='width: 200px;padding: 5px'></th>" ),
+		$secondTh = jQuery( "<th style='width: 190px;padding: 5px'></th>" ),
+		$thirdTh = jQuery( "<th style='width: 180px;padding: 5px'></th>" ),
 
 		// Most browsers completely ignore the border-box and height settings.
 		// The computed height is instead just line-height + border.
 		// Either way, what we're doing in css.js is correct.
 		$td = jQuery( "<td style='height: 20px;padding: 5px;border: 1px solid;line-height:18px'>text</td>" ),
 
-		$tbody = jQuery( "<tbody />" ).appendTo( $table ),
-		$textarea = jQuery( "<textarea style='height: 0;padding: 2px;border: 1px solid;box-sizing: border-box' />" ).appendTo( "#qunit-fixture" );
+		$tbody = jQuery( "<tbody></tbody>" ).appendTo( $table ),
+		$textarea = jQuery( "<textarea style='height: 0;padding: 2px;border: 1px solid;box-sizing: border-box'></textarea>" ).appendTo( "#qunit-fixture" );
 
-	jQuery( "<tr />" ).appendTo( $thead ).append( $firstTh );
-	jQuery( "<tr />" ).appendTo( $thead ).append( $secondTh );
-	jQuery( "<tr />" ).appendTo( $thead ).append( $thirdTh );
+	jQuery( "<tr></tr>" ).appendTo( $thead ).append( $firstTh );
+	jQuery( "<tr></tr>" ).appendTo( $thead ).append( $secondTh );
+	jQuery( "<tr></tr>" ).appendTo( $thead ).append( $thirdTh );
 	jQuery( "<tr><td></td></tr>" ).appendTo( $tbody ).append( $td );
 
 	assert.strictEqual( $firstTh.outerWidth(), 200, "First th has outerWidth 200." );

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -597,7 +597,7 @@ QUnit.test( "animate duration 0", function( assert ) {
 	} );
 	this.clock.tick( 200 );
 
-	$elem = jQuery( "<div />" );
+	$elem = jQuery( "<div></div>" );
 	$elem.show( 0, function() {
 		assert.ok( true, "Show callback with no duration" );
 	} );
@@ -1282,7 +1282,7 @@ QUnit.test( "animate with CSS shorthand properties", function( assert ) {
 QUnit.test( "hide hidden elements, with animation (bug #7141)", function( assert ) {
 	assert.expect( 4 );
 
-	var div = jQuery( "<div id='bug7141' style='display:none'/>" ).appendTo( "#qunit-fixture" );
+	var div = jQuery( "<div id='bug7141' style='display:none'></div>" ).appendTo( "#qunit-fixture" );
 	assert.equal( div.css( "display" ), "none", "Element is initially hidden" );
 	div.hide( 10, function() {
 		assert.equal( div.css( "display" ), "none", "Element is hidden in .hide() callback" );
@@ -1583,10 +1583,10 @@ QUnit.test( "animate should set display for disconnected nodes", function( asser
 			toggle: [ 1 ],
 			slideToggle: []
 		},
-		$divEmpty = jQuery( "<div/>" ),
+		$divEmpty = jQuery( "<div></div>" ),
 		$divTest = jQuery( "<div>test</div>" ),
-		$divNone = jQuery( "<div style='display: none;'/>" ),
-		$divInline = jQuery( "<div style='display: inline;'/>" ),
+		$divNone = jQuery( "<div style='display: none;'></div>" ),
+		$divInline = jQuery( "<div style='display: inline;'></div>" ),
 		nullParentDisplay = $divEmpty.css( "display" ),
 		underFragmentDisplay = $divTest.css( "display" ),
 		clock = this.clock;
@@ -1604,7 +1604,7 @@ QUnit.test( "animate should set display for disconnected nodes", function( asser
 		"show() should not change display if it already set" );
 
 	jQuery.each( showMethods, function( name, opt ) {
-		jQuery.fn[ name ].apply( jQuery( "<div/>" ), opt.concat( [ function() {
+		jQuery.fn[ name ].apply( jQuery( "<div></div>" ), opt.concat( [ function() {
 			assert.strictEqual( jQuery( this ).css( "display" ), nullParentDisplay,
 				"." + name + " block with null parentNode" );
 		} ] ) );
@@ -1615,7 +1615,7 @@ QUnit.test( "animate should set display for disconnected nodes", function( asser
 		} ] ) );
 	} );
 	jQuery.each( toggleMethods, function( name, opt ) {
-		jQuery.fn[ name ].apply( jQuery( "<div/>" ), opt.concat( [ function() {
+		jQuery.fn[ name ].apply( jQuery( "<div></div>" ), opt.concat( [ function() {
 			assert.strictEqual( jQuery( this ).css( "display" ), "none",
 				"." + name + " block with null parentNode" );
 		} ] ) );
@@ -2340,8 +2340,8 @@ QUnit.test( "Respect display value on inline elements (#14824)", function( asser
 	assert.expect( 2 );
 
 	var clock = this.clock,
-		fromStyleSheet = jQuery( "<span id='span-14824' />" ),
-		fromStyleAttr = jQuery( "<span style='display: block;' />" );
+		fromStyleSheet = jQuery( "<span id='span-14824'></span>" ),
+		fromStyleAttr = jQuery( "<span style='display: block;'></span>" );
 
 	jQuery( "#qunit-fixture" ).append( fromStyleSheet, fromStyleAttr );
 
@@ -2441,7 +2441,7 @@ QUnit.test( "jQuery.easing._default in Tween (gh-2218)", function( assert ) {
 QUnit.test( "Display value is correct for disconnected nodes (trac-13310)", function( assert ) {
 	assert.expect( 3 );
 
-	var div = jQuery( "<div/>" );
+	var div = jQuery( "<div></div>" );
 
 	assert.equal( div.css( "display", "inline" ).hide().show().appendTo( "body" ).css( "display" ), "inline", "Initialized display value has returned" );
 	div.remove();
@@ -2462,7 +2462,7 @@ QUnit.test( "Show/hide/toggle and display: inline", function( assert ) {
 
 	var clock = this.clock;
 
-	jQuery( "<span/><div style='display:inline' title='inline div'/>" ).each( function() {
+	jQuery( "<span></span><div style='display:inline' title='inline div'></div>" ).each( function() {
 		var completed, interrupted,
 			N = 100,
 			fixture = jQuery( "#qunit-fixture" ),

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -153,7 +153,7 @@ QUnit.test( "on(), multiple events at once and namespaces", function( assert ) {
 	var cur, div,
 		obj = {};
 
-	div = jQuery( "<div/>" ).on( "focusin.a", function( e ) {
+	div = jQuery( "<div></div>" ).on( "focusin.a", function( e ) {
 		assert.equal( e.type, cur, "Verify right single event was fired." );
 	} );
 
@@ -163,7 +163,7 @@ QUnit.test( "on(), multiple events at once and namespaces", function( assert ) {
 	// manually clean up detached elements
 	div.remove();
 
-	div = jQuery( "<div/>" ).on( "click mouseover", obj, function( e ) {
+	div = jQuery( "<div></div>" ).on( "click mouseover", obj, function( e ) {
 		assert.equal( e.type, cur, "Verify right multi event was fired." );
 		assert.equal( e.data, obj, "Make sure the data came in correctly." );
 	} );
@@ -177,7 +177,7 @@ QUnit.test( "on(), multiple events at once and namespaces", function( assert ) {
 	// manually clean up detached elements
 	div.remove();
 
-	div = jQuery( "<div/>" ).on( "focusin.a focusout.b", function( e ) {
+	div = jQuery( "<div></div>" ).on( "focusin.a focusout.b", function( e ) {
 		assert.equal( e.type, cur, "Verify right multi event was fired." );
 	} );
 
@@ -195,7 +195,7 @@ QUnit.test( "on(), namespace with special add", function( assert ) {
 	assert.expect( 27 );
 
 	var i = 0,
-		div = jQuery( "<div/>" ).appendTo( "#qunit-fixture" ).on( "test", function() {
+		div = jQuery( "<div></div>" ).appendTo( "#qunit-fixture" ).on( "test", function() {
 			assert.ok( true, "Test event fired." );
 		} );
 
@@ -244,7 +244,7 @@ QUnit.test( "on(), namespace with special add", function( assert ) {
 	// Should trigger 4
 	div.off( "test" );
 
-	div = jQuery( "<div/>" ).on( "test", function() {
+	div = jQuery( "<div></div>" ).on( "test", function() {
 		assert.ok( true, "Test event fired." );
 	} );
 
@@ -876,7 +876,7 @@ QUnit.test( "mouseover triggers mouseenter", function( assert ) {
 	assert.expect( 1 );
 
 	var count = 0,
-		elem = jQuery( "<a />" );
+		elem = jQuery( "<a></a>" );
 	elem.on( "mouseenter", function() {
 		count++;
 	} );
@@ -890,7 +890,7 @@ QUnit.test( "pointerover triggers pointerenter", function( assert ) {
 	assert.expect( 1 );
 
 	var count = 0,
-		elem = jQuery( "<a />" );
+		elem = jQuery( "<a></a>" );
 	elem.on( "pointerenter", function() {
 		count++;
 	} );
@@ -1075,7 +1075,7 @@ QUnit.test( "submit event bubbles on copied forms (#11649)", function( assert ) 
 	var $formByClone, $formByHTML,
 		$testForm = jQuery( "#testForm" ),
 		$fixture = jQuery( "#qunit-fixture" ),
-		$wrapperDiv = jQuery( "<div/>" ).appendTo( $fixture );
+		$wrapperDiv = jQuery( "<div></div>" ).appendTo( $fixture );
 
 	function noSubmit( e ) {
 		e.preventDefault();
@@ -1111,7 +1111,7 @@ QUnit.test( "change event bubbles on copied forms (#11796)", function( assert ) 
 	var $formByClone, $formByHTML,
 		$form = jQuery( "#form" ),
 		$fixture = jQuery( "#qunit-fixture" ),
-		$wrapperDiv = jQuery( "<div/>" ).appendTo( $fixture );
+		$wrapperDiv = jQuery( "<div></div>" ).appendTo( $fixture );
 
 	function delegatedChange() {
 		assert.ok( true, "Make sure change event bubbles up." );
@@ -1141,7 +1141,7 @@ QUnit.test( "trigger(eventObject, [data], [fn])", function( assert ) {
 	assert.expect( 28 );
 
 	var event,
-		$parent = jQuery( "<div id='par' />" ).appendTo( "body" ),
+		$parent = jQuery( "<div id='par'></div>" ).appendTo( "body" ),
 		$child = jQuery( "<p id='child'>foo</p>" ).appendTo( $parent );
 
 	$parent.get( 0 ).style.display = "none";
@@ -1799,7 +1799,7 @@ QUnit.test( "jQuery.off using dispatched jQuery.Event", function( assert ) {
 QUnit.test( "events with type matching an Object.prototype property (gh-3256)", function( assert ) {
 	assert.expect( 1 );
 
-	var elem = jQuery( "<div/>" ),
+	var elem = jQuery( "<div></div>" ),
 		eventFired = false;
 
 	elem.appendTo( "#qunit-fixture" );
@@ -1819,7 +1819,7 @@ QUnit.test( "events with type matching an Object.prototype property, cloned elem
 	function( assert ) {
 	assert.expect( 1 );
 
-	var elem = jQuery( "<div/>" ),
+	var elem = jQuery( "<div></div>" ),
 		eventFired = false;
 
 	elem.appendTo( "#qunit-fixture" );
@@ -2788,7 +2788,7 @@ QUnit.test( ".off() removes the expando when there's no more data", function( as
 	assert.expect( 2 );
 
 	var key,
-		div = jQuery( "<div/>" ).appendTo( "#qunit-fixture" );
+		div = jQuery( "<div></div>" ).appendTo( "#qunit-fixture" );
 
 	div.on( "click", false );
 	div.on( "custom", function() {

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -88,9 +88,9 @@ function testText( valueObj, assert ) {
 	assert.equal( $multipleElements.eq( 1 ).text(), expected, "text() updates multiple elements (#11809)" );
 
 	// Prevent memory leaks #11809
-	$childDiv = jQuery( "<div/>" );
+	$childDiv = jQuery( "<div></div>" );
 	$childDiv.data( "leak", true );
-	$parentDiv = jQuery( "<div/>" );
+	$parentDiv = jQuery( "<div></div>" );
 	$parentDiv.append( $childDiv );
 	$parentDiv.text( "Dry off" );
 }
@@ -241,10 +241,10 @@ function testAppend( valueObj, assert ) {
 		assert.strictEqual( e.message || e, undefined, message );
 	}
 
-	jQuery( "<fieldset/>" ).appendTo( "#form" ).append( valueObj( "<legend id='legend'>test</legend>" ) );
+	jQuery( "<fieldset></fieldset>" ).appendTo( "#form" ).append( valueObj( "<legend id='legend'>test</legend>" ) );
 	assert.t( "Append legend", "#legend", [ "legend" ] );
 
-	$map = jQuery( "<map/>" ).append( valueObj( "<area id='map01' shape='rect' coords='50,50,150,150' href='https://www.jquery.com/' alt='jQuery'>" ) );
+	$map = jQuery( "<map></map>" ).append( valueObj( "<area id='map01' shape='rect' coords='50,50,150,150' href='https://www.jquery.com/' alt='jQuery'>" ) );
 
 	assert.equal( $map[ 0 ].childNodes.length, 1, "The area was inserted." );
 	assert.equal( $map[ 0 ].firstChild.nodeName.toLowerCase(), "area", "The area was inserted." );
@@ -264,7 +264,7 @@ function testAppend( valueObj, assert ) {
 		assert.ok( jQuery.parseHTML( "<" + name + "/>" ).length, name + " wrapped correctly" );
 	} );
 
-	jQuery( "#table colgroup" ).append( valueObj( "<col/>" ) );
+	jQuery( "#table colgroup" ).append( valueObj( "<col></col>" ) );
 	assert.equal( jQuery( "#table colgroup col" ).length, 1, "Append col" );
 
 	jQuery( "#form" )
@@ -272,12 +272,12 @@ function testAppend( valueObj, assert ) {
 		.append( valueObj( "<select id='appendSelect2'><option>Test</option></select>" ) );
 	assert.t( "Append Select", "#appendSelect1, #appendSelect2", [ "appendSelect1", "appendSelect2" ] );
 
-	assert.equal( "Two nodes", jQuery( "<div />" ).append( "Two", " nodes" ).text(), "Appending two text nodes (#4011)" );
-	assert.equal( jQuery( "<div />" ).append( "1", "", 3 ).text(), "13", "If median is false-like value, subsequent arguments should not be ignored" );
+	assert.equal( "Two nodes", jQuery( "<div></div>" ).append( "Two", " nodes" ).text(), "Appending two text nodes (#4011)" );
+	assert.equal( jQuery( "<div></div>" ).append( "1", "", 3 ).text(), "13", "If median is false-like value, subsequent arguments should not be ignored" );
 
 	// using contents will get comments regular, text, and comment nodes
 	j = jQuery( "#nonnodes" ).contents();
-	d = jQuery( "<div/>" ).appendTo( "#nonnodes" ).append( j );
+	d = jQuery( "<div></div>" ).appendTo( "#nonnodes" ).append( j );
 
 	assert.equal( jQuery( "#nonnodes" ).length, 1, "Check node,textnode,comment append moved leaving just the div" );
 	assert.equal( d.contents().length, 3, "Check node,textnode,comment append works" );
@@ -294,12 +294,12 @@ function testAppend( valueObj, assert ) {
 	$radioChecked.trigger( "click" );
 	$radioUnchecked[ 0 ].checked = false;
 
-	jQuery( "<div/>" ).insertBefore( $radioParent ).append( $radioParent );
+	jQuery( "<div></div>" ).insertBefore( $radioParent ).append( $radioParent );
 
 	assert.equal( $radioChecked[ 0 ].checked, true, "Reappending radios uphold which radio is checked" );
 	assert.equal( $radioUnchecked[ 0 ].checked, false, "Reappending radios uphold not being checked" );
 
-	assert.equal( jQuery( "<div/>" ).append( valueObj( "option<area/>" ) )[ 0 ].childNodes.length, 2, "HTML-string with leading text should be processed correctly" );
+	assert.equal( jQuery( "<div></div>" ).append( valueObj( "option<area></area>" ) )[ 0 ].childNodes.length, 2, "HTML-string with leading text should be processed correctly" );
 }
 
 QUnit.test( "append(String|Element|Array<Element>|jQuery)", function( assert ) {
@@ -637,7 +637,7 @@ QUnit.test( "appendTo(jQuery)", function( assert ) {
 	jQuery( "#select1" ).appendTo( "#foo" );
 	assert.t( "Append select", "#foo select", [ "select1" ] );
 
-	div = jQuery( "<div/>" ).on( "click", function() {
+	div = jQuery( "<div></div>" ).on( "click", function() {
 		assert.ok( true, "Running a cloned click." );
 	} );
 	div.appendTo( "#qunit-fixture, #moretests" );
@@ -645,7 +645,7 @@ QUnit.test( "appendTo(jQuery)", function( assert ) {
 	jQuery( "#qunit-fixture div" ).last().trigger( "click" );
 	jQuery( "#moretests div" ).last().trigger( "click" );
 
-	div = jQuery( "<div/>" ).appendTo( "#qunit-fixture, #moretests" );
+	div = jQuery( "<div></div>" ).appendTo( "#qunit-fixture, #moretests" );
 
 	assert.equal( div.length, 2, "appendTo returns the inserted elements" );
 
@@ -654,7 +654,7 @@ QUnit.test( "appendTo(jQuery)", function( assert ) {
 	assert.ok( jQuery( "#qunit-fixture div" ).last().hasClass( "test" ), "appendTo element was modified after the insertion" );
 	assert.ok( jQuery( "#moretests div" ).last().hasClass( "test" ), "appendTo element was modified after the insertion" );
 
-	div = jQuery( "<div/>" );
+	div = jQuery( "<div></div>" );
 	jQuery( "<span>a</span><b>b</b>" ).filter( "span" ).appendTo( div );
 
 	assert.equal( div.children().length, 1, "Make sure the right number of children were inserted." );
@@ -954,7 +954,7 @@ QUnit.test( "before(no-op)", function( assert ) {
 	assert.expect( 2 );
 
 	var set;
-	set = jQuery( "<div/>" ).before( "<span>test</span>" );
+	set = jQuery( "<div></div>" ).before( "<span>test</span>" );
 	assert.equal( set[ 0 ].nodeName.toLowerCase(), "div", "Insert before a disconnected node should be a no-op" );
 	assert.equal( set.length, 1, "Insert the element before the disconnected node. should be a no-op" );
 } );
@@ -973,8 +973,8 @@ QUnit.test( ".before() and .after() disconnected node", function( assert ) {
 
 	assert.expect( 2 );
 
-	assert.equal( jQuery( "<input type='checkbox'/>" ).before( "<div/>" ).length, 1, "before() on disconnected node is no-op" );
-	assert.equal( jQuery( "<input type='checkbox'/>" ).after( "<div/>" ).length, 1, "after() on disconnected node is no-op" );
+	assert.equal( jQuery( "<input type='checkbox'/>" ).before( "<div></div>" ).length, 1, "before() on disconnected node is no-op" );
+	assert.equal( jQuery( "<input type='checkbox'/>" ).after( "<div></div>" ).length, 1, "after() on disconnected node is no-op" );
 } );
 
 QUnit.test( "insert with .before() on disconnected node last", function( assert ) {
@@ -983,7 +983,7 @@ QUnit.test( "insert with .before() on disconnected node last", function( assert 
 
 	var expectedBefore = "This is a normal link: bugaYahoo";
 
-	jQuery( "#yahoo" ).add( "<span/>" ).before( "<b>buga</b>" );
+	jQuery( "#yahoo" ).add( "<span></span>" ).before( "<b>buga</b>" );
 	assert.equal( jQuery( "#en" ).text(), expectedBefore, "Insert String before with disconnected node last" );
 } );
 
@@ -993,7 +993,7 @@ QUnit.test( "insert with .before() on disconnected node first", function( assert
 
 	var expectedBefore = "This is a normal link: bugaYahoo";
 
-	jQuery( "<span/>" ).add( "#yahoo" ).before( "<b>buga</b>" );
+	jQuery( "<span></span>" ).add( "#yahoo" ).before( "<b>buga</b>" );
 	assert.equal( jQuery( "#en" ).text(), expectedBefore, "Insert String before with disconnected node first" );
 } );
 
@@ -1003,7 +1003,7 @@ QUnit.test( "insert with .before() on disconnected node last", function( assert 
 
 	var expectedAfter = "This is a normal link: Yahoobuga";
 
-	jQuery( "#yahoo" ).add( "<span/>" ).after( "<b>buga</b>" );
+	jQuery( "#yahoo" ).add( "<span></span>" ).after( "<b>buga</b>" );
 	assert.equal( jQuery( "#en" ).text(), expectedAfter, "Insert String after with disconnected node last" );
 } );
 
@@ -1013,7 +1013,7 @@ QUnit.test( "insert with .before() on disconnected node last", function( assert 
 
 	var expectedAfter = "This is a normal link: Yahoobuga";
 
-	jQuery( "<span/>" ).add( "#yahoo" ).after( "<b>buga</b>" );
+	jQuery( "<span></span>" ).add( "#yahoo" ).after( "<b>buga</b>" );
 	assert.equal( jQuery( "#en" ).text(), expectedAfter, "Insert String after with disconnected node first" );
 } );
 
@@ -1133,7 +1133,7 @@ QUnit.test( ".after(disconnected node)", function( assert ) {
 
 	assert.expect( 2 );
 
-	var set = jQuery( "<div/>" ).before( "<span>test</span>" );
+	var set = jQuery( "<div></div>" ).before( "<span>test</span>" );
 	assert.equal( set[ 0 ].nodeName.toLowerCase(), "div", "Insert after a disconnected node should be a no-op" );
 	assert.equal( set.length, 1, "Insert the element after the disconnected node should be a no-op" );
 } );
@@ -1215,10 +1215,10 @@ function testReplaceWith( val, assert ) {
 	jQuery( "#anchor1" ).contents().replaceWith( val( tmp ) );
 	assert.deepEqual( jQuery( "#anchor1" ).contents().get(), [ tmp ], "Replace text node with element" );
 
-	tmp = jQuery( "<div/>" ).appendTo( "#qunit-fixture" ).on( "click", function() {
+	tmp = jQuery( "<div></div>" ).appendTo( "#qunit-fixture" ).on( "click", function() {
 		assert.ok( true, "Newly bound click run." );
 	} );
-	y = jQuery( "<div/>" ).appendTo( "#qunit-fixture" ).on( "click", function() {
+	y = jQuery( "<div></div>" ).appendTo( "#qunit-fixture" ).on( "click", function() {
 		assert.ok( false, "Previously bound click run." );
 	} );
 	child = y.append( "<b>test</b>" ).find( "b" ).on( "click", function() {
@@ -1232,7 +1232,7 @@ function testReplaceWith( val, assert ) {
 	y.trigger( "click" ); // Shouldn't be run
 	child.trigger( "click" ); // Shouldn't be run
 
-	y = jQuery( "<div/>" ).appendTo( "#qunit-fixture" ).on( "click", function() {
+	y = jQuery( "<div></div>" ).appendTo( "#qunit-fixture" ).on( "click", function() {
 		assert.ok( false, "Previously bound click run." );
 	} );
 	child2 = y.append( "<u>test</u>" ).find( "u" ).on( "click", function() {
@@ -1244,13 +1244,13 @@ function testReplaceWith( val, assert ) {
 
 	child2.trigger( "click" );
 
-	set = jQuery( "<div/>" ).replaceWith( val( "<span>test</span>" ) );
+	set = jQuery( "<div></div>" ).replaceWith( val( "<span>test</span>" ) );
 	assert.equal( set[ 0 ].nodeName.toLowerCase(), "div", "No effect on a disconnected node." );
 	assert.equal( set.length, 1, "No effect on a disconnected node." );
 	assert.equal( set[ 0 ].childNodes.length, 0, "No effect on a disconnected node." );
 
 	child = jQuery( "#qunit-fixture" ).children().first();
-	$div = jQuery( "<div class='pathological'/>" ).insertBefore( child );
+	$div = jQuery( "<div class='pathological'></div>" ).insertBefore( child );
 	$div.replaceWith( $div );
 	assert.deepEqual( jQuery( ".pathological", "#qunit-fixture" ).get(), $div.get(),
 		"Self-replacement" );
@@ -1307,7 +1307,7 @@ QUnit.test( "Empty replaceWith (trac-13401; trac-13596; gh-2204)", function( ass
 
 	assert.expect( 25 );
 
-	var $el = jQuery( "<div/><div/>" ).html( "<p>0</p>" ),
+	var $el = jQuery( "<div></div><div></div>" ).html( "<p>0</p>" ),
 		expectedHTML = $el.html(),
 		tests = {
 			"empty string": "",
@@ -1320,13 +1320,13 @@ QUnit.test( "Empty replaceWith (trac-13401; trac-13596; gh-2204)", function( ass
 		};
 
 	jQuery.each( tests, function( label, input ) {
-		$el.html( "<a/>" ).children().replaceWith( input );
+		$el.html( "<a></a>" ).children().replaceWith( input );
 		assert.strictEqual( $el.html(), "", "replaceWith(" + label + ")" );
-		$el.html( "<b/>" ).children().replaceWith( function() { return input; } );
+		$el.html( "<b></b>" ).children().replaceWith( function() { return input; } );
 		assert.strictEqual( $el.html(), "", "replaceWith(function returning " + label + ")" );
-		$el.html( "<i/>" ).children().replaceWith( function( i ) { return input; } );
+		$el.html( "<i></i>" ).children().replaceWith( function( i ) { return input; } );
 		assert.strictEqual( $el.html(), "", "replaceWith(other function returning " + label + ")" );
-		$el.html( "<p/>" ).children().replaceWith( function( i ) {
+		$el.html( "<p></p>" ).children().replaceWith( function( i ) {
 			return i ?
 				input :
 				jQuery( this ).html( i + "" );
@@ -1447,7 +1447,7 @@ QUnit.test( "clone()", function( assert ) {
 	div.remove();
 
 	// Verify that cloned children can keep event listeners
-	div = jQuery( "<div/>" ).append( [ document.createElement( "table" ), document.createElement( "table" ) ] );
+	div = jQuery( "<div></div>" ).append( [ document.createElement( "table" ), document.createElement( "table" ) ] );
 	div.find( "table" ).on( "click", function() {
 		assert.ok( true, "Bound event still exists." );
 	} );
@@ -1474,7 +1474,7 @@ QUnit.test( "clone()", function( assert ) {
 	div.remove();
 
 	// Test both html() and clone() for <embed> and <object> types
-	div = jQuery( "<div/>" ).html( "<embed height='355' width='425' src='https://www.youtube.com/v/3KANI2dpXLw&amp;hl=en'></embed>" );
+	div = jQuery( "<div></div>" ).html( "<embed height='355' width='425' src='https://www.youtube.com/v/3KANI2dpXLw&amp;hl=en'></embed>" );
 
 	clone = div.clone( true );
 	assert.equal( clone.length, 1, "One element cloned" );
@@ -1484,7 +1484,7 @@ QUnit.test( "clone()", function( assert ) {
 	// this is technically an invalid object, but because of the special
 	// classid instantiation it is the only kind that IE has trouble with,
 	// so let's test with it too.
-	div = jQuery( "<div/>" ).html( "<object height='355' width='425' classid='clsid:D27CDB6E-AE6D-11cf-96B8-444553540000'>  <param name='movie' value='https://www.youtube.com/v/3KANI2dpXLw&amp;hl=en'>  <param name='wmode' value='transparent'> </object>" );
+	div = jQuery( "<div></div>" ).html( "<object height='355' width='425' classid='clsid:D27CDB6E-AE6D-11cf-96B8-444553540000'>  <param name='movie' value='https://www.youtube.com/v/3KANI2dpXLw&amp;hl=en'>  <param name='wmode' value='transparent'> </object>" );
 
 	clone = div.clone( true );
 	assert.equal( clone.length, 1, "One element cloned" );
@@ -1511,14 +1511,14 @@ QUnit.test( "clone()", function( assert ) {
 	} )();
 
 	// and here's a valid one.
-	div = jQuery( "<div/>" ).html( "<object height='355' width='425' type='application/x-shockwave-flash' data='https://www.youtube.com/v/3KANI2dpXLw&amp;hl=en'>  <param name='movie' value='https://www.youtube.com/v/3KANI2dpXLw&amp;hl=en'>  <param name='wmode' value='transparent'> </object>" );
+	div = jQuery( "<div></div>" ).html( "<object height='355' width='425' type='application/x-shockwave-flash' data='https://www.youtube.com/v/3KANI2dpXLw&amp;hl=en'>  <param name='movie' value='https://www.youtube.com/v/3KANI2dpXLw&amp;hl=en'>  <param name='wmode' value='transparent'> </object>" );
 
 	clone = div.clone( true );
 	assert.equal( clone.length, 1, "One element cloned" );
 	assert.equal( clone.html(), div.html(), "Element contents cloned" );
 	assert.equal( clone[ 0 ].nodeName.toUpperCase(), "DIV", "DIV element cloned" );
 
-	div = jQuery( "<div/>" ).data( { "a": true } );
+	div = jQuery( "<div></div>" ).data( { "a": true } );
 	clone = div.clone( true );
 	assert.equal( clone.data( "a" ), true, "Data cloned." );
 	clone.data( "a", false );
@@ -1653,12 +1653,12 @@ function testHtml( valueObj, assert ) {
 		div = jQuery( "<div></div>" ),
 		fixture = jQuery( "#qunit-fixture" );
 
-	div.html( valueObj( "<div id='parent_1'><div id='child_1'/></div><div id='parent_2'/>" ) );
+	div.html( valueObj( "<div id='parent_1'><div id='child_1'></div></div><div id='parent_2'></div>" ) );
 	assert.equal( div.children().length, 2, "Found children" );
 	assert.equal( div.children().children().length, 1, "Found grandchild" );
 
 	actual = []; expected = [];
-	tmp = jQuery( "<map/>" ).html( valueObj( "<area alt='area'/>" ) ).each( function() {
+	tmp = jQuery( "<map></map>" ).html( valueObj( "<area alt='area'></area>" ) ).each( function() {
 		expected.push( "AREA" );
 		actual.push( childNodeNames( this ) );
 	} );
@@ -1713,7 +1713,7 @@ function testHtml( valueObj, assert ) {
 	assert.equal( expected.length, 1, "Expecting one parent" );
 	assert.deepEqual( actual, expected, "Found the inserted style element" );
 
-	fixture.html( valueObj( "<select/>" ) );
+	fixture.html( valueObj( "<select></select>" ) );
 	jQuery( "#qunit-fixture select" ).html( valueObj( "<option>O1</option><option selected='selected'>O2</option><option>O3</option>" ) );
 	assert.equal( jQuery( "#qunit-fixture select" ).val(), "O2", "Selected option correct" );
 
@@ -1862,7 +1862,7 @@ QUnit.test( "html(Function) with incoming value -- jQuery.contents()", function(
 
 	assert.equal( j.html().replace( / xmlns="[^"]+"/g, "" ).toLowerCase(), "<b>bold</b>", "Check node,textnode,comment with html()" );
 
-	$div = jQuery( "<div />" );
+	$div = jQuery( "<div></div>" );
 
 	assert.equal( $div.html( function( i, val ) {
 		assert.equal( val, "", "Make sure the incoming value is correct." );
@@ -1874,7 +1874,7 @@ QUnit.test( "html(Function) with incoming value -- jQuery.contents()", function(
 		return 0;
 	} ).html(), "0", "Setting a zero as html" );
 
-	$div2 = jQuery( "<div/>" );
+	$div2 = jQuery( "<div></div>" );
 	insert = "&lt;div&gt;hello1&lt;/div&gt;";
 	assert.equal( $div2.html( function( i, val ) {
 		assert.equal( val, "", "Make sure the incoming value is correct." );
@@ -2170,7 +2170,7 @@ QUnit.test( "jQuery.cleanData", function( assert ) {
 QUnit.test( "jQuery.cleanData eliminates all private data (gh-2127)", function( assert ) {
 	assert.expect( 3 );
 
-	var div = jQuery( "<div/>" ).appendTo( "#qunit-fixture" );
+	var div = jQuery( "<div></div>" ).appendTo( "#qunit-fixture" );
 
 	jQuery._data( div[ 0 ], "gh-2127", "testing" );
 
@@ -2190,7 +2190,7 @@ QUnit.test( "jQuery.cleanData eliminates all public data", function( assert ) {
 	assert.expect( 3 );
 
 	var key,
-		div = jQuery( "<div/>" );
+		div = jQuery( "<div></div>" );
 	div.data( "some", "data" );
 	assert.ok( !jQuery.isEmptyObject( jQuery.data( div[ 0 ] ) ),  "Ensure some public data exists" );
 
@@ -2212,7 +2212,7 @@ QUnit.test( "domManip plain-text caching (trac-6779)", function( assert ) {
 
 	// DOM manipulation fails if added text matches an Object method
 	var i,
-		$f = jQuery( "<div />" ).appendTo( "#qunit-fixture" ),
+		$f = jQuery( "<div></div>" ).appendTo( "#qunit-fixture" ),
 		bad = [ "start-", "toString", "hasOwnProperty", "append", "here&there!", "-end" ];
 
 	for ( i = 0; i < bad.length; i++ ) {
@@ -2381,7 +2381,7 @@ QUnit.test( "Guard against exceptions when clearing safeChildNodes", function( a
 	var div;
 
 	try {
-		div = jQuery( "<div/><hr/><code/><b/>" );
+		div = jQuery( "<div></div><hr/><code></code><b></b>" );
 	} catch ( e ) {}
 
 	assert.ok( div && div.jquery, "Created nodes safely, guarded against exceptions on safeChildNodes[ -1 ]" );
@@ -2391,11 +2391,11 @@ QUnit.test( "Ensure oldIE creates a new set on appendTo (#8894)", function( asse
 
 	assert.expect( 5 );
 
-	assert.strictEqual( jQuery( "<div/>" ).clone().addClass( "test" ).appendTo( "<div/>" ).end().end().hasClass( "test" ), false, "Check jQuery.fn.appendTo after jQuery.clone" );
-	assert.strictEqual( jQuery( "<div/>" ).find( "p" ).end().addClass( "test" ).appendTo( "<div/>" ).end().end().hasClass( "test" ), false, "Check jQuery.fn.appendTo after jQuery.fn.find" );
-	assert.strictEqual( jQuery( "<div/>" ).text( "test" ).addClass( "test" ).appendTo( "<div/>" ).end().end().hasClass( "test" ), false, "Check jQuery.fn.appendTo after jQuery.fn.text" );
-	assert.strictEqual( jQuery( "<bdi/>" ).clone().addClass( "test" ).appendTo( "<div/>" ).end().end().hasClass( "test" ), false, "Check jQuery.fn.appendTo after clone html5 element" );
-	assert.strictEqual( jQuery( "<p/>" ).appendTo( "<div/>" ).end().length, jQuery( "<p>test</p>" ).appendTo( "<div/>" ).end().length, "Elements created with createElement and with createDocumentFragment should be treated alike" );
+	assert.strictEqual( jQuery( "<div></div>" ).clone().addClass( "test" ).appendTo( "<div></div>" ).end().end().hasClass( "test" ), false, "Check jQuery.fn.appendTo after jQuery.clone" );
+	assert.strictEqual( jQuery( "<div></div>" ).find( "p" ).end().addClass( "test" ).appendTo( "<div></div>" ).end().end().hasClass( "test" ), false, "Check jQuery.fn.appendTo after jQuery.fn.find" );
+	assert.strictEqual( jQuery( "<div></div>" ).text( "test" ).addClass( "test" ).appendTo( "<div></div>" ).end().end().hasClass( "test" ), false, "Check jQuery.fn.appendTo after jQuery.fn.text" );
+	assert.strictEqual( jQuery( "<bdi></bdi>" ).clone().addClass( "test" ).appendTo( "<div></div>" ).end().end().hasClass( "test" ), false, "Check jQuery.fn.appendTo after clone html5 element" );
+	assert.strictEqual( jQuery( "<p></p>" ).appendTo( "<div></div>" ).end().length, jQuery( "<p>test</p>" ).appendTo( "<div></div>" ).end().length, "Elements created with createElement and with createDocumentFragment should be treated alike" );
 } );
 
 QUnit.test( "html() - script exceptions bubble (#11743)", function( assert ) {
@@ -2485,7 +2485,7 @@ QUnit.test( "script evaluation (#11795)", function( assert ) {
 			"<script>QUnit.assert.ok( true, 'evaluated: inner no type' );</script>",
 		"</div>"
 	].join( "" ) );
-	scriptsIn.appendTo( jQuery( "<div class='detached'/>" ) );
+	scriptsIn.appendTo( jQuery( "<div class='detached'></div>" ) );
 	objGlobal.ok = isOk;
 
 	scriptsOut = fixture.append( scriptsIn ).find( "script" );
@@ -2502,7 +2502,7 @@ QUnit.test( "script evaluation (#11795)", function( assert ) {
 
 	if ( jQuery.ajax ) {
 		Globals.register( "testBar" );
-		jQuery( "#qunit-fixture" ).append( "<script src='" + url( "mock.php?action=testbar" ) + "'/>" );
+		jQuery( "#qunit-fixture" ).append( "<script src='" + url( "mock.php?action=testbar" ) + "'></script>" );
 		assert.strictEqual( window.testBar, "bar", "Global script evaluation" );
 	} else {
 		assert.ok( true, "No jQuery.ajax" );
@@ -2524,7 +2524,7 @@ QUnit[ jQuery.ajax ? "test" : "skip" ]( "jQuery._evalUrl (#12838)", function( as
 		assert.equal( ( input.url || input ).slice( -1 ), expectedArgument, message );
 		expectedArgument++;
 	};
-	jQuery( "#qunit-fixture" ).append( "<script src='1'/><script src='2'/>" );
+	jQuery( "#qunit-fixture" ).append( "<script src='1'></script><script src='2'></script>" );
 	assert.equal( expectedArgument, 3, "synchronous execution" );
 
 	message = "custom implementation";
@@ -2533,7 +2533,7 @@ QUnit[ jQuery.ajax ? "test" : "skip" ]( "jQuery._evalUrl (#12838)", function( as
 	jQuery.ajax = function( options ) {
 		assert.strictEqual( options, {}, "Unexpected call to jQuery.ajax" );
 	};
-	jQuery( "#qunit-fixture" ).append( "<script src='3'/><script src='4'/>" );
+	jQuery( "#qunit-fixture" ).append( "<script src='3'></script><script src='4'></script>" );
 
 	jQuery.ajax = ajax;
 	jQuery._evalUrl = evalUrl;
@@ -2547,7 +2547,7 @@ QUnit.test( "jQuery.htmlPrefilter (gh-1747)", function( assert ) {
 		invocations = 0,
 		done = assert.async(),
 		htmlPrefilter = jQuery.htmlPrefilter,
-		fixture = jQuery( "<div/>" ).appendTo( "#qunit-fixture" ),
+		fixture = jQuery( "<div></div>" ).appendTo( "#qunit-fixture" ),
 		poison = "<script>jQuery.htmlPrefilter.assert.ok( false, 'script not executed' );</script>";
 
 	jQuery.htmlPrefilter = function( html ) {
@@ -2563,7 +2563,7 @@ QUnit.test( "jQuery.htmlPrefilter (gh-1747)", function( assert ) {
 	expectedArgument = "A-" + poison + "B-" + poison + poison + "C-";
 	fixture.html( expectedArgument );
 
-	expectedArgument = "D-" + poison + "E-" + "<del/><div>" + poison + poison + "</div>" + "F-";
+	expectedArgument = "D-" + poison + "E-" + "<del></del><div>" + poison + poison + "</div>" + "F-";
 	fixture.append( expectedArgument );
 
 	expectedArgument = poison;
@@ -2618,7 +2618,7 @@ QUnit.test( "Index for function argument should be received (#13094)", function(
 
 	var i = 0;
 
-	jQuery( "<div/><div/>" ).before( function( index ) {
+	jQuery( "<div></div><div></div>" ).before( function( index ) {
 		assert.equal( index, i++, "Index should be correct" );
 	} );
 
@@ -2644,7 +2644,7 @@ QUnit.test( "Make sure specific elements with content created correctly (#13232)
 			thead: "<tr><td>thead</td></tr>",
 			tbody: "<tr><td>tbody</td></tr>",
 			tfoot: "<tr><td>tfoot</td></tr>",
-			colgroup: "<col span='5' />",
+			colgroup: "<col span='5'></col>",
 			caption: "caption",
 			tr: "<td>tr</td>",
 			th: "th",
@@ -2665,23 +2665,19 @@ QUnit.test( "Make sure specific elements with content created correctly (#13232)
 		args.push( html );
 	} );
 
-	jQuery.fn.append.apply( jQuery( "<div/>" ), args ).children().each( function( i ) {
+	jQuery.fn.append.apply( jQuery( "<div></div>" ), args ).children().each( function( i ) {
 		assert.strictEqual( this.nodeName.toLowerCase(), results[ i ] );
 	} );
 } );
 
 QUnit.test( "Validate creation of multiple quantities of certain elements (#13818)", function( assert ) {
-	assert.expect( 44 );
+	assert.expect( 22 );
 
 	var tags = [ "thead", "tbody", "tfoot", "colgroup", "col", "caption", "tr", "th", "td", "optgroup", "option" ];
 
 	jQuery.each( tags, function( index, tag ) {
-		jQuery( "<" + tag + "/><" + tag + "/>" ).each( function() {
-			assert.ok( this.nodeName.toLowerCase() === tag, tag + " empty elements created correctly" );
-		} );
-
-		jQuery( "<" + this + "></" + tag + "><" + tag + "></" + tag + ">" ).each( function() {
-			assert.ok( this.nodeName.toLowerCase() === tag, tag + " elements with closing tag created correctly" );
+		jQuery( "<" + tag + "></" + tag + "><" + tag + "></" + tag + ">" ).each( function() {
+			assert.ok( this.nodeName.toLowerCase() === tag, tag + " elements created correctly" );
 		} );
 	} );
 } );
@@ -2729,7 +2725,7 @@ QUnit.test( "Make sure tfoot element will not be appended to tbody element of ta
 	table.appendChild( document.createElement( "tbody" ) );
 	document.getElementById( "qunit-fixture" ).appendChild( table );
 
-	jQuery( table ).append( "<tfoot/>" );
+	jQuery( table ).append( "<tfoot></tfoot>" );
 
 	// Lowercase and replace spaces to remove possible browser inconsistencies
 	html = table.innerHTML.toLowerCase().replace( /\s/g, "" );
@@ -2768,7 +2764,7 @@ QUnit.test( "Make sure col element is appended correctly", function( assert ) {
 
 	jQuery( table ).appendTo( "#qunit-fixture" );
 
-	jQuery( "<col width='150'/>" ).prependTo( table );
+	jQuery( "<col width='150'></col>" ).prependTo( table );
 
 	assert.strictEqual( table.find( "td" ).width(), 150 );
 } );
@@ -2783,7 +2779,7 @@ QUnit.test( "Make sure tr is not appended to the wrong tbody (gh-3439)", functio
 			"</td></tr></thead>",
 		newRow = "<tr><td>added</td></tr>",
 		htmlExpected = htmlIn.replace( "</thead>", "</thead>" + newRow ),
-		table = supportjQuery( "<table/>" ).html( htmlIn ).appendTo( "#qunit-fixture" )[ 0 ];
+		table = supportjQuery( "<table></table>" ).html( htmlIn ).appendTo( "#qunit-fixture" )[ 0 ];
 
 	jQuery( table ).append( newRow );
 
@@ -2798,7 +2794,7 @@ QUnit.test( "Make sure tags with single-character names are found (gh-4124)", fu
 
 	var htmlOut,
 		htmlIn = "<p>foo<!--<td>--></p>",
-		$el = jQuery( "<div/>" );
+		$el = jQuery( "<div></div>" );
 
 	$el.html( htmlIn );
 
@@ -2847,7 +2843,7 @@ QUnit.test( "Ignore content from unsuccessful responses (gh-4126)", function( as
 
 	try {
 		jQuery( "#qunit-fixture" ).append(
-			"<script src='" + url( "mock.php?action=error" ) + "'/>" );
+			"<script src='" + url( "mock.php?action=error" ) + "'></script>" );
 		assert.ok( true, "no error thrown from embedding script with unsuccessful-response src" );
 	} catch ( e ) {
 		throw e;

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -5,7 +5,7 @@ if ( !jQuery.fn.offset ) {
 }
 
 var supportsScroll, alwaysScrollable,
-	forceScroll = supportjQuery( "<div/>" ).css( { width: 2000, height: 2000 } ),
+	forceScroll = supportjQuery( "<div></div>" ).css( { width: 2000, height: 2000 } ),
 	checkSupport = function( assert ) {
 
 		// Only run once
@@ -75,7 +75,7 @@ QUnit.test( "disconnected element", function( assert ) {
 QUnit.test( "hidden (display: none) element", function( assert ) {
 	assert.expect( 4 );
 
-	var node = jQuery( "<div style='display: none' />" ).appendTo( "#qunit-fixture" ),
+	var node = jQuery( "<div style='display: none'></div>" ).appendTo( "#qunit-fixture" ),
 		result = node.offset();
 
 	node.remove();
@@ -92,7 +92,7 @@ QUnit.test( "hidden (display: none) element", function( assert ) {
 QUnit.test( "0 sized element", function( assert ) {
 	assert.expect( 4 );
 
-	var node = jQuery( "<div style='margin: 5px; width: 0; height: 0' />" ).appendTo( "#qunit-fixture" ),
+	var node = jQuery( "<div style='margin: 5px; width: 0; height: 0'></div>" ).appendTo( "#qunit-fixture" ),
 		result = node.offset();
 
 	node.remove();
@@ -106,7 +106,7 @@ QUnit.test( "0 sized element", function( assert ) {
 QUnit.test( "hidden (visibility: hidden) element", function( assert ) {
 	assert.expect( 4 );
 
-	var node = jQuery( "<div style='margin: 5px; visibility: hidden' />" ).appendTo( "#qunit-fixture" ),
+	var node = jQuery( "<div style='margin: 5px; visibility: hidden'></div>" ).appendTo( "#qunit-fixture" ),
 		result = node.offset();
 
 	node.remove();
@@ -736,7 +736,7 @@ QUnit.test( "offsetParent", function( assert ) {
 QUnit.test( "fractions (see #7730 and #7885)", function( assert ) {
 	assert.expect( 2 );
 
-	jQuery( "body" ).append( "<div id='fractions'/>" );
+	jQuery( "body" ).append( "<div id='fractions'></div>" );
 
 	var result,
 		expected = { "top": 1000, "left": 1000 },

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -95,7 +95,7 @@ QUnit.test( "element", function( assert ) {
 	// Check for unique-ness and sort order
 	assert.deepEqual( jQuery( "p, div p" ), jQuery( "p" ), "Check for duplicates: p, div p" );
 
-	jQuery( "<h1 id='h1'/><h2 id='h2'/><h2 id='h2-2'/>" ).prependTo( "#qunit-fixture" );
+	jQuery( "<h1 id='h1'></h1><h2 id='h2'></h2><h2 id='h2-2'></h2>" ).prependTo( "#qunit-fixture" );
 	assert.t( "Checking sort order", "#qunit-fixture h2, #qunit-fixture h1", [ "h1", "h2", "h2-2" ] );
 
 	if ( QUnit.jQuerySelectorsPos ) {
@@ -401,7 +401,7 @@ QUnit.test( "name", function( assert ) {
 QUnit.test( "comma-separated", function( assert ) {
 	assert.expect( 4 );
 
-	var fixture = jQuery( "<div><h2><span/></h2><div><p><span/></p><p/></div></div>" );
+	var fixture = jQuery( "<div><h2><span></span></h2><div><p><span></span></p><p></p></div></div>" );
 
 	assert.equal( fixture.find( "h2, div p" ).filter( "p" ).length, 2, "has to find two <p>" );
 	assert.equal( fixture.find( "h2, div p" ).filter( "h2" ).length, 1, "has to find one <h2>" );
@@ -554,7 +554,7 @@ QUnit.test( "attributes - equals", function( assert ) {
 	assert.t( "input[type=text]", "#form input[type=text]", [ "text1", "text2", "hidden2", "name" ] );
 	assert.t( "input[type=search]", "#form input[type=search]", [ "search" ] );
 
-	withScript = supportjQuery( "<div><span><script src=''/></span></div>" );
+	withScript = supportjQuery( "<div><span><script src=''></script></span></div>" );
 	assert.ok( withScript.find( "#moretests script[src]" ).has( "script" ), "script[src] (jQuery #13777)" );
 
 	assert.t( "Boolean attribute equals name", "#select2 option[selected='selected']", [ "option2d" ] );
@@ -853,7 +853,7 @@ QUnit.test( "pseudo - nth-child", function( assert ) {
 QUnit.test( "pseudo - nth-last-child", function( assert ) {
 	assert.expect( 30 );
 
-	jQuery( "#qunit-fixture" ).append( "<form id='nth-last-child-form'/><i/><i/><i/><i/>" );
+	jQuery( "#qunit-fixture" ).append( "<form id='nth-last-child-form'></form><i></i><i></i><i></i><i></i>" );
 	assert.t( "Nth-last-child", "form:nth-last-child(5)", [ "nth-last-child-form" ] );
 	assert.t( "Nth-last-child (with whitespace)", "form:nth-last-child( 5 )", [ "nth-last-child-form" ] );
 
@@ -969,7 +969,7 @@ QUnit.test( "pseudo - misc", function( assert ) {
 
 	var select, tmp, input;
 
-	jQuery( "<h1 id='h1'/><h2 id='h2'/><h2 id='h2-2'/>" ).prependTo( "#qunit-fixture" );
+	jQuery( "<h1 id='h1'></h1><h2 id='h2'></h2><h2 id='h2-2'></h2>" ).prependTo( "#qunit-fixture" );
 
 	if ( QUnit.jQuerySelectors ) {
 		assert.t( "Headers", "#qunit-fixture :header", [ "h1", "h2", "h2-2" ] );
@@ -1428,7 +1428,7 @@ QUnit.test( "pseudo - a:(dis|en)abled", function( assert ) {
 	assert.expect( 2 );
 
 	var enabled, disabled,
-		container = jQuery( "<div/>" ),
+		container = jQuery( "<div></div>" ),
 		anchor = jQuery( "<a href='#'>Link</a>" );
 
 	container.appendTo( "#qunit-fixture" );
@@ -1445,7 +1445,7 @@ QUnit.test( "pseudo - :target and :root", function( assert ) {
 
 	// Target
 	var oldHash,
-		$link = jQuery( "<a/>" ).attr( {
+		$link = jQuery( "<a></a>" ).attr( {
 			href: "#",
 			id: "new-link"
 		} ).appendTo( "#qunit-fixture" );
@@ -1673,8 +1673,8 @@ QUnit[
 
 	var timeout,
 		done = assert.async(),
-		container = jQuery( "<div/>" ),
-		child = jQuery( "<div/>" );
+		container = jQuery( "<div></div>" ),
+		child = jQuery( "<div></div>" );
 
 	child.appendTo( container );
 	container.appendTo( "#qunit-fixture" );
@@ -1728,7 +1728,7 @@ QUnit.test( "caching does not introduce bugs", function( assert ) {
 QUnit.test( "disconnected nodes", function( assert ) {
 	assert.expect( 1 );
 
-	var $div = jQuery( "<div/>" );
+	var $div = jQuery( "<div></div>" );
 	assert.equal( $div.is( "div" ), true, "Make sure .is('nodeName') works on disconnected nodes." );
 } );
 
@@ -1749,7 +1749,7 @@ QUnit[ QUnit.jQuerySelectors && document.body.getRootNode ? "test" : "skip" ](
 	"Shadow DOM nodes supported as root", function( assert ) {
 	assert.expect( 2 );
 
-	var shadowHost = jQuery( "<div/>" ).appendTo( "#qunit-fixture" )[ 0 ];
+	var shadowHost = jQuery( "<div></div>" ).appendTo( "#qunit-fixture" )[ 0 ];
 	var shadowRoot = shadowHost.attachShadow( { mode: "open" } );
 
 	shadowRoot.innerHTML = "<div class='vagabond'><p></p></div>";

--- a/test/unit/traversing.js
+++ b/test/unit/traversing.js
@@ -252,7 +252,7 @@ QUnit.test( "index()", function( assert ) {
 
 	assert.equal( jQuery( "#text2" ).index(), 2, "Returns the index of a child amongst its siblings" );
 
-	assert.equal( jQuery( "<div/>" ).index(), -1, "Node without parent returns -1" );
+	assert.equal( jQuery( "<div></div>" ).index(), -1, "Node without parent returns -1" );
 } );
 
 QUnit.test( "index(Object|String|undefined)", function( assert ) {
@@ -557,7 +557,7 @@ QUnit.test( "has(Element)", function( assert ) {
 	obj = jQuery( "#qunit-fixture" ).has( jQuery( "#sndp" )[ 0 ] );
 	assert.deepEqual( obj.get(), q( "qunit-fixture" ), "Keeps elements that have the element as a descendant" );
 
-	detached = jQuery( "<a><b><i/></b></a>" );
+	detached = jQuery( "<a><b><i></i></b></a>" );
 	assert.deepEqual( detached.has( detached.find( "i" )[ 0 ] ).get(), detached.get(), "...Even when detached" );
 
 	multipleParent = jQuery( "#qunit-fixture, #header" ).has( jQuery( "#sndp" )[ 0 ] );
@@ -572,7 +572,7 @@ QUnit.test( "has(Selector)", function( assert ) {
 	obj = jQuery( "#qunit-fixture" ).has( "#sndp" );
 	assert.deepEqual( obj.get(), q( "qunit-fixture" ), "Keeps elements that have any element matching the selector as a descendant" );
 
-	detached = jQuery( "<a><b><i/></b></a>" );
+	detached = jQuery( "<a><b><i></i></b></a>" );
 	assert.deepEqual( detached.has( "i" ).get(), detached.get(), "...Even when detached" );
 
 	multipleParent = jQuery( "#qunit-fixture, #header" ).has( "#sndp" );
@@ -593,7 +593,7 @@ QUnit.test( "has(Arrayish)", function( assert ) {
 	simple = jQuery( "#qunit-fixture" ).has( jQuery( "#sndp" ) );
 	assert.deepEqual( simple.get(), q( "qunit-fixture" ), "Keeps elements that have any element in the jQuery list as a descendant" );
 
-	detached = jQuery( "<a><b><i/></b></a>" );
+	detached = jQuery( "<a><b><i></i></b></a>" );
 	assert.deepEqual( detached.has( detached.find( "i" ) ).get(), detached.get(), "...Even when detached" );
 
 	multipleParent = jQuery( "#qunit-fixture, #header" ).has( jQuery( "#sndp" ) );
@@ -625,7 +625,7 @@ QUnit.test( "siblings([String])", function( assert ) {
 	var set = q( "sndp", "en", "sap" );
 	assert.deepEqual( jQuery( "#en, #sndp" ).siblings().get(), set, "Check for unique results from siblings" );
 	assert.deepEqual( jQuery( "#option5a" ).siblings( "option[data-attr]" ).get(), q( "option5c" ), "Has attribute selector in siblings (#9261)" );
-	assert.equal( jQuery( "<a/>" ).siblings().length, 0, "Detached elements have no siblings (#11370)" );
+	assert.equal( jQuery( "<a></a>" ).siblings().length, 0, "Detached elements have no siblings (#11370)" );
 } );
 
 QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "siblings([String])", function( assert ) {
@@ -792,7 +792,7 @@ QUnit.test( "contents()", function( assert ) {
 
 	assert.equal( jQuery( "div", ibody ).text(), "span text", "Make sure the correct div is still left after deletion in IFrame" );
 
-	jQuery( "<table/>", ibody ).append( "<tr><td>cell</td></tr>" ).appendTo( ibody );
+	jQuery( "<table></table>", ibody ).append( "<tr><td>cell</td></tr>" ).appendTo( ibody );
 	jQuery( "table", ibody ).remove();
 	assert.equal( jQuery( "div", ibody ).length, 1, "Check for JS error on add and delete of a table in IFrame" );
 
@@ -820,7 +820,7 @@ QUnit.test( "contents() for <template />", function( assert ) {
 
 	assert.equal( contents.find( "span" ).text(), "Hello, Web Component!", "Find span in template and check its text" );
 
-	jQuery( "<div id='templateTest' />" ).append(
+	jQuery( "<div id='templateTest'></div>" ).append(
 			jQuery( jQuery.map( contents, function( node ) {
 					return document.importNode( node, true );
 			} ) )
@@ -934,7 +934,7 @@ QUnit.test( "add(String selector)", function( assert ) {
 		"Check elements from document"
 	);
 
-	divs = jQuery( "<div/>" ).add( "#sndp" );
+	divs = jQuery( "<div></div>" ).add( "#sndp" );
 	assert.ok( divs[ 0 ].parentNode, "Sort with the disconnected node last (started with disconnected first)." );
 } );
 
@@ -952,7 +952,7 @@ QUnit.test( "add(String html)", function( assert ) {
 	assert.expect( 3 );
 
 	var x,
-		divs = jQuery( "#sndp" ).add( "<div/>" );
+		divs = jQuery( "#sndp" ).add( "<div></div>" );
 
 	assert.ok( !divs[ 1 ].parentNode, "Sort with the disconnected node last." );
 
@@ -965,7 +965,7 @@ QUnit.test( "add(jQuery)", function( assert ) {
 	assert.expect( 4 );
 
 	var x,
-		tmp = jQuery( "<div/>" );
+		tmp = jQuery( "<div></div>" );
 
 	x = jQuery( [] )
 	.add(
@@ -994,7 +994,7 @@ QUnit.test( "add(Element)", function( assert ) {
 	assert.expect( 2 );
 
 	var x,
-		tmp = jQuery( "<div/>" );
+		tmp = jQuery( "<div></div>" );
 
 	x = jQuery( [] ).add( jQuery( "<p id='x1'>xxx</p>" ).appendTo( tmp )[ 0 ] ).add( jQuery( "<p id='x2'>xxx</p>" ).appendTo( tmp )[ 0 ] );
 	assert.equal( x[ 0 ].id, "x1", "Check on-the-fly element1" );

--- a/test/unit/wrap.js
+++ b/test/unit/wrap.js
@@ -74,7 +74,7 @@ function testWrap( val, assert ) {
 		cacheLength++;
 	}
 
-	j = jQuery( "<label/>" ).wrap( val( "<li/>" ) );
+	j = jQuery( "<label></label>" ).wrap( val( "<li></li>" ) );
 	assert.equal(
 		j[ 0 ] .nodeName.toUpperCase(), "LABEL", "Element is a label"
 	);
@@ -90,7 +90,7 @@ function testWrap( val, assert ) {
 	);
 
 	// Wrap an element containing a text node
-	j = jQuery( "<span/>" ).wrap( "<div>test</div>" );
+	j = jQuery( "<span></span>" ).wrap( "<div>test</div>" );
 	assert.equal(
 		j[ 0 ].previousSibling.nodeType, 3, "Make sure the previous node is a text element"
 	);
@@ -112,7 +112,7 @@ function testWrap( val, assert ) {
 	);
 
 	// Wrap an element with a jQuery set
-	j = jQuery( "<span/>" ).wrap( jQuery( "<div></div>" ) );
+	j = jQuery( "<span></span>" ).wrap( jQuery( "<div></div>" ) );
 	assert.equal(
 		j[ 0 ].parentNode.nodeName.toLowerCase(), "div", "Wrapping works."
 	);
@@ -128,7 +128,7 @@ function testWrap( val, assert ) {
 		jQuery( this ).off();
 	} );
 
-	j = jQuery( "<span/>" ).wrap( result );
+	j = jQuery( "<span></span>" ).wrap( result );
 	assert.equal(
 		j[ 0 ].parentNode.nodeName.toLowerCase(), "div", "Wrapping works."
 	);
@@ -313,7 +313,7 @@ QUnit.test( "wrapInner(Element)", function( assert ) {
 	assert.expect( 5 );
 
 	var num,
-		div = jQuery( "<div/>" );
+		div = jQuery( "<div></div>" );
 
 	num = jQuery( "#first" ).children().length;
 	jQuery( "#first" ).wrapInner( document.getElementById( "empty" ) );
@@ -375,7 +375,7 @@ QUnit.test( "wrapInner(Function) returns Element", function( assert ) {
 
 	var num,
     val = manipulationFunctionReturningObj,
-		div = jQuery( "<div/>" );
+		div = jQuery( "<div></div>" );
 
 	num = jQuery( "#first" ).children().length;
 	jQuery( "#first" ).wrapInner( val( document.getElementById( "empty" ) ) );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Make tests pass with jQuery.htmlPrefilter being an identity function.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
