### PR TITLE
Docs: Remove the CLA checkbox in the pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,6 @@ should start with an issue. Mention the issue number here.
 Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
 -->
 
-* [ ] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
 * [ ] New tests have been added to show the fix or feature works
 * [ ] Grunt build and unit tests pass locally with these changes
 * [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The EasyCLA status check is required so this won't get missed. The old JSF CLA
is dead, the provided link doesn't return meaningful information. There's no
good replacement link for the old CLA; PR authors are just supposed to sign the
new CLA by clicking on a link posted by the EasyCLA bot when they submit their
first PR since EasyCLA was enabled for the repo.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
