### PR TITLE
Tests: Allow statusText to be "success" in AJAX tests

### DIFF
--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -1704,7 +1704,8 @@ QUnit.module( "ajax", {
 		var done = assert.async();
 		jQuery.ajax( url( "mock.php?action=status&code=200&text=Hello" ) ).done( function( _, statusText, jqXHR ) {
 			assert.strictEqual( statusText, "success", "callback status text ok for success" );
-			assert.ok( jqXHR.statusText === "Hello" || jqXHR.statusText === "OK", "jqXHR status text ok for success (" + jqXHR.statusText + ")" );
+			assert.ok( [ "Hello", "OK", "success" ].indexOf( jqXHR.statusText ) > -1,
+				"jqXHR status text ok for success (" + jqXHR.statusText + ")" );
 			jQuery.ajax( url( "mock.php?action=status&code=404&text=World" ) ).fail( function( jqXHR, statusText ) {
 				assert.strictEqual( statusText, "error", "callback status text ok for error" );
 				done();


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

In HTTP/2, status message is not supported and whatever is reported as
statusText differs between browsers. In Chrome & Safari it's "success", in
Firefox & IE it's "OK". So far "success" wasn't allowed. This made the tests
pass locally if you're running an HTTP/1.1 server but on TestSwarm which is
now proxied via an HTTP/2-equipped Cloudflare, the relevant test started failing
in Chrome & Safari.

Allow "success" to resolve the issue.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
