### PR TITLE
Tests: Strip untypical callback parameter characters from PHP files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
-sudo: false
+os: linux
 node_js:
-- "0.10"
-- "0.12"
 - "4"
-- "5"
 - "6"
+- "8"
+- "10"
+- "12"
+- "14"

--- a/test/data/jsonp.php
+++ b/test/data/jsonp.php
@@ -1,14 +1,15 @@
 <?php
 error_reporting(0);
+function cleanCallback( $callback ) {
+	return preg_replace( '/[^a-z0-9_]/i', '', $callback );
+}
 $callback = $_REQUEST['callback'];
 if ( ! $callback ) {
 	$callback = explode("?",end(explode("/",$_SERVER['REQUEST_URI'])));
 	$callback = $callback[0];
 }
-$json = $_REQUEST['json'];
-if($json) {
-	echo $callback . '([ {"name": "John", "age": 21}, {"name": "Peter", "age": 25 } ])';
-} else {
-	echo $callback . '({ "data": {"lang": "en", "length": 25} })';
-}
+$json = $_REQUEST['json'] ?
+	'[ { "name": "John", "age": 21 }, { "name": "Peter", "age": 25 } ]' :
+	'{ "data": { "lang": "en", "length": 25 } }';
+echo cleanCallback( $callback ) . '(' . $json . ')';
 ?>

--- a/test/data/with_fries_over_jsonp.php
+++ b/test/data/with_fries_over_jsonp.php
@@ -1,7 +1,11 @@
 <?php
 error_reporting(0);
+function cleanCallback( $callback ) {
+	return preg_replace( '/[^a-z0-9_]/i', '', $callback );
+}
 $callback = $_REQUEST['callback'];
+$cleanCallback = cleanCallback( $callback );
 $json = $_REQUEST['json'];
 $text = json_encode(file_get_contents(dirname(__FILE__)."/with_fries.xml"));
-echo "$callback($text)";
+echo "$cleanCallback($text)\n";
 ?>

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -1758,14 +1758,20 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 		};
 	} );
 
-	testIframeWithCallback(
-		"#14379 - jQuery.ajax() on unload",
-		"ajax/onunload.html",
-		function( status, assert ) {
-			assert.expect( 1 );
-			assert.strictEqual( status, "success", "Request completed" );
-		}
-	);
+	// Chrome 78 dropped support for synchronous XHR requests inside of
+	// beforeunload, unload, pagehide, and visibilitychange event handlers.
+	// See https://bugs.chromium.org/p/chromium/issues/detail?id=952452
+	// Safari 13 did similar changes. The below check will catch them both.
+	if ( !/safari/i.test( navigator.userAgent ) ) {
+		testIframeWithCallback(
+			"#14379 - jQuery.ajax() on unload",
+			"ajax/onunload.html",
+			function( status, assert ) {
+				assert.expect( 1 );
+				assert.strictEqual( status, "success", "Request completed" );
+			}
+		);
+	}
 
 	ajaxTest( "#14683 - jQuery.ajax() - Exceptions thrown synchronously by xhr.send should be caught", 4, function( assert ) {
 		return [ {

--- a/test/unit/support.js
+++ b/test/unit/support.js
@@ -223,6 +223,7 @@ testIframeWithCallback(
 			"reliableMarginRight": true
 		};
 	} else if ( /firefox/i.test( userAgent ) ) {
+		version = userAgent.match( /firefox\/(\d+)/i )[ 1 ];
 		expected = {
 			"ajax": true,
 			"boxSizingReliable": true,
@@ -237,7 +238,7 @@ testIframeWithCallback(
 			"pixelMarginRight": true,
 			"pixelPosition": true,
 			"radioValue": true,
-			"reliableMarginLeft": false,
+			"reliableMarginLeft": version >= 61,
 			"reliableMarginRight": true
 		};
 	} else if ( /iphone os 9_/i.test( userAgent ) ) {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Only allow alphanumeric characters & underscores for callback parameters.
This is only test code so we're not fixing any security issue but it happens
often enough that the whole jQuery repository directory structure is deployed
onto the server with PHP enabled that it makes is easy to introduce security
issues if this cleanup is not done.

This is a 1.x/2.x version of PR gh-4871.

The change doesn't require a release; it's meant at installations testing
the latest state of `1.12-stable` & `2.2-stable` branches.

This change also fixes testing on Travis & on Chrome/Firefox.

Ref gh-4764
Ref gh-4871

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
