### PR TITLE
Tests: Recognize callbacks with dots in the Node.js mock server

### DIFF
--- a/test/middleware-mockserver.js
+++ b/test/middleware-mockserver.js
@@ -101,7 +101,7 @@ var mocks = {
 		} else if ( req.query.callback ) {
 			callback = Promise.resolve( req.query.callback );
 		} else if ( req.method === "GET" ) {
-			callback = Promise.resolve( req.url.match( /^.+\/([^\/?.]+)\?.+$/ )[ 1 ] );
+			callback = Promise.resolve( req.url.match( /^.+\/([^\/?]+)\?.+$/ )[ 1 ] );
 		} else {
 			callback = getBody( req ).then( function( body ) {
 				return body.trim().replace( "callback=", "" );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

This aligns the Node.js server with the previous PHP one in accepting `mock.php`
as a callback which is triggered by a recently added test. This prevents the
request crashing on that Node.js server and printing a JS error:
```
TypeError: Cannot read property '1' of null
```

Ref gh-4754

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
