### PR TITLE
Ajax: Execute JSONP error script responses

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -746,8 +746,10 @@ jQuery.extend( {
 				response = ajaxHandleResponses( s, jqXHR, responses );
 			}
 
-			// Use a noop converter for missing script
-			if ( !isSuccess && jQuery.inArray( "script", s.dataTypes ) > -1 ) {
+			// Use a noop converter for missing script but not if jsonp
+			if ( !isSuccess &&
+				jQuery.inArray( "script", s.dataTypes ) > -1 &&
+				jQuery.inArray( "json", s.dataTypes ) < 0 ) {
 				s.converters[ "text script" ] = function() {};
 			}
 

--- a/test/data/mock.php
+++ b/test/data/mock.php
@@ -233,6 +233,19 @@ QUnit.assert.ok( true, "mock executed");';
 		}
 	}
 
+	protected function errorWithJSONPAndResponseBodyScript( $req ) {
+		header( 'HTTP/1.0 404 Not Found' );
+		if ( isset( $req->query['withScriptContentType'] ) ) {
+			header( 'Content-Type: application/javascript' );
+		}
+		if ( isset( $req->query['callback'] ) ) {
+			$callback = $req->query['callback'];
+			echo $callback . '( {"status": 404, "msg": "Not Found"} )';
+		} else {
+			echo 'QUnit.assert.ok( false, "Mock return erroneously executed" );';
+		}
+	}
+
 	public function __construct() {
 		$this->cspFile = __DIR__ . '/support/csp.log';
 	}

--- a/test/data/mock.php
+++ b/test/data/mock.php
@@ -233,19 +233,6 @@ QUnit.assert.ok( true, "mock executed");';
 		}
 	}
 
