### PR TITLE
Build: Take core-js-bundle from the external directory as well

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -77,6 +77,9 @@ module.exports = function( grunt ) {
 					destPrefix: "external"
 				},
 				files: {
+					"core-js-bundle/core-js-bundle.js": "core-js-bundle/minified.js",
+					"core-js-bundle/LICENSE": "core-js-bundle/LICENSE",
+
 					"npo/npo.js": "native-promise-only/lib/npo.src.js",
 
 					"qunit/qunit.js": "qunit/qunit/qunit.js",

--- a/test/data/core/jquery-iterability-transpiled.html
+++ b/test/data/core/jquery-iterability-transpiled.html
@@ -3,7 +3,7 @@
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 	<title>jQuery objects transpiled iterability test page</title>
-	<script src="../../../node_modules/core-js-bundle/minified.js"></script>
+	<script src="../../../external/core-js-bundle/core-js-bundle.js"></script>
 	<script src="../../jquery.js"></script>
 	<script src="../iframeTest.js"></script>
 	<script src="jquery-iterability-transpiled.js"></script>


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Build: Take core-js-bundle from the external directory as well

That package was missed in gh-4865 as it only broke browsers needing the
polyfill which is just IE at the moment. Thus, it broke Core tests in IE only.

Ref gh-4865

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
