### PR TITLE
Manipulation: Don't remove HTML comments from scripts

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -40,7 +40,8 @@ var
 
 	// checked="checked" or checked
 	rchecked = /checked\s*(?:[^=]|=\s*.checked.)/i,
-	rcleanScript = /^\s*<!(?:\[CDATA\[|--)|(?:\]\]|--)>\s*$/g;
+
+	rcleanScript = /^\s*<!\[CDATA\[|\]\]>\s*$/g;
 
 // Prefer a tbody over its parent table for containing new rows
 function manipulationTarget( elem, content ) {
@@ -195,6 +196,12 @@ function domManip( collection, args, callback, ignored ) {
 								}, doc );
 							}
 						} else {
+
+							// Clean the CDATA sections from script contents. This shouldn't be
+							// needed as in XML documents they're already not visible when
+							// inspecting element contents and in HTML documents they have no
+							// meaning but we're preserving that logic for backwards compatibility.
+							// This will be removed completely in 4.0. See gh-4904.
 							DOMEval( node.textContent.replace( rcleanScript, "" ), node, doc );
 						}
 					}

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -197,7 +197,7 @@ function domManip( collection, args, callback, ignored ) {
 							}
 						} else {
 
-							// Clean the CDATA sections from script contents. This shouldn't be
+							// Unwrap a CDATA section containing script contents. This shouldn't be
 							// needed as in XML documents they're already not visible when
 							// inspecting element contents and in HTML documents they have no
 							// meaning but we're preserving that logic for backwards compatibility.

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -2268,7 +2268,7 @@ QUnit.test( "domManip plain-text caching (trac-6779)", function( assert ) {
 
 QUnit.test( "domManip executes scripts containing html comments or CDATA (trac-9221)", function( assert ) {
 
-	assert.expect( 3 );
+	assert.expect( 4 );
 
 	jQuery( [
 		"<script type='text/javascript'>",
@@ -2291,6 +2291,17 @@ QUnit.test( "domManip executes scripts containing html comments or CDATA (trac-9
 		"<!--//--><![CDATA[//><!--",
 		"QUnit.assert.ok( true, '<!--//--><![CDATA[//><!-- (Drupal case) handled' );",
 		"//--><!]]>",
+		"</script>"
+	].join( "\n" ) ).appendTo( "#qunit-fixture" );
+
+	// ES2015 in Annex B requires HTML-style comment delimiters (`<!--` & `-->`) to act as
+	// single-line comment delimiters; i.e. they should be treated as `//`.
+	// See gh-4904
+	jQuery( [
+		"<script type='text/javascript'>",
+		"<!-- Same-line HTML comment",
+		"QUnit.assert.ok( true, '<!-- Same-line HTML comment' );",
+		"-->",
 		"</script>"
 	].join( "\n" ) ).appendTo( "#qunit-fixture" );
 } );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

When evaluating scripts, jQuery strips out the possible wrapping HTML comment
and a CDATA section. However, all supported browsers are already doing that
when loading JS via appending a script tag to the DOM which is how we've been
doing `jQuery.globalEval` since jQuery 3.0.0. jQuery logic was imperfect, e.g.
it just stripped the `<!--` and `-->` markers, respectively at the beginning or
the end of the script contents. However, browsers are also stripping everything
following those markers in the same line, treating them as single-line comments
delimiters; this is now also mandated by ECMAScript 2015 in Annex B. Instead
of fixing the jQuery logic, just let the browser do its thing.

We still need to strip CDATA sections for backwards compatibility. This
shouldn't be needed as in XML documents they're already not visible when
inspecting element contents and in HTML documents they have no meaning but
we're preserving that logic for backwards compatibility. This will be removed
completely in 4.0.

Fixes gh-4904

-8 bytes

4.0 version of this PR: #4906

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
