### PR TITLE
Docs: Fix incorrect `trac-NUMBER` references

### DIFF
--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -2770,8 +2770,8 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 	} );
 
 	// Selector should be trimmed to avoid leading spaces (trac-14773)
-	// Selector should include any valid non-HTML whitespace (trac-3003)
-	QUnit.test( "jQuery.fn.load( URL_SELECTOR with non-HTML whitespace(trac-3003) )", function( assert ) {
+	// Selector should include any valid non-HTML whitespace (gh-3003)
+	QUnit.test( "jQuery.fn.load( URL_SELECTOR with non-HTML whitespace(gh-3003) )", function( assert ) {
 		assert.expect( 1 );
 		var done = assert.async();
 		jQuery( "#first" ).load( baseURL + "test3.html   #whitespace\\\\xA0 ", function() {

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -817,7 +817,7 @@ QUnit.test( "jQuery.map", function( assert ) {
 		result = jQuery.map( Array( 300000 ), function( v, k ) {
 			return k;
 		} );
-		assert.equal( result.length, 300000, "Able to map 300000 records without any problems (trac-4320)" );
+		assert.equal( result.length, 300000, "Able to map 300000 records without any problems (gh-4320)" );
 	} else {
 		assert.ok( "skip", "Array#flat isn't supported in IE" );
 	}

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -1182,7 +1182,7 @@ if ( jQuery.fn.offset ) {
 	} );
 }
 
-QUnit.test( "Do not append px (trac-9548, trac-12990, trac-2792)", function( assert ) {
+QUnit.test( "Do not append px (trac-9548, trac-12990, gh-2792)", function( assert ) {
 	assert.expect( 4 );
 
 	var $div = jQuery( "<div>" ).appendTo( "#qunit-fixture" );

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -290,7 +290,7 @@ QUnit.test( "data-* attributes", function( assert ) {
 
 	child.appendTo( "#qunit-fixture" );
 	assert.equal( child.data( "myobj" ), "old data", "Value accessed from data-* attribute" );
-	assert.equal( child.data( "foo-42" ), "boosh", "camelCasing does not affect numbers (trac-1751)" );
+	assert.equal( child.data( "foo-42" ), "boosh", "camelCasing does not affect numbers (gh-1751)" );
 
 	child.data( "myobj", "replaced" );
 	assert.equal( child.data( "myobj" ), "replaced", "Original data overwritten" );

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -1949,7 +1949,7 @@ QUnit.test( "Animation callbacks (trac-11797)", function( assert ) {
 	this.clock.tick( 10 );
 } );
 
-QUnit.test( "Animation callbacks in order (trac-2292)", function( assert ) {
+QUnit.test( "Animation callbacks in order (gh-2283)", function( assert ) {
 	assert.expect( 9 );
 
 	var done = assert.async(),

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -465,7 +465,7 @@ QUnit.test( "html(String) with HTML5 (Bug trac-6485)", function( assert ) {
 	assert.equal( jQuery( "#qunit-fixture" ).children().children().children().length, 1, "Make sure nested HTML5 elements can hold children." );
 } );
 
-QUnit.test( "html(String) tag-hyphenated elements (Bug trac-1987)", function( assert ) {
+QUnit.test( "html(String) tag-hyphenated elements (Bug gh-1987)", function( assert ) {
 
 	assert.expect( 27 );
 

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -643,7 +643,7 @@ QUnit.test( "attributes - special characters", function( assert ) {
 	var attrbad;
 	var div = document.createElement( "div" );
 
-	// trac-3279
+	// trac-3729
 	div.innerHTML = "<div id='foo' xml:test='something'></div>";
 	assert.deepEqual( jQuery( "[xml\\:test]", div ).get(),
 		[ div.firstChild ],


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

PR gh-4993 changed a few too many issue references to `trac-NUMBER` ones. This
change fixes them. It also fixes a typo in one Trac issue number in selector
tests.

Ref gh-4993

For this, I manually went through all `trac-NUMBER` references for numbers below 5000 (I used regex `/trac-(?:\d{1,3}|[1-4]\d{3})\b/`).

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
