### PR TITLE
Tests: Remove remaining obsolete jQuery.cache references

### DIFF
--- a/test/data/testrunner.js
+++ b/test/data/testrunner.js
@@ -2,12 +2,10 @@
 
 "use strict";
 
-// Store the old counts so that we only assert on tests that have actually leaked,
+// Store the old count so that we only assert on tests that have actually leaked,
 // instead of asserting every time a test has leaked sometime in the past
-var oldCacheLength = 0,
-	oldActive = 0,
+var oldActive = 0,
 
-	expectedDataKeys = {},
 	splice = [].splice,
 	ajaxSettings = jQuery.ajaxSettings;
 
@@ -26,11 +24,6 @@ QUnit.config.requireExpects = true;
  * teardown function on all modules' lifecycle object.
  */
 window.moduleTeardown = function( assert ) {
-	var i, expectedKeys, actualKeys,
-		cacheLength = 0;
-
-	// Reset data register
-	expectedDataKeys = {};
 
 	// Check for (and clean up, if possible) incomplete animations/requests/etc.
 	if ( jQuery.timers && jQuery.timers.length !== 0 ) {
@@ -47,19 +40,6 @@ window.moduleTeardown = function( assert ) {
 	}
 
 	Globals.cleanup();
-
-	for ( i in jQuery.cache ) {
-		++cacheLength;
-	}
-
-	// Because QUnit doesn't have a mechanism for retrieving
-	// the number of expected assertions for a test,
-	// if we unconditionally assert any of these,
-	// the test will fail with too many assertions :|
-	if ( cacheLength !== oldCacheLength ) {
-		assert.equal( cacheLength, oldCacheLength, "No unit tests leak memory in jQuery.cache" );
-		oldCacheLength = cacheLength;
-	}
 };
 
 QUnit.done( function() {

--- a/test/unit/wrap.js
+++ b/test/unit/wrap.js
@@ -21,7 +21,7 @@ function manipulationFunctionReturningObj( value ) {
 
 function testWrap( val, assert ) {
 
-	assert.expect( 19 );
+	assert.expect( 18 );
 
 	var defaultText, result, j, i, cacheLength;
 
@@ -68,25 +68,12 @@ function testWrap( val, assert ) {
 		"Check node,textnode,comment wraps doesn't hurt text"
 	);
 
-	// Try wrapping a disconnected node
-	cacheLength = 0;
-	for ( i in jQuery.cache ) {
-		cacheLength++;
-	}
-
 	j = jQuery( "<label></label>" ).wrap( val( "<li></li>" ) );
 	assert.equal(
 		j[ 0 ] .nodeName.toUpperCase(), "LABEL", "Element is a label"
 	);
 	assert.equal(
 		j[ 0 ].parentNode.nodeName.toUpperCase(), "LI", "Element has been wrapped"
-	);
-
-	for ( i in jQuery.cache ) {
-		cacheLength--;
-	}
-	assert.equal(
-		cacheLength, 0, "No memory leak in jQuery.cache (bug #7165)"
 	);
 
 	// Wrap an element containing a text node


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Tests: Remove remaining obsolete jQuery.cache references

PR gh-4586 removed some of those but not all.

Ref gh-4586

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
