### PR TITLE
Tests: Disable CSS Custom Properties tests in old Safari/iOS

### DIFF
--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -1732,6 +1732,8 @@ QUnit.test( "Do not throw on frame elements from css method (#15098)", function(
 
 ( function() {
 	var supportsCssVars,
+		oldSafari = /iphone os 9_/i.test( navigator.userAgent ) ||
+			/\b9\.\d+(\.\d+)* safari/i.test( navigator.userAgent ),
 		elem = jQuery( "<div>" ).appendTo( document.body ),
 		div = elem[ 0 ];
 
@@ -1739,7 +1741,15 @@ QUnit.test( "Do not throw on frame elements from css method (#15098)", function(
 	supportsCssVars = !!getComputedStyle( div ).getPropertyValue( "--prop" );
 	elem.remove();
 
-	QUnit[ supportsCssVars ? "test" : "skip" ]( "css(--customProperty)", function( assert ) {
+	QUnit[
+
+		// Support: iOS 9.3 only, Safari 9.1 only
+		// Safari 9.1 & iOS 9.3 support CSS custom properties but that support
+		// is buggy which crashes our tests.
+		supportsCssVars && !oldSafari ?
+			"test" :
+			"skip"
+	]( "css(--customProperty)", function( assert ) {
 		jQuery( "#qunit-fixture" ).append(
 			"<style>\n" +
 			"    .test__customProperties {\n" +


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Safari 9.1 & iOS 9.3 support CSS custom properties but that support
is buggy which crashes our tests. Disable those tests there.

See https://caniuse.com/css-variables

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
