### PR TITLE
Tests: Fix flakiness in the "jQuery.ajax() - JSONP - Same Domain" test

### DIFF
--- a/test/middleware-mockserver.js
+++ b/test/middleware-mockserver.js
@@ -93,7 +93,9 @@ var mocks = {
 	},
 	jsonp: function( req, resp, next ) {
 		var callback;
-		if ( req.query.callback ) {
+		if ( Array.isArray( req.query.callback ) ) {
+			callback = Promise.resolve( req.query.callback[ req.query.callback.length - 1 ] );
+		} else if ( req.query.callback ) {
 			callback = Promise.resolve( req.query.callback );
 		} else if ( req.method === "GET" ) {
 			callback = Promise.resolve( req.url.match( /^.+\/([^\/?.]+)\?.+$/ )[ 1 ] );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The "jQuery.ajax() - JSONP - Same Domain" test is firing a request with
a duplicate "callback" parameter, something like (simplified):
```
mock.php?action=jsonp&callback=jQuery_1&callback=jQuery_2
```

There was a difference in how the PHP & Node.js implementations of the jsonp
action in the mock server handled situations like that. The PHP implementation
was using the latest parameter while the Node.js one was turning it into an
array but the code didn't handle this situation. Because of how JavaScript
stringifies arrays, while the PHP implementation injected the following code:
```js
jQuery_2(payload)
```
the Node.js one was injecting the following one:
```js
jQuery_1,jQuery_2(payload)
```
This is a comma expression in JavaScript; it so turned out that in the majority
of cases both callbacks were identical so it was more like:
```js
jQuery_1,jQuery_1(payload)
```
which evaluates to `jQuery_1(payload)` when `jQuery_1` is defined, making the
test go as expected. In many cases, though, especially on Travis, the callbacks
were different, triggering an `Uncaught ReferenceError` error & requiring
frequent manual re-runs of Travis builds.

This commit fixes the logic in the mock Node.js server, adding special handling
for arrays.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
