### PR TITLE
Tests: Strip untypical callback parameter characters from mock.php

### DIFF
--- a/test/data/mock.php
+++ b/test/data/mock.php
@@ -1,7 +1,12 @@
 <?php
+
 /**
  * Keep in sync with /test/middleware-mockserver.js
  */
+function cleanCallback( $callback ) {
+	return preg_replace( '/[^a-z0-9_]/i', '', $callback );
+}
+
 class MockServer {
 	protected function contentType( $req ) {
 		$type = $req->query['contentType'];
@@ -65,7 +70,8 @@ class MockServer {
 				array_values( $req->headers )
 			);
 
-			echo $req->query['callback'] . "(" . json_encode( [ 'headers' => $headers ] ) . ")";
+			echo cleanCallback( $req->query['callback'] ) .
+				"(" . json_encode( [ 'headers' => $headers ] ) . ")";
 		} else {
 			echo 'QUnit.assert.ok( true, "mock executed" );';
 		}
@@ -105,17 +111,17 @@ QUnit.assert.ok( true, "mock executed");';
 		} else {
 			$callback = $_POST['callback'];
 		}
-		if ( isset( $req->query['array'] ) ) {
-			echo $callback . '([ {"name": "John", "age": 21}, {"name": "Peter", "age": 25 } ])';
-		} else {
-			echo $callback . '({ "data": {"lang": "en", "length": 25} })';
-		}
+		$json = isset( $req->query['array'] ) ?
+			'[ { "name": "John", "age": 21 }, { "name": "Peter", "age": 25 } ]' :
+			'{ "data": { "lang": "en", "length": 25 } }';
+		echo cleanCallback( $callback ) . '(' . $json . ')';
 	}
 
 	protected function xmlOverJsonp( $req ) {
 		$callback = $_REQUEST['callback'];
+		$cleanCallback = cleanCallback( $callback );
 		$text = json_encode( file_get_contents( __DIR__ . '/with_fries.xml' ) );
-		echo "$callback($text)\n";
+		echo "$cleanCallback($text)\n";
 	}
 
 	protected function error( $req ) {
@@ -243,7 +249,7 @@ QUnit.assert.ok( true, "mock executed");';
 		}
 		if ( isset( $req->query['callback'] ) ) {
 			$callback = $req->query['callback'];
-			echo $callback . '( {"status": 404, "msg": "Not Found"} )';
+			echo cleanCallback( $callback ) . '( {"status": 404, "msg": "Not Found"} )';
 		} else {
 			echo 'QUnit.assert.ok( false, "Mock return erroneously executed" );';
 		}

--- a/test/middleware-mockserver.js
+++ b/test/middleware-mockserver.js
@@ -7,6 +7,10 @@ var cspLog = "";
 /**
  * Keep in sync with /test/mock.php
  */
+function cleanCallback( callback ) {
+	return callback.replace( /[^a-z0-9_]/gi, "" );
+}
+
 var mocks = {
 	contentType: function( req, resp ) {
 		resp.writeHead( 200, {
@@ -73,7 +77,7 @@ var mocks = {
 		}
 
 		if ( req.query.callback ) {
-			resp.end( req.query.callback + "(" + JSON.stringify( {
+			resp.end( cleanCallback( req.query.callback ) + "(" + JSON.stringify( {
 				headers: req.headers
 			} ) + ")" );
 		} else {
@@ -126,14 +130,14 @@ var mocks = {
 				{ data: { lang: "en", length: 25 } }
 			);
 		callback.then( function( cb ) {
-			resp.end( cb + "(" + json + ")" );
+			resp.end( cleanCallback( cb ) + "(" + json + ")" );
 		}, next );
 	},
 	xmlOverJsonp: function( req, resp ) {
 		var callback = req.query.callback;
 		var body = fs.readFileSync( __dirname + "/data/with_fries.xml" ).toString();
 		resp.writeHead( 200 );
-		resp.end( callback + "(" + JSON.stringify( body ) + ")\n" );
+		resp.end( cleanCallback( callback ) + "(" + JSON.stringify( body ) + ")\n" );
 	},
 	error: function( req, resp ) {
 		if ( req.query.json ) {
@@ -256,10 +260,11 @@ var mocks = {
 		if ( req.query.withScriptContentType ) {
 			resp.writeHead( 404, { "Content-Type": "application/javascript" } );
 		} else {
-			resp.writeHead( 404 );
+			resp.writeHead( 404, { "Content-Type": "text/html; charset=UTF-8" } );
 		}
 		if ( req.query.callback ) {
-			resp.end( req.query.callback + "( {\"status\": 404, \"msg\": \"Not Found\"} )" );
+			resp.end( cleanCallback( req.query.callback ) +
+				"( {\"status\": 404, \"msg\": \"Not Found\"} )" );
 		} else {
 			resp.end( "QUnit.assert.ok( false, \"Mock return erroneously executed\" );" );
 		}


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Strip untypical callback parameter characters from mock.php.
Only allow alphanumeric characters & underscores for callback parameters.
The change is done both for the PHP server as well as the Node.js-based version.
This is only test code so we're not fixing any security issue but it happens
often enough that the whole jQuery repository directory structure is deployed
onto the server with PHP enabled that it makes is easy to introduce security
issues if this cleanup is not done.

Ref gh-4764

I'd like to also merge a version of this to the `2.2-stable` & `1.12-stable` branches as the `jsonp.php` file has the same issues as `mock.php` with some `action` parameters.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
