### PR TITLE
Build: Reduce the slim build header comment & jQuery.fn.jquery

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -60,7 +60,7 @@ module.exports = function( grunt ) {
 		const done = this.async();
 
 		try {
-			let flag, index;
+			const slimFlags = [ "-ajax", "-callbacks", "-deferred", "-effects" ];
 			const flags = this.flags;
 			const optIn = flags[ "*" ];
 			let name = grunt.option( "filename" );
@@ -69,6 +69,21 @@ module.exports = function( grunt ) {
 			const excluded = [];
 			const included = [];
 			let version = grunt.config( "pkg.version" );
+
+			// We'll skip printing the whole big exclusions for a bare `build:*:*:slim` which
+			// usually comes from `custom:slim`.
+			const isPureSlim = !!( flags.slim && flags[ "*" ] &&
+				Object.keys( flags ).length === 2 );
+
+			delete flags[ "*" ];
+
+			if ( flags.slim ) {
+				delete flags.slim;
+				for ( const flag of slimFlags ) {
+					flags[ flag ] = true;
+				}
+			}
+
 
 			/**
 			 * Recursively calls the excluder to remove on all modules in the list
@@ -187,8 +202,7 @@ module.exports = function( grunt ) {
 			//                     trumped by explicit exclude of dependency)
 			//  *:+effects         none except effects and its dependencies
 			//                     (explicit include trumps implicit exclude of dependency)
-			delete flags[ "*" ];
-			for ( flag in flags ) {
+			for ( const flag in flags ) {
 				excluder( flag );
 			}
 
@@ -198,7 +212,8 @@ module.exports = function( grunt ) {
 				read( inputFileName ).replace( /\n*export default jQuery;\n*/, "\n" ) );
 
 			// Replace exports/global with a noop noConflict
-			if ( ( index = excluded.indexOf( "exports/global" ) ) > -1 ) {
+			if ( excluded.includes( "exports/global" ) ) {
+				const index = excluded.indexOf( "exports/global" );
 				setOverride( `${ srcFolder }/exports/global.js`,
 					"import jQuery from \"../core.js\";\n\n" +
 						"jQuery.noConflict = function() {};" );
@@ -224,13 +239,24 @@ module.exports = function( grunt ) {
 			grunt.verbose.writeflags( excluded, "Excluded" );
 			grunt.verbose.writeflags( included, "Included" );
 
-			// append excluded modules to version
-			if ( excluded.length ) {
-				version += " -" + excluded.join( ",-" );
+			// Indicate a Slim build without listing all of the exclusions
+			// to save space.
+			if ( isPureSlim ) {
+				version += " slim";
 
-				// set pkg.version to version with excludes, so minified file picks it up
-				grunt.config.set( "pkg.version", version );
-				grunt.verbose.writeln( "Version changed to " + version );
+			// Append excluded modules to version.
+			} else if ( excluded.length ) {
+				version += " -" + excluded.join( ",-" );
+			}
+
+			if ( excluded.length ) {
+
+				// Set pkg.version to version with excludes or with the "slim" marker,
+				// so minified file picks it up but skip the commit hash the same way
+				// it's done for the full build.
+				const commitlessVersion = version.replace( " " + process.env.COMMIT, "" );
+				grunt.config.set( "pkg.version", commitlessVersion );
+				grunt.verbose.writeln( "Version changed to " + commitlessVersion );
 
 				// Replace excluded modules with empty sources.
 				for ( const module of excluded ) {
@@ -299,18 +325,7 @@ module.exports = function( grunt ) {
 	grunt.registerTask( "custom", function() {
 		const args = this.args;
 		const modules = args.length ?
-			args[ 0 ]
-				.split( "," )
-
-				// Replace "slim" with respective exclusions meant for
-				// the official slim build
-				.reduce( ( acc, elem ) => acc.concat(
-					elem === "slim" ?
-						[ "-ajax", "-callbacks", "-deferred", "-effects" ] :
-						[ elem ]
-				), [] )
-
-				.join( ":" ) :
+			args[ 0 ].split( "," ).join( ":" ) :
 			"";
 		const done = this.async();
 		const insight = new Insight( {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

So far, the slim build was expanded to its full exclusion list, generating the
following `jQuery.fn.jquery`:
```
v4.0.0-pre -ajax,-ajax/jsonp,-ajax/load,-ajax/script,-ajax/var/location,-ajax/var/nonce,-ajax/var/rquery,-ajax/xhr,-manipulation/_evalUrl,-deprecated/ajax-event-alias,-callbacks,-deferred,-deferred/exceptionHook,-effects,-effects/Tween,-effects/animatedSelector,-queue,-queue/delay,-core/ready
```

This PR changes it to just `v4.0.0-pre slim`. Only the pure slim build is
treated this way, any modification to it goes through the old expansion; e.g.
for `custom:slim,-deprecated` we get the following `jQuery.fn.jquery`:
```
v4.0.0-pre -deprecated,-deprecated/ajax-event-alias,-deprecated/event,-ajax,-ajax/jsonp,-ajax/load,-ajax/script,-ajax/var/location,-ajax/var/nonce,-ajax/var/rquery,-ajax/xhr,-manipulation/_evalUrl,-callbacks,-deferred,-deferred/exceptionHook,-effects,-effects/Tween,-effects/animatedSelector,-queue,-queue/delay,-core/ready
```

Since the version string is also put in the jQuery header comment, it also got
smaller.

Also, the logic to skip including the commit hash in the header comment - when
provided through the COMMIT environment variable which we do in Jenkins - in
minified builds headers has been applied to builds with exclusions as well.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
