### PR TITLE
Tests: Skip ETag AJAX tests on TestSwarm

### DIFF
--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -1634,12 +1634,25 @@ QUnit.module( "ajax", {
 		function( label, cache ) {
 			jQuery.each(
 				{
-					"If-Modified-Since": "mock.php?action=ims",
-					"Etag": "mock.php?action=etag"
+					"If-Modified-Since": {
+						url: "mock.php?action=ims",
+						qunitMethod: "test"
+					},
+					"Etag": {
+						url: "mock.php?action=etag",
+
+						// Support: TestSwarm
+						// TestSwarm is now proxied via Cloudflare which cuts out
+						// headers relevant for ETag tests, failing them. We're still
+						// running those tests in Karma on Chrome & Firefox (including
+						// Firefox ESR).
+						qunitMethod: QUnit.isSwarm ? "skip" : "test"
+					}
 				},
-				function( type, url ) {
-					url = baseURL + url + "&ts=" + ifModifiedNow++;
-					QUnit.test( "jQuery.ajax() - " + type + " support" + label, function( assert ) {
+				function( type, data ) {
+					var url = baseURL + data.url + "&ts=" + ifModifiedNow++;
+					QUnit[ data.qunitMethod ]( "jQuery.ajax() - " + type +
+							" support" + label, function( assert ) {
 						assert.expect( 4 );
 						var done = assert.async();
 						jQuery.ajax( {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

TestSwarm is now proxied via Cloudflare which cuts out headers relevant for
ETag tests, failing them. We're still running those tests in Karma on Chrome
& Firefox (including Firefox ESR).

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
