### PR TITLE
Resolve JQMigrate Warning when using .fadeTo

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -493,7 +493,7 @@ jQuery.fn.extend( {
 	fadeTo: function( speed, to, easing, callback ) {
 
 		// Show any hidden elements after setting opacity to 0
-		return this.filter( isHiddenWithinTree ).css( "opacity", 0 ).show()
+		return this.filter( isHiddenWithinTree ).css( "opacity", "0" ).show()
 
 			// Animate to the value specified
 			.end().animate( { opacity: to }, speed, easing, callback );


### PR DESCRIPTION



> ### Summary ###
JQMigrate generates a warning in some circumstances when using effects .fadeTo method, as it provides a numeric value to the .css method internally.  Since the recommendation is to always provide the string representation of the value, that should be done for internal functions as well as when being called externally.

No unit test updates should be needed, as existing fadeTo unit tests should be sufficient.

> JQMIGRATE: Use of number-typed values is deprecated in jQuery.fn.css
> Cause: In past versions, when a number-typed value was passed to .css() jQuery converted it to a string and added "px" to the end. As the CSS standard has evolved, an increasingly large set of CSS properties now accept values that are unitless numbers, where this behavior is incorrect. It has become impractical to manage these exceptions in the jQuery.cssNumber object. In addition, some CSS properties like line-height can accept both a bare number 2 or a pixel value 2px. jQuery cannot know the correct way to interpret $.css("line-height", 2) and currently treats it as "2px".
> 
> Solution: Always pass string values to .css(), and explicitly add units where required. For example, use $.css("line-height", "2") to specify 200% of the current line height or $.css("line-height", "2px") to specify pixels. When the numeric value is in a variable, ensure the value is converted to string, e.g. $.css("line-height", String(height)) and $.css("line-height", height+"px").
> 


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works 
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
