### PR TITLE
Event: Don't break focus triggering after `.on(focus).off(focus)`

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -746,10 +746,10 @@ jQuery.each( { focus: "focusin", blur: "focusout" }, function( type, delegateTyp
 			return true;
 		},
 
-		// Suppress native focus or blur as it's already being fired
-		// in leverageNative.
-		_default: function() {
-			return true;
+		// Suppress native focus or blur if we're currently inside
+		// a leveraged native-event stack
+		_default: function( event ) {
+			return dataPriv.get( event.target, type );
 		},
 
 		delegateType: delegateType

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -3325,6 +3325,22 @@ QUnit.test( "focus change during a focus handler (gh-4382)", function( assert ) 
 	} );
 } );
 
+QUnit.test( "trigger(focus) works after .on(focus).off(focus) (gh-4867)", function( assert ) {
+	assert.expect( 1 );
+
+	var input = jQuery( "<input />" );
+
+	input.appendTo( "#qunit-fixture" );
+
+	input
+		.on( "focus", function() {} )
+		.off( "focus" );
+
+	input.trigger( "focus" );
+
+	assert.equal( document.activeElement, input[ 0 ], "input has focus" );
+} );
+
 // TODO replace with an adaptation of
 // https://github.com/jquery/jquery/pull/1367/files#diff-a215316abbaabdf71857809e8673ea28R2464
 ( function() {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The `_default` function in the special event settings for focus/blur has
always returned `true` since gh-4813 as the event was already being fired
from `leverageNative`. However, that only works if there's an active handler
on that element; this made a quick consecutive call:

```js
elem.on( "focus", function() {} ).off( "focus" );
```

make subsequent `.trigger( "focus" )` calls to not do any triggering.

The solution, already used in a similar `_default` method for the `click` event,
is to check for the `dataPriv` entry on the element for the focus event
(similarly for blur).

Fixes gh-4867

+10 bytes

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
