### PR TITLE
Event: Make focus re-triggering not focus the original element back

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -11,9 +11,7 @@ import nodeName from "./core/nodeName.js";
 import "./core/init.js";
 import "./selector.js";
 
-var currentFocusTarget,
-	focusTriggersInProgress = 0,
-	rtypenamespace = /^([^.]*)(?:\.(.+)|)/;
+var rtypenamespace = /^([^.]*)(?:\.(.+)|)/;
 
 function returnTrue() {
 	return true;
@@ -583,13 +581,6 @@ function leverageNative( el, type, expectSync ) {
 			// Fire an inner synthetic event with the original arguments
 			} else if ( saved.length ) {
 
-				// Track the number of focus triggers in progress to know when
-				// `currentFocusTarget` can be cleared to save memory.
-				if ( type === "focus" ) {
-					focusTriggersInProgress++;
-					currentFocusTarget = this;
-				}
-
 				// ...and capture the result
 				dataPriv.set( this, type, {
 					value: jQuery.event.trigger(
@@ -604,15 +595,6 @@ function leverageNative( el, type, expectSync ) {
 
 				// Abort handling of the native event
 				event.stopImmediatePropagation();
-
-				if ( type === "focus" ) {
-					focusTriggersInProgress--;
-
-					// Don't hold onto the last focused element when it's no longer needed.
-					if ( !focusTriggersInProgress ) {
-						currentFocusTarget = undefined;
-					}
-				}
 			}
 		}
 	} );
@@ -764,12 +746,10 @@ jQuery.each( { focus: "focusin", blur: "focusout" }, function( type, delegateTyp
 			return true;
 		},
 
-		// Suppress native `.focus()` if another element has received focus since.
-		// This prevents focus from erroneously going back to the first element
-		// which may happen as the leverageNative hack changes the order of triggered
-		// events.
+		// Suppress native focus or blur as it's already being fired
+		// in leverageNative.
 		_default: function() {
-			return type === "focus" && this !== currentFocusTarget;
+			return true;
 		},
 
 		delegateType: delegateType

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -3292,7 +3292,7 @@ QUnit.test( "native-backed events preserve trigger data (gh-1741, gh-4139)", fun
 } );
 
 QUnit.test( "focus change during a focus handler (gh-4382)", function( assert ) {
-	assert.expect( 1 );
+	assert.expect( 2 );
 
 	var done = assert.async(),
 		select = jQuery( "<select><option selected='selected'>A</option></select>" ),
@@ -3306,10 +3306,21 @@ QUnit.test( "focus change during a focus handler (gh-4382)", function( assert ) 
 		button.trigger( "focus" );
 	} );
 
+	jQuery( document ).on( "focusin.focusTests", function( ev ) {
+		// Support: IE 11+
+		// In IE focus is async so focusin on document is fired multiple times,
+		// for each of the elements. In other browsers it's fired just once, for
+		// the last one.
+		if ( ev.target === button[ 0 ] ) {
+			assert.ok( true, "focusin propagated to document from the button" );
+		}
+	} );
+
 	select.trigger( "focus" );
 
 	setTimeout( function() {
 		assert.strictEqual( document.activeElement, button[ 0 ], "Focus redirect worked" );
+		jQuery( document ).off( ".focusTests" );
 		done();
 	} );
 } );

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -3291,6 +3291,29 @@ QUnit.test( "native-backed events preserve trigger data (gh-1741, gh-4139)", fun
 	}, 50 );
 } );
 
+QUnit.test( "focus change during a focus handler (gh-4382)", function( assert ) {
+	assert.expect( 1 );
+
+	var done = assert.async(),
+		select = jQuery( "<select><option selected='selected'>A</option></select>" ),
+		button = jQuery( "<button>Focus target</button>" );
+
+	jQuery( "#qunit-fixture" )
+		.append( select )
+		.append( button );
+
+	select.on( "focus", function() {
+		button.trigger( "focus" );
+	} );
+
+	select.trigger( "focus" );
+
+	setTimeout( function() {
+		assert.strictEqual( document.activeElement, button[ 0 ], "Focus redirect worked" );
+		done();
+	} );
+} );
+
 // TODO replace with an adaptation of
 // https://github.com/jquery/jquery/pull/1367/files#diff-a215316abbaabdf71857809e8673ea28R2464
 ( function() {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

If during a focus handler another focus event is triggered:

```js
elem1.on( "focus", function() {
	elem2.trigger( "focus" );
} );
```

due to their synchronous nature everywhere outside of IE the hack added in
gh-4279 to leverage native events causes the native `.focus()` method to be
called last for the initial element, making it steal the focus back. To resolve
this, we now skip calling the native method if focus was changed.

A side effect of this change is that now `focusin` will only propagate to the
document for the last focused element. This is a change in behavior but it also
aligns us better with how this works with native methods.

Fixes gh-4382
Ref gh-4279

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
