### PR TITLE
CSS: Don't special-case backslashes when trimming CSS Custom Properties

### DIFF
--- a/src/css/curCSS.js
+++ b/src/css/curCSS.js
@@ -2,7 +2,7 @@ import jQuery from "../core.js";
 import isAttached from "../core/isAttached.js";
 import getStyles from "./var/getStyles.js";
 import rcustomProp from "./var/rcustomProp.js";
-import rtrim from "../var/rtrim.js";
+import rtrimAscii from "../var/rtrimAscii.js";
 
 function curCSS( elem, name, computed ) {
 	var ret,
@@ -16,7 +16,7 @@ function curCSS( elem, name, computed ) {
 
 		// trim whitespace for custom property (issue gh-4926)
 		if ( isCustomProp ) {
-			ret = ret.replace( rtrim, "$1" );
+			ret = ret.replace( rtrimAscii, "$1" );
 		}
 
 		if ( ret === "" && !isAttached( elem ) ) {

--- a/src/css/var/rcustomProp.js
+++ b/src/css/var/rcustomProp.js
@@ -1,1 +1,1 @@
-export default ( /^--/ );
+export default /^--/;

--- a/src/selector.js
+++ b/src/selector.js
@@ -7,7 +7,6 @@ import pop from "./var/pop.js";
 import push from "./var/push.js";
 import whitespace from "./var/whitespace.js";
 import rbuggyQSA from "./selector/rbuggyQSA.js";
-import rtrim from "./var/rtrim.js";
 import isIE from "./var/isIE.js";
 
 // The following utils are attached directly to the jQuery object.
@@ -72,6 +71,7 @@ var i,
 
 	// Leading and non-escaped trailing whitespace, capturing some non-whitespace characters preceding the latter
 	rwhitespace = new RegExp( whitespace + "+", "g" ),
+	rtrim = new RegExp( "^" + whitespace + "+|((?:^|[^\\\\])(?:\\\\.)*)" + whitespace + "+$", "g" ),
 
 	rcomma = new RegExp( "^" + whitespace + "*," + whitespace + "*" ),
 	rcombinators = new RegExp( "^" + whitespace + "*([>+~]|" + whitespace + ")" +

--- a/src/var/rtrim.js
+++ b/src/var/rtrim.js
@@ -1,6 +1,0 @@
-import whitespace from "./whitespace.js";
-
-export default new RegExp(
-	"^" + whitespace + "+|((?:^|[^\\\\])(?:\\\\.)*)" + whitespace + "+$",
-	"g"
-);

--- a/src/var/rtrimAscii.js
+++ b/src/var/rtrimAscii.js
@@ -1,0 +1,5 @@
+import whitespace from "./whitespace.js";
+
+export default new RegExp(
+	"^" + whitespace + "*(.*?)" + whitespace + "*$"
+);

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -1748,6 +1748,7 @@ QUnit.testUnlessIE( "css(--customProperty)", function( assert ) {
 		"        --prop10:\f\r\n\t val10 \f\r\n\t;\n" +
 		"        --prop11:\u000C\u000D\u000A\u0009\u0020val11\u0020\u0009\u000A\u000D\u000C;\n" +
 		"        --prop12:\u000Bval12\u000B;\n" +
+		"        --prop13: \\ ;\n" +
 		"    }\n" +
 		"</style>"
 	);
@@ -1756,7 +1757,7 @@ QUnit.testUnlessIE( "css(--customProperty)", function( assert ) {
 		$elem = jQuery( "<div>" ).addClass( "test__customProperties" )
 			.appendTo( "#qunit-fixture" ),
 		webkitOrBlink = /\bsafari\b/i.test( navigator.userAgent ),
-		expected = 17;
+		expected = 18;
 
 	if ( webkitOrBlink ) {
 		expected -= 2;
@@ -1802,6 +1803,7 @@ QUnit.testUnlessIE( "css(--customProperty)", function( assert ) {
 	assert.equal( $elem.css( "--prop10" ), "val10", "Multiple preceding and following escaped unicode whitespace trimmed" );
 	assert.equal( $elem.css( "--prop11" ), "val11", "Multiple preceding and following unicode whitespace trimmed" );
 	assert.equal( $elem.css( "--prop12" ), "\u000Bval12\u000B", "Multiple preceding and following non-CSS whitespace reserved" );
+	assert.equal( $elem.css( "--prop13" ), "\\", "Whitespace surrounding a backslash" );
 } );
 
 // IE doesn't support CSS variables.


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The original logic from PR gh-4930 re-used the `rtrim` regex from the selector
module but selectors have special escaping rules which means whitespace
following a backslash character would not get trimmed.

This change splits the logic at the unfortunate but necessary cost of size.

Ref gh-4926
Ref gh-4930

This is at +44 bytes now but together with gh-4930 where it should be included it's at about half that.

When this lands, I'll CP gh-4930 together with this PR to `3.x-stable`.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
