### PR TITLE
Tests: Add self-closing tag parsing test

### DIFF
--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -151,6 +151,10 @@ QUnit.test( "jQuery()", function( assert ) {
 	elem = jQuery( "<input type='hidden'>", {} );
 	assert.strictEqual( elem[ 0 ].ownerDocument, document,
 		"Empty attributes object is not interpreted as a document (trac-8950)" );
+
+	elem = jQuery( "<div><h3><i /></h3>\n<span>test</span></div>" );
+	assert.strictEqual( elem.html(), "<h3><i></i>\n<span>test</span></h3>",
+		"Self-closing tags should be parsed correctly when the html code contains line breaks" );
 } );
 
 QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "jQuery(selector, context)", function( assert ) {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

I added a test to reproduce a bug I encountered, but I don't know how to modify the relevant source code to fix this bug. If someone tells me the relevant clue, then maybe I will fix this bug.

This bug will not appear with the version older than 3.5.0

The following are the test results:

```text
HeadlessChrome 78.0.3904 (Linux 0.0.0) core jQuery() FAILED
	Self-closing tags should be parsed correctly when the html code contains line breaks
	Expected: "<h3><i></i>
	<span>test</span></h3>"
	Actual: "<h3><i></i></h3><i>
	<span>test</span></i>"
	    at Object.<anonymous> (test/unit/core.js:156:9)
	    at runTest (node_modules/qunit/qunit/qunit.js:3044:30)
	    at Test.run (node_modules/qunit/qunit/qunit.js:3030:6)
	    at node_modules/qunit/qunit/qunit.js:3257:12
	    at processTaskQueue (node_modules/qunit/qunit/qunit.js:2623:24)
	    at node_modules/qunit/qunit/qunit.js:2627:8
	
	Expected 29 assertions, but 30 were run
	    at test/unit/core.js:22:7

```

![image](https://user-images.githubusercontent.com/1730073/86895864-ab541d80-c137-11ea-9479-b475b90d7ea7.png)

![image](https://user-images.githubusercontent.com/1730073/86895906-be66ed80-c137-11ea-8427-ff7f4d0439fc.png)


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
