### PR TITLE
Build: Move ESLint max-len disable-directive to dist/.eslintrc.json

### DIFF
--- a/dist/.eslintrc.json
+++ b/dist/.eslintrc.json
@@ -20,7 +20,8 @@
 			"rules": {
 				// That is okay for the built version
 				"no-multiple-empty-lines": "off",
-				// Version number substituion may trigger max-len
+				// When custom compilation is used, the version string
+				// can get large. Accept that in the built version.
 				"max-len": "off",
 				"one-var": "off"
 			}

--- a/dist/.eslintrc.json
+++ b/dist/.eslintrc.json
@@ -20,6 +20,8 @@
 			"rules": {
 				// That is okay for the built version
 				"no-multiple-empty-lines": "off",
+				// Version number substituion may trigger max-len
+				"max-len": "off",
 				"one-var": "off"
 			}
 		}

--- a/src/core.js
+++ b/src/core.js
@@ -14,8 +14,6 @@ import isWindow from "./var/isWindow.js";
 import DOMEval from "./core/DOMEval.js";
 import toType from "./core/toType.js";
 
-// When custom compilation is used, the version string can get large.
-// eslint-disable-next-line max-len
 var version = "@VERSION",
 
 	rhtmlSuffix = /HTML$/i,


### PR DESCRIPTION
This disable-directive only applies to the built version, so put it in /dist. This avoids a warning about an unused directive in the source version.
Follow-up to #4520

### Checklist ###
* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
