### PR TITLE
Deprecated: Remove jQuery.trim

### DIFF
--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -1,6 +1,5 @@
 import jQuery from "./core.js";
 import slice from "./var/slice.js";
-import trim from "./var/trim.js";
 
 import "./deprecated/ajax-event-alias.js";
 import "./deprecated/event.js";
@@ -42,8 +41,4 @@ jQuery.holdReady = function( hold ) {
 	} else {
 		jQuery.ready( true );
 	}
-};
-
-jQuery.trim = function( text ) {
-	return text == null ? "" : trim.call( text );
 };

--- a/src/var/trim.js
+++ b/src/var/trim.js
@@ -1,1 +1,0 @@
-export default "".trim;

--- a/test/unit/deprecated.js
+++ b/test/unit/deprecated.js
@@ -199,25 +199,3 @@ QUnit[ jQuery.proxy ? "test" : "skip" ]( "jQuery.proxy", function( assert ) {
 	cb = jQuery.proxy( fn, null, "arg1", "arg2" );
 	cb.call( thisObject, "arg3" );
 } );
-
-QUnit[ jQuery.trim ? "test" : "skip" ]( "trim", function( assert ) {
-	assert.expect( 13 );
-
-	var nbsp = String.fromCharCode( 160 );
-
-	assert.equal( jQuery.trim( "hello  " ), "hello", "trailing space" );
-	assert.equal( jQuery.trim( "  hello" ), "hello", "leading space" );
-	assert.equal( jQuery.trim( "  hello   " ), "hello", "space on both sides" );
-	assert.equal( jQuery.trim( "  " + nbsp + "hello  " + nbsp + " " ), "hello", "&nbsp;" );
-
-	assert.equal( jQuery.trim(), "", "Nothing in." );
-	assert.equal( jQuery.trim( undefined ), "", "Undefined" );
-	assert.equal( jQuery.trim( null ), "", "Null" );
-	assert.equal( jQuery.trim( 5 ), "5", "Number" );
-	assert.equal( jQuery.trim( false ), "false", "Boolean" );
-
-	assert.equal( jQuery.trim( " " ), "", "space should be trimmed" );
-	assert.equal( jQuery.trim( "ipad\xA0" ), "ipad", "nbsp should be trimmed" );
-	assert.equal( jQuery.trim( "\uFEFF" ), "", "zwsp should be trimmed" );
-	assert.equal( jQuery.trim( "\uFEFF \xA0! | \uFEFF" ), "! |", "leading/trailing should be trimmed" );
-} );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The API has been deprecated in 3.5.0 so it can be removed in 4.0.0.

Ref gh-4461

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
