### PR TITLE
Offset: Increase search depth when finding the 'real' offset parent

### DIFF
--- a/src/offset.js
+++ b/src/offset.js
@@ -125,11 +125,10 @@ jQuery.fn.extend( {
 				offsetParent !== doc.documentElement &&
 				jQuery.css( offsetParent, "position" ) === "static" ) {
 
-				offsetParent = offsetParent.offsetParent;
+				offsetParent = offsetParent.offsetParent || doc.documentElement;
 			}
-			if ( offsetParent &&
-				offsetParent !== doc.documentElement && offsetParent !== elem &&
-				offsetParent.nodeType === 1 ) {
+			if ( offsetParent && offsetParent !== elem && offsetParent.nodeType === 1 &&
+				jQuery.css( offsetParent, "position" ) !== "static" ) {
 
 				// Incorporate borders into its offset, since they are outside its content origin
 				parentOffset = jQuery( offsetParent ).offset();

--- a/src/offset.js
+++ b/src/offset.js
@@ -122,12 +122,14 @@ jQuery.fn.extend( {
 			doc = elem.ownerDocument;
 			offsetParent = elem.offsetParent || doc.documentElement;
 			while ( offsetParent &&
-				( offsetParent === doc.body || offsetParent === doc.documentElement ) &&
+				offsetParent !== doc.documentElement &&
 				jQuery.css( offsetParent, "position" ) === "static" ) {
 
-				offsetParent = offsetParent.parentNode;
+				offsetParent = offsetParent.offsetParent;
 			}
-			if ( offsetParent && offsetParent !== elem && offsetParent.nodeType === 1 ) {
+			if ( offsetParent &&
+				offsetParent !== doc.documentElement && offsetParent !== elem &&
+				offsetParent.nodeType === 1 ) {
 
 				// Incorporate borders into its offset, since they are outside its content origin
 				parentOffset = jQuery( offsetParent ).offset();

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -436,13 +436,16 @@ testIframe( "fixed", "offset/fixed.html", function( assert, $, window ) {
 } );
 
 testIframe( "table", "offset/table.html", function( assert, $ ) {
-	assert.expect( 4 );
+	assert.expect( 6 );
 
 	assert.equal( $( "#table-1" ).offset().top, 6, "jQuery('#table-1').offset().top" );
 	assert.equal( $( "#table-1" ).offset().left, 6, "jQuery('#table-1').offset().left" );
 
 	assert.equal( $( "#th-1" ).offset().top, 10, "jQuery('#th-1').offset().top" );
 	assert.equal( $( "#th-1" ).offset().left, 10, "jQuery('#th-1').offset().left" );
+
+	assert.equal( $( "#th-1" ).position().top, 10, "jQuery('#th-1').position().top" );
+	assert.equal( $( "#th-1" ).position().left, 10, "jQuery('#th-1').position().left" );
 } );
 
 testIframe( "scroll", "offset/scroll.html", function( assert, $, win ) {


### PR DESCRIPTION
### Summary ###
Continue searching for the next positioned offsetParent (or the document) when calculating `position()`.

This fixes the seemingly inconsistent behaviour that occurred when calling `position()` on elements inside tables; for which the [offsetParent](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent) changes based on its `position` css property. e.g
```
<div id="positioned-container" style="position: relative;">
    <table>
        <tr>
            <td>
                <span id="static"></span>
                <span id="relative" style="position: relative;"></span>
                <span id="absolute" style="position: absolute;"></span>
            </td>
        </tr>
    </table>
</div>

The offsetParent of #static is td
The offsetParent of #relative and #absolute is #positioned-container
```

Previously `$('#static').position()` was returning the position relative to the containing `<td>` element, while `$('#relative').position()` was returning the position relative to `#positioned-container`

Now, both elements return their position relative to the containing `#positioned-container`

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
