### PR TITLE
Build: Explicitly exclude the queue module from the slim build

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -60,7 +60,7 @@ module.exports = function( grunt ) {
 		const done = this.async();
 
 		try {
-			const slimFlags = [ "-ajax", "-callbacks", "-deferred", "-effects" ];
+			const slimFlags = [ "-ajax", "-callbacks", "-deferred", "-effects", "-queue" ];
 			const flags = this.flags;
 			const optIn = flags[ "*" ];
 			let name = grunt.option( "filename" );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The queue module is not present in the slim build as it depends on deferred
and our Gruntfile specifies excluding deferred should also exclude queue:
https://github.com/jquery/jquery/blob/3.5.1/Gruntfile.js#L66
This commit makes this exclusion explicit so that the queue module never
accidentally gets re-included in the slim build if it stopped importing from
the deferred module directly.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
