### PR TITLE
Docs: Replace `#NUMBER` Trac issue references with `trac-NUMBER`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ In the spirit of open source software development, jQuery always encourages comm
 2. [Core Style Guide](https://contribute.jquery.org/style-guide/js/)
 3. [Writing Code for jQuery Foundation Projects](https://contribute.jquery.org/code/)
 
+### References to issues/PRs
+
+GitHub issues/PRs are usually referenced via `gh-NUMBER`, where `NUMBER` is the numerical ID of the issue/PR. You can find such an issue/PR under `https://github.com/jquery/jquery/issues/NUMBER`.
+
+jQuery has used a different bug tracker - based on Trac - in the past, available under [bugs.jquery.com](https://bugs.jquery.com/). It is being kept in read only mode so that referring to past discussions is possible. When jQuery source references one of those issues, it uses the pattern `trac-NUMBER`, where `NUMBER` is the numerical ID of the issue. You can find such an issue under `https://bugs.jquery.com/ticket/NUMBER`.
+
 
 Environments in which to use jQuery
 --------------------------------------

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -22,7 +22,7 @@ var
 	rantiCache = /([?&])_=[^&]*/,
 	rheaders = /^(.*?):[ \t]*([^\r\n]*)$/mg,
 
-	// #7653, #8125, #8152: local protocol detection
+	// trac-7653, trac-8125, trac-8152: local protocol detection
 	rlocalProtocol = /^(?:about|app|app-storage|.+-extension|file|res|widget):$/,
 	rnoContent = /^(?:GET|HEAD)$/,
 	rprotocol = /^\/\//,
@@ -45,7 +45,7 @@ var
 	 */
 	transports = {},
 
-	// Avoid comment-prolog char sequence (#10098); must appease lint and evade compression
+	// Avoid comment-prolog char sequence (trac-10098); must appease lint and evade compression
 	allTypes = "*/".concat( "*" ),
 
 	// Anchor tag for parsing the document origin
@@ -116,7 +116,7 @@ function inspectPrefiltersOrTransports( structure, options, originalOptions, jqX
 
 // A special extend for ajax options
 // that takes "flat" options (not to be deep extended)
-// Fixes #9887
+// Fixes trac-9887
 function ajaxExtend( target, src ) {
 	var key, deep,
 		flatOptions = jQuery.ajaxSettings.flatOptions || {};
@@ -527,12 +527,12 @@ jQuery.extend( {
 		deferred.promise( jqXHR );
 
 		// Add protocol if not provided (prefilters might expect it)
-		// Handle falsy url in the settings object (#10093: consistency with old signature)
+		// Handle falsy url in the settings object (trac-10093: consistency with old signature)
 		// We also use the url parameter if available
 		s.url = ( ( url || s.url || location.href ) + "" )
 			.replace( rprotocol, location.protocol + "//" );
 
-		// Alias method option to type as per ticket #12004
+		// Alias method option to type as per ticket trac-12004
 		s.type = options.method || options.type || s.method || s.type;
 
 		// Extract dataTypes list
@@ -575,7 +575,7 @@ jQuery.extend( {
 		}
 
 		// We can fire global events as of now if asked to
-		// Don't fire events if jQuery.event is undefined in an AMD-usage scenario (#15118)
+		// Don't fire events if jQuery.event is undefined in an AMD-usage scenario (trac-15118)
 		fireGlobals = jQuery.event && s.global;
 
 		// Watch for a new set of requests
@@ -604,7 +604,7 @@ jQuery.extend( {
 			if ( s.data && ( s.processData || typeof s.data === "string" ) ) {
 				cacheURL += ( rquery.test( cacheURL ) ? "&" : "?" ) + s.data;
 
-				// #9682: remove data so that it's not used in an eventual retry
+				// trac-9682: remove data so that it's not used in an eventual retry
 				delete s.data;
 			}
 

--- a/src/ajax/xhr.js
+++ b/src/ajax/xhr.js
@@ -18,7 +18,7 @@ var xhrSuccessStatus = {
 		0: 200,
 
 		// Support: IE <=9 only
-		// #1450: sometimes IE returns 1223 when it should be 204
+		// trac-1450: sometimes IE returns 1223 when it should be 204
 		1223: 204
 	},
 	xhrSupported = jQuery.ajaxSettings.xhr();
@@ -90,7 +90,7 @@ jQuery.ajaxTransport( function( options ) {
 								} else {
 									complete(
 
-										// File: protocol always yields status 0; see #8605, #14207
+										// File: protocol always yields status 0; see trac-8605, trac-14207
 										xhr.status,
 										xhr.statusText
 									);
@@ -151,7 +151,7 @@ jQuery.ajaxTransport( function( options ) {
 					xhr.send( options.hasContent && options.data || null );
 				} catch ( e ) {
 
-					// #14683: Only rethrow if this hasn't been notified as an error yet
+					// trac-14683: Only rethrow if this hasn't been notified as an error yet
 					if ( callback ) {
 						throw e;
 					}

--- a/src/attributes/prop.js
+++ b/src/attributes/prop.js
@@ -62,7 +62,7 @@ jQuery.extend( {
 				// Support: IE <=9 - 11 only
 				// elem.tabIndex doesn't always return the
 				// correct value when it hasn't been explicitly set
-				// Use proper attribute retrieval(#12072)
+				// Use proper attribute retrieval (trac-12072)
 				var tabindex = jQuery.find.attr( elem, "tabindex" );
 
 				if ( tabindex ) {

--- a/src/attributes/val.js
+++ b/src/attributes/val.js
@@ -91,7 +91,7 @@ jQuery.extend( {
 					val :
 
 					// Support: IE <=10 - 11 only
-					// option.text throws exceptions (#14686, #14858)
+					// option.text throws exceptions (trac-14686, trac-14858)
 					// Strip and collapse whitespace
 					// https://html.spec.whatwg.org/#strip-and-collapse-whitespace
 					stripAndCollapse( jQuery.text( elem ) );
@@ -118,7 +118,7 @@ jQuery.extend( {
 					option = options[ i ];
 
 					// Support: IE <=9 only
-					// IE8-9 doesn't update selected after form reset (#2551)
+					// IE8-9 doesn't update selected after form reset (trac-2551)
 					if ( ( option.selected || i === index ) &&
 
 							// Don't return options that are disabled or in a disabled optgroup

--- a/src/core/camelCase.js
+++ b/src/core/camelCase.js
@@ -13,7 +13,7 @@ function fcamelCase( _all, letter ) {
 
 // Convert dashed to camelCase; used by the css and data modules
 // Support: IE <=9 - 11, Edge 12 - 15
-// Microsoft forgot to hump their vendor prefix (#9572)
+// Microsoft forgot to hump their vendor prefix (trac-9572)
 function camelCase( string ) {
 	return string.replace( rmsPrefix, "ms-" ).replace( rdashAlpha, fcamelCase );
 }

--- a/src/core/init.js
+++ b/src/core/init.js
@@ -14,8 +14,8 @@ define( [
 var rootjQuery,
 
 	// A simple way to check for HTML strings
-	// Prioritize #id over <tag> to avoid XSS via location.hash (#9521)
-	// Strict HTML recognition (#11290: must start with <)
+	// Prioritize #id over <tag> to avoid XSS via location.hash (trac-9521)
+	// Strict HTML recognition (trac-11290: must start with <)
 	// Shortcut simple #id case for speed
 	rquickExpr = /^(?:\s*(<[\w\W]+>)[^>]*|#([\w-]+))$/,
 

--- a/src/core/ready-no-deferred.js
+++ b/src/core/ready-no-deferred.js
@@ -30,7 +30,7 @@ jQuery.extend( {
 	isReady: false,
 
 	// A counter to track how many items to wait for before
-	// the ready event fires. See #6781
+	// the ready event fires. See trac-6781
 	readyWait: 1,
 
 	ready: function( wait ) {

--- a/src/core/ready.js
+++ b/src/core/ready.js
@@ -31,7 +31,7 @@ jQuery.extend( {
 	isReady: false,
 
 	// A counter to track how many items to wait for before
-	// the ready event fires. See #6781
+	// the ready event fires. See trac-6781
 	readyWait: 1,
 
 	// Handle when the DOM is ready

--- a/src/css.js
+++ b/src/css.js
@@ -265,15 +265,15 @@ jQuery.extend( {
 		if ( value !== undefined ) {
 			type = typeof value;
 
-			// Convert "+=" or "-=" to relative numbers (#7345)
+			// Convert "+=" or "-=" to relative numbers (trac-7345)
 			if ( type === "string" && ( ret = rcssNum.exec( value ) ) && ret[ 1 ] ) {
 				value = adjustCSS( elem, name, ret );
 
-				// Fixes bug #9237
+				// Fixes bug trac-9237
 				type = "number";
 			}
 
-			// Make sure that null and NaN values aren't set (#7116)
+			// Make sure that null and NaN values aren't set (trac-7116)
 			if ( value == null || value !== value ) {
 				return;
 			}

--- a/src/css/curCSS.js
+++ b/src/css/curCSS.js
@@ -25,8 +25,8 @@ function curCSS( elem, name, computed ) {
 	computed = computed || getStyles( elem );
 
 	// getPropertyValue is needed for:
-	//   .css('filter') (IE 9 only, #12537)
-	//   .css('--customProperty) (#3144)
+	//   .css('filter') (IE 9 only, trac-12537)
+	//   .css('--customProperty) (gh-3144)
 	if ( computed ) {
 		ret = computed.getPropertyValue( name ) || computed[ name ];
 

--- a/src/css/support.js
+++ b/src/css/support.js
@@ -70,7 +70,7 @@ define( [
 	}
 
 	// Support: IE <=9 - 11 only
-	// Style of cloned element affects source element cloned (#8908)
+	// Style of cloned element affects source element cloned (trac-8908)
 	div.style.backgroundClip = "content-box";
 	div.cloneNode( true ).style.backgroundClip = "";
 	support.clearCloneStyle = div.style.backgroundClip === "content-box";

--- a/src/css/var/getStyles.js
+++ b/src/css/var/getStyles.js
@@ -3,7 +3,7 @@ define( function() {
 
 	return function( elem ) {
 
-		// Support: IE <=11 only, Firefox <=30 (#15098, #14150)
+		// Support: IE <=11 only, Firefox <=30 (trac-15098, trac-14150)
 		// IE throws on elements created in popups
 		// FF meanwhile throws on frame elements through "defaultView.getComputedStyle"
 		var view = elem.ownerDocument.defaultView;

--- a/src/data.js
+++ b/src/data.js
@@ -109,7 +109,7 @@ jQuery.fn.extend( {
 					while ( i-- ) {
 
 						// Support: IE 11 only
-						// The attrs elements can be null (#14894)
+						// The attrs elements can be null (trac-14894)
 						if ( attrs[ i ] ) {
 							name = attrs[ i ].name;
 							if ( name.indexOf( "data-" ) === 0 ) {

--- a/src/data/Data.js
+++ b/src/data/Data.js
@@ -25,7 +25,7 @@ Data.prototype = {
 			value = {};
 
 			// We can accept data for non-element nodes in modern browsers,
-			// but we should not, see #8335.
+			// but we should not, see trac-8335.
 			// Always return an empty object.
 			if ( acceptData( owner ) ) {
 

--- a/src/effects.js
+++ b/src/effects.js
@@ -310,7 +310,7 @@ function Animation( elem, properties, options ) {
 				remaining = Math.max( 0, animation.startTime + animation.duration - currentTime ),
 
 				// Support: Android 2.3 only
-				// Archaic crash bug won't allow us to use `1 - ( 0.5 || 0 )` (#12497)
+				// Archaic crash bug won't allow us to use `1 - ( 0.5 || 0 )` (trac-12497)
 				temp = remaining / animation.duration || 0,
 				percent = 1 - temp,
 				index = 0,

--- a/src/event.js
+++ b/src/event.js
@@ -393,15 +393,15 @@ jQuery.event = {
 
 			for ( ; cur !== this; cur = cur.parentNode || this ) {
 
-				// Don't check non-elements (#13208)
-				// Don't process clicks on disabled elements (#6911, #8165, #11382, #11764)
+				// Don't check non-elements (trac-13208)
+				// Don't process clicks on disabled elements (trac-6911, trac-8165, trac-11382, trac-11764)
 				if ( cur.nodeType === 1 && !( event.type === "click" && cur.disabled === true ) ) {
 					matchedHandlers = [];
 					matchedSelectors = {};
 					for ( i = 0; i < delegateCount; i++ ) {
 						handleObj = handlers[ i ];
 
-						// Don't conflict with Object.prototype properties (#13203)
+						// Don't conflict with Object.prototype properties (trac-13203)
 						sel = handleObj.selector + " ";
 
 						if ( matchedSelectors[ sel ] === undefined ) {
@@ -655,7 +655,7 @@ jQuery.Event = function( src, props ) {
 
 		// Create target properties
 		// Support: Safari <=6 - 7 only
-		// Target should not be a text node (#504, #13143)
+		// Target should not be a text node (trac-504, trac-13143)
 		this.target = ( src.target && src.target.nodeType === 3 ) ?
 			src.target.parentNode :
 			src.target;

--- a/src/event/trigger.js
+++ b/src/event/trigger.js
@@ -75,8 +75,8 @@ jQuery.extend( jQuery.event, {
 			return;
 		}
 
-		// Determine event propagation path in advance, per W3C events spec (#9951)
-		// Bubble up to document, then to window; watch for a global ownerDocument var (#9724)
+		// Determine event propagation path in advance, per W3C events spec (trac-9951)
+		// Bubble up to document, then to window; watch for a global ownerDocument var (trac-9724)
 		if ( !onlyHandlers && !special.noBubble && !isWindow( elem ) ) {
 
 			bubbleType = special.delegateType || type;
@@ -128,7 +128,7 @@ jQuery.extend( jQuery.event, {
 				acceptData( elem ) ) {
 
 				// Call a native DOM method on the target with the same name as the event.
-				// Don't do default actions on window, that's where global variables be (#6170)
+				// Don't do default actions on window, that's where global variables be (trac-6170)
 				if ( ontype && isFunction( elem[ type ] ) && !isWindow( elem ) ) {
 
 					// Don't re-trigger an onFOO event when we call its FOO() method

--- a/src/exports/global.js
+++ b/src/exports/global.js
@@ -25,8 +25,8 @@ jQuery.noConflict = function( deep ) {
 };
 
 // Expose jQuery and $ identifiers, even in AMD
-// (#7102#comment:10, https://github.com/jquery/jquery/pull/557)
-// and CommonJS for browser emulators (#13566)
+// (trac-7102#comment:10, https://github.com/jquery/jquery/pull/557)
+// and CommonJS for browser emulators (trac-13566)
 if ( typeof noGlobal === "undefined" ) {
 	window.jQuery = window.$ = jQuery;
 }

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -155,7 +155,7 @@ function domManip( collection, args, callback, ignored ) {
 
 			// Use the original fragment for the last item
 			// instead of the first because it can end up
-			// being emptied incorrectly in certain situations (#8070).
+			// being emptied incorrectly in certain situations (trac-8070).
 			for ( ; i < l; i++ ) {
 				node = fragment;
 

--- a/src/manipulation/_evalUrl.js
+++ b/src/manipulation/_evalUrl.js
@@ -8,7 +8,7 @@ jQuery._evalUrl = function( url, options, doc ) {
 	return jQuery.ajax( {
 		url: url,
 
-		// Make this explicit, since user can override this through ajaxSetup (#11264)
+		// Make this explicit, since user can override this through ajaxSetup (trac-11264)
 		type: "GET",
 		dataType: "script",
 		cache: true,

--- a/src/manipulation/buildFragment.js
+++ b/src/manipulation/buildFragment.js
@@ -58,7 +58,7 @@ function buildFragment( elems, context, scripts, selection, ignored ) {
 				// Remember the top-level container
 				tmp = fragment.firstChild;
 
-				// Ensure the created nodes are orphaned (#12392)
+				// Ensure the created nodes are orphaned (trac-12392)
 				tmp.textContent = "";
 			}
 		}

--- a/src/manipulation/getAll.js
+++ b/src/manipulation/getAll.js
@@ -8,7 +8,7 @@ define( [
 function getAll( context, tag ) {
 
 	// Support: IE <=9 - 11 only
-	// Use typeof to avoid zero-argument method invocation on host objects (#15151)
+	// Use typeof to avoid zero-argument method invocation on host objects (trac-15151)
 	var ret;
 
 	if ( typeof context.getElementsByTagName !== "undefined" ) {

--- a/src/manipulation/support.js
+++ b/src/manipulation/support.js
@@ -11,9 +11,9 @@ define( [
 		input = document.createElement( "input" );
 
 	// Support: Android 4.0 - 4.3 only
-	// Check state lost if the name is set (#11217)
+	// Check state lost if the name is set (trac-11217)
 	// Support: Windows Web Apps (WWA)
-	// `name` and `type` must use .setAttribute for WWA (#14901)
+	// `name` and `type` must use .setAttribute for WWA (trac-14901)
 	input.setAttribute( "type", "radio" );
 	input.setAttribute( "checked", "checked" );
 	input.setAttribute( "name", "t" );

--- a/src/manipulation/wrapMap.js
+++ b/src/manipulation/wrapMap.js
@@ -4,7 +4,7 @@ define( [
 
 "use strict";
 
-// We have to close these tags to support XHTML (#13200)
+// We have to close these tags to support XHTML (trac-13200)
 var wrapMap = {
 
 	// XHTML parsers do not magically insert elements in the

--- a/src/selector-native.js
+++ b/src/selector-native.js
@@ -230,7 +230,7 @@ jQuery.extend( jQuery.find, {
 	attr: function( elem, name ) {
 		var fn = jQuery.expr.attrHandle[ name.toLowerCase() ],
 
-			// Don't get fooled by Object.prototype properties (jQuery #13807)
+			// Don't get fooled by Object.prototype properties (jQuery trac-13807)
 			value = fn && hasOwn.call( jQuery.expr.attrHandle, name.toLowerCase() ) ?
 				fn( elem, name, jQuery.isXMLDoc( elem ) ) :
 				undefined;

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -23,7 +23,7 @@
 		// (such as Node.js), expose a factory as module.exports.
 		// This accentuates the need for the creation of a real `window`.
 		// e.g. var jQuery = require("jquery")(window);
-		// See ticket #14549 for more info.
+		// See ticket trac-14549 for more info.
 		module.exports = global.document ?
 			factory( global, true ) :
 			function( w ) {

--- a/test/data/ajax/onunload.html
+++ b/test/data/ajax/onunload.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 	<meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
-	<title>onunload ajax requests (#14379)</title>
+	<title>onunload ajax requests (trac-14379)</title>
 	<script src="../../jquery.js"></script>
 	<script src="../iframeTest.js"></script>
 </head>

--- a/test/data/core/aliased.html
+++ b/test/data/core/aliased.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 	<meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
-	<title>alias-masked DOM properties (#14074)</title>
+	<title>alias-masked DOM properties (trac-14074)</title>
 	<script>
 		var errors = [];
 		window.onerror = function( errorMessage, filePath, lineNumber ) {

--- a/test/data/core/onready.html
+++ b/test/data/core/onready.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 	<meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
-	<title>alias-masked DOM properties (#14074)</title>
+	<title>alias-masked DOM properties (trac-14074)</title>
 	<script>
 		var error = false;
 		window.onready = function() { error = "Called window.onready"; };

--- a/test/data/data/dataAttrs.html
+++ b/test/data/data/dataAttrs.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-	<title>IE11 onpageshow strangeness (#14894)</title>
+	<title>IE11 onpageshow strangeness (trac-14894)</title>
 	<script src="../../jquery.js"></script>
 	<script src="../iframeTest.js"></script>
 	<script>
@@ -12,6 +12,6 @@
 	</script>
 </head>
 <body x-what="test" data-result="ok" onload="x=1" onpageshow="x=1">
-    Test for #14894
+    Test for trac-14894
 </body>
 </html>

--- a/test/data/event/focusElem.html
+++ b/test/data/event/focusElem.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 	<meta http-equiv="Content-type" content="text/html; charset=utf-8">
-	<title>.focus() (activeElement access #13393)</title>
+	<title>.focus() (activeElement access trac-13393)</title>
 
 	<script src="../../jquery.js"></script>
 	<script src="../iframeTest.js"></script>

--- a/test/data/event/focusinCrossFrame.html
+++ b/test/data/event/focusinCrossFrame.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 	<meta http-equiv="Content-type" content="text/html; charset=utf-8">
-	<title>focusin event cross-frame (#14180)</title>
+	<title>focusin event cross-frame (trac-14180)</title>
 
 	<script src="../../jquery.js"></script>
 	<script src="../iframeTest.js"></script>

--- a/test/data/event/promiseReady.html
+++ b/test/data/event/promiseReady.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=utf-8">
-<title>Test case for jQuery ticket #11470</title>
+<title>Test case for jQuery ticket trac-11470</title>
 <script src="../../jquery.js"></script>
 <script src="../iframeTest.js"></script>
 <script type="text/javascript">

--- a/test/data/event/syncReady.html
+++ b/test/data/event/syncReady.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=utf-8">
-<title>Test case for jQuery ticket #10067</title>
+<title>Test case for jQuery ticket trac-10067</title>
 <script src="../../jquery.js"></script>
 <script src="../iframeTest.js"></script>
 </head>

--- a/test/data/readywait.html
+++ b/test/data/readywait.html
@@ -45,9 +45,9 @@
 	<p>
 		This is a test page for jQuery.readyWait and jQuery.holdReady,
 		see
-		<a href="https://bugs.jquery.com/ticket/6781">#6781</a>
+		<a href="https://bugs.jquery.com/ticket/6781">trac-6781</a>
 		and
-		<a href="https://bugs.jquery.com/ticket/8803">#8803</a>.
+		<a href="https://bugs.jquery.com/ticket/8803">trac-8803</a>.
 	</p>
 	<p>
 	Test for jQuery.holdReady, which can be used

--- a/test/data/testsuite.css
+++ b/test/data/testsuite.css
@@ -112,16 +112,16 @@ div#fx-tests div.noback {
 #nothiddendivchild.em { font-size: 2em; }
 #nothiddendivchild.prct { font-size: 150%; }
 
-/* #9239 Attach a background to the body( avoid crashes in removing the test element in support ) */
+/* trac-9239 Attach a background to the body( avoid crashes in removing the test element in support ) */
 body, div { background: url(1x1.jpg) no-repeat -1000px 0; }
 
-/* #10501 */
+/* trac-10501 */
 section { background:#f0f; display:block; }
 
-/* #11971 */
+/* trac-11971 */
 #foo { background: url(1x1.jpg) right bottom no-repeat; }
 
-/* #14824 */
+/* trac-14824 */
 #span-14824 { display: block; }
 
 #display { display: list-item !important; }

--- a/test/networkerror.html
+++ b/test/networkerror.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <!--
-	Test for #8135
+	Test for trac-8135
 
 	Thanks John Firebaugh for this test page based on his gist
 	https://gist.github.com/807090
@@ -41,7 +41,7 @@
 	<div>
 		This is a test page for
 		<a href="https://bugs.jquery.com/ticket/8135">
-			#8135
+			trac-8135
 		</a>
 		which was reported in Firefox when accessing properties
 		of an XMLHttpRequest object after a network error occurred.

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -646,7 +646,7 @@ QUnit.module( "ajax", {
 		};
 	} );
 
-	ajaxTest( "#15118 - jQuery.ajax() - function without jQuery.event", 1, function( assert ) {
+	ajaxTest( "trac-15118 - jQuery.ajax() - function without jQuery.event", 1, function( assert ) {
 		var holder;
 		return {
 			url: url( "mock.php?action=json" ),
@@ -662,7 +662,7 @@ QUnit.module( "ajax", {
 		};
 	} );
 
-	ajaxTest( "#15160 - jQuery.ajax() - request manually aborted in ajaxSend", 3, function( assert ) {
+	ajaxTest( "trac-15160 - jQuery.ajax() - request manually aborted in ajaxSend", 3, function( assert ) {
 		return {
 			setup: function() {
 				jQuery( document ).on( "ajaxSend", function( e, jqXHR ) {
@@ -1818,7 +1818,7 @@ QUnit.module( "ajax", {
 		};
 	} );
 
-	ajaxTest( "#2688 - jQuery.ajax() - beforeSend, cancel request", 2, function( assert ) {
+	ajaxTest( "trac-2688 - jQuery.ajax() - beforeSend, cancel request", 2, function( assert ) {
 		return {
 			create: function() {
 				return jQuery.ajax( {
@@ -1844,7 +1844,7 @@ QUnit.module( "ajax", {
 		};
 	} );
 
-	ajaxTest( "#2806 - jQuery.ajax() - data option - evaluate function values", 1, function( assert ) {
+	ajaxTest( "trac-2806 - jQuery.ajax() - data option - evaluate function values", 1, function( assert ) {
 		return {
 			url: baseURL + "mock.php?action=echoQuery",
 			data: {
@@ -1858,7 +1858,7 @@ QUnit.module( "ajax", {
 		};
 	} );
 
-	QUnit.test( "#7531 - jQuery.ajax() - Location object as url", function( assert ) {
+	QUnit.test( "trac-7531 - jQuery.ajax() - Location object as url", function( assert ) {
 		assert.expect( 1 );
 
 		var xhr,
@@ -1876,7 +1876,7 @@ QUnit.module( "ajax", {
 	} );
 
 	jQuery.each( [ " - Same Domain", " - Cross Domain" ], function( crossDomain, label ) {
-		ajaxTest( "#7578 - jQuery.ajax() - JSONP - default for cache option" + label, 1, function( assert ) {
+		ajaxTest( "trac-7578 - jQuery.ajax() - JSONP - default for cache option" + label, 1, function( assert ) {
 			return {
 				url: baseURL + "mock.php?action=jsonp",
 				dataType: "jsonp",
@@ -1890,7 +1890,7 @@ QUnit.module( "ajax", {
 		} );
 	} );
 
-	ajaxTest( "#8107 - jQuery.ajax() - multiple method signatures introduced in 1.5", 4, function( assert ) {
+	ajaxTest( "trac-8107 - jQuery.ajax() - multiple method signatures introduced in 1.5", 4, function( assert ) {
 		return [
 			{
 				create: function() {
@@ -1929,7 +1929,7 @@ QUnit.module( "ajax", {
 	} );
 
 	jQuery.each( [ " - Same Domain", " - Cross Domain" ], function( crossDomain, label ) {
-		ajaxTest( "#8205 - jQuery.ajax() - JSONP - re-use callbacks name" + label, 4, function( assert ) {
+		ajaxTest( "trac-8205 - jQuery.ajax() - JSONP - re-use callbacks name" + label, 4, function( assert ) {
 			return {
 				url: baseURL + "mock.php?action=jsonp",
 				dataType: "jsonp",
@@ -1967,7 +1967,7 @@ QUnit.module( "ajax", {
 		} );
 	} );
 
-	QUnit.test( "#9887 - jQuery.ajax() - Context with circular references (#9887)", function( assert ) {
+	QUnit.test( "trac-9887 - jQuery.ajax() - Context with circular references (trac-9887)", function( assert ) {
 		assert.expect( 2 );
 
 		var success = false,
@@ -2001,7 +2001,7 @@ QUnit.module( "ajax", {
 			};
 		}
 
-		ajaxTest( "#10093 - jQuery.ajax() - falsy url " + title, 4, function( assert ) {
+		ajaxTest( "trac-10093 - jQuery.ajax() - falsy url " + title, 4, function( assert ) {
 			return [
 				request( assert, "", "empty string" ),
 				request( assert, false ),
@@ -2011,7 +2011,7 @@ QUnit.module( "ajax", {
 		} );
 	} );
 
-	ajaxTest( "#11151 - jQuery.ajax() - parse error body", 2, function( assert ) {
+	ajaxTest( "trac-11151 - jQuery.ajax() - parse error body", 2, function( assert ) {
 		return {
 			url: url( "mock.php?action=error&json=1" ),
 			dataFilter: function( string ) {
@@ -2025,7 +2025,7 @@ QUnit.module( "ajax", {
 		};
 	} );
 
-	ajaxTest( "#11426 - jQuery.ajax() - loading binary data shouldn't throw an exception in IE", 1, function( assert ) {
+	ajaxTest( "trac-11426 - jQuery.ajax() - loading binary data shouldn't throw an exception in IE", 1, function( assert ) {
 		return {
 			url: url( "1x1.jpg" ),
 			success: function( data ) {
@@ -2058,7 +2058,7 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 	} );
 }
 
-	QUnit.test( "#11743 - jQuery.ajax() - script, throws exception", function( assert ) {
+	QUnit.test( "trac-11743 - jQuery.ajax() - script, throws exception", function( assert ) {
 		assert.expect( 1 );
 		var done = assert.async();
 		var onerror = window.onerror;
@@ -2093,7 +2093,7 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 		}
 
 		ajaxTest(
-			"#12004 - jQuery.ajax() - method is an alias of type - " +
+			"trac-12004 - jQuery.ajax() - method is an alias of type - " +
 			globalOption + " set globally", 3,
 			function( assert ) {
 				return {
@@ -2112,7 +2112,7 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 		);
 	} );
 
-	ajaxTest( "#13276 - jQuery.ajax() - compatibility between XML documents from ajax requests and parsed string", 1, function( assert ) {
+	ajaxTest( "trac-13276 - jQuery.ajax() - compatibility between XML documents from ajax requests and parsed string", 1, function( assert ) {
 		return {
 			url: baseURL + "dashboard.xml",
 			dataType: "xml",
@@ -2130,7 +2130,7 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 		};
 	} );
 
-	ajaxTest( "#13292 - jQuery.ajax() - converter is bypassed for 204 requests", 3, function( assert ) {
+	ajaxTest( "trac-13292 - jQuery.ajax() - converter is bypassed for 204 requests", 3, function( assert ) {
 		return {
 			url: baseURL + "mock.php?action=status&code=204&text=No+Content",
 			dataType: "testing",
@@ -2152,7 +2152,7 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 		};
 	} );
 
-	ajaxTest( "#13388 - jQuery.ajax() - responseXML", 3, function( assert ) {
+	ajaxTest( "trac-13388 - jQuery.ajax() - responseXML", 3, function( assert ) {
 		return {
 			url: url( "with_fries.xml" ),
 			dataType: "xml",
@@ -2164,7 +2164,7 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 		};
 	} );
 
-	ajaxTest( "#13922 - jQuery.ajax() - converter is bypassed for HEAD requests", 3, function( assert ) {
+	ajaxTest( "trac-13922 - jQuery.ajax() - converter is bypassed for HEAD requests", 3, function( assert ) {
 		return {
 			url: baseURL + "mock.php?action=json",
 			method: "HEAD",
@@ -2197,7 +2197,7 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 	// to exclude Edge specifically here so that the test continues to run there.
 	if ( !/safari/i.test( navigator.userAgent ) || /edge\//i.test( navigator.userAgent ) ) {
 		testIframe(
-			"#14379 - jQuery.ajax() on unload",
+			"trac-14379 - jQuery.ajax() on unload",
 			"ajax/onunload.html",
 			function( assert, jQuery, window, document, status ) {
 				assert.expect( 1 );
@@ -2206,7 +2206,7 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 		);
 	}
 
-	ajaxTest( "#14683 - jQuery.ajax() - Exceptions thrown synchronously by xhr.send should be caught", 4, function( assert ) {
+	ajaxTest( "trac-14683 - jQuery.ajax() - Exceptions thrown synchronously by xhr.send should be caught", 4, function( assert ) {
 		return [ {
 			url: baseURL + "mock.php?action=echoData",
 			method: "POST",
@@ -2429,7 +2429,7 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 
 //----------- jQuery.domManip()
 
-	QUnit.test( "#11264 - jQuery.domManip() - no side effect because of ajaxSetup or global events", function( assert ) {
+	QUnit.test( "trac-11264 - jQuery.domManip() - no side effect because of ajaxSetup or global events", function( assert ) {
 		assert.expect( 1 );
 
 		jQuery.ajaxSetup( {
@@ -2446,7 +2446,7 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 	} );
 
 	QUnit.test(
-		"jQuery#load() - always use GET method even if it overrided through ajaxSetup (#11264)",
+		"jQuery#load() - always use GET method even if it overrided through ajaxSetup (trac-11264)",
 		function( assert ) {
 			assert.expect( 1 );
 			var done = assert.async();
@@ -2483,7 +2483,7 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 	);
 
 	QUnit.test(
-		"#11402 - jQuery.domManip() - script in comments are properly evaluated",
+		"trac-11402 - jQuery.domManip() - script in comments are properly evaluated",
 		function( assert ) {
 			assert.expect( 2 );
 			jQuery( "#qunit-fixture" ).load( baseURL + "cleanScript.html", assert.async() );
@@ -2506,7 +2506,7 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 		} );
 	} );
 
-	QUnit.test( "#8277 - jQuery.get( String, Function ) - data in ajaxSettings", function( assert ) {
+	QUnit.test( "trac-8277 - jQuery.get( String, Function ) - data in ajaxSettings", function( assert ) {
 		assert.expect( 1 );
 		var done = assert.async();
 		jQuery.ajaxSetup( {
@@ -2597,7 +2597,7 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 		jQuery.getScript( url( "mock.php?action=testbar" ) ).done( assert.async() );
 	} );
 
-	QUnit.test( "#8082 - jQuery.getScript( String, Function ) - source as responseText", function( assert ) {
+	QUnit.test( "trac-8082 - jQuery.getScript( String, Function ) - source as responseText", function( assert ) {
 		assert.expect( 2 );
 		var done = assert.async();
 
@@ -2684,7 +2684,7 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 		} );
 	} );
 
-	// Selector should be trimmed to avoid leading spaces (#14773)
+	// Selector should be trimmed to avoid leading spaces (trac-14773)
 	QUnit.test( "jQuery.fn.load( URL_SELECTOR with spaces )", function( assert ) {
 		assert.expect( 1 );
 		var done = assert.async();
@@ -2694,9 +2694,9 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 		} );
 	} );
 
-	// Selector should be trimmed to avoid leading spaces (#14773)
-	// Selector should include any valid non-HTML whitespace (#3003)
-	QUnit.test( "jQuery.fn.load( URL_SELECTOR with non-HTML whitespace(#3003) )", function( assert ) {
+	// Selector should be trimmed to avoid leading spaces (trac-14773)
+	// Selector should include any valid non-HTML whitespace (gh-3003)
+	QUnit.test( "jQuery.fn.load( URL_SELECTOR with non-HTML whitespace(gh-3003) )", function( assert ) {
 		assert.expect( 1 );
 		var done = assert.async();
 		jQuery( "#first" ).load( baseURL + "test3.html   #whitespace\\\\xA0 ", function() {
@@ -2827,7 +2827,7 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 		).always( done );
 	} );
 
-	QUnit.test( "#2046 - jQuery.fn.load( String, Function ) with ajaxSetup on dataType json", function( assert ) {
+	QUnit.test( "trac-2046 - jQuery.fn.load( String, Function ) with ajaxSetup on dataType json", function( assert ) {
 		assert.expect( 1 );
 		var done = assert.async();
 
@@ -2842,7 +2842,7 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 		jQuery( "#first" ).load( baseURL + "test3.html" );
 	} );
 
-	QUnit.test( "#10524 - jQuery.fn.load() - data specified in ajaxSettings is merged in", function( assert ) {
+	QUnit.test( "trac-10524 - jQuery.fn.load() - data specified in ajaxSettings is merged in", function( assert ) {
 		assert.expect( 1 );
 		var done = assert.async();
 

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -82,9 +82,9 @@ QUnit.test( "attr(String)", function( assert ) {
 	assert.equal( jQuery( "#form" ).attr( "action", "newformaction" ).attr( "action" ), "newformaction", "Check that action attribute was changed" );
 	assert.equal( jQuery( "#testForm" ).attr( "target" ), undefined, "Retrieving target does not equal the input with name=target" );
 	assert.equal( jQuery( "#testForm" ).attr( "target", "newTarget" ).attr( "target" ), "newTarget", "Set target successfully on a form" );
-	assert.equal( jQuery( "#testForm" ).removeAttr( "id" ).attr( "id" ), undefined, "Retrieving id does not equal the input with name=id after id is removed [#7472]" );
+	assert.equal( jQuery( "#testForm" ).removeAttr( "id" ).attr( "id" ), undefined, "Retrieving id does not equal the input with name=id after id is removed [trac-7472]" );
 
-	// Bug #3685 (form contains input with name="name")
+	// Bug trac-3685 (form contains input with name="name")
 	assert.equal( jQuery( "#testForm" ).attr( "name" ), undefined, "Retrieving name does not retrieve input with name=name" );
 	extras.remove();
 
@@ -142,13 +142,13 @@ QUnit.test( "attr(String)", function( assert ) {
 	assert.ok( !!~styleElem.attr( "style" ).indexOf( "UPPERlower.gif" ), "Check style attribute getter" );
 	assert.ok( !!~styleElem.attr( "style", "position:absolute;" ).attr( "style" ).indexOf( "absolute" ), "Check style setter" );
 
-	// Check value on button element (#1954)
+	// Check value on button element (trac-1954)
 	$button = jQuery( "<button>text</button>" ).insertAfter( "#button" );
 	assert.strictEqual( $button.attr( "value" ), undefined, "Absence of value attribute on a button" );
 	assert.equal( $button.attr( "value", "foobar" ).attr( "value" ), "foobar", "Value attribute on a button does not return innerHTML" );
 	assert.equal( $button.attr( "value", "baz" ).html(), "text", "Setting the value attribute does not change innerHTML" );
 
-	// Attributes with a colon on a table element (#1591)
+	// Attributes with a colon on a table element (trac-1591)
 	assert.equal( jQuery( "#table" ).attr( "test:attrib" ), undefined, "Retrieving a non-existent attribute on a table with a colon does not throw an error." );
 	assert.equal( jQuery( "#table" ).attr( "test:attrib", "foobar" ).attr( "test:attrib" ), "foobar", "Setting an attribute on a table with a colon does not throw an error." );
 
@@ -166,11 +166,11 @@ QUnit.test( "attr(String)", function( assert ) {
 	assert.strictEqual( jQuery( "<select><option value='property'></option></select>" ).attr( "value" ), undefined, "An unset value on a select returns undefined." );
 
 	$form = jQuery( "#form" ).attr( "enctype", "multipart/form-data" );
-	assert.equal( $form.prop( "enctype" ), "multipart/form-data", "Set the enctype of a form (encoding in IE6/7 #6743)" );
+	assert.equal( $form.prop( "enctype" ), "multipart/form-data", "Set the enctype of a form (encoding in IE6/7 trac-6743)" );
 
 } );
 
-QUnit.test( "attr(String) on cloned elements, #9646", function( assert ) {
+QUnit.test( "attr(String) on cloned elements, trac-9646", function( assert ) {
 	assert.expect( 4 );
 
 	var div,
@@ -295,7 +295,7 @@ QUnit.test( "attr(String, Object)", function( assert ) {
 	assert.equal( $input.attr( "name" ), "something", "Check element creation gets/sets the name attribute." );
 	assert.equal( $input.attr( "id" ), "specified", "Check element creation gets/sets the id attribute." );
 
-	// As of fixing #11115, we only guarantee boolean property update for checked and selected
+	// As of fixing trac-11115, we only guarantee boolean property update for checked and selected
 	$input = jQuery( "<input type='checkbox'/>" ).attr( "checked", true );
 	assert.equal( $input.prop( "checked" ), true, "Setting checked updates property (verified by .prop)" );
 	assert.equal( $input[ 0 ].checked, true, "Setting checked updates property (verified by native property)" );
@@ -377,13 +377,13 @@ QUnit.test( "attr(String, Object)", function( assert ) {
 	jQuery.each( [ commentNode, textNode, attributeNode ], function( i, elem ) {
 		var $elem = jQuery( elem );
 		$elem.attr( "nonexisting", "foo" );
-		assert.strictEqual( $elem.attr( "nonexisting" ), undefined, "attr(name, value) works correctly on comment and text nodes (bug #7500)." );
+		assert.strictEqual( $elem.attr( "nonexisting" ), undefined, "attr(name, value) works correctly on comment and text nodes (bug trac-7500)." );
 	} );
 
 	jQuery.each( [ window, document, obj, "#firstp" ], function( i, elem ) {
 		var oldVal = elem.nonexisting,
 			$elem = jQuery( elem );
-		assert.strictEqual( $elem.attr( "nonexisting" ), undefined, "attr works correctly for non existing attributes (bug #7500)." );
+		assert.strictEqual( $elem.attr( "nonexisting" ), undefined, "attr works correctly for non existing attributes (bug trac-7500)." );
 		assert.equal( $elem.attr( "nonexisting", "foo" ).attr( "nonexisting" ), "foo", "attr falls back to prop on unsupported arguments" );
 		elem.nonexisting = oldVal;
 	} );
@@ -402,7 +402,7 @@ QUnit.test( "attr(String, Object)", function( assert ) {
 
 	assert.equal( jQuery( "#area1" ).attr( "value" ), undefined, "Value attribute is distinct from value property." );
 
-	// for #1070
+	// for trac-1070
 	jQuery( "#name" ).attr( "someAttr", "0" );
 	assert.equal( jQuery( "#name" ).attr( "someAttr" ), "0", "Set attribute to a string of '0'" );
 	jQuery( "#name" ).attr( "someAttr", 0 );
@@ -462,7 +462,7 @@ QUnit.test( "attr(String, Object)", function( assert ) {
 	} ).appendTo( "#testForm" );
 	assert.equal( $radio.val(), "sup", "Value is not reset when type is set after value on a radio" );
 
-	// Setting attributes on svg elements (bug #3116)
+	// Setting attributes on svg elements (bug trac-3116)
 	$svg = jQuery(
 		"<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' version='1.1' baseProfile='full' width='200' height='200'>" +
 
@@ -474,9 +474,9 @@ QUnit.test( "attr(String, Object)", function( assert ) {
 
 	// undefined values are chainable
 	jQuery( "#name" ).attr( "maxlength", "5" ).removeAttr( "nonexisting" );
-	assert.equal( typeof jQuery( "#name" ).attr( "maxlength", undefined ), "object", ".attr('attribute', undefined) is chainable (#5571)" );
-	assert.equal( jQuery( "#name" ).attr( "maxlength", undefined ).attr( "maxlength" ), "5", ".attr('attribute', undefined) does not change value (#5571)" );
-	assert.equal( jQuery( "#name" ).attr( "nonexisting", undefined ).attr( "nonexisting" ), undefined, ".attr('attribute', undefined) does not create attribute (#5571)" );
+	assert.equal( typeof jQuery( "#name" ).attr( "maxlength", undefined ), "object", ".attr('attribute', undefined) is chainable (trac-5571)" );
+	assert.equal( jQuery( "#name" ).attr( "maxlength", undefined ).attr( "maxlength" ), "5", ".attr('attribute', undefined) does not change value (trac-5571)" );
+	assert.equal( jQuery( "#name" ).attr( "nonexisting", undefined ).attr( "nonexisting" ), undefined, ".attr('attribute', undefined) does not create attribute (trac-5571)" );
 } );
 
 QUnit.test( "attr(non-ASCII)", function( assert ) {
@@ -596,7 +596,7 @@ QUnit.test( "removeAttr(String)", function( assert ) {
 	assert.equal( jQuery( "#form" ).removeAttr( "id" ).attr( "id" ), undefined, "Remove id" );
 	assert.equal( jQuery( "#foo" ).attr( "style", "position:absolute;" ).removeAttr( "style" ).attr( "style" ), undefined, "Check removing style attribute" );
 	assert.equal( jQuery( "#form" ).attr( "style", "position:absolute;" ).removeAttr( "style" ).attr( "style" ), undefined, "Check removing style attribute on a form" );
-	assert.equal( jQuery( "<div style='position: absolute'></div>" ).appendTo( "#foo" ).removeAttr( "style" ).prop( "style" ).cssText, "", "Check removing style attribute (#9699 Webkit)" );
+	assert.equal( jQuery( "<div style='position: absolute'></div>" ).appendTo( "#foo" ).removeAttr( "style" ).prop( "style" ).cssText, "", "Check removing style attribute (trac-9699 Webkit)" );
 	assert.equal( jQuery( "#fx-test-group" ).attr( "height", "3px" ).removeAttr( "height" ).get( 0 ).style.height, "1px", "Removing height attribute has no effect on height set with style attribute" );
 
 	jQuery( "#check1" ).removeAttr( "checked" ).prop( "checked", true ).removeAttr( "checked" );
@@ -605,13 +605,13 @@ QUnit.test( "removeAttr(String)", function( assert ) {
 	assert.equal( document.getElementById( "text1" ).readOnly, false, "removeAttr sets boolean properties to false" );
 
 	jQuery( "#option2c" ).removeAttr( "selected" );
-	assert.equal( jQuery( "#option2d" ).attr( "selected" ), "selected", "Removing `selected` from an option that is not selected does not remove selected from the currently selected option (#10870)" );
+	assert.equal( jQuery( "#option2d" ).attr( "selected" ), "selected", "Removing `selected` from an option that is not selected does not remove selected from the currently selected option (trac-10870)" );
 
 	try {
 		$first = jQuery( "#first" ).attr( "contenteditable", "true" ).removeAttr( "contenteditable" );
 		assert.equal( $first.attr( "contenteditable" ), undefined, "Remove the contenteditable attribute" );
 	} catch ( e ) {
-		assert.ok( false, "Removing contenteditable threw an error (#10429)" );
+		assert.ok( false, "Removing contenteditable threw an error (trac-10429)" );
 	}
 
 	$first = jQuery( "<div Case='mixed'></div>" );
@@ -737,26 +737,26 @@ QUnit.test( "prop(String, Object) on null/undefined", function( assert ) {
 	select.appendChild( optgroup );
 
 	assert.equal( jQuery( option ).prop( "selected" ), true, "Make sure that a single option is selected, even when in an optgroup." );
-	assert.equal( jQuery( document ).prop( "nodeName" ), "#document", "prop works correctly on document nodes (bug #7451)." );
+	assert.equal( jQuery( document ).prop( "nodeName" ), "#document", "prop works correctly on document nodes (bug trac-7451)." );
 
 	attributeNode = document.createAttribute( "irrelevant" );
 	commentNode = document.createComment( "some comment" );
 	textNode = document.createTextNode( "some text" );
 	obj = {};
 	jQuery.each( [ document, attributeNode, commentNode, textNode, obj, "#firstp" ], function( i, ele ) {
-		assert.strictEqual( jQuery( ele ).prop( "nonexisting" ), undefined, "prop works correctly for non existing attributes (bug #7500)." );
+		assert.strictEqual( jQuery( ele ).prop( "nonexisting" ), undefined, "prop works correctly for non existing attributes (bug trac-7500)." );
 	} );
 
 	obj = {};
 	jQuery.each( [ document, obj ], function( i, ele ) {
 		var $ele = jQuery( ele );
 		$ele.prop( "nonexisting", "foo" );
-		assert.equal( $ele.prop( "nonexisting" ), "foo", "prop(name, value) works correctly for non existing attributes (bug #7500)." );
+		assert.equal( $ele.prop( "nonexisting" ), "foo", "prop(name, value) works correctly for non existing attributes (bug trac-7500)." );
 	} );
 	jQuery( document ).removeProp( "nonexisting" );
 
 	$form = jQuery( "#form" ).prop( "enctype", "multipart/form-data" );
-	assert.equal( $form.prop( "enctype" ), "multipart/form-data", "Set the enctype of a form (encoding in IE6/7 #6743)" );
+	assert.equal( $form.prop( "enctype" ), "multipart/form-data", "Set the enctype of a form (encoding in IE6/7 trac-6743)" );
 } );
 
 QUnit.test( "prop('tabindex')", function( assert ) {
@@ -879,12 +879,12 @@ QUnit.test( "removeProp(String)", function( assert ) {
 	jQuery.each( [ document, obj ], function( i, ele ) {
 		var $ele = jQuery( ele );
 		$ele.prop( "nonexisting", "foo" ).removeProp( "nonexisting" );
-		assert.strictEqual( ele[ "nonexisting" ], undefined, "removeProp works correctly on non DOM element nodes (bug #7500)." );
+		assert.strictEqual( ele[ "nonexisting" ], undefined, "removeProp works correctly on non DOM element nodes (bug trac-7500)." );
 	} );
 	jQuery.each( [ commentNode, textNode, attributeNode ], function( i, ele ) {
 		var $ele = jQuery( ele );
 		$ele.prop( "nonexisting", "foo" ).removeProp( "nonexisting" );
-		assert.strictEqual( ele[ "nonexisting" ], undefined, "removeProp works correctly on non DOM element nodes (bug #7500)." );
+		assert.strictEqual( ele[ "nonexisting" ], undefined, "removeProp works correctly on non DOM element nodes (bug trac-7500)." );
 	} );
 } );
 
@@ -903,7 +903,7 @@ QUnit.test( "val()", function( assert ) {
 	var checks, $button;
 	assert.equal( jQuery( "#text1" ).val(), "Test", "Check for value of input element" );
 
-	// ticket #1714 this caused a JS error in IE
+	// ticket trac-1714 this caused a JS error in IE
 	assert.equal( jQuery( "#first" ).val(), "", "Check a paragraph element to see if it has a value" );
 	assert.ok( jQuery( [] ).val() === undefined, "Check an empty jQuery object will return undefined from val" );
 
@@ -941,7 +941,7 @@ QUnit.test( "val()", function( assert ) {
 	assert.strictEqual(
 		jQuery( "<select name='select12584' id='select12584'><option value='1' disabled='disabled'>1</option></select>" ).val(),
 		null,
-		"Select-one with only option disabled (#12584)"
+		"Select-one with only option disabled (trac-12584)"
 	);
 
 	if ( jQuery.fn.serialize ) {
@@ -992,7 +992,7 @@ QUnit.test( "val() with non-matching values on dropdown list", function( assert 
 if ( "value" in document.createElement( "meter" ) &&
 			"value" in document.createElement( "progress" ) ) {
 
-	QUnit.test( "val() respects numbers without exception (Bug #9319)", function( assert ) {
+	QUnit.test( "val() respects numbers without exception (Bug trac-9319)", function( assert ) {
 
 		assert.expect( 4 );
 
@@ -1060,7 +1060,7 @@ QUnit.test( "val(Function)", function( assert ) {
 	testVal( functionReturningObj, assert );
 } );
 
-QUnit.test( "val(Array of Numbers) (Bug #7123)", function( assert ) {
+QUnit.test( "val(Array of Numbers) (Bug trac-7123)", function( assert ) {
 	assert.expect( 4 );
 	jQuery( "#form" ).append( "<input type='checkbox' name='arrayTest' value='1' /><input type='checkbox' name='arrayTest' value='2' /><input type='checkbox' name='arrayTest' value='3' checked='checked' /><input type='checkbox' name='arrayTest' value='4' />" );
 	var elements = jQuery( "#form input[name=arrayTest]" ).val( [ 1, 2 ] );
@@ -1124,7 +1124,7 @@ QUnit.test( "val(Function) with incoming value", function( assert ) {
 } );
 
 // testing if a form.reset() breaks a subsequent call to a select element's .val() (in IE only)
-QUnit.test( "val(select) after form.reset() (Bug #2551)", function( assert ) {
+QUnit.test( "val(select) after form.reset() (Bug trac-2551)", function( assert ) {
 	assert.expect( 3 );
 
 	jQuery( "<form id='kk' name='kk'><select id='kkk'><option value='cf'>cf</option><option value='gf'>gf</option></select></form>" ).appendTo( "#qunit-fixture" );
@@ -1641,7 +1641,7 @@ QUnit.test( "contents().hasClass() returns correct values", function( assert ) {
 	assert.ok( !$contents.hasClass( "undefined" ), "Did not find 'undefined' in $contents (correctly)" );
 } );
 
-QUnit.test( "hasClass correctly interprets non-space separators (#13835)", function( assert ) {
+QUnit.test( "hasClass correctly interprets non-space separators (trac-13835)", function( assert ) {
 	assert.expect( 4 );
 
 	var
@@ -1661,7 +1661,7 @@ QUnit.test( "hasClass correctly interprets non-space separators (#13835)", funct
 	} );
 } );
 
-QUnit.test( "coords returns correct values in IE6/IE7, see #10828", function( assert ) {
+QUnit.test( "coords returns correct values in IE6/IE7, see trac-10828", function( assert ) {
 	assert.expect( 1 );
 
 	var area,
@@ -1671,7 +1671,7 @@ QUnit.test( "coords returns correct values in IE6/IE7, see #10828", function( as
 	assert.equal( area.attr( "coords" ), "0,0,0,0", "did not retrieve coords correctly" );
 } );
 
-QUnit.test( "should not throw at $(option).val() (#14686)", function( assert ) {
+QUnit.test( "should not throw at $(option).val() (trac-14686)", function( assert ) {
 	assert.expect( 1 );
 
 	try {
@@ -1687,7 +1687,7 @@ QUnit.test( "option value not trimmed when setting via parent select", function(
 	assert.equal( jQuery( "<select><option> 2</option></select>" ).val( "2" ).val(), "2" );
 } );
 
-QUnit.test( "Insignificant white space returned for $(option).val() (#14858, gh-2978)", function( assert ) {
+QUnit.test( "Insignificant white space returned for $(option).val() (trac-14858, gh-2978)", function( assert ) {
 	assert.expect( 16 );
 
 	var val = jQuery( "<option></option>" ).val();

--- a/test/unit/callbacks.js
+++ b/test/unit/callbacks.js
@@ -100,7 +100,7 @@ jQuery.each( tests, function( strFlags, resultString ) {
 					assert.strictEqual( cblist.disabled(), true, ".disabled() becomes true" );
 					assert.strictEqual( cblist.locked(), true, "disabling locks" );
 
-					// Emptying while firing (#13517)
+					// Emptying while firing (trac-13517)
 					cblist = jQuery.Callbacks( flags );
 					cblist.add( cblist.empty );
 					cblist.add( function() {

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -92,7 +92,7 @@ QUnit.test( "jQuery()", function( assert ) {
 	} catch(e){
 		pass = false;
 	}
-	assert.ok( pass, "jQuery('&lt;tag&gt;') needs optional document parameter to ease cross-frame DOM wrangling, see #968" );*/
+	assert.ok( pass, "jQuery('&lt;tag&gt;') needs optional document parameter to ease cross-frame DOM wrangling, see trac-968" );*/
 
 	assert.equal( code.length, 1, "Correct number of elements generated for code" );
 	assert.equal( code.parent().length, 0, "Make sure that the generated HTML has no parent." );
@@ -146,7 +146,7 @@ QUnit.test( "jQuery()", function( assert ) {
 	for ( i = 0; i < 3; ++i ) {
 		elem = jQuery( "<input type='text' value='TEST' />" );
 	}
-	assert.equal( elem[ 0 ].defaultValue, "TEST", "Ensure cached nodes are cloned properly (Bug #6655)" );
+	assert.equal( elem[ 0 ].defaultValue, "TEST", "Ensure cached nodes are cloned properly (Bug trac-6655)" );
 
 	elem = jQuery( "<input type='hidden'>", {} );
 	assert.strictEqual( elem[ 0 ].ownerDocument, document,
@@ -182,7 +182,7 @@ QUnit.test( "globalEval with 'use strict'", function( assert ) {
 	assert.equal( window.strictEvalTest, 1, "Test variable declarations are global (strict mode)" );
 } );
 
-QUnit.test( "globalEval execution after script injection (#7862)", function( assert ) {
+QUnit.test( "globalEval execution after script injection (trac-7862)", function( assert ) {
 	assert.expect( 1 );
 
 	var now,
@@ -465,7 +465,7 @@ QUnit.test( "jQuery('html')", function( assert ) {
 	j = jQuery( "<span>hi</span> there <!-- mon ami -->" );
 	assert.ok( j.length >= 2, "Check node,textnode,comment creation (some browsers delete comments)" );
 
-	assert.ok( !jQuery( "<option>test</option>" )[ 0 ].selected, "Make sure that options are auto-selected #2050" );
+	assert.ok( !jQuery( "<option>test</option>" )[ 0 ].selected, "Make sure that options are auto-selected trac-2050" );
 
 	assert.ok( jQuery( "<div></div>" )[ 0 ], "Create a div with closing tag." );
 	assert.ok( jQuery( "<table></table>" )[ 0 ], "Create a table with closing tag." );
@@ -506,7 +506,7 @@ QUnit.test( "jQuery(element with non-alphanumeric name)", function( assert ) {
 	} );
 } );
 
-QUnit.test( "jQuery('massive html #7990')", function( assert ) {
+QUnit.test( "jQuery('massive html trac-7990')", function( assert ) {
 	assert.expect( 3 );
 
 	var i,
@@ -528,7 +528,7 @@ QUnit.test( "jQuery('html', context)", function( assert ) {
 
 	var $div = jQuery( "<div></div>" )[ 0 ],
 		$span = jQuery( "<span></span>", $div );
-	assert.equal( $span.length, 1, "verify a span created with a div context works, #1763" );
+	assert.equal( $span.length, 1, "verify a span created with a div context works, trac-1763" );
 } );
 
 QUnit.test( "jQuery(selector, xml).text(str) - loaded via xml document", function( assert ) {
@@ -536,7 +536,7 @@ QUnit.test( "jQuery(selector, xml).text(str) - loaded via xml document", functio
 
 	var xml = createDashboardXML(),
 
-	// tests for #1419 where ie was a problem
+	// tests for trac-1419 where ie was a problem
 		tab = jQuery( "tab", xml ).eq( 0 );
 	assert.equal( tab.text(), "blabla", "verify initial text correct" );
 	tab.text( "newtext" );
@@ -793,7 +793,7 @@ QUnit.test( "jQuery.map", function( assert ) {
 	result = jQuery.map( Array( 4 ), function( v, k ) {
 		return k % 2 ? k : [ k, k, k ];
 	} );
-	assert.equal( result.join( "" ), "00012223", "Array results flattened (#2616)" );
+	assert.equal( result.join( "" ), "00012223", "Array results flattened (trac-2616)" );
 
 	result = jQuery.map( [ [ [ 1, 2 ], 3 ], 4 ], function( v, k ) {
 		return v;
@@ -808,7 +808,7 @@ QUnit.test( "jQuery.map", function( assert ) {
 		result = jQuery.map( Array( 300000 ), function( v, k ) {
 			return k;
 		} );
-		assert.equal( result.length, 300000, "Able to map 300000 records without any problems (#4320)" );
+		assert.equal( result.length, 300000, "Able to map 300000 records without any problems (gh-4320)" );
 	} else {
 		assert.ok( "skip", "Array#flat doesn't supported on all browsers" );
 	}
@@ -845,14 +845,14 @@ QUnit.test( "jQuery.merge()", function( assert ) {
 		"First empty"
 	);
 
-	// Fixed at [5998], #3641
+	// Fixed at [5998], trac-3641
 	assert.deepEqual(
 		jQuery.merge( [ -2, -1 ], [ 0, 1, 2 ] ),
 		[ -2, -1, 0, 1, 2 ],
 		"Second array including a zero (falsy)"
 	);
 
-	// After fixing #5527
+	// After fixing trac-5527
 	assert.deepEqual(
 		jQuery.merge( [], [ null, undefined ] ),
 		[ null, undefined ],
@@ -996,7 +996,7 @@ QUnit.test( "jQuery.extend(Object, Object)", function( assert ) {
 
 	assert.ok( jQuery.extend( true, {}, nestedarray )[ "arr" ] !== arr, "Deep extend of object must clone child array" );
 
-	// #5991
+	// trac-5991
 	assert.ok( Array.isArray( jQuery.extend( true, { "arr": {} }, nestedarray )[ "arr" ] ), "Cloned array have to be an Array" );
 	assert.ok( jQuery.isPlainObject( jQuery.extend( true, { "arr": arr }, { "arr": {} } )[ "arr" ] ), "Cloned object have to be an plain object" );
 
@@ -1044,13 +1044,13 @@ QUnit.test( "jQuery.extend(Object, Object)", function( assert ) {
 	assert.deepEqual( target, { bar:5 }, "Check to make sure a recursive obj doesn't go never-ending loop by not copying it over" );
 
 	ret = jQuery.extend( true, { foo: [] }, { foo: [ 0 ] } ); // 1907
-	assert.equal( ret.foo.length, 1, "Check to make sure a value with coercion 'false' copies over when necessary to fix #1907" );
+	assert.equal( ret.foo.length, 1, "Check to make sure a value with coercion 'false' copies over when necessary to fix trac-1907" );
 
 	ret = jQuery.extend( true, { foo: "1,2,3" }, { foo: [ 1, 2, 3 ] } );
 	assert.ok( typeof ret.foo !== "string", "Check to make sure values equal with coercion (but not actually equal) overwrite correctly" );
 
 	ret = jQuery.extend( true, { foo:"bar" }, { foo:null } );
-	assert.ok( typeof ret.foo !== "undefined", "Make sure a null value doesn't crash with deep extend, for #1908" );
+	assert.ok( typeof ret.foo !== "undefined", "Make sure a null value doesn't crash with deep extend, for trac-1908" );
 
 	obj = { foo:null };
 	jQuery.extend( true, obj, { foo:"notnull" } );
@@ -1356,7 +1356,7 @@ QUnit.test( "jQuery.parseHTML", function( assert ) {
 	assert.equal( jQuery.parseHTML( "text" )[ 0 ].nodeType, 3, "Parsing text returns a text node" );
 	assert.equal( jQuery.parseHTML( "\t<div></div>" )[ 0 ].nodeValue, "\t", "Preserve leading whitespace" );
 
-	assert.equal( jQuery.parseHTML( " <div></div> " )[ 0 ].nodeType, 3, "Leading spaces are treated as text nodes (#11290)" );
+	assert.equal( jQuery.parseHTML( " <div></div> " )[ 0 ].nodeType, 3, "Leading spaces are treated as text nodes (trac-11290)" );
 
 	html = jQuery.parseHTML( "<div>test div</div>" );
 
@@ -1458,7 +1458,7 @@ QUnit[
 } );
 
 testIframe(
-	"Conditional compilation compatibility (#13274)",
+	"Conditional compilation compatibility (trac-13274)",
 	"core/cc_on.html",
 	function( assert, jQuery, window, document, cc_on, errors ) {
 		assert.expect( 3 );
@@ -1473,7 +1473,7 @@ testIframe(
 // this test there is preferred to complicating the hard-to-test core/ready code further.
 if ( !/iphone os 7_/i.test( navigator.userAgent ) ) {
 	testIframe(
-		"document ready when jQuery loaded asynchronously (#13655)",
+		"document ready when jQuery loaded asynchronously (trac-13655)",
 		"core/dynamic_ready.html",
 		function( assert, jQuery, window, document, ready ) {
 			assert.expect( 1 );
@@ -1483,7 +1483,7 @@ if ( !/iphone os 7_/i.test( navigator.userAgent ) ) {
 }
 
 testIframe(
-	"Tolerating alias-masked DOM properties (#14074)",
+	"Tolerating alias-masked DOM properties (trac-14074)",
 	"core/aliased.html",
 	function( assert, jQuery, window, document, errors ) {
 		assert.expect( 1 );
@@ -1492,7 +1492,7 @@ testIframe(
 );
 
 testIframe(
-	"Don't call window.onready (#14802)",
+	"Don't call window.onready (trac-14802)",
 	"core/onready.html",
 	function( assert, jQuery, window, document, error ) {
 		assert.expect( 1 );

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -33,7 +33,7 @@ QUnit.test( "css(String|Hash)", function( assert ) {
 
 	div2.remove();
 
-	// handle negative numbers by setting to zero #11604
+	// handle negative numbers by setting to zero trac-11604
 	jQuery( "#nothiddendiv" ).css( { "width": 1, "height": 1 } );
 
 	width = parseFloat( jQuery( "#nothiddendiv" ).css( "width" ) );
@@ -113,7 +113,7 @@ QUnit.test( "css(String|Hash)", function( assert ) {
 
 	div = jQuery( "<div></div>" ).css( { position: "absolute", "z-index": 1000 } ).appendTo( "#qunit-fixture" );
 	assert.strictEqual( div.css( "z-index" ), "1000",
-		"Make sure that a string z-index is returned from css('z-index') (#14432)." );
+		"Make sure that a string z-index is returned from css('z-index') (trac-14432)." );
 } );
 
 QUnit.test( "css() explicit and relative values", function( assert ) {
@@ -325,11 +325,11 @@ QUnit.test( "css(String, Object)", function( assert ) {
 	catch ( e ) {
 		success = false;
 	}
-	assert.ok( success, "Setting RGBA values does not throw Error (#5509)" );
+	assert.ok( success, "Setting RGBA values does not throw Error (trac-5509)" );
 
 	jQuery( "#foo" ).css( "font", "7px/21px sans-serif" );
 	assert.strictEqual( jQuery( "#foo" ).css( "line-height" ), "21px",
-		"Set font shorthand property (#14759)" );
+		"Set font shorthand property (trac-14759)" );
 } );
 
 QUnit.test( "css(String, Object) with negative values", function( assert ) {
@@ -702,7 +702,7 @@ QUnit[
 	} );
 } );
 
-QUnit.test( "hide hidden elements (bug #7141)", function( assert ) {
+QUnit.test( "hide hidden elements (bug trac-7141)", function( assert ) {
 	assert.expect( 3 );
 
 	var div = jQuery( "<div style='display:none'></div>" ).appendTo( "#qunit-fixture" );
@@ -715,7 +715,7 @@ QUnit.test( "hide hidden elements (bug #7141)", function( assert ) {
 	div.remove();
 } );
 
-QUnit.test( "show() after hide() should always set display to initial value (#14750)", function( assert ) {
+QUnit.test( "show() after hide() should always set display to initial value (trac-14750)", function( assert ) {
 	assert.expect( 1 );
 
 	var div = jQuery( "<div></div>" ),
@@ -993,7 +993,7 @@ QUnit[ jQuery.find.compile && jQuery.fn.toggle ? "test" : "skip" ]( "toggle()", 
 	assert.strictEqual( x.toggle().css( "display" ), "none", "is hidden" );
 	assert.strictEqual( x.toggle().css( "display" ), "block", "is visible" );
 
-	// Ensure hide() is called when toggled (#12148)
+	// Ensure hide() is called when toggled (trac-12148)
 	oldHide = jQuery.fn.hide;
 	jQuery.fn.hide = function() {
 		assert.ok( true, name + " method called on toggle" );
@@ -1054,7 +1054,7 @@ QUnit[ jQuery.find.compile && jQuery.fn.toggle &&
 	assert.strictEqual( $shadowChild.css( "display" ), "block", "is visible" );
 } );
 
-QUnit.test( "jQuery.css(elem, 'height') doesn't clear radio buttons (bug #1095)", function( assert ) {
+QUnit.test( "jQuery.css(elem, 'height') doesn't clear radio buttons (bug trac-1095)", function( assert ) {
 	assert.expect( 4 );
 
 	var $checkedtest = jQuery( "#checkedtest" );
@@ -1066,7 +1066,7 @@ QUnit.test( "jQuery.css(elem, 'height') doesn't clear radio buttons (bug #1095)"
 	assert.ok( !jQuery( "input[type='checkbox']", $checkedtest ).last().attr( "checked" ), "Check last checkbox still NOT checked." );
 } );
 
-QUnit.test( "internal ref to elem.runtimeStyle (bug #7608)", function( assert ) {
+QUnit.test( "internal ref to elem.runtimeStyle (bug trac-7608)", function( assert ) {
 	assert.expect( 1 );
 	var result = true;
 
@@ -1105,18 +1105,18 @@ QUnit.test( "computed margins (trac-3333; gh-2237)", function( assert ) {
 	assert.equal( $child.css( "marginLeft" ), "25px", "auto margins are computed to pixels" );
 } );
 
-QUnit.test( "box model properties incorrectly returning % instead of px, see #10639 and #12088", function( assert ) {
+QUnit.test( "box model properties incorrectly returning % instead of px, see trac-10639 and trac-12088", function( assert ) {
 	assert.expect( 2 );
 
 	var container = jQuery( "<div></div>" ).width( 400 ).appendTo( "#qunit-fixture" ),
 		el = jQuery( "<div></div>" ).css( { "width": "50%", "marginRight": "50%" } ).appendTo( container ),
 		el2 = jQuery( "<div></div>" ).css( { "width": "50%", "minWidth": "300px", "marginLeft": "25%" } ).appendTo( container );
 
-	assert.equal( el.css( "marginRight" ), "200px", "css('marginRight') returning % instead of px, see #10639" );
-	assert.equal( el2.css( "marginLeft" ), "100px", "css('marginLeft') returning incorrect pixel value, see #12088" );
+	assert.equal( el.css( "marginRight" ), "200px", "css('marginRight') returning % instead of px, see trac-10639" );
+	assert.equal( el2.css( "marginLeft" ), "100px", "css('marginLeft') returning incorrect pixel value, see trac-12088" );
 } );
 
-QUnit.test( "jQuery.cssProps behavior, (bug #8402)", function( assert ) {
+QUnit.test( "jQuery.cssProps behavior, (bug trac-8402)", function( assert ) {
 	assert.expect( 2 );
 
 	var div = jQuery( "<div>" ).appendTo( document.body ).css( {
@@ -1133,7 +1133,7 @@ QUnit.test( "jQuery.cssProps behavior, (bug #8402)", function( assert ) {
 	jQuery.cssProps.top = undefined;
 } );
 
-QUnit.test( "widows & orphans #8936", function( assert ) {
+QUnit.test( "widows & orphans trac-8936", function( assert ) {
 
 	var $p = jQuery( "<p>" ).appendTo( "#qunit-fixture" );
 
@@ -1150,15 +1150,15 @@ QUnit.test( "widows & orphans #8936", function( assert ) {
 	$p.remove();
 } );
 
-QUnit.test( "can't get css for disconnected in IE<9, see #10254 and #8388", function( assert ) {
+QUnit.test( "can't get css for disconnected in IE<9, see trac-10254 and trac-8388", function( assert ) {
 	assert.expect( 2 );
 	var span, div;
 
 	span = jQuery( "<span></span>" ).css( "background-image", "url(" + baseURL + "1x1.jpg)" );
-	assert.notEqual( span.css( "background-image" ), null, "can't get background-image in IE<9, see #10254" );
+	assert.notEqual( span.css( "background-image" ), null, "can't get background-image in IE<9, see trac-10254" );
 
 	div = jQuery( "<div></div>" ).css( "top", 10 );
-	assert.equal( div.css( "top" ), "10px", "can't get top in IE<9, see #8388" );
+	assert.equal( div.css( "top" ), "10px", "can't get top in IE<9, see trac-8388" );
 } );
 
 QUnit.test( "Ensure styles are retrieving from parsed html on document fragments", function( assert ) {
@@ -1171,7 +1171,7 @@ QUnit.test( "Ensure styles are retrieving from parsed html on document fragments
 	assert.equal( $span.css( "font-size" ), "14px", "Font-size retrievable on parsed HTML node" );
 } );
 
-QUnit.test( "can't get background-position in IE<9, see #10796", function( assert ) {
+QUnit.test( "can't get background-position in IE<9, see trac-10796", function( assert ) {
 	var div = jQuery( "<div></div>" ).appendTo( "#qunit-fixture" ),
 		units = [
 			"0 0",
@@ -1190,22 +1190,22 @@ QUnit.test( "can't get background-position in IE<9, see #10796", function( asser
 
 	for ( ; i < l; i++ ) {
 		div.css( "background-position", units [ i ] );
-		assert.ok( div.css( "background-position" ), "can't get background-position in IE<9, see #10796" );
+		assert.ok( div.css( "background-position" ), "can't get background-position in IE<9, see trac-10796" );
 	}
 } );
 
 if ( jQuery.fn.offset ) {
-	QUnit.test( "percentage properties for left and top should be transformed to pixels, see #9505", function( assert ) {
+	QUnit.test( "percentage properties for left and top should be transformed to pixels, see trac-9505", function( assert ) {
 		assert.expect( 2 );
 		var parent = jQuery( "<div style='position:relative;width:200px;height:200px;margin:0;padding:0;border-width:0'></div>" ).appendTo( "#qunit-fixture" ),
 			div = jQuery( "<div style='position: absolute; width: 20px; height: 20px; top:50%; left:50%'></div>" ).appendTo( parent );
 
-		assert.equal( div.css( "top" ), "100px", "position properties not transformed to pixels, see #9505" );
-		assert.equal( div.css( "left" ), "100px", "position properties not transformed to pixels, see #9505" );
+		assert.equal( div.css( "top" ), "100px", "position properties not transformed to pixels, see trac-9505" );
+		assert.equal( div.css( "left" ), "100px", "position properties not transformed to pixels, see trac-9505" );
 	} );
 }
 
-QUnit.test( "Do not append px (#9548, #12990, #2792)", function( assert ) {
+QUnit.test( "Do not append px (trac-9548, trac-12990, gh-2792)", function( assert ) {
 	assert.expect( 3 );
 
 	var $div = jQuery( "<div>" ).appendTo( "#qunit-fixture" );
@@ -1281,16 +1281,16 @@ QUnit[
 	}
 } );
 
-QUnit.test( "css('width') and css('height') should respect box-sizing, see #11004", function( assert ) {
+QUnit.test( "css('width') and css('height') should respect box-sizing, see trac-11004", function( assert ) {
 	assert.expect( 4 );
 
 	var el_dis = jQuery( "<div style='width:300px;height:300px;margin:2px;padding:2px;box-sizing:border-box;'>test</div>" ),
 		el = el_dis.clone().appendTo( "#qunit-fixture" );
 
-	assert.equal( el.css( "width" ), el.css( "width", el.css( "width" ) ).css( "width" ), "css('width') is not respecting box-sizing, see #11004" );
-	assert.equal( el_dis.css( "width" ), el_dis.css( "width", el_dis.css( "width" ) ).css( "width" ), "css('width') is not respecting box-sizing for disconnected element, see #11004" );
-	assert.equal( el.css( "height" ), el.css( "height", el.css( "height" ) ).css( "height" ), "css('height') is not respecting box-sizing, see #11004" );
-	assert.equal( el_dis.css( "height" ), el_dis.css( "height", el_dis.css( "height" ) ).css( "height" ), "css('height') is not respecting box-sizing for disconnected element, see #11004" );
+	assert.equal( el.css( "width" ), el.css( "width", el.css( "width" ) ).css( "width" ), "css('width') is not respecting box-sizing, see trac-11004" );
+	assert.equal( el_dis.css( "width" ), el_dis.css( "width", el_dis.css( "width" ) ).css( "width" ), "css('width') is not respecting box-sizing for disconnected element, see trac-11004" );
+	assert.equal( el.css( "height" ), el.css( "height", el.css( "height" ) ).css( "height" ), "css('height') is not respecting box-sizing, see trac-11004" );
+	assert.equal( el_dis.css( "height" ), el_dis.css( "height", el_dis.css( "height" ) ).css( "height" ), "css('height') is not respecting box-sizing for disconnected element, see trac-11004" );
 } );
 
 QUnit.test( "table rows width/height should be unaffected by inline styles", function( assert ) {
@@ -1314,7 +1314,7 @@ QUnit.test( "table rows width/height should be unaffected by inline styles", fun
 } );
 
 testIframe(
-	"css('width') should work correctly before document ready (#14084)",
+	"css('width') should work correctly before document ready (trac-14084)",
 	"css/cssWidthBeforeDocReady.html",
 	function( assert, jQuery, window, document, cssWidthBeforeDocReady ) {
 		assert.expect( 1 );
@@ -1377,20 +1377,20 @@ testIframe(
 	} );
 } )();
 
-QUnit.test( "certain css values of 'normal' should be convertable to a number, see #8627", function( assert ) {
+QUnit.test( "certain css values of 'normal' should be convertable to a number, see trac-8627", function( assert ) {
 	assert.expect( 3 );
 
 	var el = jQuery( "<div style='letter-spacing:normal;font-weight:normal;'>test</div>" ).appendTo( "#qunit-fixture" );
 
-	assert.ok( !isNaN( parseFloat( el.css( "letterSpacing" ) ) ), "css('letterSpacing') not convertable to number, see #8627" );
-	assert.ok( !isNaN( parseFloat( el.css( "fontWeight" ) ) ), "css('fontWeight') not convertable to number, see #8627" );
+	assert.ok( !isNaN( parseFloat( el.css( "letterSpacing" ) ) ), "css('letterSpacing') not convertable to number, see trac-8627" );
+	assert.ok( !isNaN( parseFloat( el.css( "fontWeight" ) ) ), "css('fontWeight') not convertable to number, see trac-8627" );
 	assert.equal( typeof el.css( "fontWeight" ), "string", ".css() returns a string" );
 } );
 
 // Support: IE 9 only
 // Only run this test in IE9
 if ( document.documentMode === 9 ) {
-	QUnit.test( ".css('filter') returns a string in IE9, see #12537", function( assert ) {
+	QUnit.test( ".css('filter') returns a string in IE9, see trac-12537", function( assert ) {
 		assert.expect( 1 );
 
 		assert.equal( jQuery( "<div style='-ms-filter:\"progid:DXImageTransform.Microsoft.gradient(startColorstr=#FFFFFF, endColorstr=#ECECEC)\";'></div>" ).css( "filter" ), "progid:DXImageTransform.Microsoft.gradient(startColorstr=#FFFFFF, endColorstr=#ECECEC)", "IE9 returns the correct value from css('filter')." );
@@ -1437,7 +1437,7 @@ QUnit.test( "cssHooks - expand", function( assert ) {
 
 } );
 
-QUnit.test( "css opacity consistency across browsers (#12685)", function( assert ) {
+QUnit.test( "css opacity consistency across browsers (trac-12685)", function( assert ) {
 	assert.expect( 3 );
 
 	var el,
@@ -1465,8 +1465,8 @@ QUnit[ jQuery.find.compile ? "test" : "skip" ]( ":visible/:hidden selectors", fu
 	assert.ok( !jQuery( "#nothiddendiv" ).is( ":visible" ), "Modified CSS display: Assert element is hidden" );
 	jQuery( "#nothiddendiv" ).css( { "display": "block" } );
 	assert.ok( jQuery( "#nothiddendiv" ).is( ":visible" ), "Modified CSS display: Assert element is visible" );
-	assert.ok( !jQuery( window ).is( ":visible" ), "Calling is(':visible') on window does not throw an exception (#10267)." );
-	assert.ok( !jQuery( document ).is( ":visible" ), "Calling is(':visible') on document does not throw an exception (#10267)." );
+	assert.ok( !jQuery( window ).is( ":visible" ), "Calling is(':visible') on window does not throw an exception (trac-10267)." );
+	assert.ok( !jQuery( document ).is( ":visible" ), "Calling is(':visible') on document does not throw an exception (trac-10267)." );
 
 	assert.ok( jQuery( "#nothiddendiv" ).is( ":visible" ), "Modifying CSS display: Assert element is visible" );
 	jQuery( "#nothiddendiv" ).css( "display", "none" );
@@ -1487,9 +1487,9 @@ QUnit[ jQuery.find.compile ? "test" : "skip" ]( ":visible/:hidden selectors", fu
 
 	$table = jQuery( "#table" );
 	$table.html( "<tr><td style='display:none'>cell</td><td>cell</td></tr>" );
-	assert.equal( jQuery( "#table td:visible" ).length, 1, "hidden cell is not perceived as visible (#4512). Works on table elements" );
+	assert.equal( jQuery( "#table td:visible" ).length, 1, "hidden cell is not perceived as visible (trac-4512). Works on table elements" );
 	$table.css( "display", "none" ).html( "<tr><td>cell</td><td>cell</td></tr>" );
-	assert.equal( jQuery( "#table td:visible" ).length, 0, "hidden cell children not perceived as visible (#4512)" );
+	assert.equal( jQuery( "#table td:visible" ).length, 0, "hidden cell children not perceived as visible (trac-4512)" );
 
 	assert.t( "Is Visible", "#qunit-fixture div:visible:lt(2)", [ "foo", "nothiddendiv" ] );
 	assert.t( "Is Not Hidden", "#qunit-fixture:hidden", [] );
@@ -1499,7 +1499,7 @@ QUnit[ jQuery.find.compile ? "test" : "skip" ]( ":visible/:hidden selectors", fu
 	assert.ok( $a.is( ":visible" ), "Anchor tag with flow content is visible (gh-2227)" );
 } );
 
-QUnit.test( "Keep the last style if the new one isn't recognized by the browser (#14836)", function( assert ) {
+QUnit.test( "Keep the last style if the new one isn't recognized by the browser (trac-14836)", function( assert ) {
 	assert.expect( 1 );
 
 	var el = jQuery( "<div></div>" ).css( "position", "absolute" ).css( "position", "fake value" );
@@ -1530,7 +1530,7 @@ QUnit.test( "Reset the style if set to an empty string", function( assert ) {
 } );
 
 QUnit.test(
-	"Clearing a Cloned Element's Style Shouldn't Clear the Original Element's Style (#8908)",
+	"Clearing a Cloned Element's Style Shouldn't Clear the Original Element's Style (trac-8908)",
 	function( assert ) {
 		assert.expect( 24 );
 		var done = assert.async();
@@ -1614,7 +1614,7 @@ QUnit.test(
 		exist = "order" in style || "WebkitOrder" in style;
 
 	if ( exist ) {
-		QUnit.test( "Don't append px to CSS \"order\" value (#14049)", function( assert ) {
+		QUnit.test( "Don't append px to CSS \"order\" value (trac-14049)", function( assert ) {
 			assert.expect( 1 );
 
 			var $elem = jQuery( "<div></div>" );
@@ -1625,7 +1625,7 @@ QUnit.test(
 	}
 } )();
 
-QUnit.test( "Do not throw on frame elements from css method (#15098)", function( assert ) {
+QUnit.test( "Do not throw on frame elements from css method (trac-15098)", function( assert ) {
 	assert.expect( 1 );
 
 	var frameWin, frameDoc,

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -143,7 +143,7 @@ QUnit.test( "jQuery.data({})", function( assert ) {
 QUnit.test( "jQuery.data(window)", function( assert ) {
 	assert.expect( 25 );
 
-	// remove bound handlers from window object to stop potential false positives caused by fix for #5280 in
+	// remove bound handlers from window object to stop potential false positives caused by fix for trac-5280 in
 	// transports/xhr.js
 	jQuery( window ).off( "unload" );
 
@@ -172,7 +172,7 @@ QUnit.test( "jQuery.data(object/flash)", function( assert ) {
 } );
 
 // attempting to access the data of an undefined jQuery element should be undefined
-QUnit.test( "jQuery().data() === undefined (#14101)", function( assert ) {
+QUnit.test( "jQuery().data() === undefined (trac-14101)", function( assert ) {
 	assert.expect( 2 );
 
 	assert.strictEqual( jQuery().data(), undefined );
@@ -201,7 +201,7 @@ QUnit.test( ".data()", function( assert ) {
 
 	dataObj = jQuery.extend( true, {}, jQuery( obj ).data() );
 
-	assert.deepEqual( dataObj, { "foo": "baz" }, "Retrieve data object from a wrapped JS object (#7524)" );
+	assert.deepEqual( dataObj, { "foo": "baz" }, "Retrieve data object from a wrapped JS object (trac-7524)" );
 } );
 
 function testDataTypes( $obj, assert ) {
@@ -232,7 +232,7 @@ QUnit.test( "jQuery(Element).data(String, Object).data(String)", function( asser
 	assert.strictEqual( div.data( "test" ), undefined, "No data exists initially" );
 	assert.strictEqual( div.data( "test", "success" ).data( "test" ), "success", "Data added" );
 	assert.strictEqual( div.data( "test", "overwritten" ).data( "test" ), "overwritten", "Data overwritten" );
-	assert.strictEqual( div.data( "test", undefined ).data( "test" ), "overwritten", ".data(key,undefined) does nothing but is chainable (#5571)" );
+	assert.strictEqual( div.data( "test", undefined ).data( "test" ), "overwritten", ".data(key,undefined) does nothing but is chainable (trac-5571)" );
 	assert.strictEqual( div.data( "notexist" ), undefined, "No data exists for unset key" );
 	testDataTypes( div, assert );
 
@@ -242,7 +242,7 @@ QUnit.test( "jQuery(Element).data(String, Object).data(String)", function( asser
 QUnit.test( "jQuery(plain Object).data(String, Object).data(String)", function( assert ) {
 	assert.expect( 16 );
 
-	// #3748
+	// trac-3748
 	var $obj = jQuery( { exists: true } );
 	assert.strictEqual( $obj.data( "nothing" ), undefined, "Non-existent data returns undefined" );
 	assert.strictEqual( $obj.data( "exists" ), undefined, "Object properties are not returned as data" );
@@ -253,7 +253,7 @@ QUnit.test( "jQuery(plain Object).data(String, Object).data(String)", function( 
 	assert.deepEqual( $obj[ 0 ], { exists: true }, "removeData does not clear the object" );
 } );
 
-QUnit.test( ".data(object) does not retain references. #13815", function( assert ) {
+QUnit.test( ".data(object) does not retain references. trac-13815", function( assert ) {
 	assert.expect( 2 );
 
 	var $divs = jQuery( "<div></div><div></div>" ).appendTo( "#qunit-fixture" );
@@ -290,7 +290,7 @@ QUnit.test( "data-* attributes", function( assert ) {
 
 	child.appendTo( "#qunit-fixture" );
 	assert.equal( child.data( "myobj" ), "old data", "Value accessed from data-* attribute" );
-	assert.equal( child.data( "foo-42" ), "boosh", "camelCasing does not affect numbers (#1751)" );
+	assert.equal( child.data( "foo-42" ), "boosh", "camelCasing does not affect numbers (gh-1751)" );
 
 	child.data( "myobj", "replaced" );
 	assert.equal( child.data( "myobj" ), "replaced", "Original data overwritten" );
@@ -507,7 +507,7 @@ QUnit.test( ".removeData()", function( assert ) {
 } );
 
 if ( window.JSON && window.JSON.stringify ) {
-	QUnit.test( "JSON serialization (#8108)", function( assert ) {
+	QUnit.test( "JSON serialization (trac-8108)", function( assert ) {
 		assert.expect( 1 );
 
 		var obj = { "foo": "bar" };
@@ -562,7 +562,7 @@ QUnit.test( ".data should not miss preset data-* w/ hyphenated property names", 
 	} );
 } );
 
-QUnit.test( "jQuery.data should not miss data-* w/ hyphenated property names #14047", function( assert ) {
+QUnit.test( "jQuery.data should not miss data-* w/ hyphenated property names trac-14047", function( assert ) {
 
 	assert.expect( 1 );
 
@@ -770,7 +770,7 @@ QUnit.test( ".data supports interoperable removal of hyphenated/camelCase proper
 	} );
 } );
 
-QUnit.test( ".data supports interoperable removal of properties SET TWICE #13850", function( assert ) {
+QUnit.test( ".data supports interoperable removal of properties SET TWICE trac-13850", function( assert ) {
 	var div = jQuery( "<div>" ).appendTo( "#qunit-fixture" ),
 		datas = {
 			"non-empty": "a string",
@@ -800,7 +800,7 @@ QUnit.test( ".data supports interoperable removal of properties SET TWICE #13850
 	} );
 } );
 
-QUnit.test( ".removeData supports removal of hyphenated properties via array (#12786, gh-2257)", function( assert ) {
+QUnit.test( ".removeData supports removal of hyphenated properties via array (trac-12786, gh-2257)", function( assert ) {
 	assert.expect( 4 );
 
 	var div, plain, compare;
@@ -833,7 +833,7 @@ QUnit.test( ".removeData supports removal of hyphenated properties via array (#1
 } );
 
 // Test originally by Moschel
-QUnit.test( ".removeData should not throw exceptions. (#10080)", function( assert ) {
+QUnit.test( ".removeData should not throw exceptions. (trac-10080)", function( assert ) {
 	var done = assert.async();
 	assert.expect( 1 );
 	var frame = jQuery( "#loadediframe" );
@@ -846,7 +846,7 @@ QUnit.test( ".removeData should not throw exceptions. (#10080)", function( asser
 	frame.attr( "src", baseURL + "iframe.html?param=true" );
 } );
 
-QUnit.test( ".data only checks element attributes once. #8909", function( assert ) {
+QUnit.test( ".data only checks element attributes once. trac-8909", function( assert ) {
 	assert.expect( 2 );
 	var testing = {
 			"test": "testing",
@@ -874,7 +874,7 @@ QUnit.test( "data-* with JSON value can have newlines", function( assert ) {
 	x.remove();
 } );
 
-QUnit.test( ".data doesn't throw when calling selection is empty. #13551", function( assert ) {
+QUnit.test( ".data doesn't throw when calling selection is empty. trac-13551", function( assert ) {
 	assert.expect( 1 );
 
 	try {
@@ -911,7 +911,7 @@ QUnit.test( "acceptData", function( assert ) {
 	assert.equal( jQuery( form ) .data( "test", 42 ).data( "test" ), 42, "form with aliased DOM properties" );
 } );
 
-QUnit.test( "Check proper data removal of non-element descendants nodes (#8335)", function( assert ) {
+QUnit.test( "Check proper data removal of non-element descendants nodes (trac-8335)", function( assert ) {
 	assert.expect( 1 );
 
 	var div = jQuery( "<div>text</div>" ),
@@ -924,7 +924,7 @@ QUnit.test( "Check proper data removal of non-element descendants nodes (#8335)"
 } );
 
 testIframe(
-	"enumerate data attrs on body (#14894)",
+	"enumerate data attrs on body (trac-14894)",
 	"data/dataAttrs.html",
 	function( assert, jQuery, window, document, result ) {
 		assert.expect( 1 );

--- a/test/unit/deprecated.js
+++ b/test/unit/deprecated.js
@@ -78,7 +78,7 @@ QUnit[ jQuery.fn.click ? "test" : "skip" ]( "trigger() shortcuts", function( ass
 	elem.remove();
 
 	jQuery( "#check1" ).click( function() {
-		assert.ok( true, "click event handler for checkbox gets fired twice, see #815" );
+		assert.ok( true, "click event handler for checkbox gets fired twice, see trac-815" );
 	} ).click();
 
 	counter = 0;
@@ -366,7 +366,7 @@ QUnit[ jQuery.isFunction ? "test" : "skip" ]( "isFunction", function( assert ) {
 	// Some versions of Firefox and Chrome say this is a function
 	assert.ok( !jQuery.isFunction( obj ), "Object Element" );
 
-	// Since 1.3, this isn't supported (#2968)
+	// Since 1.3, this isn't supported (trac-2968)
 	//assert.ok( jQuery.isFunction(obj.getAttribute), "getAttribute Function" );
 
 	nodes = document.body.childNodes;
@@ -383,7 +383,7 @@ QUnit[ jQuery.isFunction ? "test" : "skip" ]( "isFunction", function( assert ) {
 	input.type = "text";
 	document.body.appendChild( input );
 
-	// Since 1.3, this isn't supported (#2968)
+	// Since 1.3, this isn't supported (trac-2968)
 	//assert.ok( jQuery.isFunction(input.focus), "A default function property" );
 
 	document.body.removeChild( input );

--- a/test/unit/dimensions.js
+++ b/test/unit/dimensions.js
@@ -38,7 +38,7 @@ function testWidth( val, assert ) {
 	$div.css( "display", "none" );
 	assert.equal( $div.width(), 30, "Test hidden div" );
 	$div.css( "display", "" );
-	$div.width( val( -1 ) ); // handle negative numbers by setting to 0 #11604
+	$div.width( val( -1 ) ); // handle negative numbers by setting to 0 trac-11604
 	assert.equal( $div.width(), 0, "Test negative width normalized to 0" );
 	$div.css( "padding", "20px" );
 	assert.equal( $div.width(), 0, "Test padding specified with pixels" );
@@ -89,7 +89,7 @@ function testHeight( val, assert ) {
 	$div.css( "display", "none" );
 	assert.equal( $div.height(), 30, "Test hidden div" );
 	$div.css( "display", "" );
-	$div.height( val( -1 ) ); // handle negative numbers by setting to 0 #11604
+	$div.height( val( -1 ) ); // handle negative numbers by setting to 0 trac-11604
 	assert.equal( $div.height(), 0, "Test negative height normalized to 0" );
 	$div.css( "padding", "20px" );
 	assert.equal( $div.height(), 0, "Test padding specified with pixels" );
@@ -279,7 +279,7 @@ QUnit.test( "outerHeight()", function( assert ) {
 	div.remove();
 } );
 
-QUnit.test( "child of a hidden elem (or unconnected node) has accurate inner/outer/Width()/Height()  see #9441 #9300", function( assert ) {
+QUnit.test( "child of a hidden elem (or unconnected node) has accurate inner/outer/Width()/Height()  see trac-9441 trac-9300", function( assert ) {
 	assert.expect( 16 );
 
 	// setup html
@@ -290,33 +290,33 @@ QUnit.test( "child of a hidden elem (or unconnected node) has accurate inner/out
 	$divNormal.appendTo( "body" );
 
 	// tests that child div of a hidden div works the same as a normal div
-	assert.equal( $divChild.width(), $divNormal.width(), "child of a hidden element width() is wrong see #9441" );
-	assert.equal( $divChild.innerWidth(), $divNormal.innerWidth(), "child of a hidden element innerWidth() is wrong see #9441" );
-	assert.equal( $divChild.outerWidth(), $divNormal.outerWidth(), "child of a hidden element outerWidth() is wrong see #9441" );
-	assert.equal( $divChild.outerWidth( true ), $divNormal.outerWidth( true ), "child of a hidden element outerWidth( true ) is wrong see #9300" );
+	assert.equal( $divChild.width(), $divNormal.width(), "child of a hidden element width() is wrong see trac-9441" );
+	assert.equal( $divChild.innerWidth(), $divNormal.innerWidth(), "child of a hidden element innerWidth() is wrong see trac-9441" );
+	assert.equal( $divChild.outerWidth(), $divNormal.outerWidth(), "child of a hidden element outerWidth() is wrong see trac-9441" );
+	assert.equal( $divChild.outerWidth( true ), $divNormal.outerWidth( true ), "child of a hidden element outerWidth( true ) is wrong see trac-9300" );
 
-	assert.equal( $divChild.height(), $divNormal.height(), "child of a hidden element height() is wrong see #9441" );
-	assert.equal( $divChild.innerHeight(), $divNormal.innerHeight(), "child of a hidden element innerHeight() is wrong see #9441" );
-	assert.equal( $divChild.outerHeight(), $divNormal.outerHeight(), "child of a hidden element outerHeight() is wrong see #9441" );
-	assert.equal( $divChild.outerHeight( true ), $divNormal.outerHeight( true ), "child of a hidden element outerHeight( true ) is wrong see #9300" );
+	assert.equal( $divChild.height(), $divNormal.height(), "child of a hidden element height() is wrong see trac-9441" );
+	assert.equal( $divChild.innerHeight(), $divNormal.innerHeight(), "child of a hidden element innerHeight() is wrong see trac-9441" );
+	assert.equal( $divChild.outerHeight(), $divNormal.outerHeight(), "child of a hidden element outerHeight() is wrong see trac-9441" );
+	assert.equal( $divChild.outerHeight( true ), $divNormal.outerHeight( true ), "child of a hidden element outerHeight( true ) is wrong see trac-9300" );
 
 	// tests that child div of an unconnected div works the same as a normal div
-	assert.equal( $divUnconnected.width(), $divNormal.width(), "unconnected element width() is wrong see #9441" );
-	assert.equal( $divUnconnected.innerWidth(), $divNormal.innerWidth(), "unconnected element innerWidth() is wrong see #9441" );
-	assert.equal( $divUnconnected.outerWidth(), $divNormal.outerWidth(), "unconnected element outerWidth() is wrong see #9441" );
-	assert.equal( $divUnconnected.outerWidth( true ), $divNormal.outerWidth( true ), "unconnected element outerWidth( true ) is wrong see #9300" );
+	assert.equal( $divUnconnected.width(), $divNormal.width(), "unconnected element width() is wrong see trac-9441" );
+	assert.equal( $divUnconnected.innerWidth(), $divNormal.innerWidth(), "unconnected element innerWidth() is wrong see trac-9441" );
+	assert.equal( $divUnconnected.outerWidth(), $divNormal.outerWidth(), "unconnected element outerWidth() is wrong see trac-9441" );
+	assert.equal( $divUnconnected.outerWidth( true ), $divNormal.outerWidth( true ), "unconnected element outerWidth( true ) is wrong see trac-9300" );
 
-	assert.equal( $divUnconnected.height(), $divNormal.height(), "unconnected element height() is wrong see #9441" );
-	assert.equal( $divUnconnected.innerHeight(), $divNormal.innerHeight(), "unconnected element innerHeight() is wrong see #9441" );
-	assert.equal( $divUnconnected.outerHeight(), $divNormal.outerHeight(), "unconnected element outerHeight() is wrong see #9441" );
-	assert.equal( $divUnconnected.outerHeight( true ), $divNormal.outerHeight( true ), "unconnected element outerHeight( true ) is wrong see #9300" );
+	assert.equal( $divUnconnected.height(), $divNormal.height(), "unconnected element height() is wrong see trac-9441" );
+	assert.equal( $divUnconnected.innerHeight(), $divNormal.innerHeight(), "unconnected element innerHeight() is wrong see trac-9441" );
+	assert.equal( $divUnconnected.outerHeight(), $divNormal.outerHeight(), "unconnected element outerHeight() is wrong see trac-9441" );
+	assert.equal( $divUnconnected.outerHeight( true ), $divNormal.outerHeight( true ), "unconnected element outerHeight( true ) is wrong see trac-9300" );
 
 	// teardown html
 	$divHiddenParent.remove();
 	$divNormal.remove();
 } );
 
-QUnit.test( "getting dimensions shouldn't modify runtimeStyle see #9233", function( assert ) {
+QUnit.test( "getting dimensions shouldn't modify runtimeStyle see trac-9233", function( assert ) {
 	assert.expect( 1 );
 
 	var $div = jQuery( "<div>" ).appendTo( "#qunit-fixture" ),
@@ -331,9 +331,9 @@ QUnit.test( "getting dimensions shouldn't modify runtimeStyle see #9233", functi
 	$div.outerWidth( true );
 
 	if ( runtimeStyle ) {
-		assert.equal( div.runtimeStyle.left, "11em", "getting dimensions modifies runtimeStyle, see #9233" );
+		assert.equal( div.runtimeStyle.left, "11em", "getting dimensions modifies runtimeStyle, see trac-9233" );
 	} else {
-		assert.ok( true, "this browser doesn't support runtimeStyle, see #9233" );
+		assert.ok( true, "this browser doesn't support runtimeStyle, see trac-9233" );
 	}
 
 	$div.remove();
@@ -348,8 +348,8 @@ QUnit.test( "table dimensions", function( assert ) {
 
 	table.find( "td" ).css( { "margin": 0, "padding": 0 } );
 
-	assert.equal( tdElem.width(), tdElem.width(), "width() doesn't alter dimension values of empty cells, see #11293" );
-	assert.equal( colElem.width(), 300, "col elements have width(), see #12243" );
+	assert.equal( tdElem.width(), tdElem.width(), "width() doesn't alter dimension values of empty cells, see trac-11293" );
+	assert.equal( colElem.width(), 300, "col elements have width(), see trac-12243" );
 } );
 
 QUnit.test( "SVG dimensions (basic content-box)", function( assert ) {
@@ -412,7 +412,7 @@ QUnit.test( "SVG dimensions (border-box)", function( assert ) {
 	svg.remove();
 } );
 
-QUnit.test( "box-sizing:border-box child of a hidden elem (or unconnected node) has accurate inner/outer/Width()/Height()  see #10413", function( assert ) {
+QUnit.test( "box-sizing:border-box child of a hidden elem (or unconnected node) has accurate inner/outer/Width()/Height()  see trac-10413", function( assert ) {
 	assert.expect( 16 );
 
 	// setup html
@@ -423,38 +423,38 @@ QUnit.test( "box-sizing:border-box child of a hidden elem (or unconnected node) 
 	$divNormal.appendTo( "body" );
 
 	// tests that child div of a hidden div works the same as a normal div
-	assert.equal( $divChild.width(), $divNormal.width(), "child of a hidden element width() is wrong see #10413" );
-	assert.equal( $divChild.innerWidth(), $divNormal.innerWidth(), "child of a hidden element innerWidth() is wrong see #10413" );
-	assert.equal( $divChild.outerWidth(), $divNormal.outerWidth(), "child of a hidden element outerWidth() is wrong see #10413" );
-	assert.equal( $divChild.outerWidth( true ), $divNormal.outerWidth( true ), "child of a hidden element outerWidth( true ) is wrong see #10413" );
+	assert.equal( $divChild.width(), $divNormal.width(), "child of a hidden element width() is wrong see trac-10413" );
+	assert.equal( $divChild.innerWidth(), $divNormal.innerWidth(), "child of a hidden element innerWidth() is wrong see trac-10413" );
+	assert.equal( $divChild.outerWidth(), $divNormal.outerWidth(), "child of a hidden element outerWidth() is wrong see trac-10413" );
+	assert.equal( $divChild.outerWidth( true ), $divNormal.outerWidth( true ), "child of a hidden element outerWidth( true ) is wrong see trac-10413" );
 
-	assert.equal( $divChild.height(), $divNormal.height(), "child of a hidden element height() is wrong see #10413" );
-	assert.equal( $divChild.innerHeight(), $divNormal.innerHeight(), "child of a hidden element innerHeight() is wrong see #10413" );
-	assert.equal( $divChild.outerHeight(), $divNormal.outerHeight(), "child of a hidden element outerHeight() is wrong see #10413" );
-	assert.equal( $divChild.outerHeight( true ), $divNormal.outerHeight( true ), "child of a hidden element outerHeight( true ) is wrong see #10413" );
+	assert.equal( $divChild.height(), $divNormal.height(), "child of a hidden element height() is wrong see trac-10413" );
+	assert.equal( $divChild.innerHeight(), $divNormal.innerHeight(), "child of a hidden element innerHeight() is wrong see trac-10413" );
+	assert.equal( $divChild.outerHeight(), $divNormal.outerHeight(), "child of a hidden element outerHeight() is wrong see trac-10413" );
+	assert.equal( $divChild.outerHeight( true ), $divNormal.outerHeight( true ), "child of a hidden element outerHeight( true ) is wrong see trac-10413" );
 
 	// tests that child div of an unconnected div works the same as a normal div
-	assert.equal( $divUnconnected.width(), $divNormal.width(), "unconnected element width() is wrong see #10413" );
-	assert.equal( $divUnconnected.innerWidth(), $divNormal.innerWidth(), "unconnected element innerWidth() is wrong see #10413" );
-	assert.equal( $divUnconnected.outerWidth(), $divNormal.outerWidth(), "unconnected element outerWidth() is wrong see #10413" );
-	assert.equal( $divUnconnected.outerWidth( true ), $divNormal.outerWidth( true ), "unconnected element outerWidth( true ) is wrong see #10413" );
+	assert.equal( $divUnconnected.width(), $divNormal.width(), "unconnected element width() is wrong see trac-10413" );
+	assert.equal( $divUnconnected.innerWidth(), $divNormal.innerWidth(), "unconnected element innerWidth() is wrong see trac-10413" );
+	assert.equal( $divUnconnected.outerWidth(), $divNormal.outerWidth(), "unconnected element outerWidth() is wrong see trac-10413" );
+	assert.equal( $divUnconnected.outerWidth( true ), $divNormal.outerWidth( true ), "unconnected element outerWidth( true ) is wrong see trac-10413" );
 
-	assert.equal( $divUnconnected.height(), $divNormal.height(), "unconnected element height() is wrong see #10413" );
-	assert.equal( $divUnconnected.innerHeight(), $divNormal.innerHeight(), "unconnected element innerHeight() is wrong see #10413" );
-	assert.equal( $divUnconnected.outerHeight(), $divNormal.outerHeight(), "unconnected element outerHeight() is wrong see #10413" );
-	assert.equal( $divUnconnected.outerHeight( true ), $divNormal.outerHeight( true ), "unconnected element outerHeight( true ) is wrong see #10413" );
+	assert.equal( $divUnconnected.height(), $divNormal.height(), "unconnected element height() is wrong see trac-10413" );
+	assert.equal( $divUnconnected.innerHeight(), $divNormal.innerHeight(), "unconnected element innerHeight() is wrong see trac-10413" );
+	assert.equal( $divUnconnected.outerHeight(), $divNormal.outerHeight(), "unconnected element outerHeight() is wrong see trac-10413" );
+	assert.equal( $divUnconnected.outerHeight( true ), $divNormal.outerHeight( true ), "unconnected element outerHeight( true ) is wrong see trac-10413" );
 
 	// teardown html
 	$divHiddenParent.remove();
 	$divNormal.remove();
 } );
 
-QUnit.test( "passing undefined is a setter #5571", function( assert ) {
+QUnit.test( "passing undefined is a setter trac-5571", function( assert ) {
 	assert.expect( 4 );
-	assert.equal( jQuery( "#nothiddendiv" ).height( 30 ).height( undefined ).height(), 30, ".height(undefined) is chainable (#5571)" );
-	assert.equal( jQuery( "#nothiddendiv" ).height( 30 ).innerHeight( undefined ).height(), 30, ".innerHeight(undefined) is chainable (#5571)" );
-	assert.equal( jQuery( "#nothiddendiv" ).height( 30 ).outerHeight( undefined ).height(), 30, ".outerHeight(undefined) is chainable (#5571)" );
-	assert.equal( jQuery( "#nothiddendiv" ).width( 30 ).width( undefined ).width(), 30, ".width(undefined) is chainable (#5571)" );
+	assert.equal( jQuery( "#nothiddendiv" ).height( 30 ).height( undefined ).height(), 30, ".height(undefined) is chainable (trac-5571)" );
+	assert.equal( jQuery( "#nothiddendiv" ).height( 30 ).innerHeight( undefined ).height(), 30, ".innerHeight(undefined) is chainable (trac-5571)" );
+	assert.equal( jQuery( "#nothiddendiv" ).height( 30 ).outerHeight( undefined ).height(), 30, ".outerHeight(undefined) is chainable (trac-5571)" );
+	assert.equal( jQuery( "#nothiddendiv" ).width( 30 ).width( undefined ).width(), 30, ".width(undefined) is chainable (trac-5571)" );
 } );
 
 QUnit.test( "setters with and without box-sizing:border-box", function( assert ) {

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -141,7 +141,7 @@ supportjQuery.each( hideOptions, function( type, setup ) {
 		// Note: inline elements are expected to be inline-block
 		// because we're showing width/height
 		// Can't animate width/height inline
-		// See #14344
+		// See trac-14344
 		var test = {
 			"div": "block",
 			"p": "block",
@@ -184,7 +184,7 @@ supportjQuery.each( hideOptions, function( type, setup ) {
 	} );
 } );
 
-// Supports #7397
+// Supports trac-7397
 supportjQuery.each( hideOptions, function( type, setup ) {
 	QUnit.test( "Persist correct display value - " + type + " hidden", function( assert ) {
 		assert.expect( 3 );
@@ -678,7 +678,7 @@ QUnit.test( "stop()", function( assert ) {
 	} );
 	this.clock.tick( 100 );
 	$two.fadeTo( 100, 0, function() {
-		assert.equal( $two.css( "opacity" ), "0", "Stop does not interfere with animations on other elements (#6641)" );
+		assert.equal( $two.css( "opacity" ), "0", "Stop does not interfere with animations on other elements (trac-6641)" );
 
 		// Reset styles
 		$one.add( $two ).css( "opacity", "" );
@@ -842,7 +842,7 @@ QUnit.test( "jQuery.fx.prototype.cur() - <1.8 Back Compat", function( assert ) {
 	assert.equal(
 		( new jQuery.fx( div, {}, "color" ) ).cur(),
 		jQuery.css( div, "color" ),
-		"Return the same value as jQuery.css for complex properties (bug #7912)"
+		"Return the same value as jQuery.css for complex properties (bug trac-7912)"
 	);
 
 	assert.strictEqual(
@@ -879,7 +879,7 @@ QUnit.test( "jQuery.fx.prototype.cur() - <1.8 Back Compat", function( assert ) {
 	assert.equal(
 		( new jQuery.fx( div, {}, "marginBottom" ) ).cur(),
 		-11000,
-		"support negative values < -10000 (bug #7193)"
+		"support negative values < -10000 (bug trac-7193)"
 	);
 
 	jQuery( div ).remove();
@@ -1131,7 +1131,7 @@ jQuery.makeTest = function( text ) {
 
 jQuery.makeTest.id = 1;
 
-QUnit.test( "jQuery.show('fast') doesn't clear radio buttons (bug #1095)", function( assert ) {
+QUnit.test( "jQuery.show('fast') doesn't clear radio buttons (bug trac-1095)", function( assert ) {
 	assert.expect( 4 );
 
 	var $checkedtest = jQuery( "#checkedtest" );
@@ -1289,7 +1289,7 @@ QUnit.test( "animate with CSS shorthand properties", function( assert ) {
 		this.clock.tick( 400 );
 } );
 
-QUnit.test( "hide hidden elements, with animation (bug #7141)", function( assert ) {
+QUnit.test( "hide hidden elements, with animation (bug trac-7141)", function( assert ) {
 	assert.expect( 4 );
 
 	var div = jQuery( "<div id='bug7141' style='display:none'></div>" ).appendTo( "#qunit-fixture" );
@@ -1304,7 +1304,7 @@ QUnit.test( "hide hidden elements, with animation (bug #7141)", function( assert
 	assert.equal( div.css( "display" ), "block", "Element is visible after animations" );
 } );
 
-QUnit.test( "animate unit-less properties (#4966)", function( assert ) {
+QUnit.test( "animate unit-less properties (trac-4966)", function( assert ) {
 	assert.expect( 2 );
 
 	var div = jQuery( "<div style='z-index: 0; position: absolute;'></div>" ).appendTo( "#qunit-fixture" );
@@ -1315,7 +1315,7 @@ QUnit.test( "animate unit-less properties (#4966)", function( assert ) {
 	this.clock.tick( 400 );
 } );
 
-QUnit.test( "animate properties missing px w/ opacity as last (#9074)", function( assert ) {
+QUnit.test( "animate properties missing px w/ opacity as last (trac-9074)", function( assert ) {
 	assert.expect( 6 );
 
 	var ml, l,
@@ -1343,7 +1343,7 @@ QUnit.test( "animate properties missing px w/ opacity as last (#9074)", function
 	div.stop().remove();
 } );
 
-QUnit.test( "callbacks should fire in correct order (#9100)", function( assert ) {
+QUnit.test( "callbacks should fire in correct order (trac-9100)", function( assert ) {
 	assert.expect( 1 );
 
 	var a = 1,
@@ -1362,7 +1362,7 @@ QUnit.test( "callbacks should fire in correct order (#9100)", function( assert )
 	this.clock.tick( 20 );
 } );
 
-QUnit.test( "callbacks that throw exceptions will be removed (#5684)", function( assert ) {
+QUnit.test( "callbacks that throw exceptions will be removed (trac-5684)", function( assert ) {
 	assert.expect( 2 );
 
 	var foo = jQuery( "#foo" );
@@ -1415,7 +1415,7 @@ QUnit.test( "animate will scale margin properties individually", function( asser
 	} );
 } );
 
-QUnit.test( "Do not append px to 'fill-opacity' #9548", function( assert ) {
+QUnit.test( "Do not append px to 'fill-opacity' trac-9548", function( assert ) {
 	assert.expect( 1 );
 
 	var $div = jQuery( "<div>" ).appendTo( "#qunit-fixture" );
@@ -1426,7 +1426,7 @@ QUnit.test( "Do not append px to 'fill-opacity' #9548", function( assert ) {
 	} );
 } );
 
-QUnit.test( "line-height animates correctly (#13855)", function( assert ) {
+QUnit.test( "line-height animates correctly (trac-13855)", function( assert ) {
 	assert.expect( 12 );
 
 	var t0,
@@ -1562,7 +1562,7 @@ QUnit.test( "Animate callbacks have correct context", function( assert ) {
 	this.clock.tick( 10 );
 } );
 
-QUnit.test( "User supplied callback called after show when fx off (#8892)", function( assert ) {
+QUnit.test( "User supplied callback called after show when fx off (trac-8892)", function( assert ) {
 	assert.expect( 2 );
 
 	var foo = jQuery( "#foo" );
@@ -1638,7 +1638,7 @@ QUnit.test( "animate should set display for disconnected nodes", function( asser
 	clock.tick( 400 );
 } );
 
-QUnit[ jQuery.find.compile ? "test" : "skip" ]( "Animation callback should not show animated element as :animated (#7157)", function( assert ) {
+QUnit[ jQuery.find.compile ? "test" : "skip" ]( "Animation callback should not show animated element as :animated (trac-7157)", function( assert ) {
 	assert.expect( 1 );
 
 	var foo = jQuery( "#foo" );
@@ -1651,7 +1651,7 @@ QUnit[ jQuery.find.compile ? "test" : "skip" ]( "Animation callback should not s
 	this.clock.tick( 100 );
 } );
 
-QUnit[ jQuery.find.compile ? "test" : "skip" ]( "Initial step callback should show element as :animated (#14623)", function( assert ) {
+QUnit[ jQuery.find.compile ? "test" : "skip" ]( "Initial step callback should show element as :animated (trac-14623)", function( assert ) {
 	assert.expect( 1 );
 
 	var foo = jQuery( "#foo" );
@@ -1668,7 +1668,7 @@ QUnit[ jQuery.find.compile ? "test" : "skip" ]( "Initial step callback should sh
 	foo.stop();
 } );
 
-QUnit.test( "hide called on element within hidden parent should set display to none (#10045)", function( assert ) {
+QUnit.test( "hide called on element within hidden parent should set display to none (trac-10045)", function( assert ) {
 	assert.expect( 3 );
 
 	var hidden = jQuery( ".hidden" ),
@@ -1721,7 +1721,7 @@ QUnit.test( "hide, fadeOut and slideUp called on element width height and width 
 	this.clock.tick( 400 );
 } );
 
-QUnit.test( "hide should not leave hidden inline elements visible (#14848)", function( assert ) {
+QUnit.test( "hide should not leave hidden inline elements visible (trac-14848)", function( assert ) {
 	assert.expect( 2 );
 
 	var el = jQuery( "#simon1" );
@@ -1824,7 +1824,7 @@ QUnit.test( "multiple unqueued and promise", function( assert ) {
 	this.clock.tick( 1000 );
 } );
 
-QUnit.test( "animate does not change start value for non-px animation (#7109)", function( assert ) {
+QUnit.test( "animate does not change start value for non-px animation (trac-7109)", function( assert ) {
 	assert.expect( 1 );
 
 	var parent = jQuery( "<div><div></div></div>" ).css( { width: 284, height: 1 } ).appendTo( "#qunit-fixture" ),
@@ -1847,7 +1847,7 @@ QUnit.test( "animate does not change start value for non-px animation (#7109)", 
 	this.clock.tick( 10 );
 } );
 
-QUnit.test( "non-px animation handles non-numeric start (#11971)", function( assert ) {
+QUnit.test( "non-px animation handles non-numeric start (trac-11971)", function( assert ) {
 	assert.expect( 2 );
 
 	var foo = jQuery( "#foo" ),
@@ -1879,7 +1879,7 @@ QUnit.test( "non-px animation handles non-numeric start (#11971)", function( ass
 	this.clock.tick( 10 );
 } );
 
-QUnit.test( "Animation callbacks (#11797)", function( assert ) {
+QUnit.test( "Animation callbacks (trac-11797)", function( assert ) {
 	assert.expect( 15 );
 
 	var prog = 0,
@@ -1959,7 +1959,7 @@ QUnit.test( "Animation callbacks (#11797)", function( assert ) {
 	this.clock.tick( 10 );
 } );
 
-QUnit.test( "Animation callbacks in order (#2292)", function( assert ) {
+QUnit.test( "Animation callbacks in order (gh-2283)", function( assert ) {
 	assert.expect( 9 );
 
 	var done = assert.async(),
@@ -1999,7 +1999,7 @@ QUnit.test( "Animation callbacks in order (#2292)", function( assert ) {
 	this.clock.tick( dur + 10 );
 } );
 
-QUnit.test( "Animate properly sets overflow hidden when animating width/height (#12117)", function( assert ) {
+QUnit.test( "Animate properly sets overflow hidden when animating width/height (trac-12117)", function( assert ) {
 	assert.expect( 8 );
 
 	jQuery.each( [ "height", "width" ], function( _, prop ) {
@@ -2017,7 +2017,7 @@ QUnit.test( "Animate properly sets overflow hidden when animating width/height (
 	} );
 } );
 
-QUnit.test( "Each tick of the timer loop uses a fresh time (#12837)", function( assert ) {
+QUnit.test( "Each tick of the timer loop uses a fresh time (trac-12837)", function( assert ) {
 	var lastVal,
 		tmp = jQuery( {
 			test: 0
@@ -2042,7 +2042,7 @@ QUnit.test( "Each tick of the timer loop uses a fresh time (#12837)", function( 
 	tmp.stop();
 } );
 
-QUnit.test( "Animations with 0 duration don't ease (#12273)", function( assert ) {
+QUnit.test( "Animations with 0 duration don't ease (trac-12273)", function( assert ) {
 	assert.expect( 1 );
 
 	jQuery.easing.test = function() {
@@ -2067,7 +2067,7 @@ jQuery.map( [ "toggle", "slideToggle", "fadeToggle" ], function( method ) {
 	// this test would look a lot better if we were using something to override
 	// the default timers
 	var duration = 1500;
-	QUnit.test( "toggle state tests: " + method + " (#8685)", function( assert ) {
+	QUnit.test( "toggle state tests: " + method + " (trac-8685)", function( assert ) {
 		function secondToggle() {
 			var stopped = parseFloat( element.css( check ) );
 			tested = false;
@@ -2296,7 +2296,7 @@ QUnit.test( ".finish() calls finish of custom queue functions", function( assert
 	div.remove();
 } );
 
-QUnit.test( ".finish() is applied correctly when multiple elements were animated (#13937)", function( assert ) {
+QUnit.test( ".finish() is applied correctly when multiple elements were animated (trac-13937)", function( assert ) {
 	assert.expect( 3 );
 
 	var elems = jQuery( "<a>0</a><a>1</a><a>2</a>" );
@@ -2313,7 +2313,7 @@ QUnit.test( ".finish() is applied correctly when multiple elements were animated
 	this.clock.tick( 1500 );
 } );
 
-QUnit.test( "slideDown() after stop() (#13483)", function( assert ) {
+QUnit.test( "slideDown() after stop() (trac-13483)", function( assert ) {
 		assert.expect( 2 );
 
 		var ul = jQuery( "<ul style='height: 100px; display: block;'></ul>" )
@@ -2346,7 +2346,7 @@ QUnit.test( "slideDown() after stop() (#13483)", function( assert ) {
 		clock.tick( 10 );
 } );
 
-QUnit.test( "Respect display value on inline elements (#14824)", function( assert ) {
+QUnit.test( "Respect display value on inline elements (trac-14824)", function( assert ) {
 	assert.expect( 2 );
 
 	var clock = this.clock,

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -8,7 +8,7 @@ QUnit.module( "event", {
 QUnit.test( "null or undefined handler", function( assert ) {
 	assert.expect( 4 );
 
-	// Supports Fixes bug #7229
+	// Supports Fixes bug trac-7229
 	try {
 		jQuery( "#firstp" ).on( "click", null );
 		assert.ok( true, "Passing a null handler will not throw an exception" );
@@ -484,7 +484,7 @@ QUnit.test( "trigger() works with events that were previously stopped", function
 QUnit.test( "on(), iframes", function( assert ) {
 	assert.expect( 1 );
 
-	// events don't work with iframes, see #939 - this test fails in IE because of contentDocument
+	// events don't work with iframes, see trac-939 - this test fails in IE because of contentDocument
 	var doc = jQuery( "#loadediframe" ).contents();
 
 	jQuery( "div", doc ).on( "click", function() {
@@ -552,7 +552,7 @@ QUnit.test( "on(), namespaced events, cloned events", function( assert ) {
 		assert.equal( this.nodeType, 1, "Check node,textnode,comment on just does real nodes" );
 	} ).trigger( "tester" );
 
-	// Make sure events stick with appendTo'd elements (which are cloned) #2027
+	// Make sure events stick with appendTo'd elements (which are cloned) trac-2027
 	jQuery( "<a href='#fail' class='test'>test</a>" ).on( "click", function() { return false; } ).appendTo( "#qunit-fixture" );
 	assert.ok( jQuery( "a.test" ).eq( 0 ).triggerHandler( "click" ) === false, "Handler is bound to appendTo'd elements" );
 } );
@@ -589,7 +589,7 @@ QUnit.test( "on(), multi-namespaced events", function( assert ) {
 		check( "click.test.abc", "Namespaced click triggered" );
 	} );
 
-	// Those would not trigger/off (#5303)
+	// Those would not trigger/off (trac-5303)
 	jQuery( "#firstp" ).trigger( "click.a.test" );
 	jQuery( "#firstp" ).off( "click.a.test" );
 
@@ -812,7 +812,7 @@ QUnit.test( "off(type)", function( assert ) {
 		.off( "error1 error2", error )
 		.trigger( "error1" ).triggerHandler( "error2" );
 
-	message = "unbind many"; // #3538
+	message = "unbind many"; // trac-3538
 	$elem.on( "error1 error2", error )
 		.off( "error1 error2" )
 		.trigger( "error1" ).triggerHandler( "error2" );
@@ -1041,7 +1041,7 @@ QUnit.test( "trigger(type, [data], [fn])", function( assert ) {
 	} catch ( e ) {
 		pass = false;
 	}
-	assert.ok( pass, "Trigger on a table with a colon in the even type, see #3533" );
+	assert.ok( pass, "Trigger on a table with a colon in the even type, see trac-3533" );
 
 	form = jQuery( "<form action=''></form>" ).appendTo( "body" );
 
@@ -1069,7 +1069,7 @@ QUnit.test( "trigger(type, [data], [fn])", function( assert ) {
 	form.remove();
 } );
 
-QUnit.test( "submit event bubbles on copied forms (#11649)", function( assert ) {
+QUnit.test( "submit event bubbles on copied forms (trac-11649)", function( assert ) {
 	assert.expect( 3 );
 
 	var $formByClone, $formByHTML,
@@ -1105,7 +1105,7 @@ QUnit.test( "submit event bubbles on copied forms (#11649)", function( assert ) 
 	$testForm.off( "submit", noSubmit );
 } );
 
-QUnit.test( "change event bubbles on copied forms (#11796)", function( assert ) {
+QUnit.test( "change event bubbles on copied forms (trac-11796)", function( assert ) {
 	assert.expect( 3 );
 
 	var $formByClone, $formByHTML,
@@ -1227,7 +1227,7 @@ QUnit.test( "trigger(eventObject, [data], [fn])", function( assert ) {
 	assert.equal( event.isDefaultPrevented(), false, "default not prevented" );
 } );
 
-QUnit.test( ".trigger() bubbling on disconnected elements (#10489)", function( assert ) {
+QUnit.test( ".trigger() bubbling on disconnected elements (trac-10489)", function( assert ) {
 	assert.expect( 2 );
 
 	jQuery( window ).on( "click", function() {
@@ -1251,7 +1251,7 @@ QUnit.test( ".trigger() bubbling on disconnected elements (#10489)", function( a
 	jQuery( window ).off( "click" );
 } );
 
-QUnit.test( ".trigger() doesn't bubble load event (#10717)", function( assert ) {
+QUnit.test( ".trigger() doesn't bubble load event (trac-10717)", function( assert ) {
 	assert.expect( 1 );
 
 	jQuery( window ).on( "load", function() {
@@ -1269,7 +1269,7 @@ QUnit.test( ".trigger() doesn't bubble load event (#10717)", function( assert ) 
 	jQuery( window ).off( "load" );
 } );
 
-QUnit.test( "Delegated events in SVG (#10791; #13180)", function( assert ) {
+QUnit.test( "Delegated events in SVG (trac-10791; trac-13180)", function( assert ) {
 	assert.expect( 2 );
 
 	var useElem, e,
@@ -1295,7 +1295,7 @@ QUnit.test( "Delegated events in SVG (#10791; #13180)", function( assert ) {
 		.end();
 
 	// Fire a native click on an SVGElementInstance (the instance tree of an SVG <use>)
-	// to confirm that it doesn't break our event delegation handling (#13180)
+	// to confirm that it doesn't break our event delegation handling (trac-13180)
 	useElem = svg.find( "#use" )[ 0 ];
 	if ( document.createEvent && useElem && useElem.instanceRoot ) {
 		e = document.createEvent( "MouseEvents" );
@@ -1321,7 +1321,7 @@ QUnit.test( "Delegated events with malformed selectors (gh-3071)", function( ass
 	assert.ok( true, "malformed selector does not throw on event" );
 } );
 
-QUnit.test( "Delegated events in forms (#10844; #11145; #8165; #11382, #11764)", function( assert ) {
+QUnit.test( "Delegated events in forms (trac-10844; trac-11145; trac-8165; trac-11382, trac-11764)", function( assert ) {
 	assert.expect( 5 );
 
 	// Alias names like "id" cause havoc
@@ -1376,7 +1376,7 @@ QUnit.test( "Delegated events in forms (#10844; #11145; #8165; #11382, #11764)",
 	form.remove();
 } );
 
-QUnit.test( "Submit event can be stopped (#11049)", function( assert ) {
+QUnit.test( "Submit event can be stopped (trac-11049)", function( assert ) {
 	assert.expect( 1 );
 
 	// Since we manually bubble in IE, make sure inner handlers get a chance to cancel
@@ -1450,7 +1450,7 @@ QUnit.test( "jQuery.Event( type, props )", function( assert ) {
 	assert.equal( event.type, "keydown", "Verify type" );
 
 	// ensure "type" in props won't clobber the one set by constructor
-	assert.equal( jQuery.inArray( "type", jQuery.event.props ), -1, "'type' property not in props (#10375)" );
+	assert.equal( jQuery.inArray( "type", jQuery.event.props ), -1, "'type' property not in props (trac-10375)" );
 
 	assert.ok( "keyCode" in event, "Special 'keyCode' property exists" );
 
@@ -1844,7 +1844,7 @@ QUnit[ jQuery.find.compile ? "test" : "skip" ]( "delegated event with delegateTa
 	assert.expect( 3 );
 	var markup = jQuery( "<div><ul><li><a id=\"a0\"></a><ul id=\"ul0\"><li class=test><a id=\"a0_0\"></a></li><li><a id=\"a0_1\"></a></li></ul></li></ul></div>" ).appendTo( "#qunit-fixture" );
 
-	// Non-positional selector (#12383)
+	// Non-positional selector (trac-12383)
 	markup.find( "#ul0" )
 		.on( "click", "div li a", function() {
 			assert.ok( false, "div is ABOVE the delegation point!" );
@@ -1858,7 +1858,7 @@ QUnit[ jQuery.find.compile ? "test" : "skip" ]( "delegated event with delegateTa
 		.find( "#a0_0" ).trigger( "click" ).end()
 		.off( "click" );
 
-	// Positional selector (#11315)
+	// Positional selector (trac-11315)
 	markup.find( "ul" ).eq( 0 )
 		.on( "click", ">li>a", function() {
 			assert.ok( this.id === "a0", "child li was clicked" );
@@ -1874,7 +1874,7 @@ QUnit[ jQuery.find.compile ? "test" : "skip" ]( "delegated event with delegateTa
 	markup.remove();
 } );
 
-QUnit.test( "delegated event with selector matching Object.prototype property (#13203)", function( assert ) {
+QUnit.test( "delegated event with selector matching Object.prototype property (trac-13203)", function( assert ) {
 	assert.expect( 1 );
 
 	var matched = 0;
@@ -1888,7 +1888,7 @@ QUnit.test( "delegated event with selector matching Object.prototype property (#
 	assert.equal( matched, 0, "Nothing matched 'toString'" );
 } );
 
-QUnit.test( "delegated event with intermediate DOM manipulation (#13208)", function( assert ) {
+QUnit.test( "delegated event with intermediate DOM manipulation (trac-13208)", function( assert ) {
 	assert.expect( 1 );
 
 	jQuery( "#foo" ).on( "click", "[id=sap]", function() {} );
@@ -2182,7 +2182,7 @@ QUnit.test( "focusin bubbles", function( assert ) {
 	jQuery( "body" ).off( "focusin.focusinBubblesTest" );
 } );
 
-QUnit.test( "custom events with colons (#3533, #8272)", function( assert ) {
+QUnit.test( "custom events with colons (trac-3533, trac-8272)", function( assert ) {
 	assert.expect( 1 );
 
 	var tab = jQuery( "<table><tr><td>trigger</td></tr></table>" ).appendTo( "body" );
@@ -2365,7 +2365,7 @@ QUnit.test( "special on name mapping", function( assert ) {
 	delete jQuery.event.special[ "gutfeeling" ];
 } );
 
-QUnit.test( ".on and .off, selective mixed removal (#10705)", function( assert ) {
+QUnit.test( ".on and .off, selective mixed removal (trac-10705)", function( assert ) {
 	assert.expect( 7 );
 
 	var timingx = function( e ) {
@@ -2387,7 +2387,7 @@ QUnit.test( ".on and .off, selective mixed removal (#10705)", function( assert )
 		.trigger( "click" );	// 0
 } );
 
-QUnit.test( ".on( event-map, null-selector, data ) #11130", function( assert ) {
+QUnit.test( ".on( event-map, null-selector, data ) trac-11130", function( assert ) {
 
 	assert.expect( 1 );
 
@@ -2403,7 +2403,7 @@ QUnit.test( ".on( event-map, null-selector, data ) #11130", function( assert ) {
 	$p.on( map, null, data ).trigger( "foo" );
 } );
 
-QUnit.test( "clone() delegated events (#11076)", function( assert ) {
+QUnit.test( "clone() delegated events (trac-11076)", function( assert ) {
 	assert.expect( 3 );
 
 	var counter = { "center": 0, "fold": 0, "centerfold": 0 },
@@ -2740,7 +2740,7 @@ QUnit.test( "trigger click on checkbox, fires change event", function( assert ) 
 	} ).trigger( "click" );
 } );
 
-QUnit.test( "Namespace preserved when passed an Event (#12739)", function( assert ) {
+QUnit.test( "Namespace preserved when passed an Event (trac-12739)", function( assert ) {
 	assert.expect( 4 );
 
 	var markup = jQuery(
@@ -2828,7 +2828,7 @@ QUnit.test( "make sure events cloned correctly", function( assert ) {
 	clone.find( "#check1" ).trigger( "change" ); // 0 events should fire
 } );
 
-QUnit.test( "String.prototype.namespace does not cause trigger() to throw (#13360)", function( assert ) {
+QUnit.test( "String.prototype.namespace does not cause trigger() to throw (trac-13360)", function( assert ) {
 	assert.expect( 1 );
 	var errored = false;
 
@@ -2843,7 +2843,7 @@ QUnit.test( "String.prototype.namespace does not cause trigger() to throw (#1336
 	delete String.prototype.namespace;
 } );
 
-QUnit.test( "Inline event result is returned (#13993)", function( assert ) {
+QUnit.test( "Inline event result is returned (trac-13993)", function( assert ) {
 	assert.expect( 1 );
 
 	var result = jQuery( "<p onclick='return 42'>hello</p>" ).triggerHandler( "click" );
@@ -3109,7 +3109,7 @@ QUnit.test( "Check order of focusin/focusout events", function( assert ) {
 	}
 } );
 
-QUnit.test( "focus-blur order (#12868)", function( assert ) {
+QUnit.test( "focus-blur order (trac-12868)", function( assert ) {
 	assert.expect( 5 );
 
 	var order,

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -39,9 +39,9 @@ QUnit.test( "text()", function( assert ) {
 
 	// Check serialization of text values
 	assert.equal( jQuery( document.createTextNode( "foo" ) ).text(), "foo", "Text node was retrieved from .text()." );
-	assert.notEqual( jQuery( document ).text(), "", "Retrieving text for the document retrieves all text (#10724)." );
+	assert.notEqual( jQuery( document ).text(), "", "Retrieving text for the document retrieves all text (trac-10724)." );
 
-	// Retrieve from document fragments #10864
+	// Retrieve from document fragments trac-10864
 	frag = document.createDocumentFragment();
 	frag.appendChild( document.createTextNode( "foo" ) );
 
@@ -49,7 +49,7 @@ QUnit.test( "text()", function( assert ) {
 
 	$newLineTest = jQuery( "<div>test<br/>testy</div>" ).appendTo( "#moretests" );
 	$newLineTest.find( "br" ).replaceWith( "\n" );
-	assert.equal( $newLineTest.text(), "test\ntesty", "text() does not remove new lines (#11153)" );
+	assert.equal( $newLineTest.text(), "test\ntesty", "text() does not remove new lines (trac-11153)" );
 
 	$newLineTest.remove();
 } );
@@ -58,7 +58,7 @@ QUnit.test( "text(undefined)", function( assert ) {
 
 	assert.expect( 1 );
 
-	assert.equal( jQuery( "#foo" ).text( "<div" ).text( undefined )[ 0 ].innerHTML, "&lt;div", ".text(undefined) is chainable (#5571)" );
+	assert.equal( jQuery( "#foo" ).text( "<div" ).text( undefined )[ 0 ].innerHTML, "&lt;div", ".text(undefined) is chainable (trac-5571)" );
 } );
 
 function testText( valueObj, assert ) {
@@ -78,16 +78,16 @@ function testText( valueObj, assert ) {
 
 	assert.equal( j[ 2 ].nodeType, 8, "Check node,textnode,comment with text()" );
 
-	// Update multiple elements #11809
+	// Update multiple elements trac-11809
 	expected = "New";
 
 	$multipleElements = jQuery( "<div>Hello</div>" ).add( "<div>World</div>" );
 	$multipleElements.text( expected );
 
-	assert.equal( $multipleElements.eq( 0 ).text(), expected, "text() updates multiple elements (#11809)" );
-	assert.equal( $multipleElements.eq( 1 ).text(), expected, "text() updates multiple elements (#11809)" );
+	assert.equal( $multipleElements.eq( 0 ).text(), expected, "text() updates multiple elements (trac-11809)" );
+	assert.equal( $multipleElements.eq( 1 ).text(), expected, "text() updates multiple elements (trac-11809)" );
 
-	// Prevent memory leaks #11809
+	// Prevent memory leaks trac-11809
 	$childDiv = jQuery( "<div></div>" );
 	$childDiv.data( "leak", true );
 	$parentDiv = jQuery( "<div></div>" );
@@ -187,7 +187,7 @@ function testAppendForObject( valueObj, isFragment, assert ) {
 
 	assert.equal( $base.clone().append( valueObj( document.getElementById( "form" ).cloneNode( true ) ) ).children( "form" ).length,
 		1,
-		"Check for appending a form (#910)" + type
+		"Check for appending a form (trac-910)" + type
 	);
 }
 
@@ -272,7 +272,7 @@ function testAppend( valueObj, assert ) {
 		.append( valueObj( "<select id='appendSelect2'><option>Test</option></select>" ) );
 	assert.t( "Append Select", "#appendSelect1, #appendSelect2", [ "appendSelect1", "appendSelect2" ] );
 
-	assert.equal( "Two nodes", jQuery( "<div></div>" ).append( "Two", " nodes" ).text(), "Appending two text nodes (#4011)" );
+	assert.equal( "Two nodes", jQuery( "<div></div>" ).append( "Two", " nodes" ).text(), "Appending two text nodes (trac-4011)" );
 	assert.equal( jQuery( "<div></div>" ).append( "1", "", 3 ).text(), "13", "If median is false-like value, subsequent arguments should not be ignored" );
 
 	// using contents will get comments regular, text, and comment nodes
@@ -310,7 +310,7 @@ QUnit.test( "append(Function)", function( assert ) {
 	testAppend( manipulationFunctionReturningObj, assert );
 } );
 
-QUnit.test( "append(param) to object, see #11280", function( assert ) {
+QUnit.test( "append(param) to object, see trac-11280", function( assert ) {
 
 	assert.expect( 5 );
 
@@ -402,7 +402,7 @@ QUnit.test( "append(Function) returns Number", function( assert ) {
 	assert.ok( jQuery( "#sap" )[ 0 ].innerHTML.match( /5$/ ), "Check for appending a number" );
 } );
 
-QUnit.test( "XML DOM manipulation (#9960)", function( assert ) {
+QUnit.test( "XML DOM manipulation (trac-9960)", function( assert ) {
 
 	assert.expect( 5 );
 
@@ -430,7 +430,7 @@ QUnit.test( "XML DOM manipulation (#9960)", function( assert ) {
 	assert.deepEqual( jQuery( "state", xml2 ).get(), scxml1.find( "state" ).get(), "replaceWith" );
 } );
 
-QUnit.test( "append HTML5 sectioning elements (Bug #6485)", function( assert ) {
+QUnit.test( "append HTML5 sectioning elements (Bug trac-6485)", function( assert ) {
 
 	assert.expect( 2 );
 
@@ -446,7 +446,7 @@ QUnit.test( "append HTML5 sectioning elements (Bug #6485)", function( assert ) {
 } );
 
 if ( jQuery.css ) {
-	QUnit.test( "HTML5 Elements inherit styles from style rules (Bug #10501)", function( assert ) {
+	QUnit.test( "HTML5 Elements inherit styles from style rules (Bug trac-10501)", function( assert ) {
 
 		assert.expect( 1 );
 
@@ -458,7 +458,7 @@ if ( jQuery.css ) {
 	} );
 }
 
-QUnit.test( "html(String) with HTML5 (Bug #6485)", function( assert ) {
+QUnit.test( "html(String) with HTML5 (Bug trac-6485)", function( assert ) {
 
 	assert.expect( 2 );
 
@@ -467,7 +467,7 @@ QUnit.test( "html(String) with HTML5 (Bug #6485)", function( assert ) {
 	assert.equal( jQuery( "#qunit-fixture" ).children().children().children().length, 1, "Make sure nested HTML5 elements can hold children." );
 } );
 
-QUnit.test( "html(String) tag-hyphenated elements (Bug #1987)", function( assert ) {
+QUnit.test( "html(String) tag-hyphenated elements (Bug gh-1987)", function( assert ) {
 
 	assert.expect( 27 );
 
@@ -575,7 +575,7 @@ QUnit.test( "IE8 serialization bug", function( assert ) {
 	assert.equal( wrapper.children( "link" ).length, 1, "Link elements are insertable with .html()" );
 } );
 
-QUnit.test( "html() object element #10324", function( assert ) {
+QUnit.test( "html() object element trac-10324", function( assert ) {
 
 	assert.expect( 1 );
 
@@ -994,7 +994,7 @@ QUnit.test( "before(no-op)", function( assert ) {
 	assert.equal( set.length, 1, "Insert the element before the disconnected node. should be a no-op" );
 } );
 
-QUnit.test( "before and after w/ empty object (#10812)", function( assert ) {
+QUnit.test( "before and after w/ empty object (trac-10812)", function( assert ) {
 
 	assert.expect( 1 );
 
@@ -1230,7 +1230,7 @@ function testReplaceWith( val, assert ) {
 	assert.ok( !jQuery( "#baz" )[ 0 ], "Verify that original element is gone, after element" );
 
 	jQuery( "#bar" ).replaceWith( "<div id='yahoo'></div>", "...", "<div id='baz'></div>" );
-	assert.deepEqual( jQuery( "#yahoo, #baz" ).get(), q( "yahoo", "baz" ),  "Replace element with multiple arguments (#13722)" );
+	assert.deepEqual( jQuery( "#yahoo, #baz" ).get(), q( "yahoo", "baz" ),  "Replace element with multiple arguments (trac-13722)" );
 	assert.strictEqual( jQuery( "#yahoo" )[ 0 ].nextSibling, jQuery( "#baz" )[ 0 ].previousSibling, "Argument order preserved" );
 	assert.deepEqual( jQuery( "#bar" ).get(), [], "Verify that original element is gone, after multiple arguments" );
 
@@ -1243,7 +1243,7 @@ function testReplaceWith( val, assert ) {
 	assert.ok( !jQuery( "#groups" )[ 0 ], "Verify that original element is gone, after jQuery collection" );
 
 	jQuery( "#mark, #first" ).replaceWith( val( "<span class='replacement'></span><span class='replacement'></span>" ) );
-	assert.equal( jQuery( "#qunit-fixture .replacement" ).length, 4, "Replace multiple elements (#12449)" );
+	assert.equal( jQuery( "#qunit-fixture .replacement" ).length, 4, "Replace multiple elements (trac-12449)" );
 	assert.deepEqual( jQuery( "#mark, #first" ).get(), [], "Verify that original elements are gone, after replace multiple" );
 
 	tmp = jQuery( "<b>content</b>" )[ 0 ];
@@ -1291,7 +1291,7 @@ function testReplaceWith( val, assert ) {
 		"Self-replacement" );
 	$div.replaceWith( child );
 	assert.deepEqual( jQuery( "#qunit-fixture" ).children().first().get(), child.get(),
-		"Replacement with following sibling (#13810)" );
+		"Replacement with following sibling (trac-13810)" );
 	assert.deepEqual( jQuery( ".pathological", "#qunit-fixture" ).get(), [],
 		"Replacement with following sibling (context removed)" );
 
@@ -1411,7 +1411,7 @@ QUnit.test( "replaceAll(jQuery)", function( assert ) {
 	assert.ok( !jQuery( "#yahoo" )[ 0 ], "Verify that original element is gone, after set of elements" );
 } );
 
-QUnit.test( "jQuery.clone() (#8017)", function( assert ) {
+QUnit.test( "jQuery.clone() (trac-8017)", function( assert ) {
 
 	assert.expect( 2 );
 
@@ -1423,7 +1423,7 @@ QUnit.test( "jQuery.clone() (#8017)", function( assert ) {
 	assert.equal( main.childNodes.length, clone.childNodes.length, "Simple child length to ensure a large dom tree copies correctly" );
 } );
 
-QUnit.test( "append to multiple elements (#8070)", function( assert ) {
+QUnit.test( "append to multiple elements (trac-8070)", function( assert ) {
 
 	assert.expect( 2 );
 
@@ -1578,7 +1578,7 @@ QUnit.test( "clone()", function( assert ) {
 	body.remove();
 } );
 
-QUnit.test( "clone(script type=non-javascript) (#11359)", function( assert ) {
+QUnit.test( "clone(script type=non-javascript) (trac-11359)", function( assert ) {
 
 	assert.expect( 3 );
 
@@ -1591,7 +1591,7 @@ QUnit.test( "clone(script type=non-javascript) (#11359)", function( assert ) {
 	dest.remove();
 } );
 
-QUnit.test( "clone(form element) (Bug #3879, #6655)", function( assert ) {
+QUnit.test( "clone(form element) (Bug trac-3879, trac-6655)", function( assert ) {
 
 	assert.expect( 5 );
 
@@ -1616,7 +1616,7 @@ QUnit.test( "clone(form element) (Bug #3879, #6655)", function( assert ) {
 	assert.equal( clone[ 0 ].defaultValue, "foo", "Textarea defaultValue cloned correctly" );
 } );
 
-QUnit.test( "clone(multiple selected options) (Bug #8129)", function( assert ) {
+QUnit.test( "clone(multiple selected options) (Bug trac-8129)", function( assert ) {
 
 	assert.expect( 1 );
 
@@ -1665,14 +1665,14 @@ QUnit.test( "html(undefined)", function( assert ) {
 
 	assert.expect( 1 );
 
-	assert.equal( jQuery( "#foo" ).html( "<i>test</i>" ).html( undefined ).html().toLowerCase(), "<i>test</i>", ".html(undefined) is chainable (#5571)" );
+	assert.equal( jQuery( "#foo" ).html( "<i>test</i>" ).html( undefined ).html().toLowerCase(), "<i>test</i>", ".html(undefined) is chainable (trac-5571)" );
 } );
 
 QUnit.test( "html() on empty set", function( assert ) {
 
 	assert.expect( 1 );
 
-	assert.strictEqual( jQuery().html(), undefined, ".html() returns undefined for empty sets (#11962)" );
+	assert.strictEqual( jQuery().html(), undefined, ".html() returns undefined for empty sets (trac-11962)" );
 } );
 
 function childNodeNames( node ) {
@@ -1773,7 +1773,7 @@ function testHtml( valueObj, assert ) {
 	fixture.html( valueObj( "<script type='text/javascript'>QUnit.assert.ok( true, 'Injection of identical script' );</script>" ) );
 	fixture.html( valueObj( "<script type='text/javascript'>QUnit.assert.ok( true, 'Injection of identical script' );</script>" ) );
 	fixture.html( valueObj( "<script type='text/javascript'>QUnit.assert.ok( true, 'Injection of identical script' );</script>" ) );
-	fixture.html( valueObj( "foo <form><script type='text/javascript'>QUnit.assert.ok( true, 'Injection of identical script (#975)' );</script></form>" ) );
+	fixture.html( valueObj( "foo <form><script type='text/javascript'>QUnit.assert.ok( true, 'Injection of identical script (trac-975)' );</script></form>" ) );
 
 	jQuery.scriptorder = 0;
 	fixture.html( valueObj( [
@@ -1933,7 +1933,7 @@ QUnit.test( "html(Function) with incoming value -- jQuery.contents()", function(
 	} ).html().replace( />/g, "&gt;" ), " " + insert, "Verify escaped insertion." );
 } );
 
-QUnit.test( "clone()/html() don't expose jQuery/Sizzle expandos (#12858)", function( assert ) {
+QUnit.test( "clone()/html() don't expose jQuery/Sizzle expandos (trac-12858)", function( assert ) {
 
 	assert.expect( 2 );
 
@@ -2020,7 +2020,7 @@ QUnit.test( "remove() event cleaning ", function( assert ) {
 	cleanUp.remove();
 } );
 
-QUnit.test( "remove() in document order #13779", function( assert ) {
+QUnit.test( "remove() in document order trac-13779", function( assert ) {
 	assert.expect( 1 );
 
 	var last,
@@ -2347,7 +2347,7 @@ testIframe(
 	QUnit[ jQuery.ajax ? "test" : "skip" ]
 );
 
-QUnit.test( "jQuery.clone - no exceptions for object elements #9587", function( assert ) {
+QUnit.test( "jQuery.clone - no exceptions for object elements trac-9587", function( assert ) {
 
 	assert.expect( 1 );
 
@@ -2359,7 +2359,7 @@ QUnit.test( "jQuery.clone - no exceptions for object elements #9587", function( 
 	}
 } );
 
-QUnit.test( "Cloned, detached HTML5 elems (#10667,10670)", function( assert ) {
+QUnit.test( "Cloned, detached HTML5 elems (trac-10667, trac-10670)", function( assert ) {
 
 	assert.expect( 7 );
 
@@ -2439,7 +2439,7 @@ QUnit.test( "Guard against exceptions when clearing safeChildNodes", function( a
 	assert.ok( div && div.jquery, "Created nodes safely, guarded against exceptions on safeChildNodes[ -1 ]" );
 } );
 
-QUnit.test( "Ensure oldIE creates a new set on appendTo (#8894)", function( assert ) {
+QUnit.test( "Ensure oldIE creates a new set on appendTo (trac-8894)", function( assert ) {
 
 	assert.expect( 5 );
 
@@ -2450,7 +2450,7 @@ QUnit.test( "Ensure oldIE creates a new set on appendTo (#8894)", function( asse
 	assert.strictEqual( jQuery( "<p></p>" ).appendTo( "<div></div>" ).end().length, jQuery( "<p>test</p>" ).appendTo( "<div></div>" ).end().length, "Elements created with createElement and with createDocumentFragment should be treated alike" );
 } );
 
-QUnit.test( "html() - script exceptions bubble (#11743)", function( assert ) {
+QUnit.test( "html() - script exceptions bubble (trac-11743)", function( assert ) {
 	assert.expect( 2 );
 	var done = assert.async(),
 		onerror = window.onerror;
@@ -2492,7 +2492,7 @@ QUnit.test( "checked state is cloned with clone()", function( assert ) {
 	assert.equal( jQuery( elem ).clone().attr( "id", "clone" )[ 0 ].checked, true, "Checked true state correctly cloned" );
 } );
 
-QUnit.test( "manipulate mixed jQuery and text (#12384, #12346)", function( assert ) {
+QUnit.test( "manipulate mixed jQuery and text (trac-12384, trac-12346)", function( assert ) {
 
 	assert.expect( 2 );
 
@@ -2508,7 +2508,7 @@ QUnit.test( "manipulate mixed jQuery and text (#12384, #12346)", function( asser
 	assert.equal( div.find( "*" ).length, 3, "added 2 paragraphs after inner div" );
 } );
 
-QUnit.test( "script evaluation (#11795)", function( assert ) {
+QUnit.test( "script evaluation (trac-11795)", function( assert ) {
 
 	assert.expect( 13 );
 
@@ -2562,7 +2562,7 @@ QUnit.test( "script evaluation (#11795)", function( assert ) {
 	}
 } );
 
-QUnit[ jQuery.ajax ? "test" : "skip" ]( "jQuery._evalUrl (#12838)", function( assert ) {
+QUnit[ jQuery.ajax ? "test" : "skip" ]( "jQuery._evalUrl (trac-12838)", function( assert ) {
 
 	assert.expect( 5 );
 
@@ -2631,7 +2631,7 @@ QUnit.test( "jQuery.htmlPrefilter (gh-1747)", function( assert ) {
 	}, 100 );
 } );
 
-QUnit.test( "insertAfter, insertBefore, etc do not work when destination is original element. Element is removed (#4087)", function( assert ) {
+QUnit.test( "insertAfter, insertBefore, etc do not work when destination is original element. Element is removed (trac-4087)", function( assert ) {
 
 	assert.expect( 10 );
 
@@ -2665,7 +2665,7 @@ QUnit.test( "insertAfter, insertBefore, etc do not work when destination is orig
 	} );
 } );
 
-QUnit.test( "Index for function argument should be received (#13094)", function( assert ) {
+QUnit.test( "Index for function argument should be received (trac-13094)", function( assert ) {
 	assert.expect( 2 );
 
 	var i = 0;
@@ -2687,7 +2687,7 @@ QUnit.test( "Make sure jQuery.fn.remove can work on elements in documentFragment
 	assert.equal( fragment.childNodes.length, 0, "div element was removed from documentFragment" );
 } );
 
-QUnit.test( "Make sure specific elements with content created correctly (#13232)", function( assert ) {
+QUnit.test( "Make sure specific elements with content created correctly (trac-13232)", function( assert ) {
 	assert.expect( 20 );
 
 	var results = [],
@@ -2718,7 +2718,7 @@ QUnit.test( "Make sure specific elements with content created correctly (#13232)
 	} );
 } );
 
-QUnit.test( "Validate creation of multiple quantities of certain elements (#13818)", function( assert ) {
+QUnit.test( "Validate creation of multiple quantities of certain elements (trac-13818)", function( assert ) {
 	assert.expect( 22 );
 
 	var tags = [ "thead", "tbody", "tfoot", "colgroup", "col", "caption", "tr", "th", "td", "optgroup", "option" ];

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -60,8 +60,8 @@ QUnit.module( "offset", { beforeEach: function( assert ) {
 
 QUnit.test( "empty set", function( assert ) {
 	assert.expect( 2 );
-	assert.strictEqual( jQuery().offset(), undefined, "offset() returns undefined for empty set (#11962)" );
-	assert.strictEqual( jQuery().position(), undefined, "position() returns undefined for empty set (#11962)" );
+	assert.strictEqual( jQuery().offset(), undefined, "offset() returns undefined for empty set (trac-11962)" );
+	assert.strictEqual( jQuery().position(), undefined, "position() returns undefined for empty set (trac-11962)" );
 } );
 
 QUnit.test( "disconnected element", function( assert ) {
@@ -193,7 +193,7 @@ testIframe( "absolute", "offset/absolute.html", function( assert, $ ) {
 		assert.equal( $( this.id ).position().left, this.left, "jQuery('" + this.id + "').position().left" );
 	} );
 
-	// test #5781
+	// test trac-5781
 	offset = $( "#positionTest" ).offset( { "top": 10, "left": 10 } ).offset();
 	assert.equal( offset.top,  10, "Setting offset on element with position absolute but 'auto' values." );
 	assert.equal( offset.left, 10, "Setting offset on element with position absolute but 'auto' values." );
@@ -498,8 +498,8 @@ testIframe( "scroll", "offset/scroll.html", function( assert, $, win ) {
 	assert.equal( $( "#scroll-1-1" ).scrollLeft(), 0, "jQuery('#scroll-1-1').scrollLeft()" );
 
 	// scroll method chaining
-	assert.equal( $( "#scroll-1" ).scrollTop( undefined ).scrollTop(), 5, ".scrollTop(undefined) is chainable (#5571)" );
-	assert.equal( $( "#scroll-1" ).scrollLeft( undefined ).scrollLeft(), 5, ".scrollLeft(undefined) is chainable (#5571)" );
+	assert.equal( $( "#scroll-1" ).scrollTop( undefined ).scrollTop(), 5, ".scrollTop(undefined) is chainable (trac-5571)" );
+	assert.equal( $( "#scroll-1" ).scrollLeft( undefined ).scrollLeft(), 5, ".scrollLeft(undefined) is chainable (trac-5571)" );
 
 	win.name = "test";
 
@@ -549,7 +549,7 @@ QUnit.test( "chaining", function( assert ) {
 	var coords = { "top":  1, "left":  1 };
 	assert.equal( jQuery( "#absolute-1" ).offset( coords ).jquery, jQuery.fn.jquery, "offset(coords) returns jQuery object" );
 	assert.equal( jQuery( "#non-existent" ).offset( coords ).jquery, jQuery.fn.jquery, "offset(coords) with empty jQuery set returns jQuery object" );
-	assert.equal( jQuery( "#absolute-1" ).offset( undefined ).jquery, jQuery.fn.jquery, "offset(undefined) returns jQuery object (#5571)" );
+	assert.equal( jQuery( "#absolute-1" ).offset( undefined ).jquery, jQuery.fn.jquery, "offset(undefined) returns jQuery object (trac-5571)" );
 } );
 
 // Test complex content under a variety of <html>/<body> positioning styles
@@ -778,11 +778,11 @@ QUnit.test( "offsetParent", function( assert ) {
 	area.remove();
 
 	div = jQuery( "<div>" ).css( { "position": "absolute" } ).appendTo( "body" );
-	assert.equal( div.offsetParent()[ 0 ], document.documentElement, "Absolutely positioned div returns html as offset parent, see #12139" );
+	assert.equal( div.offsetParent()[ 0 ], document.documentElement, "Absolutely positioned div returns html as offset parent, see trac-12139" );
 	div.remove();
 } );
 
-QUnit.test( "fractions (see #7730 and #7885)", function( assert ) {
+QUnit.test( "fractions (see trac-7730 and trac-7885)", function( assert ) {
 	assert.expect( 2 );
 
 	jQuery( "body" ).append( "<div id='fractions'></div>" );

--- a/test/unit/queue.js
+++ b/test/unit/queue.js
@@ -41,7 +41,7 @@ QUnit.test( "queue() with other types", function( assert ) {
 
 	assert.equal( $div.queue( "foo" ).length, 4, "Testing queue length" );
 
-	assert.equal( $div.queue( "foo", undefined ).queue( "foo" ).length, 4, ".queue('name',undefined) does nothing but is chainable (#5571)" );
+	assert.equal( $div.queue( "foo", undefined ).queue( "foo" ).length, 4, ".queue('name',undefined) does nothing but is chainable (trac-5571)" );
 
 	$div.dequeue( "foo" );
 

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -14,10 +14,10 @@ QUnit.test( "element", function( assert ) {
 	assert.deepEqual( jQuery( "p", jQuery( "#qunit-fixture" ) ).get(), q( "firstp", "ap", "sndp", "en", "sap", "first" ), "Finding elements with a jQuery object context." );
 	assert.deepEqual( jQuery( "#qunit-fixture" ).find( "p" ).get(), q( "firstp", "ap", "sndp", "en", "sap", "first" ), "Finding elements with a context via .find()." );
 
-	assert.ok( jQuery( "#length" ).length, "<input name=\"length\"> cannot be found under IE, see #945" );
-	assert.ok( jQuery( "#lengthtest input" ).length, "<input name=\"length\"> cannot be found under IE, see #945" );
+	assert.ok( jQuery( "#length" ).length, "<input name=\"length\"> cannot be found under IE, see trac-945" );
+	assert.ok( jQuery( "#lengthtest input" ).length, "<input name=\"length\"> cannot be found under IE, see trac-945" );
 
-	// #7533
+	// trac-7533
 	assert.equal( jQuery( "<div id=\"A'B~C.D[E]\"><p>foo</p></div>" ).find( "p" ).length, 1, "Find where context root is a node and has an ID with CSS3 meta characters" );
 } );
 
@@ -43,7 +43,7 @@ QUnit.test( "id", function( assert ) {
 	assert.t( "Child escaped ID", "form > #foo\\:bar", [ "foo:bar" ] );
 	assert.t( "Child escaped ID", "form > #test\\.foo\\[5\\]bar", [ "test.foo[5]bar" ] );
 
-	assert.t( "ID Selector, child ID present", "#form > #radio1", [ "radio1" ] ); // bug #267
+	assert.t( "ID Selector, child ID present", "#form > #radio1", [ "radio1" ] ); // bug trac-267
 	assert.t( "ID Selector, not an ancestor ID", "#form #first", [] );
 	assert.t( "ID Selector, not a child ID", "#form > #option1a", [] );
 
@@ -55,7 +55,7 @@ QUnit.test( "id", function( assert ) {
 
 	assert.t( "ID Selector on Form with an input that has a name of 'id'", "#lengthtest", [ "lengthtest" ] );
 
-	assert.t( "ID selector with non-existent ancestor", "#asdfasdf #foobar", [] ); // bug #986
+	assert.t( "ID selector with non-existent ancestor", "#asdfasdf #foobar", [] ); // bug trac-986
 
 	assert.t( "Underscore ID", "#types_all", [ "types_all" ] );
 	assert.t( "Dash ID", "#qunit-fixture", [ "qunit-fixture" ] );
@@ -122,7 +122,7 @@ QUnit.test( "child and adjacent", function( assert ) {
 	if ( jQuery.find.compile ) {
 		assert.t( "Element Preceded By, Containing", "#liveHandlerOrder ~ div em:contains('1')", [ "siblingfirst" ] );
 		assert.t( "Combinators are not skipped when mixing general and specific", "#siblingTest > em:contains('x') + em ~ span", [] );
-		assert.equal( jQuery( "#listWithTabIndex li:eq(2) ~ li" ).length, 1, "Find by general sibling combinator (#8310)" );
+		assert.equal( jQuery( "#listWithTabIndex li:eq(2) ~ li" ).length, 1, "Find by general sibling combinator (trac-8310)" );
 	} else {
 		assert.ok( "skip", ":contains not supported in selector-native" );
 		assert.ok( "skip", ":contains not supported in selector-native" );
@@ -133,9 +133,9 @@ QUnit.test( "child and adjacent", function( assert ) {
 	assert.t( "Multiple combinators selects all levels", "#siblingTest > em *", [ "siblingchild", "siblinggrandchild", "siblinggreatgrandchild" ] );
 	assert.t( "Multiple sibling combinators doesn't miss general siblings", "#siblingTest > em:first-child + em ~ span", [ "siblingspan" ] );
 
-	assert.equal( jQuery( "#listWithTabIndex" ).length, 1, "Parent div for next test is found via ID (#8310)" );
-	assert.equal( jQuery( "#__sizzle__" ).length, 0, "Make sure the temporary id assigned by sizzle is cleared out (#8310)" );
-	assert.equal( jQuery( "#listWithTabIndex" ).length, 1, "Parent div for previous test is still found via ID (#8310)" );
+	assert.equal( jQuery( "#listWithTabIndex" ).length, 1, "Parent div for next test is found via ID (trac-8310)" );
+	assert.equal( jQuery( "#__sizzle__" ).length, 0, "Make sure the temporary id assigned by sizzle is cleared out (trac-8310)" );
+	assert.equal( jQuery( "#listWithTabIndex" ).length, 1, "Parent div for previous test is still found via ID (trac-8310)" );
 
 	assert.t( "Verify deep class selector", "div.blah > p > a", [] );
 	assert.t( "No element deep selector", "div.foo > span > a", [] );
@@ -212,7 +212,7 @@ QUnit.test( "attributes", function( assert ) {
 
 	assert.t( "Grouped Form Elements", "input[name='foo[bar]']", [ "hidden2" ] );
 
-	// Make sure attribute value quoting works correctly. See jQuery #6093; #6428; #13894
+	// Make sure attribute value quoting works correctly. See jQuery trac-6093; trac-6428; trac-13894
 	// Use seeded results to bypass querySelectorAll optimizations
 	attrbad = jQuery(
 		"<input type='hidden' id='attrbad_space' name='foo bar'/>" +
@@ -232,7 +232,7 @@ QUnit.test( "attributes", function( assert ) {
 	assert.t( "input[type=search]", "#form input[type=search]", [ "search" ] );
 
 	withScript = supportjQuery( "<div><span><script src=''/></span></div>" );
-	assert.ok( withScript.find( "#moretests script[src]" ).has( "script" ), "script[src] (jQuery #13777)" );
+	assert.ok( withScript.find( "#moretests script[src]" ).has( "script" ), "script[src] (jQuery trac-13777)" );
 
 	div = document.getElementById( "foo" );
 	assert.t( "Object.prototype property \"constructor\" (negative)", "[constructor]", [] );
@@ -246,7 +246,7 @@ QUnit.test( "attributes", function( assert ) {
 
 	if ( jQuery.find.compile ) {
 
-		// #12600
+		// trac-12600
 		assert.ok(
 			jQuery( "<select value='12600'><option value='option' selected='selected'></option><option value=''></option></select>" )
 			.prop( "value", "option" )
@@ -263,7 +263,7 @@ QUnit.test( "attributes", function( assert ) {
 	}
 
 
-	// #11115
+	// trac-11115
 	assert.ok( jQuery( "<input type='checkbox' checked='checked'/>" ).prop( "checked", false ).is( "[checked]" ),
 		"[checked] selects by attribute (positive)"
 	);
@@ -376,9 +376,9 @@ testIframe(
 		} );
 		t( "Enumerated attribute", "[spellcheck]", [ "span1" ] );
 
-		t( "tabindex selector does not retrieve all elements in IE6/7 (#8473)",
+		t( "tabindex selector does not retrieve all elements in IE6/7 (trac-8473)",
 			"form, [tabindex]", [ "form1", "text1" ] );
-		t( "Improperly named form elements do not interfere with form selections (#9570)", "form[name='formName']", [ "form1" ] );
+		t( "Improperly named form elements do not interfere with form selections (trac-9570)", "form[name='formName']", [ "form1" ] );
 	}
 );
 
@@ -503,7 +503,7 @@ testIframe(
 	}
 );
 
-QUnit.test( "Iframe dispatch should not affect jQuery (#13936)", function( assert ) {
+QUnit.test( "Iframe dispatch should not affect jQuery (trac-13936)", function( assert ) {
 	assert.expect( 1 );
 	var loaded = false,
 		thrown = false,

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -34,7 +34,7 @@ QUnit.test( "jQuery.param()", function( assert ) {
 
 	assert.equal( decodeURIComponent( jQuery.param( { "a": [ 1, 2, 3 ], "b[]": [ 4, 5, 6 ], "c[d]": [ 7, 8, 9 ], "e": { "f": [ 10 ], "g": [ 11, 12 ], "h": 13 } } ) ), "a[]=1&a[]=2&a[]=3&b[]=4&b[]=5&b[]=6&c[d][]=7&c[d][]=8&c[d][]=9&e[f][]=10&e[g][]=11&e[g][]=12&e[h]=13", "Make sure params are not double-encoded." );
 
-	// #7945
+	// trac-7945
 	assert.equal( jQuery.param( { "jquery": "1.4.2" } ), "jquery=1.4.2", "Check that object with a jQuery property get serialized correctly" );
 
 	params = { "foo":"bar", "baz":42, "quux":"All your base are belong to us" };

--- a/test/unit/support.js
+++ b/test/unit/support.js
@@ -19,7 +19,7 @@ function getComputedSupport( support ) {
 
 if ( jQuery.css ) {
 	testIframe(
-		"body background is not lost if set prior to loading jQuery (#9239)",
+		"body background is not lost if set prior to loading jQuery (trac-9239)",
 		"support/bodyBackground.html",
 		function( assert, jQuery, window, document, color, support ) {
 			assert.expect( 2 );

--- a/test/unit/traversing.js
+++ b/test/unit/traversing.js
@@ -47,7 +47,7 @@ QUnit.test( "find(node|jQuery object)", function( assert ) {
 	assert.equal( $two.find( $first ).length, 0, "first is in the collection and not within two" );
 	assert.equal( $two.find( $first ).length, 0, "first is in the collection and not within two(node)" );
 
-	assert.equal( $two.find( $foo[ 0 ] ).addBack().length, 2, "find preserves the pushStack, see #12009" );
+	assert.equal( $two.find( $foo[ 0 ] ).addBack().length, 2, "find preserves the pushStack, see trac-12009" );
 } );
 
 QUnit.test( "is(String|undefined)", function( assert ) {
@@ -80,7 +80,7 @@ QUnit.test( "is(String|undefined)", function( assert ) {
 	assert.ok( jQuery( "#en" ).is( "[lang=\"de\"] , [lang=\"en\"]" ), "Comma-separated; Check for lang attribute: Expect en or de" );
 } );
 
-QUnit.test( "is() against non-elements (#10178)", function( assert ) {
+QUnit.test( "is() against non-elements (trac-10178)", function( assert ) {
 	assert.expect( 14 );
 
 	var label, i, test,
@@ -186,10 +186,10 @@ QUnit[ jQuery.find.compile ? "test" : "skip" ]( "is() with positional selectors"
 	isit( "#posp em", "#posp a em:last", true );
 	isit( "#posp em", "#posp a em:eq(2)", false );
 
-	assert.ok( jQuery( "#option1b" ).is( "#select1 option:not(:first)" ), "POS inside of :not() (#10970)" );
+	assert.ok( jQuery( "#option1b" ).is( "#select1 option:not(:first)" ), "POS inside of :not() (trac-10970)" );
 
-	assert.ok( jQuery( posp[ 0 ] ).is( "p:last" ), "context constructed from a single node (#13797)" );
-	assert.ok( !jQuery( posp[ 0 ] ).find( "#firsta" ).is( "a:first" ), "context derived from a single node (#13797)" );
+	assert.ok( jQuery( posp[ 0 ] ).is( "p:last" ), "context constructed from a single node (trac-13797)" );
+	assert.ok( !jQuery( posp[ 0 ] ).find( "#firsta" ).is( "a:first" ), "context derived from a single node (trac-13797)" );
 } );
 
 QUnit.test( "index()", function( assert ) {
@@ -350,14 +350,14 @@ QUnit.test( "closest()", function( assert ) {
 		"Non-string match target"
 	);
 
-	// Bug #7369
+	// Bug trac-7369
 	assert.equal( jQuery( "<div foo='bar'></div>" ).closest( "[foo]" ).length, 1, "Disconnected nodes with attribute selector" );
 	assert.equal( jQuery( "<div>text</div>" ).closest( "[lang]" ).length, 0, "Disconnected nodes with text and non-existent attribute selector" );
 
 	assert.ok( !jQuery( document ).closest( "#foo" ).length, "Calling closest on a document fails silently" );
 
 	jq = jQuery( "<div>text</div>" );
-	assert.deepEqual( jq.contents().closest( "*" ).get(), jq.get(), "Text node input (#13332)" );
+	assert.deepEqual( jq.contents().closest( "*" ).get(), jq.get(), "Text node input (trac-13332)" );
 } );
 
 QUnit[ jQuery.find.compile ? "test" : "skip" ]( "closest() with positional selectors", function( assert ) {
@@ -565,8 +565,8 @@ QUnit.test( "siblings([String])", function( assert ) {
 
 	var set = q( "sndp", "en", "sap" );
 	assert.deepEqual( jQuery( "#en, #sndp" ).siblings().get(), set, "Check for unique results from siblings" );
-	assert.deepEqual( jQuery( "#option5a" ).siblings( "option[data-attr]" ).get(), q( "option5c" ), "Has attribute selector in siblings (#9261)" );
-	assert.equal( jQuery( "<a></a>" ).siblings().length, 0, "Detached elements have no siblings (#11370)" );
+	assert.deepEqual( jQuery( "#option5a" ).siblings( "option[data-attr]" ).get(), q( "option5c" ), "Has attribute selector in siblings (trac-9261)" );
+	assert.equal( jQuery( "<a></a>" ).siblings().length, 0, "Detached elements have no siblings (trac-11370)" );
 } );
 
 QUnit[ jQuery.find.compile ? "test" : "skip" ]( "siblings([String])", function( assert ) {
@@ -598,7 +598,7 @@ QUnit.test( "parent([String])", function( assert ) {
 	assert.deepEqual( jQuery( "#en, #sndp" ).parent().get(), q( "foo" ), "Check for unique results from parent" );
 
 	$el = jQuery( "<div>text</div>" );
-	assert.deepEqual( $el.contents().parent().get(), $el.get(), "Check for parent of text node (#13265)" );
+	assert.deepEqual( $el.contents().parent().get(), $el.get(), "Check for parent of text node (trac-13265)" );
 } );
 
 QUnit.test( "parents([String])", function( assert ) {
@@ -1008,7 +1008,7 @@ QUnit.test( "add(String, Context)", function( assert ) {
 	assert.deepEqual( jQuery( document.getElementById( "firstp" ) ).add( "#ap", document.getElementsByTagName( "body" )[ 0 ] ).get(), q( "firstp", "ap" ), "Add gEBId to selector, in context" );
 } );
 
-QUnit.test( "eq('-1') #10616", function( assert ) {
+QUnit.test( "eq('-1') trac-10616", function( assert ) {
 	assert.expect( 3 );
 	var $divs = jQuery( "div" );
 
@@ -1017,7 +1017,7 @@ QUnit.test( "eq('-1') #10616", function( assert ) {
 	assert.deepEqual( $divs.eq( "-1" ), $divs.eq( -1 ), "String and number -1 match" );
 } );
 
-QUnit.test( "index(no arg) #10977", function( assert ) {
+QUnit.test( "index(no arg) trac-10977", function( assert ) {
 	assert.expect( 2 );
 	var $list, fragment, div;
 
@@ -1032,7 +1032,7 @@ QUnit.test( "index(no arg) #10977", function( assert ) {
 	assert.equal( jQuery( div ).index(), 0, "If jQuery#index called on element whose parent is fragment, it still should work correctly" );
 } );
 
-QUnit.test( "traversing non-elements with attribute filters (#12523)", function( assert ) {
+QUnit.test( "traversing non-elements with attribute filters (trac-12523)", function( assert ) {
 	assert.expect( 5 );
 
 	var nonnodes = jQuery( "#nonnodes" ).contents();

--- a/test/unit/wrap.js
+++ b/test/unit/wrap.js
@@ -47,11 +47,11 @@ function testWrap( val, assert ) {
 		var checkbox = this;
 
 		assert.ok(
-		checkbox.checked, "Checkbox's state is erased after wrap() action, see #769"
+		checkbox.checked, "Checkbox's state is erased after wrap() action, see trac-769"
 	);
 		jQuery( checkbox ).wrap( val( "<div id='c1' style='display:none;'></div>" ) );
 		assert.ok(
-		checkbox.checked, "Checkbox's state is erased after wrap() action, see #769"
+		checkbox.checked, "Checkbox's state is erased after wrap() action, see trac-769"
 	);
 	} ).prop( "checked", false )[ 0 ].click();
 
@@ -131,7 +131,7 @@ QUnit.test( "wrap(Function)", function( assert ) {
 	testWrap( manipulationFunctionReturningObj, assert );
 } );
 
-QUnit.test( "wrap(Function) with index (#10177)", function( assert ) {
+QUnit.test( "wrap(Function) with index (trac-10177)", function( assert ) {
 	var expectedIndex = 0,
 		targets = jQuery( "#qunit-fixture p" );
 
@@ -147,7 +147,7 @@ QUnit.test( "wrap(Function) with index (#10177)", function( assert ) {
 	} );
 } );
 
-QUnit.test( "wrap(String) consecutive elements (#10177)", function( assert ) {
+QUnit.test( "wrap(String) consecutive elements (trac-10177)", function( assert ) {
 	var targets = jQuery( "#qunit-fixture p" );
 
 	assert.expect( targets.length * 2 );
@@ -484,7 +484,7 @@ QUnit.test( "unwrap( selector )", function( assert ) {
 	jQuery( "body > span.unwrap" ).remove();
 } );
 
-QUnit.test( "jQuery(<tag>) & wrap[Inner/All]() handle unknown elems (#10667)", function( assert ) {
+QUnit.test( "jQuery(<tag>) & wrap[Inner/All]() handle unknown elems (trac-10667)", function( assert ) {
 
 	assert.expect( 2 );
 
@@ -503,7 +503,7 @@ QUnit.test( "jQuery(<tag>) & wrap[Inner/All]() handle unknown elems (#10667)", f
 	);
 } );
 
-QUnit.test( "wrapping scripts (#10470)", function( assert ) {
+QUnit.test( "wrapping scripts (trac-10470)", function( assert ) {
 
 	assert.expect( 2 );
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

This is a version of gh-4993 for the `3.x-stable` branch.

The GitHub UI treats `#NUMBER` as referring to its own issues which is confusing
when in jQuery source it's usually referring to the old deprecated Trac instance
at https://bugs.jquery.com. This change replaces all such Trac references with
`trac-NUMBER`.

A few of the references came with the Sizzle integration and referred to the
Sizzle GitHub bug tracker. Those have been replaced with full links instead.

A new entry describing issue reference conventions has been added to README.

Ref gh-4993
Ref 5d5ea015114092c157311c4948f7cc3d8c8e7f8a

Note: this PR already includes changes from #4995.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
