### PR TITLE
Core: Don't rely on splice being present on input

### DIFF
--- a/src/selector/uniqueSort.js
+++ b/src/selector/uniqueSort.js
@@ -80,7 +80,7 @@ jQuery.uniqueSort = function( results ) {
 			}
 		}
 		while ( j-- ) {
-			results.splice( duplicates[ j ], 1 );
+			Array.prototype.splice.call( results, duplicates[ j ] , 1 );
 		}
 	}
 

--- a/src/selector/uniqueSort.js
+++ b/src/selector/uniqueSort.js
@@ -1,6 +1,7 @@
 import jQuery from "../core.js";
 import document from "../var/document.js";
 import sort from "../var/sort.js";
+import splice from "../var/splice.js";
 
 var hasDuplicate;
 
@@ -80,7 +81,7 @@ jQuery.uniqueSort = function( results ) {
 			}
 		}
 		while ( j-- ) {
-			Array.prototype.splice.call( results, duplicates[ j ] , 1 );
+			splice.call( results, duplicates[ j ], 1 );
 		}
 	}
 

--- a/src/var/splice.js
+++ b/src/var/splice.js
@@ -1,0 +1,3 @@
+import arr from "./arr.js";
+
+export default arr.splice;

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -1956,8 +1956,9 @@ QUnit.test( "jQuery.uniqueSort", function( assert ) {
 
 	jQuery.each( tests, function( label, test ) {
 		var length = test.length || test.input.length;
-		//we duplicate the test.input, because if not it is modified by the uniqueSort and the second test becomes worthless
-    assert.deepEqual( jQuery.uniqueSort( test.input.slice( 0 ) ).slice( 0, length ), test.expected, label + " (array)" );
+		// We duplicate `test.input` because otherwise it is modified by `uniqueSort`
+		// and the second test becomes worthless.
+		assert.deepEqual( jQuery.uniqueSort( test.input.slice( 0 ) ).slice( 0, length ), test.expected, label + " (array)" );
 		assert.deepEqual( jQuery.uniqueSort( new Arrayish( test.input ) ).sliceForTestOnly( 0, length ), test.expected, label + " (quasi-array)" );
 	} );
 } );

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -1958,8 +1958,10 @@ QUnit.test( "jQuery.uniqueSort", function( assert ) {
 		var length = test.length || test.input.length;
 		// We duplicate `test.input` because otherwise it is modified by `uniqueSort`
 		// and the second test becomes worthless.
-		assert.deepEqual( jQuery.uniqueSort( test.input.slice( 0 ) ).slice( 0, length ), test.expected, label + " (array)" );
-		assert.deepEqual( jQuery.uniqueSort( new Arrayish( test.input ) ).sliceForTestOnly( 0, length ), test.expected, label + " (quasi-array)" );
+		assert.deepEqual( jQuery.uniqueSort( test.input.slice( 0 ) ).slice( 0, length ),
+			test.expected, label + " (array)" );
+		assert.deepEqual( jQuery.uniqueSort( new Arrayish( test.input ) ).sliceForTestOnly( 0, length ),
+			test.expected, label + " (quasi-array)" );
 	} );
 } );
 

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -1894,9 +1894,7 @@ QUnit.test( "jQuery.uniqueSort", function( assert ) {
 		}
 	}
 	Arrayish.prototype = {
-		slice: [].slice,
-		sort: [].sort,
-		splice: [].splice
+		sliceForTestOnly: [].slice
 	};
 
 	var i, tests,
@@ -1958,8 +1956,9 @@ QUnit.test( "jQuery.uniqueSort", function( assert ) {
 
 	jQuery.each( tests, function( label, test ) {
 		var length = test.length || test.input.length;
-		assert.deepEqual( jQuery.uniqueSort( test.input ).slice( 0, length ), test.expected, label + " (array)" );
-		assert.deepEqual( jQuery.uniqueSort( new Arrayish( test.input ) ).slice( 0, length ), test.expected, label + " (quasi-array)" );
+		//we duplicate the test.input, because if not it is modified by the uniqueSort and the second test becomes worthless
+    assert.deepEqual( jQuery.uniqueSort( test.input.slice( 0 ) ).slice( 0, length ), test.expected, label + " (array)" );
+		assert.deepEqual( jQuery.uniqueSort( new Arrayish( test.input ) ).sliceForTestOnly( 0, length ), test.expected, label + " (quasi-array)" );
 	} );
 } );
 


### PR DESCRIPTION
Without this fix it does that

TypeError: results.splice is not a function
    at Function.jQuery.uniqueSort (https://code.jquery.com/jquery-git.js:664:12)
    at jQuery.fn.init.find (https://code.jquery.com/jquery-git.js:2394:27)
    at gocusihafe.js:3:4

Reproduced here:
https://jsbin.com/gocusihafe/1/edit?html,css,js,console,output

### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
