### PR TITLE
feat: option to include unselected values in form serialize

### DIFF
--- a/src/serialize.js
+++ b/src/serialize.js
@@ -92,8 +92,25 @@ jQuery.param = function( a, traditional ) {
 };
 
 jQuery.fn.extend( {
-	serialize: function() {
-		return jQuery.param( this.serializeArray() );
+	serialize: function( includeUnselected ) {
+		var serialized = jQuery.param( this.serializeArray() ), empty = "";
+
+		this.each( function() {
+			if ( includeUnselected ) {
+				jQuery( this ).find(
+					"input[name][type=checkbox]:not(:checked),input[name][type=radio]:not(:checked)"
+				).each( function() {
+					empty += ( empty !== "" ? "&" : "" ) + this.name + "=";
+				} );
+				jQuery( this ).find( "select[name][multiple]" ).each( function() {
+					if ( jQuery( this ).find( "option:selected" ).length === 0 ) {
+						empty += ( empty !== "" ? "&" : "" ) + this.name + "=";
+					}
+				} );
+			}
+		} );
+
+		return serialized + ( ( serialized !== "" && empty !== "" ) ? "&" : "" ) + empty;
 	},
 	serializeArray: function() {
 		return this.map( function() {

--- a/test/data/qunit-fixture.html
+++ b/test/data/qunit-fixture.html
@@ -21,16 +21,17 @@
 <ol id="empty"></ol>
 <form id="form" action="formaction">
 	<label for="action" id="label-for">Action:</label>
-	<input type="text" name="action" value="Test" id="text1" maxlength="30"/>
-	<input type="text" name="text2" value="Test" id="text2" disabled="disabled"/>
-	<input type="radio" name="radio1" id="radio1" value="on"/>
+	<input type="text" name="action" value="Test" id="text1" maxlength="30" />
+	<input type="text" name="text2" value="Test" id="text2" disabled="disabled" />
+	<input type="radio" name="radio1" id="radio1" value="on" />
 
-	<input type="radio" name="radio2" id="radio2" checked="checked"/>
-	<input type="checkbox" name="check" id="check1" checked="checked"/>
-	<input type="checkbox" id="check2" value="on"/>
+	<input type="radio" name="radio2" id="radio2" checked="checked" />
+	<input type="checkbox" name="check" id="check1" checked="checked" />
+	<input type="checkbox" id="check2" value="on" />
+	<input type="checkbox" name="check3" id="check3" value="on" />
 
-	<input type="hidden" name="hidden" id="hidden1"/>
-	<input type="text" style="display:none;" name="foo[bar]" id="hidden2"/>
+	<input type="hidden" name="hidden" id="hidden1" />
+	<input type="text" style="display:none;" name="foo[bar]" id="hidden2" />
 
 	<input type="text" id="name" name="name" value="name" />
 	<input type="search" id="search" name="search" value="search" />
@@ -71,6 +72,11 @@
 		<option id="option5a" value="3">1</option>
 		<option id="option5b" value="2">2</option>
 		<option id="option5c" value="1" data-attr="">3</option>
+	</select>
+	<select name="select6" id="select6" multiple="multiple">
+		<option id="option6a" value="3">1</option>
+		<option id="option6b" value="2">2</option>
+		<option id="option6c" value="1" data-attr="">3</option>
 	</select>
 
 	<object id="object1" codebase="stupid">
@@ -136,6 +142,9 @@ Z</textarea>
 	</select>
 	<select name="S4">
 		<option value="" selected="selected">NO</option>
+	</select>
+	<select name="S5" multiple="multiple">
+		<option value="abc">ABC</option>
 	</select>
 	<input type="submit" name="sub1" value="NO" />
 	<input type="submit" name="sub2" value="NO" />

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -116,7 +116,7 @@ QUnit.test( "jQuery.param() Constructed prop values", function( assert ) {
 } );
 
 QUnit.test( "serialize()", function( assert ) {
-	assert.expect( 6 );
+	assert.expect( 12 );
 
 	// Add html5 elements only for serialize because selector can't yet find them on non-html5 browsers
 	jQuery( "#search" ).after(
@@ -129,25 +129,49 @@ QUnit.test( "serialize()", function( assert ) {
 		"action=Test&radio2=on&check=on&hidden=&foo%5Bbar%5D=&name=name&search=search&email=dave%40jquery.com&number=43&select1=&select2=3&select3=1&select3=2&select5=3",
 		"Check form serialization as query string" );
 
+	assert.equal( jQuery( "#form" ).serialize( true ),
+		"action=Test&radio2=on&check=on&hidden=&foo%5Bbar%5D=&name=name&search=search&email=dave%40jquery.com&number=43&select1=&select2=3&select3=1&select3=2&select5=3&radio1=&check3=&select6=",
+		"Check form serialization (including unselected values) as query string" );
+
 	assert.equal( jQuery( "input,select,textarea,button", "#form" ).serialize(),
 		"action=Test&radio2=on&check=on&hidden=&foo%5Bbar%5D=&name=name&search=search&email=dave%40jquery.com&number=43&select1=&select2=3&select3=1&select3=2&select5=3",
 		"Check input serialization as query string" );
+
+	assert.equal( jQuery( "input,select,textarea,button", "#form" ).serialize( true ),
+		"action=Test&radio2=on&check=on&hidden=&foo%5Bbar%5D=&name=name&search=search&email=dave%40jquery.com&number=43&select1=&select2=3&select3=1&select3=2&select5=3",
+		"Check input serialization (including unselected values) as query string" );
 
 	assert.equal( jQuery( "#testForm" ).serialize(),
 		"T3=%3F%0D%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My%20Name=me&S1=abc&S3=YES&S4=",
 		"Check form serialization as query string" );
 
+	assert.equal( jQuery( "#testForm" ).serialize( true ),
+		"T3=%3F%0D%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My%20Name=me&S1=abc&S3=YES&S4=&C1=&C2=&R1=&R1=&S2=&S5=",
+		"Check form serialization (including unselected values) as query string" );
+
 	assert.equal( jQuery( "input,select,textarea,button", "#testForm" ).serialize(),
 		"T3=%3F%0D%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My%20Name=me&S1=abc&S3=YES&S4=",
 		"Check input serialization as query string" );
+
+	assert.equal( jQuery( "input,select,textarea,button", "#testForm" ).serialize( true ),
+		"T3=%3F%0D%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My%20Name=me&S1=abc&S3=YES&S4=",
+		"Check input serialization (including unselected values) as query string" );
 
 	assert.equal( jQuery( "#form, #testForm" ).serialize(),
 		"action=Test&radio2=on&check=on&hidden=&foo%5Bbar%5D=&name=name&search=search&email=dave%40jquery.com&number=43&select1=&select2=3&select3=1&select3=2&select5=3&T3=%3F%0D%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My%20Name=me&S1=abc&S3=YES&S4=",
 		"Multiple form serialization as query string" );
 
+	assert.equal( jQuery( "#form, #testForm" ).serialize( true ),
+		"action=Test&radio2=on&check=on&hidden=&foo%5Bbar%5D=&name=name&search=search&email=dave%40jquery.com&number=43&select1=&select2=3&select3=1&select3=2&select5=3&T3=%3F%0D%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My%20Name=me&S1=abc&S3=YES&S4=&radio1=&check3=&select6=&C1=&C2=&R1=&R1=&S2=&S5=",
+		"Multiple form serialization (including unselected values) as query string" );
+
 	assert.equal( jQuery( "#form, #testForm input, #testForm select, #testForm textarea, #testForm button" ).serialize(),
 		"action=Test&radio2=on&check=on&hidden=&foo%5Bbar%5D=&name=name&search=search&email=dave%40jquery.com&number=43&select1=&select2=3&select3=1&select3=2&select5=3&T3=%3F%0D%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My%20Name=me&S1=abc&S3=YES&S4=",
 		"Mixed form/input serialization as query string" );
+
+	assert.equal( jQuery( "#form, #testForm input, #testForm select, #testForm textarea, #testForm button" ).serialize( true ),
+		"action=Test&radio2=on&check=on&hidden=&foo%5Bbar%5D=&name=name&search=search&email=dave%40jquery.com&number=43&select1=&select2=3&select3=1&select3=2&select5=3&T3=%3F%0D%0AZ&H1=x&H2=&PWD=&T1=&T2=YES&My%20Name=me&S1=abc&S3=YES&S4=&radio1=&check3=&select6=",
+		"Mixed form/input serialization (including unselected values) as query string" );
 
 	jQuery( "#html5email, #html5number" ).remove();
 } );


### PR DESCRIPTION
### Summary ###
New optional parameter `includeUnseleted` in **Form Serialize** - `serialize: function( includeUnselected )` that specifies that we'd like to output **unselected** `input[type=radio]`, `input[type=checkbox]` and `select[multiple]` elements to the QueryString as empty values, e.g. _myRadioButton=&myCheckbox=&myMultiSelect=_

this commit resolves #5033

### Checklist ###

* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com