### PR TITLE
Core: Bring back QtWebKit support for jQuery 3.x

### DIFF
--- a/src/var/isFunction.js
+++ b/src/var/isFunction.js
@@ -1,13 +1,17 @@
-define( function() {
+define( [
+	"./toString"
+], function() {
 	"use strict";
 
 	return function isFunction( obj ) {
 
-		// Support: Chrome <=57, Firefox <=52, QtWeb <=3.8.5, WebKit <=534.34,
-		// wkhtmltopdf tool <=0.12.5
+		// Support: Chrome <=57, Firefox <=52
 		// In some browsers, typeof returns "function" for HTML <object> elements
 		// (i.e., `typeof document.createElement( "object" ) === "function"`).
-		// We don't want to classify *any* DOM node or DOM collection as a function.
+		// We don't want to classify *any* DOM node as a function.
+		// Support: QtWeb <=3.8.5, WebKit <=534.34, wkhtmltopdf tool <=0.12.5
+		// Plus for old WebKit, typeof returns "function" for HTML collections
+		// (e.g., `typeof document.getElementsByTagName("div") === "function"`). (gh-4756)
 		return typeof obj === "function" && typeof obj.nodeType !== "number" &&
 			[ "[object HTMLCollection]", "[object NodeList]" ]
 				.indexOf( toString.call( obj ) ) === -1;

--- a/src/var/isFunction.js
+++ b/src/var/isFunction.js
@@ -3,12 +3,14 @@ define( function() {
 
 	return function isFunction( obj ) {
 
-		// Support: Chrome <=57, Firefox <=52
+		// Support: Chrome <=57, Firefox <=52, QtWeb <=3.8.5, WebKit <=534.34,
+		// wkhtmltopdf tool <=0.12.5
 		// In some browsers, typeof returns "function" for HTML <object> elements
 		// (i.e., `typeof document.createElement( "object" ) === "function"`).
-		// We don't want to classify *any* DOM node as a function.
+		// We don't want to classify *any* DOM node or DOM collection as a function.
 		return typeof obj === "function" && typeof obj.nodeType !== "number" &&
-			[ "[object HTMLCollection]", "[object NodeList]" ].indexOf( obj.toString() ) === -1;
+			[ "[object HTMLCollection]", "[object NodeList]" ]
+				.indexOf( toString.call( obj ) ) === -1;
 	};
 
 } );

--- a/src/var/isFunction.js
+++ b/src/var/isFunction.js
@@ -1,6 +1,4 @@
-define( [
-	"./toString"
-], function( toString ) {
+define( function() {
 	"use strict";
 
 	return function isFunction( obj ) {

--- a/src/var/isFunction.js
+++ b/src/var/isFunction.js
@@ -1,6 +1,6 @@
 define( [
 	"./toString"
-], function() {
+], function( toString ) {
 	"use strict";
 
 	return function isFunction( obj ) {

--- a/src/var/isFunction.js
+++ b/src/var/isFunction.js
@@ -7,7 +7,8 @@ define( function() {
 		// In some browsers, typeof returns "function" for HTML <object> elements
 		// (i.e., `typeof document.createElement( "object" ) === "function"`).
 		// We don't want to classify *any* DOM node as a function.
-		return typeof obj === "function" && typeof obj.nodeType !== "number";
+		return typeof obj === "function" && typeof obj.nodeType !== "number" &&
+			[ "[object HTMLCollection]", "[object NodeList]" ].indexOf( obj.toString() ) === -1;
 	};
 
 } );

--- a/src/var/isFunction.js
+++ b/src/var/isFunction.js
@@ -13,8 +13,7 @@ define( [
 		// Plus for old WebKit, typeof returns "function" for HTML collections
 		// (e.g., `typeof document.getElementsByTagName("div") === "function"`). (gh-4756)
 		return typeof obj === "function" && typeof obj.nodeType !== "number" &&
-			[ "[object HTMLCollection]", "[object NodeList]" ]
-				.indexOf( toString.call( obj ) ) === -1;
+			typeof obj.item !== "function";
 	};
 
 } );


### PR DESCRIPTION
Fix allows jQuery to recognize that DOM types such as HTMLCollection or NodeList are not functions.

Fixes gh-4756

### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
