### PR TITLE
Build: Followups after introducing ES modules compiled via Rollup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,14 +1,5 @@
 {
 	"root": true,
 
-	"extends": "./.eslintrc-node.json",
-
-	"overrides": [
-		{
-			"files": "rollup.config.js",
-			"parserOptions": {
-				"sourceType": "module"
-			}
-		}
-	]
+	"extends": "./.eslintrc-node.json"
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,7 +24,7 @@ module.exports = function( grunt ) {
 	grunt.initConfig( {
 		pkg: grunt.file.readJSON( "package.json" ),
 		dst: readOptionalJSON( "dist/.destination.json" ),
-		"compare_size": {
+		compare_size: {
 			files: [ "dist/jquery.js", "dist/jquery.min.js" ],
 			options: {
 				compress: {
@@ -232,7 +232,7 @@ module.exports = function( grunt ) {
 						"test/data/jquery-1.9.1.js",
 						"test/data/testinit-jsdom.js",
 
-						// We don't support various loading methods like AMD,
+						// We don't support various loading methods like esmodules,
 						// choosing a version etc. for jsdom.
 						"dist/jquery.js",
 

--- a/build/tasks/amd.js
+++ b/build/tasks/amd.js
@@ -19,7 +19,8 @@ module.exports = function( grunt ) {
 
 	const outputRollupOptions = {
 		format: "amd",
-		dir: "amd"
+		dir: "amd",
+		indent: false
 	};
 
 	grunt.registerTask(

--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -54,7 +54,7 @@ module.exports = function( grunt ) {
 
 	grunt.registerMultiTask(
 		"build",
-		"Concatenate source, remove sub AMD definitions, " +
+		"Build jQuery ECMAScript modules, " +
 			"(include/exclude modules with +/- flags), embed date/version",
 	async function() {
 		const done = this.async();
@@ -302,7 +302,7 @@ module.exports = function( grunt ) {
 				);
 
 			grunt.file.write( name, compiledContents );
-			grunt.log.ok( "File '" + name + "' created." );
+			grunt.log.ok( `File '${ name }' created.` );
 			done();
 		} catch ( err ) {
 			done( err );

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -34,7 +34,7 @@
 					// Code Style. This makes that indentation check is not
 					// performed for 1 depth of outer FunctionExpressions
 					"ignoredNodes": [
-						"Program > ExpressionStatement > CallExpression > FunctionExpression > *"
+						"Program > ExpressionStatement > CallExpression > :last-child > *"
 					]
 				} ]
 			},

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -576,7 +576,7 @@ jQuery.extend( {
 		}
 
 		// We can fire global events as of now if asked to
-		// Don't fire events if jQuery.event is undefined in an ESM-usage scenario (#15118)
+		// Don't fire events if jQuery.event is undefined in an ESM-usage scenario (trac-15118)
 		fireGlobals = jQuery.event && s.global;
 
 		// Watch for a new set of requests

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -576,7 +576,7 @@ jQuery.extend( {
 		}
 
 		// We can fire global events as of now if asked to
-		// Don't fire events if jQuery.event is undefined in an AMD-usage scenario (#15118)
+		// Don't fire events if jQuery.event is undefined in an ESM-usage scenario (#15118)
 		fireGlobals = jQuery.event && s.global;
 
 		// Watch for a new set of requests


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

This PR cleans up a few comments & configurations that are out of date
after the migration to ES modules backed by a Rollup-based compilation.

Also, de-indent AMD modules. This will preserve a more similar
structure to the one on 3.x-stable where the body of the main `define`
wrapper is not indented.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
