### PR TITLE
Tests: Remove a workaround for a Firefox XML parsing issue

### DIFF
--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -1456,13 +1456,7 @@ QUnit.testUnlessIE( "jQuery.parseXML - error reporting", function( assert ) {
 	column = columnMatch && columnMatch[ 1 ];
 
 	assert.strictEqual( line, "1", "reports error line" );
-
-	// Support: Firefox 96-97+
-	// Newer Firefox may report the column number smaller by 2 than it should.
-	// Accept both values until the issue is fixed.
-	// See https://bugzilla.mozilla.org/show_bug.cgi?id=1751796
-	assert.ok( [ "9", "11" ].indexOf( column ) > -1, "reports error column" );
-	// assert.strictEqual( column, "11", "reports error column" );
+	assert.strictEqual( column, "11", "reports error column" );
 } );
 
 testIframe(


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Firefox 96-100 used to report the column number smaller by 2 than it should
in the `parsererror` element generated for invalid XML documents. Since that
version range is unsupported now and it includes no ESR versions, the workaround
can now be dropped.

Ref gh-5018

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
