### PR TITLE
Ajax: Overwrite s.contentType with content-type header value, if any

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -862,7 +862,8 @@ jQuery.each( [ "get", "post" ], function( _i, method ) {
 } );
 
 jQuery.ajaxPrefilter( function( s ) {
-	for ( var i in s.headers ) {
+	var i;
+	for ( i in s.headers ) {
 		if ( i.toLowerCase() === "content-type" ) {
 			s.contentType = s.headers[ i ] || "";
 		}

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -862,11 +862,9 @@ jQuery.each( [ "get", "post" ], function( _i, method ) {
 } );
 
 jQuery.ajaxPrefilter( function( s ) {
-	if ( s.data && s.processData ) {
-		for ( var i in s.headers ) {
-			if ( i.toLowerCase() === "content-type" ) {
-				s.contentType = s.headers[ i ] || "";
-			}
+	for ( var i in s.headers ) {
+		if ( i.toLowerCase() === "content-type" ) {
+			s.contentType = s.headers[ i ] || "";
 		}
 	}
 } );

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -861,4 +861,14 @@ jQuery.each( [ "get", "post" ], function( _i, method ) {
 	};
 } );
 
+jQuery.ajaxPrefilter( function( s ) {
+	if ( s.data && s.processData ) {
+		for ( var i in s.headers ) {
+			if ( i.toLowerCase() === "content-type" ) {
+				s.contentType = s.headers[ i ] || "";
+			}
+		}
+	}
+} );
+
 export default jQuery;

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -1442,6 +1442,19 @@ QUnit.module( "ajax", {
 		};
 	} );
 
+	ajaxTest( "jQuery.ajax() - override contentType with header (gh-4119)", 1, function( assert ) {
+		return {
+			url: "bogus.html",
+			contentType: "application/json",
+			headers: { "content-type": "application/x-www-form-urlencoded" },
+			beforeSend: function( _, s ) {
+				assert.strictEqual( s.contentType, "application/x-www-form-urlencoded", "contentType is overwritten" );
+				return false;
+			},
+			error: true
+		};
+	} );
+
 	ajaxTest( "jQuery.ajax() - data - no processing POST", 1, function( assert ) {
 		return {
 			url: "bogus.html",

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -1448,7 +1448,8 @@ QUnit.module( "ajax", {
 			contentType: "application/json",
 			headers: { "content-type": "application/x-www-form-urlencoded" },
 			beforeSend: function( _, s ) {
-				assert.strictEqual( s.contentType, "application/x-www-form-urlencoded", "contentType is overwritten" );
+				assert.strictEqual( s.contentType, "application/x-www-form-urlencoded",
+					"contentType is overwritten" );
 				return false;
 			},
 			error: true

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -1410,7 +1410,7 @@ QUnit.module( "ajax", {
 		};
 	} );
 
-	ajaxTest( "jQuery.ajax() - don't escape %20 in contentType (gh-4119)", 1, function( assert ) {
+	ajaxTest( "jQuery.ajax() - don't escape %20 with contentType override (gh-4119)", 1, function( assert ) {
 		return {
 			url: "bogus.html",
 			contentType: "application/x-www-form-urlencoded",
@@ -1420,6 +1420,22 @@ QUnit.module( "ajax", {
 			data: "{\"val\":\"%20\"}",
 			beforeSend: function( _, s ) {
 				assert.strictEqual( s.data, "{\"val\":\"%20\"}", "data is not %20-encoded" );
+				return false;
+			},
+			error: true
+		};
+	} );
+
+	ajaxTest( "jQuery.ajax() - escape %20 with contentType override (gh-4119)", 1, function( assert ) {
+		return {
+			url: "bogus.html",
+			contentType: "application/json",
+			headers: { "content-type": "application/x-www-form-urlencoded" },
+			method: "post",
+			dataType: "json",
+			data: "{\"val\":\"%20\"}",
+			beforeSend: function( _, s ) {
+				assert.strictEqual( s.data, "{\"val\":\"+\"}", "data is %20-encoded" );
 				return false;
 			},
 			error: true

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -1410,6 +1410,22 @@ QUnit.module( "ajax", {
 		};
 	} );
 
+	ajaxTest( "jQuery.ajax() - don't escape %20 in contentType (gh-4119)", 1, function( assert ) {
+		return {
+			url: "bogus.html",
+			contentType: "application/x-www-form-urlencoded",
+			headers: { "content-type": "application/json" },
+			method: "post",
+			dataType: "json",
+			data: "{\"val\":\"%20\"}",
+			beforeSend: function( _, s ) {
+				assert.strictEqual( s.data, "{\"val\":\"%20\"}", "data is not %20-encoded" );
+				return false;
+			},
+			error: true
+		};
+	} );
+
 	ajaxTest( "jQuery.ajax() - data - no processing POST", 1, function( assert ) {
 		return {
 			url: "bogus.html",


### PR DESCRIPTION
### Summary ###
Overwrite s.contentType with content-type header value, if any
Fixes #4119 

### Checklist ###
* [X] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [X] New tests have been added to show the fix or feature works
* [X] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com
