### PR TITLE
Build: Restore the external directory

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 amd
+external
 node_modules
 *.min.js
 dist/**

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ npm-debug.log*
 !/dist/.eslintrc.json
 
 /amd
-
+/external
 /node_modules
 
 /test/data/core/jquery-iterability-transpiled.js

--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,7 @@
 /.travis.yml
 
 /build
+/external
 /speed
 /test
 /Gruntfile.js

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -71,6 +71,25 @@ module.exports = function( grunt ) {
 				}
 			}
 		},
+		npmcopy: {
+			all: {
+				options: {
+					destPrefix: "external"
+				},
+				files: {
+					"npo/npo.js": "native-promise-only/lib/npo.src.js",
+
+					"qunit/qunit.js": "qunit/qunit/qunit.js",
+					"qunit/qunit.css": "qunit/qunit/qunit.css",
+					"qunit/LICENSE.txt": "qunit/LICENSE.txt",
+
+					"requirejs/require.js": "requirejs/require.js",
+
+					"sinon/sinon.js": "sinon/pkg/sinon.js",
+					"sinon/LICENSE.txt": "sinon/LICENSE"
+				}
+			}
+		},
 		jsonlint: {
 			pkg: {
 				src: [ "package.json" ]
@@ -162,9 +181,9 @@ module.exports = function( grunt ) {
 				},
 				files: [
 					"test/data/jquery-1.9.1.js",
-					"node_modules/sinon/pkg/sinon.js",
-					"node_modules/native-promise-only/lib/npo.src.js",
-					"node_modules/requirejs/require.js",
+					"external/sinon/sinon.js",
+					"external/npo/npo.js",
+					"external/requirejs/require.js",
 					"test/data/testinit.js",
 
 					"test/jquery.js",
@@ -188,7 +207,7 @@ module.exports = function( grunt ) {
 						served: true,
 						nocache: true
 					},
-					{ pattern: "node_modules/**", included: false, served: true },
+					{ pattern: "external/**", included: false, served: true },
 					{
 						pattern: "test/**/*.@(js|css|jpg|html|xml|svg)",
 						included: false,
@@ -343,6 +362,7 @@ module.exports = function( grunt ) {
 	] );
 
 	grunt.registerTask( "test:prepare", [
+		"npmcopy",
 		"qunit_fixture",
 		"babel:tests"
 	] );

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "grunt-jsonlint": "2.1.2",
     "grunt-karma": "4.0.0",
     "grunt-newer": "1.3.0",
+    "grunt-npmcopy": "0.2.0",
     "gzip-js": "0.3.2",
     "husky": "4.2.5",
     "insight": "0.10.3",

--- a/test/index.html
+++ b/test/index.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>jQuery Test Suite</title>
-	<link rel="stylesheet" href="../node_modules/qunit/qunit/qunit.css" />
+	<link rel="stylesheet" href="../external/qunit/qunit.css" />
 	<link rel="stylesheet" href="data/testsuite.css" />
 
 	<!--
@@ -12,10 +12,10 @@
 	-->
 	<script src="data/jquery-1.9.1.js"></script>
 
-	<script src="../node_modules/qunit/qunit/qunit.js"></script>
-	<script src="../node_modules/sinon/pkg/sinon.js"></script>
-	<script src="../node_modules/native-promise-only/lib/npo.src.js"></script>
-	<script src="../node_modules/requirejs/require.js"></script>
+	<script src="../external/qunit/qunit.js"></script>
+	<script src="../external/sinon/sinon.js"></script>
+	<script src="../external/npo/npo.js"></script>
+	<script src="../external/requirejs/require.js"></script>
 	<!-- See testinit for the list of tests -->
 	<script src="data/testinit.js"></script>
 

--- a/test/karma.debug.html
+++ b/test/karma.debug.html
@@ -5,7 +5,7 @@
 	<title>DEBUG</title>
 	<meta charset="utf-8">
 	<!-- Karma serves this page from /context.html. Other files are served from /base -->
-	<link rel="stylesheet" href="/base/node_modules/qunit/qunit/qunit.css" />
+	<link rel="stylesheet" href="/base/external/qunit/qunit/qunit.css" />
 	<link rel="stylesheet" href="/base/test/data/testsuite.css" />
 </head>
 <body id="body">


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

In gh-4466, we removed the `external` directory in favor of loading some files
directly from `node_modules`. This works fine locally but when deploying code
for tests, this makes it impossible to not deploy `node_modules` as well. To
avoid the issue, this change restores usage of the `external` directory.

One change is that we no longer commit this directory to the repository, its
only purpose is to have clear isolation from `node_modules`.

Ref gh-4466

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
