### PR TITLE
Manipulation: fix the bug when append scripts to multiple elements

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -145,7 +145,7 @@ function domManip( collection, args, callback, ignored ) {
 				jQuery.map( scripts, restoreScript );
 
 				// Evaluate executable scripts on first document insertion
-				for ( i = 0; i < hasScripts; i++ ) {
+				for ( i = 0; i < scripts.length; i++ ) {
 					node = scripts[ i ];
 					if ( rscriptType.test( node.type || "" ) &&
 						!dataPriv.access( node, "globalEval" ) &&

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -2292,6 +2292,19 @@ testIframe(
 );
 
 
+QUnit.test( "Test append scripts to multiple elements gh-4818", function( assert ) {
+
+	assert.expect( 2 );
+	var done = assert.async();
+
+	jQuery( "<div class='testclass'></div><div class='testclass'></div>" ).appendTo( "#moretests" );
+	jQuery( ".testclass" ).append( "<script type='text/javascript'>QUnit.assert.ok( true, 'evaluated: inner text/javascript' );</script>" );
+
+	setTimeout( function() {
+		done();
+	}, 500 );
+} );
+
 // We need to simulate cross-domain requests with the feature that
 // both 127.0.0.1 and localhost point to the mock http server.
 // Skip the the test if we are not in localhost but make sure we run


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
Fix the bug that it is executed only once when append script to multiple elements.
#4818 

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
