### PR TITLE
Ajax: Don't auto-execute scripts unless dataType provided

### DIFF
--- a/src/ajax/script.js
+++ b/src/ajax/script.js
@@ -19,21 +19,12 @@ function canUseScriptTag( s ) {
 		( s.async && jQuery.inArray( "json", s.dataTypes ) < 0 );
 }
 
-// Prevent auto-execution of scripts when no explicit dataType was provided (See gh-2432)
-jQuery.ajaxPrefilter( function( s ) {
-	if ( s.crossDomain ) {
-		s.contents.script = false;
-	}
-} );
-
-// Install script dataType
+// Install script dataType. Don't specify `content.script` so that an explicit
+// `dataType: "script"` is required (see gh-2432, gh-4822)
 jQuery.ajaxSetup( {
 	accepts: {
 		script: "text/javascript, application/javascript, " +
 			"application/ecmascript, application/x-ecmascript"
-	},
-	contents: {
-		script: /\b(?:java|ecma)script\b/
 	},
 	converters: {
 		"text script": function( text ) {

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -71,24 +71,6 @@ QUnit.module( "ajax", {
 		};
 	} );
 
-	ajaxTest( "jQuery.ajax() - execute js for crossOrigin when dataType option is provided", 3,
-		function( assert ) {
-			return {
-				create: function( options ) {
-					options.crossDomain = true;
-					options.dataType = "script";
-					return jQuery.ajax( url( "mock.php?action=script&header=ecma" ), options );
-				},
-				success: function() {
-					assert.ok( true, "success" );
-				},
-				complete: function() {
-					assert.ok( true, "complete" );
-				}
-			};
-		}
-	);
-
 	ajaxTest( "jQuery.ajax() - custom attributes for script tag", 5,
 		function( assert ) {
 			return {
@@ -114,22 +96,34 @@ QUnit.module( "ajax", {
 		}
 	);
 
-	ajaxTest( "jQuery.ajax() - do not execute js (crossOrigin)", 2, function( assert ) {
-		return {
-			create: function( options ) {
-				options.crossDomain = true;
-				return jQuery.ajax( url( "mock.php?action=script&header" ), options );
-			},
-			success: function() {
-				assert.ok( true, "success" );
-			},
-			fail: function() {
-				assert.ok( false, "fail" );
-			},
-			complete: function() {
-				assert.ok( true, "complete" );
-			}
-		};
+	ajaxTest( "jQuery.ajax() - execute JS when dataType option is provided", 3,
+		function( assert ) {
+			return {
+				create: function( options ) {
+					options.crossDomain = true;
+					options.dataType = "script";
+					return jQuery.ajax( url( "mock.php?action=script&header=ecma" ), options );
+				},
+				success: function() {
+					assert.ok( true, "success" );
+				},
+				complete: function() {
+					assert.ok( true, "complete" );
+				}
+			};
+		}
+	);
+
+	jQuery.each( [ " - Same Domain", " - Cross Domain" ], function( crossDomain, label ) {
+		ajaxTest( "jQuery.ajax() - do not execute JS (gh-2432, gh-4822) " + label, 1, function( assert ) {
+			return {
+				url: url( "mock.php?action=script&header" ),
+				crossDomain: crossDomain,
+				success: function() {
+					assert.ok( true, "success" );
+				}
+			};
+		} );
 	} );
 
 	ajaxTest( "jQuery.ajax() - success callbacks (late binding)", 8, function( assert ) {
@@ -1437,25 +1431,6 @@ QUnit.module( "ajax", {
 				assert.ok( /(invalid|error|exception)/i.test( detailedMsg ), "Detailed parsererror message provided" );
 			}
 		};
-	} );
-
-	ajaxTest( "jQuery.ajax() - script by content-type", 2, function() {
-		return [
-			{
-				url: baseURL + "mock.php?action=script",
-				data: {
-					"header": "script"
-				},
-				success: true
-			},
-			{
-				url: baseURL + "mock.php?action=script",
-				data: {
-					"header": "ecma"
-				},
-				success: true
-			}
-		];
 	} );
 
 	ajaxTest( "jQuery.ajax() - JSON by content-type", 5, function( assert ) {


### PR DESCRIPTION
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Ajax: Don't auto-execute scripts unless dataType provided

PR gh-2588 made jQuery stop auto-execute cross-domain scripts unless
`dataType: "script"` was explicitly provided; this change landed in jQuery
3.0.0. This change extends that logic same-domain scripts as well.

After this change, to request a script under a provided URL to be evaluated,
you need to provide `dataType: "script` in `jQuery.ajax` options or to use
`jQuery.getScript`.

Fixes gh-4822
Ref gh-2432
Ref gh-2588

-28 bytes

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
