### PR TITLE
Event: Don't crash if an element is removed on blur

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -558,7 +558,13 @@ function leverageNative( el, type, expectSync ) {
 						// Cancel the outer synthetic event
 						event.stopImmediatePropagation();
 						event.preventDefault();
-						return result.value;
+
+						// Support: Chrome 86+
+						// In Chrome, if an element having a focusout handler is blurred by
+						// clicking outside of it, it invokes the handler synchronously. If
+						// that handler calls `.remove()` on the element, the data is cleared,
+						// leaving `result` undefined. We need to guard against this.
+						return result && result.value;
 					}
 
 				// If this is an inner synthetic event for an event with a bubbling surrogate

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -2630,6 +2630,33 @@ QUnit.test( "focusin on document & window", function( assert ) {
 	jQuery( document ).off( "focusout", increment );
 } );
 
+QUnit.test( "element removed during focusout (gh-4417)", function( assert ) {
+	assert.expect( 1 );
+
+	var button = jQuery( "<button>Click me</button>" );
+
+	button.appendTo( "#qunit-fixture" );
+
+	button.on( "click", function() {
+		button.trigger( "blur" );
+		assert.ok( true, "Removing the element didn't crash" );
+	} );
+
+	// Support: Chrome 86+
+	// In Chrome, if an element having a focusout handler is blurred by
+	// clicking outside of it, it invokes the handler synchronously. However,
+	// if the click happens programmatically, the invocation is asynchronous.
+	// As we have no way to simulate real user input in unit tests, simulate
+	// this behavior by calling `jQuery.cleanData` & removing the element using
+	// native APIs.
+	button[ 0 ].blur = function() {
+		jQuery.cleanData( [ this ] );
+		this.parentNode.removeChild( this );
+	};
+
+	button[ 0 ].click();
+} );
+
 testIframe(
 	"jQuery.ready promise",
 	"event/promiseReady.html",


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

In Chrome, if an element having a focusout handler is blurred by
clicking outside of it, it invokes the handler synchronously. If
that handler calls `.remove()` on the element, the data is cleared,
leaving private data undefined. We're reading a property from that
data so we need to guard against this.

Fixes gh-4417

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
