### PR TITLE
Core: Drop the root parameter of jQuery.fn.init

### DIFF
--- a/src/core/init.js
+++ b/src/core/init.js
@@ -15,17 +15,13 @@ var rootjQuery,
 	// Shortcut simple #id case for speed
 	rquickExpr = /^(?:\s*(<[\w\W]+>)[^>]*|#([\w-]+))$/,
 
-	init = jQuery.fn.init = function( selector, context, root ) {
+	init = jQuery.fn.init = function( selector, context ) {
 		var match, elem;
 
 		// HANDLE: $(""), $(null), $(undefined), $(false)
 		if ( !selector ) {
 			return this;
 		}
-
-		// Method init() accepts an alternate rootjQuery
-		// so migrate can support jQuery.sub (gh-2101)
-		root = root || rootjQuery;
 
 		// HANDLE: $(DOMElement)
 		if ( selector.nodeType ) {
@@ -36,8 +32,8 @@ var rootjQuery,
 		// HANDLE: $(function)
 		// Shortcut for document ready
 		} else if ( typeof selector === "function" ) {
-			return root.ready !== undefined ?
-				root.ready( selector ) :
+			return rootjQuery.ready !== undefined ?
+				rootjQuery.ready( selector ) :
 
 				// Execute immediately if ready is not present
 				selector( jQuery );
@@ -108,7 +104,7 @@ var rootjQuery,
 
 			// HANDLE: $(expr) & $(expr, $(...))
 			} else if ( !context || context.jquery ) {
-				return ( context || root ).find( selector );
+				return ( context || rootjQuery ).find( selector );
 
 			// HANDLE: $(expr, context)
 			// (which is just equivalent to: $(context).find(expr)


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The third parameter of `jQuery.fn.init` - `root` - was just needed to support
`jQuery.sub`. Since this API has been removed in jQuery 1.9.0 and Migrate 3.x
is not filling it in, this parameter is no longer needed.

This parameter has never been documented but it's safer to remove it in a major
update.

It would still be good to put that in the upgrade guide.

-2 bytes

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
