### PR TITLE
Build: De-indent AMD modules

### DIFF
--- a/build/tasks/amd.js
+++ b/build/tasks/amd.js
@@ -19,7 +19,8 @@ module.exports = function( grunt ) {
 
 	const outputRollupOptions = {
 		format: "amd",
-		dir: "amd"
+		dir: "amd",
+		indent: false
 	};
 
 	grunt.registerTask(


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

This will preserve a more similar structure to the one on 3.x-stable where the
body of the main `define` wrapper is not indented.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
