### PR TITLE
Fix dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Run the unit tests with a local server that supports PHP. Ensure that you run th
 
 - Windows: [WAMP download](http://www.wampserver.com/en/)
 - Mac: [MAMP download](https://www.mamp.info/en/downloads/)
-- Linux: [Setting up LAMP](https://www.linux.com/learn/tutorials/288158-easy-lamp-server-installation)
+- Linux: [Setting up LAMP](https://www.linux.com/training-tutorials/easy-lamp-server-installation/)
 - [Mongoose (most platforms)](https://code.google.com/p/mongoose/)
 
 


### PR DESCRIPTION
The link to the linux lamp installation is no longer working. The website in question has simply moved the webpage, so this patch links to the new location on the same page.



### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
