### PR TITLE
Build:Event: Make sure all source modules' exports are used

### DIFF
--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -13,6 +13,10 @@
 	"rules": {
 		"import/extensions": [ "error", "always" ],
 		"import/no-cycle": "error",
+		"import/no-unused-modules": [ "error", {
+			"unusedExports": true,
+			"ignoreExports": [ "src/*.js" ]
+		} ],
 		"indent": [ "error", "tab", {
 			"outerIIFEBody": 0
 		} ]

--- a/src/core/init.js
+++ b/src/core/init.js
@@ -118,5 +118,3 @@ init.prototype = jQuery.fn;
 
 // Initialize central reference
 rootjQuery = jQuery( document );
-
-export default init;

--- a/src/core/parseXML.js
+++ b/src/core/parseXML.js
@@ -20,5 +20,3 @@ jQuery.parseXML = function( data ) {
 	}
 	return xml;
 };
-
-export default jQuery.parseXML;

--- a/src/core/var/rhtml.js
+++ b/src/core/var/rhtml.js
@@ -1,1 +1,0 @@
-export default ( /HTML$/i );

--- a/src/event/trigger.js
+++ b/src/event/trigger.js
@@ -190,5 +190,3 @@ jQuery.fn.extend( {
 		}
 	}
 } );
-
-export default jQuery;

--- a/src/jquery.js
+++ b/src/jquery.js
@@ -11,6 +11,7 @@ import "./queue.js";
 import "./queue/delay.js";
 import "./attributes.js";
 import "./event.js";
+import "./event/trigger.js";
 import "./manipulation.js";
 import "./manipulation/_evalUrl.js";
 import "./wrap.js";

--- a/src/manipulation/_evalUrl.js
+++ b/src/manipulation/_evalUrl.js
@@ -22,5 +22,3 @@ jQuery._evalUrl = function( url, options, doc ) {
 		}
 	} );
 };
-
-export default jQuery._evalUrl;


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Make sure all source modules' exports are used.

To achieve that, use `eslint-plugin-import`'s `no-unused-modules` rule.

Also, explicitly import `event/trigger.js` from `jquery.js`; so far it was only
imported from ajax.js, making it mistakenly skipped in the
`custom:slim,-deprecated` build.

-5 bytes! :)

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
