### PR TITLE
Build: Make the import/no-unused-modules ESLint rule work in WebStorm

### DIFF
--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -15,7 +15,16 @@
 		"import/no-cycle": "error",
 		"import/no-unused-modules": [ "error", {
 			"unusedExports": true,
-			"ignoreExports": [ "src/*.js" ]
+
+			// When run via WebStorm, the root path against which these paths
+			// are resolved is the path where this ESLint config file lies,
+			// i.e. `src`. When run via the command line, it's usually the root
+			// folder of the jQuery repository. This pattern intends to catch both.
+			// Note that we cannot specify two patterns here:
+			//     [ "src/*.js", "*.js" ]
+			// as they're analyzed individually and the rule crashes if a pattern
+			// cannot be matched.
+			"ignoreExports": [ "{src/,}*.js" ]
 		} ],
 		"indent": [ "error", "tab", {
 			"outerIIFEBody": 0


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

When run via WebStorm, the root path against which paths in the config of the
`import/no-unused-modules` ESLint rule are resolved is the path where the ESLint
config file that defines the rule lies, i.e. `src`. When run via the command
line, it's usually the root folder of the jQuery repository. This pattern
intends to catch both.

Note that we cannot specify two patterns here:
```js
[ "src/*.js", "*.js" ]
```
as they're analyzed individually and the rule crashes if a pattern cannot be
matched.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
