### PR TITLE
Support: ensure display is set to block for the support div

### DIFF
--- a/src/css/support.js
+++ b/src/css/support.js
@@ -33,10 +33,11 @@ support.reliableTrDimensions = function() {
 		tr.style.height = "1px";
 		div.style.height = "9px";
 
-		// Support: Android 8 Chrome 86+
+		// Support: Android Chrome 86+
 		// In our bodyBackground.html iframe,
 		// display for all div elements is set to "inline",
-		// which causes a problem only in Android 8 Chrome 86.
+		// which causes a problem only in Android Chrome, but
+		// not consistently across all devices.
 		// Ensuring the div is display: block
 		// gets around this issue.
 		div.style.display = "block";

--- a/src/css/support.js
+++ b/src/css/support.js
@@ -33,6 +33,14 @@ support.reliableTrDimensions = function() {
 		tr.style.height = "1px";
 		div.style.height = "9px";
 
+		// Support: Android 8 Chrome 86+
+		// In our bodyBackground.html iframe,
+		// display for all div elements is set to "inline",
+		// which causes a problem only in Android 8 Chrome 86.
+		// Ensuring the div is display: block
+		// gets around this issue.
+		div.style.display = "block";
+
 		documentElement
 			.appendChild( table )
 			.appendChild( tr )


### PR DESCRIPTION
- Fixes an issue with the support test in iframes in Android 8 Chrome 86+,
  where display: inline resulted in unexpected height values.

Fixes gh-4832

### Summary ###

This ports the same change made on the 3.x-stable to the main branch.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
