### PR TITLE
Tests: Fix tests for not auto-executing scripts without dataType

### DIFF
--- a/test/middleware-mockserver.js
+++ b/test/middleware-mockserver.js
@@ -62,7 +62,7 @@ var mocks = {
 	script: function( req, resp ) {
 		if ( req.query.header === "ecma" ) {
 			resp.writeHead( 200, { "content-type": "application/ecmascript" } );
-		} else if ( req.query.header ) {
+		} else if ( "header" in req.query ) {
 			resp.writeHead( 200, { "content-type": "text/javascript" } );
 		} else {
 			resp.writeHead( 200, { "content-type": "text/html" } );

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -118,7 +118,7 @@ QUnit.module( "ajax", {
 		return {
 			create: function( options ) {
 				options.crossDomain = true;
-				return jQuery.ajax( url( "mock.php?action=script" ), options );
+				return jQuery.ajax( url( "mock.php?action=script&header" ), options );
 			},
 			success: function() {
 				assert.ok( true, "success" );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Two issues are fixed in testing for responses with a script Content-Type not
getting auto-executed unless an explicit `dataType: "script"` is provided:
* the test is now using a correct "text/javascript" Content-Type; it was using
  "text/html" until now which doesn't really check if the fix works
* the Node.js based version of the tests didn't account for an empty `header`
  query string parameter

Ref gh-2432
Ref gh-2588
Ref 39cdb8c9aa0fde68f733553ba050a2ba9d86474c

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
