### PR TITLE
Offset: Send px-ed strings to .css()

### DIFF
--- a/src/offset.js
+++ b/src/offset.js
@@ -12,6 +12,7 @@ jQuery.offset = {
 		var curPosition, curLeft, curCSSTop, curTop, curOffset, curCSSLeft, calculatePosition,
 			position = jQuery.css( elem, "position" ),
 			curElem = jQuery( elem ),
+			numberProps = {},
 			props = {};
 
 		// Set position first, in-case top/left are set even on static elem
@@ -44,14 +45,16 @@ jQuery.offset = {
 		}
 
 		if ( options.top != null ) {
-			props.top = ( options.top - curOffset.top ) + curTop;
+			numberProps.top = ( options.top - curOffset.top ) + curTop;
+			props.top = numberProps.top + "px";
 		}
 		if ( options.left != null ) {
-			props.left = ( options.left - curOffset.left ) + curLeft;
+			numberProps.left = ( options.left - curOffset.left ) + curLeft;
+			props.left = numberProps.left + "px";
 		}
 
 		if ( "using" in options ) {
-			options.using.call( elem, props );
+			options.using.call( elem, numberProps );
 
 		} else {
 			curElem.css( props );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

This is an alternative to #4508 that's smaller by 4 bytes on master & by 2 bytes on `3.x-stable`.

An upcoming release of Migrate will generate warnings for calls to `.css()`
that pass numbers rather than strings, see jquery/jquery-migrate#296. At
the moment, core's `.offset()` setter passes numbers rather than px strings
so it would throw warnings. This commit fixes that.

Fixes gh-4525
Ref gh-4508

Co-authored-by: Dave Methvin <dave.methvin@gmail.com>

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
