### PR TITLE
Revert "Offset: Send px-ed strings to .css()"

### DIFF
--- a/src/offset.js
+++ b/src/offset.js
@@ -63,12 +63,6 @@ jQuery.offset = {
 			options.using.call( elem, props );
 
 		} else {
-			if ( typeof props.top === "number" ) {
-				props.top += "px";
-			}
-			if ( typeof props.left === "number" ) {
-				props.left += "px";
-			}
 			curElem.css( props );
 		}
 	}


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The way warning against number values in `.css()` setters was done in
jquery/jquery-migrate#337 and later refined in jquery/jquery-migrate#348
there's no need to send px-ed strings for `top` & `left` as they already
don't get the "px" suffix.

This reverts commit 57038faebc6ece5bd666c28303f8a91ff59153eb.

Ref jquery/jquery-migrate/pull/337
Ref jquery/jquery-migrate/pull/348

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
