### PR TITLE
Event: Support EventListener interface objects.

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -117,6 +117,11 @@ jQuery.event = {
 			selector = handleObjIn.selector;
 		}
 
+		// Support objects implementing the EventListener interface.
+		if ( handler && typeof handler.handleEvent === "function" ) {
+			handler = handler.handleEvent.bind( handler );
+		}
+
 		// Ensure that invalid selectors throw exceptions at attach time
 		// Evaluate against documentElement in case elem is a non-element node (e.g., document)
 		if ( selector ) {

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -45,6 +45,28 @@ QUnit.test( "on() with non-null,defined data", function( assert ) {
 
 } );
 
+QUnit.test( "on() with EventListener interface object", function( assert ) {
+
+	assert.expect( 4 );
+
+	var handler = {
+		eventDelegateData: "can be found",
+		handleEvent: function( event, data ) {
+			assert.equal( data, 0, "non-null, defined data (zero) is correctly passed" );
+			assert.equal( this.eventDelegateData, "can be found", "event delegate is accessible via this" );
+		}
+	};
+
+	jQuery( "#foo" ).on( "foo.on", handler );
+	jQuery( "div" ).on( "foo.delegate", "#foo", handler );
+
+	jQuery( "#foo" ).trigger( "foo", 0 );
+
+	jQuery( "#foo" ).off( "foo.on", handler );
+	jQuery( "div" ).off( "foo.delegate", "#foo" );
+
+} );
+
 QUnit.test( "Handler changes and .trigger() order", function( assert ) {
 	assert.expect( 1 );
 


### PR DESCRIPTION
### Summary ###

When an event handler implements the `EventListener` interface (by being an object and having a function property called `handleEvent`), the handler function used internally is replaced with that `handleEvent` function bound to the handler object.
http://www.w3.org/TR/DOM-Level-2-Events/events.html#Events-EventListener
Fixes gh-1735

### Checklist ###

* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

