### PR TITLE
Core: Report browser errors in parseXML

### DIFF
--- a/src/core/parseXML.js
+++ b/src/core/parseXML.js
@@ -13,13 +13,15 @@ jQuery.parseXML = function( data ) {
 		xml = ( new window.DOMParser() ).parseFromString( data, "text/xml" );
 	} catch ( e ) {}
 
-	parserErrorElem = xml.getElementsByTagName( "parsererror" )[ 0 ];
+	parserErrorElem = xml && xml.getElementsByTagName( "parsererror" )[ 0 ];
 	if ( !xml || parserErrorElem ) {
-		jQuery.error( parserErrorElem &&
-			jQuery.map( parserErrorElem.childNodes, function( el ) {
-				return el.textContent;
-			} ).join( "\n" )
-		);
+		jQuery.error( "Invalid XML: " + (
+			parserErrorElem ?
+				jQuery.map( parserErrorElem.childNodes, function( el ) {
+					return el.textContent;
+				} ).join( "\n" ) :
+				data
+		) );
 	}
 	return xml;
 };

--- a/src/core/parseXML.js
+++ b/src/core/parseXML.js
@@ -2,7 +2,7 @@ import jQuery from "../core.js";
 
 // Cross-browser xml parsing
 jQuery.parseXML = function( data ) {
-	var xml;
+	var xml, parserErrorElem;
 	if ( !data || typeof data !== "string" ) {
 		return null;
 	}
@@ -11,12 +11,15 @@ jQuery.parseXML = function( data ) {
 	// IE throws on parseFromString with invalid input.
 	try {
 		xml = ( new window.DOMParser() ).parseFromString( data, "text/xml" );
-	} catch ( e ) {
-		xml = undefined;
-	}
+	} catch ( e ) {}
 
-	if ( !xml || xml.getElementsByTagName( "parsererror" ).length ) {
-		jQuery.error( "Invalid XML: " + data );
+	parserErrorElem = xml.getElementsByTagName( "parsererror" )[ 0 ];
+	if ( !xml || parserErrorElem ) {
+		jQuery.error( parserErrorElem &&
+			jQuery.map( parserErrorElem.childNodes, function( el ) {
+				return el.textContent;
+			} ).join( "\n" )
+		);
 	}
 	return xml;
 };

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -1393,7 +1393,7 @@ QUnit.test( "jQuery.parseHTML", function( assert ) {
 } );
 
 QUnit.test( "jQuery.parseXML", function( assert ) {
-	assert.expect( 8 );
+	assert.expect( 7 );
 
 	var xml, tmp;
 	try {
@@ -1406,12 +1406,7 @@ QUnit.test( "jQuery.parseXML", function( assert ) {
 	} catch ( e ) {
 		assert.strictEqual( e, undefined, "unexpected error" );
 	}
-	try {
-		xml = jQuery.parseXML( "<p>Not a <<b>well-formed</b> xml string</p>" );
-		assert.ok( false, "invalid xml not detected" );
-	} catch ( e ) {
-		assert.strictEqual( e.message, "Invalid XML: <p>Not a <<b>well-formed</b> xml string</p>", "invalid xml detected" );
-	}
+
 	try {
 		xml = jQuery.parseXML( "" );
 		assert.strictEqual( xml, null, "empty string => null document" );
@@ -1424,6 +1419,29 @@ QUnit.test( "jQuery.parseXML", function( assert ) {
 	} catch ( e ) {
 		assert.ok( false, "empty input throws exception" );
 	}
+} );
+
+// Support: IE 11+
+// IE throws an error when parsing invalid XML instead of reporting the error
+// in a `parsererror` element, skip the test there.
+QUnit.testUnlessIE( "jQuery.parseXML - error reporting", function( assert ) {
+	assert.expect( 2 );
+
+	var errorArg, lineMatch, line, columnMatch, column;
+
+	sinon.stub( jQuery, "error" );
+
+	jQuery.parseXML( "<p>Not a <<b>well-formed</b> xml string</p>" );
+	errorArg = jQuery.error.firstCall.lastArg.toLowerCase();
+	console.log( "errorArg", errorArg );
+
+	lineMatch = errorArg.match( /line\s*(?:number)?\s*(\d+)/ );
+	line = lineMatch && lineMatch[ 1 ];
+	columnMatch = errorArg.match( /column\s*(\d+)/ );
+	column = columnMatch && columnMatch[ 1 ];
+
+	assert.strictEqual( line, "1", "reports error line" );
+	assert.strictEqual( column, "11", "reports error column" );
 } );
 
 testIframe(

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -1393,7 +1393,7 @@ QUnit.test( "jQuery.parseHTML", function( assert ) {
 } );
 
 QUnit.test( "jQuery.parseXML", function( assert ) {
-	assert.expect( 7 );
+	assert.expect( 8 );
 
 	var xml, tmp;
 	try {
@@ -1406,7 +1406,12 @@ QUnit.test( "jQuery.parseXML", function( assert ) {
 	} catch ( e ) {
 		assert.strictEqual( e, undefined, "unexpected error" );
 	}
-
+	try {
+		xml = jQuery.parseXML( "<p>Not a <<b>well-formed</b> xml string</p>" );
+		assert.ok( false, "invalid XML not detected" );
+	} catch ( e ) {
+		assert.ok( e.message.indexOf( "Invalid XML:" ) === 0, "invalid XML detected" );
+	}
 	try {
 		xml = jQuery.parseXML( "" );
 		assert.strictEqual( xml, null, "empty string => null document" );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Fixes gh-4784

In IE 11 we'd just throw an empty error now, in others - the reported error. We wouldn't include input data in the thrown error anymore.

+10 bytes, although I cheated a bit - I also removed an assignment of `xml` to `undefined` in `catch` as any error would happen before the assignment so the variable would already hold the `undefined` value. Without this optimization, it'd be +13 bytes.

That +10 can be changed to -3 if we just call:
```js
jQuery.error( parserErrorElem && parserErrorElem.textContent )
```
but that has two issues. Here's the returned element `parsererror` (after pretty-printing) in Blink & WebKit:
```xml
<parsererror
	xmlns="http://www.w3.org/1999/xhtml"
	style="display: block; white-space: pre; border: 2px solid #c77; padding: 0 1em 0 1em; margin: 1em; background-color: #fdd; color: black">
	<h3>This page contains the following errors:</h3>
	<div style="font-family:monospace;font-size:12px">error on line 14 at column 9: Opening and ending tag mismatch: th line 0 and tr
</div>
	<h3>Below is a rendering of the page up to the first error.</h3>
</parsererror>
```
and here's the one in Gecko:
```xml
<parsererror xmlns="http://www.mozilla.org/newlayout/xml/parsererror.xml">
	XML Parsing Error: mismatched tag. Expected: &lt;/th&gt;.
Location: http://sandbox.l/test.xhtml
Line Number 14, Column 6:
	<sourcetext>			&lt;/tr&gt;\n--------------------------^</sourcetext>
</parsererror>
```

If we just print `textContent`, in Chrome the text will miss spaces in some places:
```
This page contains the following errors:error on line 14 at column 9: Opening and ending tag mismatch: th line 0 and tr
Below is a rendering of the page up to the first error.
```
That may not be enough a reason to add bytes but here's what ends up in Firefox:
```
XML Parsing Error: mismatched tag. Expected: </th>.
Location: http://sandbox.l/test.xhtml
Line Number 14, Column 6:			</tr>
--------------------------^
```
Firefox prints ASCII art which is misaligned now. With the code from this PR, here's what gets printed:
```
XML Parsing Error: mismatched tag. Expected: </th>.
Location: http://sandbox.l/test.html
Line Number 14, Column 6:
			</tr>
--------------------------^
```

On the other hand, it actually uses tabs to pad `</tr>` and the alignment depends on tab being rendered as 8 characters... So maybe we can give up on that.

**EDIT:** Actually, this will mostly be printed in the DevTools of the respective browser, here: Firefox. So it should show up correctly in the console.

Let's make a decision at the next meeting.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