-	protected function errorWithJSONPAndResponseBodyScript( $req ) {
-		header( 'HTTP/1.0 404 Not Found' );
-		if ( isset( $req->query['withScriptContentType'] ) ) {
-			header( 'Content-Type: application/javascript' );
-		}
-		if ( isset( $req->query['callback'] ) ) {
-			$callback = $req->query['callback'];
-			echo $callback . '( {"status": 404, "msg": "Not Found"} )';
-		} else {
-			echo 'QUnit.assert.ok( false, "Mock return erroneously executed" );';
-		}
-	}
-
 	public function __construct() {
 		$this->cspFile = __DIR__ . '/support/csp.log';
 	}

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -812,7 +812,7 @@ QUnit.module( "ajax", {
 			dataType: "jsonp",
 			url: url( "mock.php?action=errorWithScript" ),
 			failure: function(xhr) {
-				const expected = { "status": 404, "msg": "Not Found" };
+				var expected = { "status": 404, "msg": "Not Found" };
 				assert.strictEqual( xhr.responseJSON, expected, testMsg );
 			}
 		};

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -807,11 +807,11 @@ QUnit.module( "ajax", {
 	} );
 
 	ajaxTest( "jQuery.ajax() - do execute scripts if JSONP from unsuccessful responses", 1, function( assert ) {
-		var testMsg = "Unsuccessful JSONP requests should have a JSON body"
+		var testMsg = "Unsuccessful JSONP requests should have a JSON body";
 		return {
 			dataType: "jsonp",
 			url: url( "mock.php?action=errorWithScript" ),
-			failure: function(xhr) {
+			failure: function( xhr ) {
 				var expected = { "status": 404, "msg": "Not Found" };
 				assert.strictEqual( xhr.responseJSON, expected, testMsg );
 			}

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -811,11 +811,6 @@ QUnit.module( "ajax", {
 		return {
 			dataType: "jsonp",
 			url: url( "mock.php?action=errorWithScript" ),
-			beforeSend: function() {
-				jQuery.globalEval = function() {
-					assert.ok( false, "Should not eval" );
-				};
-			},
 			// error is the significant assertion
 			error: function( xhr ) {
 				var expected = { "status": 404, "msg": "Not Found" };

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -806,6 +806,46 @@ QUnit.module( "ajax", {
 		};
 	} );
 
+	ajaxTest( "jQuery.ajax() - do execute scripts if JSONP from unsuccessful responses", 1, function( assert) {
+		var globalEval = jQuery.globalEval;
+
+		var failConverters = {
+			"text script json": function() {
+				assert.ok( true, "Converter for unsuccessful response" );
+			}
+		};
+
+		function request( title, options ) {
+			var testMsg = title + ": expected JSON response body";
+			return jQuery.extend( {
+				beforeSend: function() {
+					jQuery.globalEval = function() {
+						assert.ok( true, "Should eval" );
+					};
+				},
+				complete: function() {
+					jQuery.globalEval = globalEval;
+				},
+				// error is the significant assertion
+				error: function( xhr ) {
+					assert.strictEqual( xhr.responseBody, {id: 1}, testMsg );
+				},
+				success: function() {
+					assert.ok( false, "Unanticipated success" );
+				}
+			}, options );
+		}
+		return [
+			request(
+				"JSONP reply with dataType",
+				{
+					dataType: "jsonp",
+					url: url( "mock.php?action=errorWithJSONPAndResponseBodyScript" ),
+				}
+			)
+		]
+	} );
+
 	ajaxTest( "jQuery.ajax() - do not execute scripts from unsuccessful responses (gh-4250)", 11, function( assert ) {
 		var globalEval = jQuery.globalEval;
 

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -807,43 +807,15 @@ QUnit.module( "ajax", {
 	} );
 
 	ajaxTest( "jQuery.ajax() - do execute scripts if JSONP from unsuccessful responses", 1, function( assert ) {
-		var globalEval = jQuery.globalEval;
-
-		var failConverters = {
-			"text script json": function() {
-				assert.ok( true, "Converter for unsuccessful response" );
+		const testMsg = "Unsuccessful JSONP requests should have a JSON body"
+		return {
+			dataType: "jsonp",
+			url: url( "mock.php?action=errorWithScript" ),
+			failure: function(xhr) {
+				const expected = { "status": 404, "msg": "Not Found" };
+				assert.strictEqual( xhr.responseJSON, expected, testMsg );
 			}
 		};
-
-		function request( title, options ) {
-			var testMsg = title + ": expected JSON response body";
-			return jQuery.extend( {
-				beforeSend: function() {
-					jQuery.globalEval = function() {
-						assert.ok( true, "Should eval" );
-					};
-				},
-				complete: function() {
-					jQuery.globalEval = globalEval;
-				},
-				// error is the significant assertion
-				error: function( xhr ) {
-					assert.strictEqual( xhr.responseBody, { id: 1 }, testMsg );
-				},
-				success: function() {
-					assert.ok( false, "Unanticipated success" );
-				}
-			}, options );
-		}
-		return [
-			request(
-				"JSONP reply with dataType",
-				{
-					dataType: "jsonp",
-					url: url( "mock.php?action=errorWithJSONPAndResponseBodyScript" )
-				}
-			)
-		];
 	} );
 
 	ajaxTest( "jQuery.ajax() - do not execute scripts from unsuccessful responses (gh-4250)", 11, function( assert ) {

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -814,7 +814,7 @@ QUnit.module( "ajax", {
 			// error is the significant assertion
 			error: function( xhr ) {
 				var expected = { "status": 404, "msg": "Not Found" };
-				assert.equal( xhr.responseJSON, expected, testMsg );
+				assert.deepEqual( xhr.responseJSON, expected, testMsg );
 			}
 		};
 	} );

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -811,7 +811,13 @@ QUnit.module( "ajax", {
 		return {
 			dataType: "jsonp",
 			url: url( "mock.php?action=errorWithScript" ),
-			failure: function( xhr ) {
+			beforeSend: function() {
+				jQuery.globalEval = function() {
+					assert.ok( false, "Should not eval" );
+				};
+			},
+			// error is the significant assertion
+			error: function( xhr ) {
 				var expected = { "status": 404, "msg": "Not Found" };
 				assert.strictEqual( xhr.responseJSON, expected, testMsg );
 			}

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -806,7 +806,7 @@ QUnit.module( "ajax", {
 		};
 	} );
 
-	ajaxTest( "jQuery.ajax() - do execute scripts if JSONP from unsuccessful responses", 1, function( assert) {
+	ajaxTest( "jQuery.ajax() - do execute scripts if JSONP from unsuccessful responses", 1, function( assert ) {
 		var globalEval = jQuery.globalEval;
 
 		var failConverters = {
@@ -828,7 +828,7 @@ QUnit.module( "ajax", {
 				},
 				// error is the significant assertion
 				error: function( xhr ) {
-					assert.strictEqual( xhr.responseBody, {id: 1}, testMsg );
+					assert.strictEqual( xhr.responseBody, { id: 1 }, testMsg );
 				},
 				success: function() {
 					assert.ok( false, "Unanticipated success" );
@@ -840,10 +840,10 @@ QUnit.module( "ajax", {
 				"JSONP reply with dataType",
 				{
 					dataType: "jsonp",
-					url: url( "mock.php?action=errorWithJSONPAndResponseBodyScript" ),
+					url: url( "mock.php?action=errorWithJSONPAndResponseBodyScript" )
 				}
 			)
-		]
+		];
 	} );
 
 	ajaxTest( "jQuery.ajax() - do not execute scripts from unsuccessful responses (gh-4250)", 11, function( assert ) {

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -807,7 +807,7 @@ QUnit.module( "ajax", {
 	} );
 
 	ajaxTest( "jQuery.ajax() - do execute scripts if JSONP from unsuccessful responses", 1, function( assert ) {
-		const testMsg = "Unsuccessful JSONP requests should have a JSON body"
+		var testMsg = "Unsuccessful JSONP requests should have a JSON body"
 		return {
 			dataType: "jsonp",
 			url: url( "mock.php?action=errorWithScript" ),

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -814,7 +814,7 @@ QUnit.module( "ajax", {
 			// error is the significant assertion
 			error: function( xhr ) {
 				var expected = { "status": 404, "msg": "Not Found" };
-				assert.strictEqual( xhr.responseJSON, expected, testMsg );
+				assert.equal( xhr.responseJSON, expected, testMsg );
 			}
 		};
 	} );


### PR DESCRIPTION
Fixes: #4771 
However, it should not parse the response if just a script
