### PR TITLE
CSS: Don’t trim whitespace of undefined custom property

### DIFF
--- a/src/css/curCSS.js
+++ b/src/css/curCSS.js
@@ -15,7 +15,7 @@ function curCSS( elem, name, computed ) {
 		ret = computed.getPropertyValue( name ) || computed[ name ];
 
 		// trim whitespace for custom property (issue gh-4926)
-		if ( isCustomProp ) {
+		if ( isCustomProp && ret !== undefined ) {
 
 			// rtrim treats U+000D CARRIAGE RETURN and U+000C FORM FEED
 			// as whitespace while CSS does not, but this is not a problem

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -1748,6 +1748,7 @@ QUnit.testUnlessIE( "css(--customProperty)", function( assert ) {
 		"        --prop10:\f\r\n\t val10 \f\r\n\t;\n" +
 		"        --prop11:\u000C\u000D\u000A\u0009\u0020val11\u0020\u0009\u000A\u000D\u000C;\n" +
 		"        --prop12:\u000Bval12\u000B;\n" +
+		"        --empty:;\n" +
 		"    }\n" +
 		"</style>"
 	);
@@ -1756,7 +1757,7 @@ QUnit.testUnlessIE( "css(--customProperty)", function( assert ) {
 		$elem = jQuery( "<div>" ).addClass( "test__customProperties" )
 			.appendTo( "#qunit-fixture" ),
 		webkitOrBlink = /\bsafari\b/i.test( navigator.userAgent ),
-		expected = 17;
+		expected = 19;
 
 	if ( webkitOrBlink ) {
 		expected -= 2;
@@ -1802,6 +1803,8 @@ QUnit.testUnlessIE( "css(--customProperty)", function( assert ) {
 	assert.equal( $elem.css( "--prop10" ), "val10", "Multiple preceding and following escaped unicode whitespace trimmed" );
 	assert.equal( $elem.css( "--prop11" ), "val11", "Multiple preceding and following unicode whitespace trimmed" );
 	assert.equal( $elem.css( "--prop12" ), "\u000Bval12\u000B", "Multiple preceding and following non-CSS whitespace reserved" );
+	assert.equal( $elem.css( "--empty" ), undefined );
+	assert.equal( $elem.css( "--nonexistent" ), undefined );
 } );
 
 // IE doesn't support CSS variables.


### PR DESCRIPTION
### Summary ###

Fixes gh-5105

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
