### PR TITLE
Tests: Use only one focusin/out handler per matching window & document

### DIFF
--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -2605,16 +2605,16 @@ QUnit.test( "focusin on document & window", function( assert ) {
 	var counter = 0,
 		input = jQuery( "<input />" );
 
+	function increment() {
+		counter++;
+	}
+
 	input.appendTo( "#qunit-fixture" );
 
 	input[ 0 ].focus();
 
-	jQuery( window ).on( "focusout", function() {
-		counter++;
-	} );
-	jQuery( document ).on( "focusout", function() {
-		counter++;
-	} );
+	jQuery( window ).on( "focusout", increment );
+	jQuery( document ).on( "focusout", increment );
 
 	input[ 0 ].blur();
 
@@ -2625,6 +2625,9 @@ QUnit.test( "focusin on document & window", function( assert ) {
 
 	assert.strictEqual( counter, 2,
 		"focusout handlers on document/window fired once only" );
+
+	jQuery( window ).off( "focusout", increment );
+	jQuery( document ).off( "focusout", increment );
 } );
 
 testIframe(


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Backport tests from a jQuery 3.x fix that's not needed on `master`.

Also, fix the "focusin from an iframe" test to actually verify the behavior
from commit 1cecf64e5aa415367a7dae0b55c2dd17b591442d - the commit that
introduced the regression - to make sure we don't regress on either front.

The main part of the modified test was checking that focusin handling in an
iframe works and that's still checked. The test was also checking that it
doesn't propagate to the parent document, though, and, apparently, in IE it
does. This one test is now blacklisted in IE.

(cherry picked from 9e15d6b469556eccfa607c5ecf53b20c84529125)
(cherry picked from 1a4f10ddc37c34c6dc3a451ee451b5c6cf367399)

Ref gh-4652
Ref gh-4656

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
