### PR TITLE
Serialize: jQuery.param: Allow serialization of standalone keys

### DIFF
--- a/src/serialize.js
+++ b/src/serialize.js
@@ -52,7 +52,7 @@ function buildParams( prefix, obj, traditional, add ) {
 
 // Serialize an array of form elements or a set of
 // key/values into a query string
-jQuery.param = function( a, traditional ) {
+jQuery.param = function( a, traditional, standaloneKeys ) {
 	var prefix,
 		s = [],
 		add = function( key, valueOrFunction ) {
@@ -62,7 +62,8 @@ jQuery.param = function( a, traditional ) {
 				valueOrFunction() :
 				valueOrFunction;
 
-			s[ s.length ] = encodeURIComponent( key ) + "=" +
+			s[ s.length ] = encodeURIComponent( key ) +
+				( standaloneKeys && value == null ? "" : "=" ) +
 				encodeURIComponent( value == null ? "" : value );
 		};
 

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -1,7 +1,7 @@
 QUnit.module( "serialize", { afterEach: moduleTeardown } );
 
 QUnit.test( "jQuery.param()", function( assert ) {
-	assert.expect( 24 );
+	assert.expect( 25 );
 
 	var params;
 
@@ -75,6 +75,9 @@ QUnit.test( "jQuery.param()", function( assert ) {
 
 	params = undefined;
 	assert.equal( jQuery.param( params ), "", "jQuery.param( undefined ) === empty string" );
+
+	params = { "param1": null };
+	assert.equal( jQuery.param( params, false, true ), "param1", "Allow null params to be abbreviated" );
 } );
 
 QUnit[ jQuery.ajax ? "test" : "skip" ]( "jQuery.param() not affected by ajaxSettings", function( assert ) {

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -1,7 +1,7 @@
 QUnit.module( "serialize", { afterEach: moduleTeardown } );
 
 QUnit.test( "jQuery.param()", function( assert ) {
-	assert.expect( 25 );
+	assert.expect( 26 );
 
 	var params;
 
@@ -78,6 +78,9 @@ QUnit.test( "jQuery.param()", function( assert ) {
 
 	params = { "param1": null };
 	assert.equal( jQuery.param( params, false, true ), "param1", "Allow null params to be abbreviated" );
+
+	params = { "foo": 1, "bar": [ 2, null ], "baz": { "qux": null, "quux": 3 } };
+	assert.equal( decodeURIComponent( jQuery.param( params, false, true ) ), "foo=1&bar[]=2&bar[]&baz[qux]&baz[quux]=3", "Allow null params to be abbreviated in nested objects" );
 } );
 
 QUnit[ jQuery.ajax ? "test" : "skip" ]( "jQuery.param() not affected by ajaxSettings", function( assert ) {

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -81,6 +81,21 @@ QUnit.test( "jQuery.param()", function( assert ) {
 
 	params = { "foo": 1, "bar": [ 2, null ], "baz": { "qux": null, "quux": 3 } };
 	assert.equal( decodeURIComponent( jQuery.param( params, false, true ) ), "foo=1&bar[]=2&bar[]&baz[qux]&baz[quux]=3", "Allow null params to be abbreviated in nested objects" );
+
+} );
+
+QUnit.test( "jQuery.param() serialization collisions", function( assert ) {
+	assert.expect( 2 );
+
+	var left, right;
+
+    left = { a: 1, b: null };
+    right = { a: 1, b: "" };
+	assert.equal( jQuery.param( left ), jQuery.param( right ), "Serialization collision with standaloneKeys disabled" );
+
+    left = { a: 1, b: null };
+    right = { a: 1, b: "" };
+	assert.notEqual( jQuery.param( left, false, true ), jQuery.param( right, false, true ), "Distinct serialization with standaloneKeys enabled" );
 } );
 
 QUnit[ jQuery.ajax ? "test" : "skip" ]( "jQuery.param() not affected by ajaxSettings", function( assert ) {

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -89,12 +89,12 @@ QUnit.test( "jQuery.param() serialization collisions", function( assert ) {
 
 	var left, right;
 
-    left = { a: 1, b: null };
-    right = { a: 1, b: "" };
+	left = { a: 1, b: null };
+	right = { a: 1, b: "" };
 	assert.equal( jQuery.param( left ), jQuery.param( right ), "Serialization collision with standaloneKeys disabled" );
 
-    left = { a: 1, b: null };
-    right = { a: 1, b: "" };
+	left = { a: 1, b: null };
+	right = { a: 1, b: "" };
 	assert.notEqual( jQuery.param( left, false, true ), jQuery.param( right, false, true ), "Distinct serialization with standaloneKeys enabled" );
 } );
 


### PR DESCRIPTION
### Summary ###
This change introduces an optional `standaloneKeys` parameter to the [jQuery.param](https://api.jquery.com/jQuery.param/) function, allowing a developer to specify that they would like to allow null-valued keys to be abbreviated (rendered without a trailing `=`) in the serialized output. 

Resolves #4707

### Checklist ###
* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com