### PR TITLE
Tests: Make Karma browser timeout larger than the QUnit one

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -232,6 +232,10 @@ module.exports = function( grunt ) {
 				],
 				reporters: [ "dots" ],
 				autoWatch: false,
+
+				// 2 minutes; has to be longer than QUnit.config.testTimeout
+				browserNoActivityTimeout: 120e3,
+
 				concurrency: 3,
 				captureTimeout: 20 * 1000,
 				singleRun: true


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Since the default Karma browser no activity timeout was lower than the QUnit
timeout, a single timing out test was interrupting the whole test run of
a browser.

The QUnit timeout is set to 1 minute so I set the Karma one to 2 minutes.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
