### PR TITLE
Data: Make the data object a regular object again

### DIFF
--- a/src/data/Data.js
+++ b/src/data/Data.js
@@ -22,7 +22,7 @@ Data.prototype = {
 
 		// If not, create one
 		if ( !value ) {
-			value = Object.create( null );
+			value = {};
 
 			// We can accept data for non-element nodes in modern browsers,
 			// but we should not, see #8335.

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -990,17 +990,20 @@ QUnit.test( ".data(prop) does not create expando", function( assert ) {
 	}
 } );
 
-QUnit.test( "keys matching Object.prototype properties  (gh-3256)", function( assert ) {
-	assert.expect( 2 );
+QUnit.test( ".data() returns a regular object (jQuery <4 only, gh-4665)", function( assert ) {
+	assert.expect( 4 );
 
-	var div = jQuery( "<div></div>" );
+	function verifyRegularObject( assert, object ) {
+		assert.strictEqual( object.hasOwnProperty, Object.prototype.hasOwnProperty,
+			"Data object has the hasOwnProperty method" );
+		assert.strictEqual( object + "", "[object Object]",
+			"Data object can be stringified" );
+	}
 
-	assert.strictEqual( div.data( "hasOwnProperty" ), undefined,
-		"hasOwnProperty not matched (before forced data creation)" );
+	var elem = jQuery( "<div></div>" );
 
-	// Force the creation of a data object for this element.
-	div.data( { foo: "bar" } );
+	verifyRegularObject( assert, elem.data() );
 
-	assert.strictEqual( div.data( "hasOwnProperty" ), undefined,
-		"hasOwnProperty not matched (after forced data creation)" );
+	elem.data( "foo", "bar" );
+	verifyRegularObject( assert, elem.data() );
 } );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Make the data object a regular object again.

The change in gh-4603 made the object returned by `elem.data()` a prototype-less
object. That's a desired change to support keys colliding with Object.prototype
properties but it's also a breaking change so it has to wait for jQuery 4.0.0.

A 3.x-only test was added to avoid breaking it in the future on this branch.

Fixes gh-4665
Ref gh-4603

-1 byte

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
