### PR TITLE
Build: Append .eslintignore paths to grunt eslint paths

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,7 +15,8 @@ module.exports = function( grunt ) {
 	var fs = require( "fs" ),
 		gzip = require( "gzip-js" ),
 		isTravis = process.env.TRAVIS,
-		travisBrowsers = process.env.BROWSERS && process.env.BROWSERS.split( "," );
+		travisBrowsers = process.env.BROWSERS && process.env.BROWSERS.split( "," ),
+		CLIEngine = require( "eslint" ).CLIEngine;
 
 	if ( !grunt.option( "filename" ) ) {
 		grunt.option( "filename", "jquery.js" );
@@ -77,9 +78,7 @@ module.exports = function( grunt ) {
 		},
 		eslint: {
 			options: {
-
-				// See https://github.com/sindresorhus/grunt-eslint/issues/119
-				quiet: true
+				maxWarnings: 0
 			},
 
 			// We have to explicitly declare "src" property otherwise "newer"
@@ -89,6 +88,14 @@ module.exports = function( grunt ) {
 			},
 			dev: {
 				src: [ "src/**/*.js", "Gruntfile.js", "test/**/*.js", "build/**/*.js" ]
+
+					// Ignore files from .eslintignore
+					// See https://github.com/sindresorhus/grunt-eslint/issues/119
+					.concat(
+						new CLIEngine()
+							.getConfigForFile( "Gruntfile.js" )
+							.ignorePatterns.map( p => "!" + p )
+					)
 			}
 		},
 		testswarm: {


### PR DESCRIPTION
### Summary ###
This allows us to turn off the `quiet` option which was suppressing warnings.

We can also set `maxWarnings` to 0 now that aren't any, which will catch `reportUnusedDisableDirectives` warnings.

### Checklist ###
* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com
