### PR TITLE
Tests: Exclude tests based on compilation flags, not API presence

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -10,6 +10,7 @@ module.exports = function( grunt ) {
 	const fs = require( "fs" );
 	const path = require( "path" );
 	const rollup = require( "rollup" );
+	const slimBuildFlags = require( "./lib/slim-build-flags" );
 	const rollupFileOverrides = require( "./lib/rollup-plugin-file-overrides" );
 	const Insight = require( "insight" );
 	const pkg = require( "../../package.json" );
@@ -60,7 +61,6 @@ module.exports = function( grunt ) {
 		const done = this.async();
 
 		try {
-			const slimFlags = [ "-ajax", "-callbacks", "-deferred", "-effects", "-queue" ];
 			const flags = this.flags;
 			const optIn = flags[ "*" ];
 			let name = grunt.option( "filename" );
@@ -79,7 +79,7 @@ module.exports = function( grunt ) {
 
 			if ( flags.slim ) {
 				delete flags.slim;
-				for ( const flag of slimFlags ) {
+				for ( const flag of slimBuildFlags ) {
 					flags[ flag ] = true;
 				}
 			}

--- a/build/tasks/lib/slim-build-flags.js
+++ b/build/tasks/lib/slim-build-flags.js
@@ -1,0 +1,10 @@
+"use strict";
+
+// NOTE: keep it in sync with test/data/testinit.js
+module.exports = [
+	"-ajax",
+	"-callbacks",
+	"-deferred",
+	"-effects",
+	"-queue"
+];

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -21,6 +21,7 @@
 		"createDashboardXML": false,
 		"createWithFriesXML": false,
 		"createXMLFragment": false,
+		"includesModule": false,
 		"moduleTeardown": false,
 		"url": false,
 		"q": false,

--- a/test/data/testinit-jsdom.js
+++ b/test/data/testinit-jsdom.js
@@ -42,6 +42,12 @@ function url( value ) {
 		new Date().getTime() + "" + parseInt( Math.random() * 100000, 10 );
 }
 
+// We only run basic tests in jsdom so we don't need to repeat the logic
+// from the regular testinit.js
+this.includesModule = function() {
+	return true;
+};
+
 // The file-loading part of testinit.js#loadTests is handled by
 // jsdom Karma config; here we just need to trigger relevant APIs.
 this.loadTests = function() {

--- a/test/data/testinit.js
+++ b/test/data/testinit.js
@@ -17,7 +17,16 @@ var FILEPATH = "/test/data/testinit.js",
 	supportjQuery = this.jQuery,
 
 	// see RFC 2606
-	externalHost = "example.com";
+	externalHost = "example.com",
+
+	// NOTE: keep it in sync with build/tasks/lib/slim-build-flags.js
+	slimBuildFlags = [
+		"-ajax",
+		"-callbacks",
+		"-deferred",
+		"-effects",
+		"-queue"
+	];
 
 this.hasPHP = true;
 this.isLocal = window.location.protocol === "file:";
@@ -308,6 +317,58 @@ QUnit.jQuerySelectors = true;
 // testing integrations with newer Web features not supported by it.
 QUnit.isIE = !!window.document.documentMode;
 QUnit.testUnlessIE = QUnit.isIE ? QUnit.skip : QUnit.test;
+
+// Returns whether a particular module like "ajax" or "deprecated"
+// is included in the current jQuery build; it handles the slim build
+// as well. The util was created so that we don't treat presence of
+// particular APIs to decide whether to run a test as then if we
+// accidentally remove an API, the tests would still not fail.
+this.includesModule = function( moduleName ) {
+
+	var excludedModulesPart, excludedModules;
+
+	// A short-cut for the slim build, e.g. "4.0.0-pre slim"
+	if ( jQuery.fn.jquery.indexOf( " slim" ) > -1 ) {
+
+		// The module is included if it does NOT exist on the list
+		// of modules excluded in the slim build
+		return slimBuildFlags.indexOf( "-" + moduleName ) === -1;
+	}
+
+	// example version for `grunt custom:-deprecated`:
+	// "4.0.0-pre -deprecated,-deprecated/ajax-event-alias,-deprecated/event"
+	excludedModulesPart = jQuery.fn.jquery
+
+		// Take the flags out of the version string.
+		// Example: "-deprecated,-deprecated/ajax-event-alias,-deprecated/event"
+		.split( " " )[ 1 ];
+
+	if ( !excludedModulesPart ) {
+
+		// No build part => the full build where everything is included.
+		return true;
+	}
+
+	excludedModules = excludedModulesPart
+
+		// Turn to an array.
+		// Example: [ "-deprecated", "-deprecated/ajax-event-alias", "-deprecated/event" ]
+		.split( "," )
+
+		// Remove the leading "-".
+		// Example: [ "deprecated", "deprecated/ajax-event-alias", "deprecated/event" ]
+		.map( function( moduleName ) {
+			return moduleName.slice( 1 );
+		} )
+
+		// Filter out deep names - ones that contain a slash.
+		// Example: [ "deprecated" ]
+		.filter( function( moduleName ) {
+			return moduleName.indexOf( "/" ) === -1;
+		} );
+
+	return excludedModules.indexOf( moduleName ) === -1;
+};
 
 this.loadTests = function() {
 

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -13,7 +13,7 @@ QUnit.module( "ajax", {
 		assert.ok( !isLocal, "Unit tests are not ran from file:// (especially in Chrome. If you must test from file:// with Chrome, run it with the --allow-file-access-from-files flag!)" );
 	} );
 
-	if ( !jQuery.ajax || ( isLocal && !hasPHP ) ) {
+	if ( !includesModule( "ajax" ) || ( isLocal && !hasPHP ) ) {
 		return;
 	}
 

--- a/test/unit/animation.js
+++ b/test/unit/animation.js
@@ -1,7 +1,7 @@
 ( function() {
 
 // Can't test what ain't there
-if ( !jQuery.fx ) {
+if ( !includesModule( "effects" ) ) {
 	return;
 }
 

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -921,7 +921,7 @@ QUnit.test( "val()", function( assert ) {
 		"Select-one with only option disabled (trac-12584)"
 	);
 
-	if ( jQuery.fn.serialize ) {
+	if ( includesModule( "serialize" ) ) {
 		checks = jQuery( "<input type='checkbox' name='test' value='1'/><input type='checkbox' name='test' value='2'/><input type='checkbox' name='test' value=''/><input type='checkbox' name='test'/>" ).appendTo( "#form" );
 
 		assert.deepEqual( checks.serialize(), "", "Get unchecked values." );

--- a/test/unit/basic.js
+++ b/test/unit/basic.js
@@ -1,6 +1,6 @@
 QUnit.module( "basic", { afterEach: moduleTeardown } );
 
-if ( jQuery.ajax ) {
+if ( includesModule( "ajax" ) ) {
 QUnit.test( "ajax", function( assert ) {
 	assert.expect( 4 );
 
@@ -33,6 +33,7 @@ QUnit.test( "ajax", function( assert ) {
 } );
 }
 
+if ( includesModule( "attributes" ) ) {
 QUnit.test( "attributes", function( assert ) {
 	assert.expect( 6 );
 
@@ -51,8 +52,9 @@ QUnit.test( "attributes", function( assert ) {
 
 	assert.strictEqual( input.val( "xyz" ).val(), "xyz", ".val getter/setter" );
 } );
+}
 
-if ( jQuery.css ) {
+if ( includesModule( "css" ) ) {
 QUnit.test( "css", function( assert ) {
 	assert.expect( 1 );
 
@@ -62,7 +64,7 @@ QUnit.test( "css", function( assert ) {
 } );
 }
 
-if ( jQuery.fn.show && jQuery.fn.hide ) {
+if ( includesModule( "css" ) ) {
 QUnit.test( "show/hide", function( assert ) {
 	assert.expect( 2 );
 
@@ -123,6 +125,7 @@ QUnit.test( "core", function( assert ) {
 		2, "jQuery.parseHTML" );
 } );
 
+if ( includesModule( "data" ) ) {
 QUnit.test( "data", function( assert ) {
 	assert.expect( 4 );
 
@@ -133,7 +136,9 @@ QUnit.test( "data", function( assert ) {
 	assert.strictEqual( elem.data( "c" ), "d", ".data from data-* attributes" );
 	assert.ok( jQuery.hasData( elem[ 0 ] ), "jQuery.hasData - true" );
 } );
+}
 
+if ( includesModule( "dimensions" ) ) {
 QUnit.test( "dimensions", function( assert ) {
 	assert.expect( 3 );
 
@@ -145,7 +150,9 @@ QUnit.test( "dimensions", function( assert ) {
 	assert.strictEqual( elem.innerWidth(), 64, ".innerWidth getter" );
 	assert.strictEqual( elem.outerWidth(), 68, ".outerWidth getter" );
 } );
+}
 
+if ( includesModule( "event" ) ) {
 QUnit.test( "event", function( assert ) {
 	assert.expect( 1 );
 
@@ -162,7 +169,9 @@ QUnit.test( "event", function( assert ) {
 		} )
 		.trigger( "click" );
 } );
+}
 
+if ( includesModule( "manipulation" ) ) {
 QUnit.test( "manipulation", function( assert ) {
 	assert.expect( 5 );
 
@@ -195,6 +204,9 @@ QUnit.test( "manipulation", function( assert ) {
 		".after/.before"
 	);
 } );
+}
+
+if ( includesModule( "offset" ) ) {
 
 // Support: jsdom 13.2+
 // jsdom returns 0 for offset-related properties
@@ -208,6 +220,7 @@ QUnit[ /jsdom\//.test( navigator.userAgent ) ? "skip" : "test" ]( "offset", func
 	assert.strictEqual( elem.position().top, 5, ".position getter" );
 	assert.strictEqual( elem.offsetParent()[ 0 ], parent[ 0 ], ".offsetParent" );
 } );
+}
 
 QUnit.test( "selector", function( assert ) {
 	assert.expect( 2 );
@@ -219,6 +232,7 @@ QUnit.test( "selector", function( assert ) {
 	assert.strictEqual( elem.find( "span.b a" )[ 0 ].nodeName, "A", ".find - one result" );
 } );
 
+if ( includesModule( "serialize" ) ) {
 QUnit.test( "serialize", function( assert ) {
 	assert.expect( 2 );
 
@@ -232,6 +246,7 @@ QUnit.test( "serialize", function( assert ) {
 		"&select1=&select2=3&select3=1&select3=2&select5=3",
 		"form serialization as query string" );
 } );
+}
 
 QUnit.test( "traversing", function( assert ) {
 	assert.expect( 12 );
@@ -253,6 +268,7 @@ QUnit.test( "traversing", function( assert ) {
 	assert.strictEqual( elem.contents()[ 3 ].nodeType, 3, ".contents" );
 } );
 
+if ( includesModule( "wrap" ) ) {
 QUnit.test( "wrap", function( assert ) {
 	assert.expect( 3 );
 
@@ -283,3 +299,4 @@ QUnit.test( "wrap", function( assert ) {
 	);
 
 } );
+}

--- a/test/unit/callbacks.js
+++ b/test/unit/callbacks.js
@@ -4,7 +4,7 @@ QUnit.module( "callbacks", {
 
 ( function() {
 
-if ( !jQuery.Callbacks ) {
+if ( !includesModule( "callbacks" ) ) {
 	return;
 }
 

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -36,23 +36,23 @@ QUnit.test( "jQuery()", function( assert ) {
 
 	// The $(html, props) signature can stealth-call any $.fn method, check for a
 	// few here but beware of modular builds where these methods may be excluded.
-	if ( jQuery.fn.click ) {
+	if ( includesModule( "deprecated" ) ) {
 		expected++;
 		attrObj[ "click" ] = function() { assert.ok( exec, "Click executed." ); };
 	}
-	if ( jQuery.fn.width ) {
+	if ( includesModule( "dimensions" ) ) {
 		expected++;
 		attrObj[ "width" ] = 10;
 	}
-	if ( jQuery.fn.offset ) {
+	if ( includesModule( "offset" ) ) {
 		expected++;
 		attrObj[ "offset" ] = { "top": 1, "left": 1 };
 	}
-	if ( jQuery.fn.css ) {
+	if ( includesModule( "css" ) ) {
 		expected += 2;
 		attrObj[ "css" ] = { "paddingLeft": 1, "paddingRight": 1 };
 	}
-	if ( jQuery.fn.attr ) {
+	if ( includesModule( "attributes" ) ) {
 		expected++;
 		attrObj.attr = { "desired": "very" };
 	}
@@ -115,20 +115,20 @@ QUnit.test( "jQuery()", function( assert ) {
 
 	elem = jQuery( "<div></div>", attrObj );
 
-	if ( jQuery.fn.width ) {
+	if ( includesModule( "dimensions" ) ) {
 		assert.equal( elem[ 0 ].style.width, "10px", "jQuery() quick setter width" );
 	}
 
-	if ( jQuery.fn.offset ) {
+	if ( includesModule( "offset" ) ) {
 		assert.equal( elem[ 0 ].style.top, "1px", "jQuery() quick setter offset" );
 	}
 
-	if ( jQuery.fn.css ) {
+	if ( includesModule( "css" ) ) {
 		assert.equal( elem[ 0 ].style.paddingLeft, "1px", "jQuery quick setter css" );
 		assert.equal( elem[ 0 ].style.paddingRight, "1px", "jQuery quick setter css" );
 	}
 
-	if ( jQuery.fn.attr ) {
+	if ( includesModule( "attributes" ) ) {
 		assert.equal( elem[ 0 ].getAttribute( "desired" ), "very", "jQuery quick setter attr" );
 	}
 
@@ -1522,7 +1522,7 @@ testIframe(
 	}
 );
 
-QUnit[ jQuery.Deferred ? "test" : "skip" ]( "jQuery.readyException (original)", function( assert ) {
+QUnit[ includesModule( "deferred" ) ? "test" : "skip" ]( "jQuery.readyException (original)", function( assert ) {
 	assert.expect( 1 );
 
 	var message;
@@ -1545,7 +1545,7 @@ QUnit[ jQuery.Deferred ? "test" : "skip" ]( "jQuery.readyException (original)", 
 	);
 } );
 
-QUnit[ jQuery.Deferred ? "test" : "skip" ]( "jQuery.readyException (custom)", function( assert ) {
+QUnit[ includesModule( "deferred" ) ? "test" : "skip" ]( "jQuery.readyException (custom)", function( assert ) {
 	assert.expect( 1 );
 
 	var done = assert.async();

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -1,4 +1,4 @@
-if ( jQuery.css ) {
+if ( includesModule( "css" ) ) {
 
 QUnit.module( "css", { afterEach: moduleTeardown } );
 
@@ -965,7 +965,7 @@ QUnit.test( "show/hide 3.0, inline hidden", function( assert ) {
 	} );
 } );
 
-QUnit[ QUnit.jQuerySelectors && jQuery.fn.toggle ? "test" : "skip" ]( "toggle()", function( assert ) {
+QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "toggle()", function( assert ) {
 	assert.expect( 9 );
 	var div, oldHide,
 		x = jQuery( "#foo" );
@@ -998,7 +998,7 @@ QUnit[ QUnit.jQuerySelectors && jQuery.fn.toggle ? "test" : "skip" ]( "toggle()"
 	jQuery.fn.hide = oldHide;
 } );
 
-QUnit[ QUnit.jQuerySelectors && jQuery.fn.toggle ? "test" : "skip" ]( "detached toggle()", function( assert ) {
+QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "detached toggle()", function( assert ) {
 	assert.expect( 6 );
 	var detached = jQuery( "<p><a></a><p>" ).find( "*" ).addBack(),
 		hiddenDetached = jQuery( "<p><a></a></p>" ).find( "*" ).addBack().css( "display", "none" ),
@@ -1022,7 +1022,7 @@ QUnit[ QUnit.jQuerySelectors && jQuery.fn.toggle ? "test" : "skip" ]( "detached 
 		"cascade-hidden element in detached tree" );
 } );
 
-QUnit[ QUnit.jQuerySelectors && jQuery.fn.toggle && !QUnit.isIE ? "test" : "skip" ](
+QUnit[ QUnit.jQuerySelectors && !QUnit.isIE ? "test" : "skip" ](
 	"shadow toggle()", function( assert ) {
 
 	assert.expect( 4 );
@@ -1171,7 +1171,7 @@ QUnit.test( "can't get background-position in IE<9, see trac-10796", function( a
 	}
 } );
 
-if ( jQuery.fn.offset ) {
+if ( includesModule( "offset" ) ) {
 	QUnit.test( "percentage properties for left and top should be transformed to pixels, see trac-9505", function( assert ) {
 		assert.expect( 2 );
 		var parent = jQuery( "<div style='position:relative;width:200px;height:200px;margin:0;padding:0;border-width:0'></div>" ).appendTo( "#qunit-fixture" ),

--- a/test/unit/deferred.js
+++ b/test/unit/deferred.js
@@ -4,7 +4,7 @@ QUnit.module( "deferred", {
 
 ( function() {
 
-if ( !jQuery.Deferred ) {
+if ( !includesModule( "deferred" ) ) {
 	return;
 }
 

--- a/test/unit/deprecated.js
+++ b/test/unit/deprecated.js
@@ -1,7 +1,8 @@
 QUnit.module( "deprecated", { afterEach: moduleTeardown } );
 
+if ( includesModule( "deprecated" ) ) {
 
-QUnit[ jQuery.fn.bind ? "test" : "skip" ]( "bind/unbind", function( assert ) {
+QUnit.test( "bind/unbind", function( assert ) {
 	assert.expect( 4 );
 
 	var markup = jQuery(
@@ -22,7 +23,7 @@ QUnit[ jQuery.fn.bind ? "test" : "skip" ]( "bind/unbind", function( assert ) {
 		.remove();
 } );
 
-QUnit[ jQuery.fn.delegate ? "test" : "skip" ]( "delegate/undelegate", function( assert ) {
+QUnit.test( "delegate/undelegate", function( assert ) {
 	assert.expect( 2 );
 
 	var markup = jQuery(
@@ -41,7 +42,7 @@ QUnit[ jQuery.fn.delegate ? "test" : "skip" ]( "delegate/undelegate", function( 
 		.remove();
 } );
 
-QUnit[ jQuery.fn.hover ? "test" : "skip" ]( "hover() mouseenter mouseleave", function( assert ) {
+QUnit.test( "hover() mouseenter mouseleave", function( assert ) {
 	assert.expect( 1 );
 
 	var times = 0,
@@ -61,7 +62,7 @@ QUnit[ jQuery.fn.hover ? "test" : "skip" ]( "hover() mouseenter mouseleave", fun
 	assert.equal( times, 4, "hover handlers fired" );
 } );
 
-QUnit[ jQuery.fn.click ? "test" : "skip" ]( "trigger() shortcuts", function( assert ) {
+QUnit.test( "trigger() shortcuts", function( assert ) {
 	assert.expect( 5 );
 
 	var counter, clickCounter,
@@ -95,7 +96,7 @@ QUnit[ jQuery.fn.click ? "test" : "skip" ]( "trigger() shortcuts", function( ass
 	assert.equal( clickCounter, 1, "Check that click, triggers onclick event handler on an a tag also" );
 } );
 
-if ( jQuery.ajax && jQuery.fn.ajaxSend ) {
+if ( includesModule( "ajax" ) ) {
 	ajaxTest( "jQuery.ajax() - events with context", 12, function( assert ) {
 		var context = document.createElement( "div" );
 
@@ -112,10 +113,10 @@ if ( jQuery.ajax && jQuery.fn.ajaxSend ) {
 		return {
 			setup: function() {
 				jQuery( context ).appendTo( "#foo" )
-					.ajaxSend( event )
-					.ajaxComplete( event )
-					.ajaxError( event )
-					.ajaxSuccess( event );
+					.on( "ajaxSend", event )
+					.on( "ajaxComplete", event )
+					.on( "ajaxError", event )
+					.on( "ajaxSuccess", event );
 			},
 			requests: [ {
 				url: url( "name.html" ),
@@ -134,7 +135,7 @@ if ( jQuery.ajax && jQuery.fn.ajaxSend ) {
 	} );
 }
 
-QUnit[ jQuery.fn.click ? "test" : "skip" ]( "Event aliases", function( assert ) {
+QUnit.test( "Event aliases", function( assert ) {
 
 	// Explicitly skipping focus/blur events due to their flakiness
 	var	$elem = jQuery( "<div></div>" ).appendTo( "#qunit-fixture" ),
@@ -152,7 +153,7 @@ QUnit[ jQuery.fn.click ? "test" : "skip" ]( "Event aliases", function( assert ) 
 	} );
 } );
 
-QUnit[ jQuery.proxy ? "test" : "skip" ]( "jQuery.proxy", function( assert ) {
+QUnit.test( "jQuery.proxy", function( assert ) {
 	assert.expect( 9 );
 
 	var test2, test3, test4, fn, cb,
@@ -199,3 +200,5 @@ QUnit[ jQuery.proxy ? "test" : "skip" ]( "jQuery.proxy", function( assert ) {
 	cb = jQuery.proxy( fn, null, "arg1", "arg2" );
 	cb.call( thisObject, "arg3" );
 } );
+
+}

--- a/test/unit/dimensions.js
+++ b/test/unit/dimensions.js
@@ -1,6 +1,6 @@
 ( function() {
 
-if ( !jQuery.fn.width ) {
+if ( !includesModule( "dimensions" ) ) {
 	return;
 }
 

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -1,7 +1,7 @@
 ( function() {
 
 // Can't test what ain't there
-if ( !jQuery.fx ) {
+if ( !includesModule( "effects" ) ) {
 	return;
 }
 

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -445,7 +445,7 @@ QUnit.test( "append HTML5 sectioning elements (Bug trac-6485)", function( assert
 	assert.equal( aside.length, 1, "HTML5 elements do not collapse their children" );
 } );
 
-QUnit[ jQuery.fn.css ? "test" : "skip" ]( "HTML5 Elements inherit styles from style rules (Bug trac-10501)", function( assert ) {
+QUnit[ includesModule( "css" ) ? "test" : "skip" ]( "HTML5 Elements inherit styles from style rules (Bug trac-10501)", function( assert ) {
 
 	assert.expect( 1 );
 
@@ -2300,7 +2300,7 @@ testIframe(
 	},
 
 	// The AJAX module is needed for jQuery._evalUrl.
-	QUnit[ jQuery.ajax ? "test" : "skip" ]
+	QUnit[ includesModule( "ajax" ) ? "test" : "skip" ]
 );
 
 
@@ -2309,7 +2309,7 @@ testIframe(
 // Skip the the test if we are not in localhost but make sure we run
 // it in Karma.
 QUnit[
-	jQuery.ajax && ( window.__karma__ || location.hostname === "localhost" ) ?
+	includesModule( "ajax" ) && ( window.__karma__ || location.hostname === "localhost" ) ?
 		"test" :
 		"skip"
 ]( "jQuery.append with crossorigin attribute", function( assert ) {
@@ -2453,7 +2453,7 @@ QUnit.test( "html() - script exceptions bubble (trac-11743)", function( assert )
 	window.onerror = function() {
 		assert.ok( true, "Exception thrown" );
 
-		if ( jQuery.ajax ) {
+		if ( includesModule( "ajax" ) ) {
 			window.onerror = function() {
 				assert.ok( true, "Exception thrown in remote script" );
 			};
@@ -2541,7 +2541,7 @@ QUnit.test( "script evaluation (trac-11795)", function( assert ) {
 	assert.deepEqual( fixture.children( "script" ).get(), scriptsOut.get(), "Scripts detached without reevaluation" );
 	objGlobal.ok = isOk;
 
-	if ( jQuery.ajax ) {
+	if ( includesModule( "ajax" ) ) {
 		Globals.register( "testBar" );
 		jQuery( "#qunit-fixture" ).append( "<script src='" + url( "mock.php?action=testbar" ) + "'></script>" );
 		assert.strictEqual( window.testBar, "bar", "Global script evaluation" );
@@ -2551,7 +2551,7 @@ QUnit.test( "script evaluation (trac-11795)", function( assert ) {
 	}
 } );
 
-QUnit[ jQuery.ajax ? "test" : "skip" ]( "jQuery._evalUrl (trac-12838)", function( assert ) {
+QUnit[ includesModule( "ajax" ) ? "test" : "skip" ]( "jQuery._evalUrl (trac-12838)", function( assert ) {
 
 	assert.expect( 5 );
 
@@ -2846,7 +2846,7 @@ QUnit.test( "Make sure tags with single-character names are found (gh-4124)", fu
 } );
 
 // The AJAX module is needed for jQuery._evalUrl.
-QUnit[ jQuery.ajax ? "test" : "skip" ]( "Insert script with data-URI (gh-1887)", function( assert ) {
+QUnit[ includesModule( "ajax" ) ? "test" : "skip" ]( "Insert script with data-URI (gh-1887)", function( assert ) {
 	assert.expect( 1 );
 
 	Globals.register( "testFoo" );
@@ -2923,7 +2923,7 @@ testIframe(
 	},
 
 	// The AJAX module is needed for jQuery._evalUrl.
-	QUnit[ jQuery.ajax ? "test" : "skip" ]
+	QUnit[ includesModule( "ajax" ) ? "test" : "skip" ]
 );
 
 testIframe(

--- a/test/unit/offset.js
+++ b/test/unit/offset.js
@@ -1,6 +1,6 @@
 ( function() {
 
-if ( !jQuery.fn.offset ) {
+if ( !includesModule( "offset" ) ) {
 	return;
 }
 

--- a/test/unit/queue.js
+++ b/test/unit/queue.js
@@ -2,7 +2,7 @@ QUnit.module( "queue", { afterEach: moduleTeardown } );
 
 ( function() {
 
-if ( !jQuery.fn.queue ) {
+if ( !includesModule( "queue" ) ) {
 	return;
 }
 
@@ -241,7 +241,7 @@ QUnit.test( "fn.promise( \"queue\" ) - called whenever last queue function is de
 	foo.dequeue( "queue" );
 } );
 
-if ( jQuery.fn.animate ) {
+if ( includesModule( "effects" ) ) {
 
 QUnit.test( "fn.promise( \"queue\" ) - waits for animation to complete before resolving", function( assert ) {
 	assert.expect( 2 );
@@ -277,7 +277,7 @@ QUnit.test( ".promise(obj)", function( assert ) {
 	assert.strictEqual( promise, obj, ".promise(type, obj) returns obj" );
 } );
 
-QUnit[ jQuery.fn.stop ? "test" : "skip" ]( "delay() can be stopped", function( assert ) {
+QUnit[ includesModule( "effects" ) ? "test" : "skip" ]( "delay() can be stopped", function( assert ) {
 	var done = assert.async();
 	assert.expect( 3 );
 	var storage = {};
@@ -314,7 +314,7 @@ QUnit[ jQuery.fn.stop ? "test" : "skip" ]( "delay() can be stopped", function( a
 	}, 1500 );
 } );
 
-QUnit[ jQuery.fn.stop ? "test" : "skip" ]( "queue stop hooks", function( assert ) {
+QUnit[ includesModule( "effects" ) ? "test" : "skip" ]( "queue stop hooks", function( assert ) {
 	assert.expect( 2 );
 	var done = assert.async();
 	var foo = jQuery( "#foo" );

--- a/test/unit/ready.js
+++ b/test/unit/ready.js
@@ -105,7 +105,7 @@ QUnit.module( "ready" );
 		} );
 	} );
 
-	QUnit[ jQuery.when ? "test" : "skip" ]( "jQuery.when(jQuery.ready)", function( assert ) {
+	QUnit[ includesModule( "deferred" ) ? "test" : "skip" ]( "jQuery.when(jQuery.ready)", function( assert ) {
 		assert.expect( 2 );
 		var done = assert.async( 2 );
 
@@ -150,7 +150,7 @@ QUnit.module( "ready" );
 	} );
 
 	// jQuery.holdReady is deprecated, skip the test if it was excluded.
-	if ( jQuery.holdReady ) {
+	if ( includesModule( "deprecated" ) ) {
 		testIframe(
 			"holdReady test needs to be a standalone test since it deals with DOM ready",
 			"readywait.html",

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -77,7 +77,7 @@ QUnit.test( "jQuery.param()", function( assert ) {
 	assert.equal( jQuery.param( params ), "", "jQuery.param( undefined ) === empty string" );
 } );
 
-QUnit[ jQuery.ajax ? "test" : "skip" ]( "jQuery.param() not affected by ajaxSettings", function( assert ) {
+QUnit[ includesModule( "ajax" ) ? "test" : "skip" ]( "jQuery.param() not affected by ajaxSettings", function( assert ) {
 	assert.expect( 1 );
 
 	var oldTraditional = jQuery.ajaxSettings.traditional;

--- a/test/unit/support.js
+++ b/test/unit/support.js
@@ -17,7 +17,7 @@ function getComputedSupport( support ) {
 	return result;
 }
 
-if ( jQuery.css ) {
+if ( includesModule( "css" ) ) {
 	testIframe(
 		"body background is not lost if set prior to loading jQuery (trac-9239)",
 		"support/bodyBackground.html",

--- a/test/unit/tween.js
+++ b/test/unit/tween.js
@@ -1,7 +1,7 @@
 ( function() {
 
 // Can't test what ain't there
-if ( !jQuery.fx ) {
+if ( !includesModule( "effects" ) ) {
 	return;
 }
 

--- a/test/unit/wrap.js
+++ b/test/unit/wrap.js
@@ -1,6 +1,6 @@
 ( function() {
 
-if ( !jQuery.fn.wrap ) { // no wrap module
+if ( !includesModule( "wrap" ) ) {
 	return;
 }
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Introduces a new test API, `includesModule`. The method returns whether
a particular module like "ajax" or "deprecated" is included in the current
jQuery build; it handles the slim build as well. The util was created so that
we don't treat presence of particular APIs to decide whether to run a test as
then if we accidentally remove an API, the tests would still not fail.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
