### PR TITLE
CSS: Include `show`, `hide` & `toggle` methods in the jQuery slim build

### DIFF
--- a/src/jquery.js
+++ b/src/jquery.js
@@ -16,6 +16,7 @@ import "./manipulation/_evalUrl.js";
 import "./wrap.js";
 import "./css.js";
 import "./css/hiddenVisibleSelectors.js";
+import "./css/showHide.js";
 import "./serialize.js";
 import "./ajax.js";
 import "./ajax/xhr.js";

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -487,9 +487,6 @@ QUnit.test( "css(Object) where values are Functions with incoming values", funct
 	jQuery( "#cssFunctionTest" ).remove();
 } );
 
-// .show(), .hide(), can be excluded from the build
-if ( jQuery.fn.show && jQuery.fn.hide ) {
-
 QUnit.test( "show()", function( assert ) {
 
 	assert.expect( 18 );
@@ -967,8 +964,6 @@ QUnit.test( "show/hide 3.0, inline hidden", function( assert ) {
 		}
 	} );
 } );
-
-}
 
 QUnit[ QUnit.jQuerySelectors && jQuery.fn.toggle ? "test" : "skip" ]( "toggle()", function( assert ) {
 	assert.expect( 9 );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The `show()`, `hide()` & `toggle()` methods were included in the 3.x jQuery slim
build. The jQuery master build accidentally started to exclude them as they were
only imported in the effects module and the new Rollup-based build system
follows the module dependency graph when excluding modules.

To resolve the issue, import the `css/showHide.js` file directly in the main
`jquery.js` file.

We don't really have tests for what gets into the slim build so I didn't add anything.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
