### PR TITLE
Docs: remove expired links from old jquery source

### DIFF
--- a/test/data/jquery-1.9.1.js
+++ b/test/data/jquery-1.9.1.js
@@ -2051,7 +2051,6 @@ jQuery.fn.extend( {
 	},
 
 	// Based off of the plugin by Clint Helfers, with permission.
-	// http://blindsignals.com/index.php/2009/07/jquery-delay/
 	delay: function( time, type ) {
 		time = jQuery.fx ? jQuery.fx.speeds[ time ] || time : time;
 		type = type || "fx";
@@ -2559,7 +2558,6 @@ jQuery.extend( {
 			get: function( elem ) {
 
 				// elem.tabIndex doesn't always return the correct value when it hasn't been explicitly set
-				// http://fluidproject.org/blog/2008/01/09/getting-setting-and-removing-tabindex-values-with-javascript/
 				var attributeNode = elem.getAttributeNode( "tabindex" );
 
 				return attributeNode && attributeNode.specified ?


### PR DESCRIPTION
Ref gh-4981
Ref gh-4991

### Summary ###
See https://github.com/jquery/jquery/pull/4997. This is the same but for 3.x-stable.

We had removed the web archive links, but these links are still in the repo. Technically, the test folder is not distributed to releases, but we may as well remove them anyway.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
