### PR TITLE
Docs: Remove links to Web Archive from source

### DIFF
--- a/src/attributes/prop.js
+++ b/src/attributes/prop.js
@@ -59,7 +59,6 @@ jQuery.extend( {
 				// Support: IE <=9 - 11+
 				// elem.tabIndex doesn't always return the
 				// correct value when it hasn't been explicitly set
-				// https://web.archive.org/web/20141116233347/http://fluidproject.org/blog/2008/01/09/getting-setting-and-removing-tabindex-values-with-javascript/
 				// Use proper attribute retrieval (trac-12072)
 				var tabindex = elem.getAttribute( "tabindex" );
 

--- a/src/queue/delay.js
+++ b/src/queue/delay.js
@@ -4,7 +4,6 @@ import "../queue.js";
 import "../effects.js"; // Delay is optional because of this dependency
 
 // Based off of the plugin by Clint Helfers, with permission.
-// https://web.archive.org/web/20100324014747/http://blindsignals.com/index.php/2009/07/jquery-delay/
 jQuery.fn.delay = function( time, type ) {
 	time = jQuery.fx ? jQuery.fx.speeds[ time ] || time : time;
 	type = type || "fx";


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Neither of the removed links is crucial; one of them refers to a site that has
since started being malicious; while the Web Archive links remain safe, some
scanners warn about such links. Removing them is the safest thing to do.

Fixes gh-4981

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
