### PR TITLE
Tests: Fix the link to QUnit CSS file

### DIFF
--- a/test/karma.debug.html
+++ b/test/karma.debug.html
@@ -5,7 +5,7 @@
 	<title>DEBUG</title>
 	<meta charset="utf-8">
 	<!-- Karma serves this page from /context.html. Other files are served from /base -->
-	<link rel="stylesheet" href="/base/external/qunit/qunit/qunit.css" />
+	<link rel="stylesheet" href="/base/external/qunit/qunit.css" />
 	<link rel="stylesheet" href="/base/test/data/testsuite.css" />
 </head>
 <body id="body">


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Without this fix, the layout is fine during the test run but all the CSS is gone
when tests finish and the results are shown.

This affects commands like `grunt karma:chrome-debug`.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
