### PR TITLE
Build: Fix commitplease husky config

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     "test:no-deprecated": "grunt test:prepare && grunt custom:-deprecated && grunt karma:main",
     "test:slim": "grunt test:prepare && grunt custom:slim && grunt karma:main",
     "test": "npm run test:slim && npm run test:no-deprecated && grunt && grunt test:slow && grunt karma:main && grunt karma:esmodules && grunt karma:amd",
-    "jenkins": "npm run test:browserless"
+    "jenkins": "npm run test:browserless",
+    "commitmsg": "commitplease .git/COMMIT_EDITMSG"
   },
   "commitplease": {
     "nohook": true,
@@ -111,7 +112,6 @@
   },
   "husky": {
     "hooks": {
-      "commit-msg": "node node_modules/commitplease",
       "pre-commit": "grunt lint:newer qunit_fixture"
     }
   }

--- a/package.json
+++ b/package.json
@@ -77,8 +77,7 @@
     "test:no-deprecated": "grunt test:prepare && grunt custom:-deprecated && grunt karma:main",
     "test:slim": "grunt test:prepare && grunt custom:slim && grunt karma:main",
     "test": "npm run test:slim && npm run test:no-deprecated && grunt && grunt test:slow && grunt karma:main && grunt karma:esmodules && grunt karma:amd",
-    "jenkins": "npm run test:browserless",
-    "commitmsg": "commitplease .git/COMMIT_EDITMSG"
+    "jenkins": "npm run test:browserless"
   },
   "commitplease": {
     "nohook": true,
@@ -112,6 +111,7 @@
   },
   "husky": {
     "hooks": {
+      "commit-msg": "commitplease .git/COMMIT_EDITMSG",
       "pre-commit": "grunt lint:newer qunit_fixture"
     }
   }


### PR DESCRIPTION
### Summary ###

Fixes gh-4735

As  defined in [commitplease README](https://github.com/jzaefferer/commitplease/blob/master/README.md):

Changed hook `commit-msg` to `commitplease .git/COMMIT_EDITMSG`
### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->

Signed-off-by: Beatriz Rezener <beatrizrezener@gmail.com>
