### PR TITLE
Tests: Switch background image from online file to local 1x1.jpg

### DIFF
--- a/test/data/testsuite.css
+++ b/test/data/testsuite.css
@@ -113,7 +113,7 @@ div#fx-tests div.noback {
 #nothiddendivchild.prct { font-size: 150%; }
 
 /* #9239 Attach a background to the body( avoid crashes in removing the test element in support ) */
-body, div { background: url(https://static.jquery.com/files/rocker/images/logo_jquery_215x53.gif) no-repeat -1000px 0; }
+body, div { background: url(1x1.jpg) no-repeat -1000px 0; }
 
 /* #10501 */
 section { background:#f0f; display:block; }

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -1557,40 +1557,32 @@ QUnit.test(
 		var done = assert.async();
 		var styles = [ {
 				name: "backgroundAttachment",
-				value: [ "fixed" ],
-				expected: [ "scroll" ]
+				value: [ "fixed" ]
 			}, {
 				name: "backgroundColor",
-				value: [ "rgb(255, 0, 0)", "rgb(255,0,0)", "#ff0000" ],
-				expected: [ "transparent" ]
+				value: [ "rgb(255, 0, 0)", "rgb(255,0,0)", "#ff0000" ]
 			}, {
 
 				// Firefox returns auto's value
 				name: "backgroundImage",
-				value: [ "url('test.png')", "url(" + baseURL + "test.png)", "url(\"" + baseURL + "test.png\")" ],
-				expected: [ "none", "url(\"https://static.jquery.com/files/rocker/images/logo_jquery_215x53.gif\")" ]
+				value: [ "url('test.png')", "url(" + baseURL + "test.png)", "url(\"" + baseURL + "test.png\")" ]
 			}, {
 				name: "backgroundPosition",
-				value: [ "5% 5%" ],
-				expected: [ "0% 0%", "-1000px 0px", "-1000px 0%" ]
+				value: [ "5% 5%" ]
 			}, {
 
 				// Firefox returns no-repeat
 				name: "backgroundRepeat",
-				value: [ "repeat-y" ],
-				expected: [ "repeat", "no-repeat" ]
+				value: [ "repeat-y" ]
 			}, {
 				name: "backgroundClip",
-				value: [ "padding-box" ],
-				expected: [ "border-box" ]
+				value: [ "padding-box" ]
 			}, {
 				name: "backgroundOrigin",
-				value: [ "content-box" ],
-				expected: [ "padding-box" ]
+				value: [ "content-box" ]
 			}, {
 				name: "backgroundSize",
-				value: [ "80px 60px" ],
-				expected: [ "auto auto" ]
+				value: [ "80px 60px" ]
 		} ];
 
 		jQuery.each( styles, function( index, style ) {
@@ -1598,8 +1590,6 @@ QUnit.test(
 				$source = jQuery( "#firstp" ),
 				source = $source[ 0 ],
 				$children = $source.children();
-
-			style.expected = style.expected.concat( [ "", "auto" ] );
 
 			if ( source.style[ style.name ] === undefined ) {
 				assert.ok( true, style.name +  ": style isn't supported and therefore not an issue" );


### PR DESCRIPTION
Avoids noise from unexpected third-party pings during development (Little Snitch popped up unexpectedly asking for this legacy CDN hostname), and avoids console noise when testing/developing jQuery offline.

### Checklist ###

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
