### PR TITLE
Data: ShadowRoot support listen events & data get/set

### DIFF
--- a/src/data/var/acceptData.js
+++ b/src/data/var/acceptData.js
@@ -7,7 +7,7 @@ export default function( owner ) {
 	//  - Node
 	//    - Node.ELEMENT_NODE
 	//    - Node.DOCUMENT_NODE
-	//    - Node.SHADOWROOT_NODE
+	//    - Node.DOCUMENT_FRAGMENT_NODE
 	//  - Object
 	//    - Any
 	return owner.nodeType === 1 || owner.nodeType === 9 ||

--- a/src/data/var/acceptData.js
+++ b/src/data/var/acceptData.js
@@ -7,7 +7,9 @@ export default function( owner ) {
 	//  - Node
 	//    - Node.ELEMENT_NODE
 	//    - Node.DOCUMENT_NODE
+	//    - Node.SHADOWROOT_NODE
 	//  - Object
 	//    - Any
-	return owner.nodeType === 1 || owner.nodeType === 9 || !( +owner.nodeType );
+	return owner.nodeType === 1 || owner.nodeType === 9 ||
+		( owner.nodeType === 11 && owner.host ) || !( +owner.nodeType );
 }

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -29,6 +29,55 @@ QUnit.test( "jQuery.data & removeData, expected returns", function( assert ) {
 
 } );
 
+QUnit[ document.body.attachShadow && document.body.getRootNode ?
+	"test" :
+	"skip"
+]( "jQuery.data & removeData, expected returns, shadow dom", function( assert ) {
+
+	assert.expect( 4 );
+
+	jQuery( "<div id='shadowHost'></div>" ).appendTo( "#qunit-fixture" );
+	var shadowHost = document.querySelector( "#shadowHost" );
+	var shadowRoot$ = jQuery( shadowHost.attachShadow( { mode: "open" } ) );
+
+	shadowRoot$.data( "hello", "world" );
+	assert.equal( shadowRoot$.data( "hello" ), "world", "shadowRoot$.data( key, value ) success" );
+
+	shadowRoot$.data( { baz: [ 1, 2, 3 ] } );
+	assert.deepEqual( shadowRoot$.data(), { hello: "world", baz: [ 1, 2, 3 ] }, "shadowRoot$.data( object ) success" );
+
+	shadowRoot$.removeData( "hello" );
+	assert.deepEqual( shadowRoot$.data(), { baz: [ 1, 2, 3 ] }, "shadowRoot$.removeData( key ) success" );
+
+	shadowRoot$.removeData();
+	assert.deepEqual( shadowRoot$.data(), {}, "shadowRoot$.removeData() success" );
+} );
+
+QUnit.test( "jQuery.data & removeData, expected returns, template dom", function( assert ) {
+
+	assert.expect( 5 );
+
+	jQuery( "<template id='template'><p>Smile!</p></template>" ).appendTo( "#qunit-fixture" );
+	var contents = jQuery( "#template" ).contents();
+	assert.equal( contents.length, 1, "Check template element contents" );
+
+	var template$ = jQuery( document.querySelector( "#template" ) );
+
+	template$.data( "hello", "world" );
+	assert.equal( template$.data( "hello" ), "world", "template$.data( key, value ) success" );
+
+	template$.data( { baz: [ 1, 2, 3 ] } );
+	assert.deepEqual( template$.data(), { hello: "world", baz: [ 1, 2, 3 ] }, "template$.data( object ) success" );
+
+	template$.removeData( "hello" );
+
+	assert.deepEqual( template$.data(), { baz: [ 1, 2, 3 ] }, "template$.removeData( key ) success" );
+
+	template$.removeData();
+
+	assert.deepEqual( template$.data(), {}, "template$.removeData() success" );
+} );
+
 QUnit.test( "jQuery._data & _removeData, expected returns", function( assert ) {
 	assert.expect( 4 );
 	var elem = document.body;

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -45,6 +45,45 @@ QUnit.test( "on() with non-null,defined data", function( assert ) {
 
 } );
 
+QUnit[ document.body.attachShadow && document.body.getRootNode ?
+	"test" :
+	"skip"
+]( "on(), shadow dom", function( assert ) {
+
+	assert.expect( 1 );
+
+	jQuery( "<div id='shadowHost'></div>" ).appendTo( "#qunit-fixture" );
+	var shadowHost = document.querySelector( "#shadowHost" );
+	var shadowRoot = shadowHost.attachShadow( { mode: "open" } );
+
+	var handler = function( event, data ) {
+		assert.equal( data, 0, "defined data (zero) is correctly passed" );
+	};
+
+	jQuery( shadowRoot ).on( "click", handler );
+	jQuery( shadowRoot ).trigger( "click", 0 );
+
+} );
+
+QUnit.test( "on(), template dom", function( assert ) {
+
+	assert.expect( 2 );
+
+	jQuery( "<template id='template'><p>Smile!</p></template>" ).appendTo( "#qunit-fixture" );
+	var contents = jQuery( "#template" ).contents();
+	assert.equal( contents.length, 1, "Check template element contents" );
+
+	var template = document.querySelector( "#template" );
+
+	var handler = function( event, data ) {
+		assert.equal( data, 0, "defined data (zero) is correctly passed" );
+	};
+
+	jQuery( template ).on( "click", handler );
+	jQuery( template ).trigger( "click", 0 );
+
+} );
+
 QUnit.test( "Handler changes and .trigger() order", function( assert ) {
 	assert.expect( 1 );
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
JQuery adds constraints, do not allow add data and add event listen to non-elements, see [bugs-8335](https://bugs.jquery.com/ticket/8335)

And ShadowRoot elements have `nodeType === 11`

But ShadowRoot elements are supported only on modern browsers, so this fix (owner.nodeType === 11 && owner.host) can be discussed here

Fixes [gh-4317](https://github.com/jquery/jquery/issues/4317) [gh-4418](https://github.com/jquery/jquery/issues/4418)

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
