### PR TITLE
CSS: Justify use of rtrim on CSS property values

### DIFF
--- a/src/css/curCSS.js
+++ b/src/css/curCSS.js
@@ -16,6 +16,12 @@ function curCSS( elem, name, computed ) {
 
 		// trim whitespace for custom property (issue gh-4926)
 		if ( isCustomProp ) {
+
+			// rtrim treats U+000D CARRIAGE RETURN and U+000C FORM FEED
+			// as whitespace while CSS does not, but this is not a problem
+			// because CSS preprocessing replaces them with U+000A LINE FEED
+			// (which *is* CSS whitespace)
+			// https://www.w3.org/TR/css-syntax-3/#input-preprocessing
 			ret = ret.replace( rtrim, "$1" );
 		}
 


### PR DESCRIPTION
CSS does not acknowledge carriage return or form feed characters as whitespace but it does replace them _with_ whitespace, making it acceptable to use `rtrim`.