### PR TITLE
Docs: Update Frequently Reported Issues in the GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -14,7 +14,7 @@ Bug Reports:
   We prefer test cases on JS Bin (https://jsbin.com/qawicop/edit?html,css,js,output) or CodePen (https://codepen.io/mgol/pen/wNWJbZ)
 
 Frequently Reported Issues:
-  * Selectors with '#' break: See https://github.com/jquery/jquery/issues/2824
+  * Self-closing tags broken in jQuery 3.5.0 or newer: please read the [jQuery 3.5.0 blog post](https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/) & the [upgrade guide](https://jquery.com/upgrade-guide/3.5/); see also issue #4681.
 -->
 
 ### Description ###


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The issue about selectors with '#' being broken is old and no longer frequently
reported so this commit removes it from the list. On the other hand, we're now
getting lots of reports about the security fix in jQuery 3.5.0 that was also
a breaking change: gh-4642. This one is now mentioned in the list.

Ref gh-4642

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
