### PR TITLE
Improved trim performance in Selector.js

### DIFF
--- a/src/selector.js
+++ b/src/selector.js
@@ -8,6 +8,7 @@ import push from "./var/push.js";
 import whitespace from "./selector/var/whitespace.js";
 import rbuggyQSA from "./selector/rbuggyQSA.js";
 import support from "./selector/support.js";
+import trim from "./var/trim.js";
 
 // The following utils are attached directly to the jQuery object.
 import "./selector/contains.js";
@@ -268,7 +269,7 @@ function find( selector, context, results, seed ) {
 	}
 
 	// All others
-	return select( selector.replace( rtrim, "$1" ), context, results, seed );
+	return select( trim.call( selector ), context, results, seed );
 }
 
 /**
@@ -825,7 +826,7 @@ Expr = jQuery.expr = {
 			// spaces as combinators
 			var input = [],
 				results = [],
-				matcher = compile( selector.replace( rtrim, "$1" ) );
+				matcher = compile( trim.call( selector ) );
 
 			return matcher[ expando ] ?
 				markFunction( function( seed, matches, _context, xml ) {


### PR DESCRIPTION
The native JavaScript trim() method works much faster than regular expressions in the case of removing whitespace from the beginning and the end of a string.

e.g. String.prototype.trim vs Trim String With Sizzle's RegEx
       (https://jsperf.com/string-prototype-trim-vs-trim-string-with-sizzle-regex)
- Testing in Chrome 81.0.4044 / Windows 10 0.0.0
   : The native trim() method works 97% faster in my PC.
- Testing in IE 11.0.0 / Windows 10 0.0.0
   : The native trim() method works 94% faster in my PC.

The trim using the regular expression of selector.js is the same as Sizzle, but it seems desirable to remove it for the following reasons.
- The current version and the later of IE9 supports String.prototype.trim. 
  jQuery v2.X has stopped supporting the prior versions in IE8.
- Since Sizzle is removed from 4.0, there is no need to keep the code.

However, since regular expressions for trim are also used for other purposes, the only portion of the codes with the improved performance with the trim () method are changed.

### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
