### PR TITLE
Tests: Skip the "jQuery.ajax() on unload" test in Safari

### DIFF
--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -2280,7 +2280,10 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 	// Chrome 78 dropped support for synchronous XHR requests inside of
 	// beforeunload, unload, pagehide, and visibilitychange event handlers.
 	// See https://bugs.chromium.org/p/chromium/issues/detail?id=952452
-	if ( !/chrome/i.test( navigator.userAgent ) ) {
+	// Safari 13 did similar changes. The below check will catch them both.
+	// Edge Legacy fakes Chrome which fakes Safari in their user agents so we need
+	// to exclude Edge specifically here so that the test continues to run there.
+	if ( !/safari/i.test( navigator.userAgent ) || /edge\//i.test( navigator.userAgent ) ) {
 		testIframe(
 			"#14379 - jQuery.ajax() on unload",
 			"ajax/onunload.html",


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The test has been already skipped in Chrome as it dropped support for such
requests and now Safari has joined the squad.

This will resolve AJAX test errors we've had for a while in Safari 13 & iOS 13.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
