### PR TITLE
Deferred: Deprecate setTimeout() usage under latest browsers.

### DIFF
--- a/src/deferred.js
+++ b/src/deferred.js
@@ -40,6 +40,8 @@ function adoptValue( value, resolve, reject, noValue ) {
 	}
 }
 
+var asap = window.queueMicrotask || window.setTimeout;
+
 jQuery.extend( {
 
 	Deferred: function( func ) {
@@ -221,7 +223,7 @@ jQuery.extend( {
 								if ( jQuery.Deferred.getStackHook ) {
 									process.stackTrace = jQuery.Deferred.getStackHook();
 								}
-								window.setTimeout( process );
+								asap( process );
 							}
 						};
 					}

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -1522,7 +1522,37 @@ testIframe(
 	}
 );
 
-QUnit[ includesModule( "deferred" ) ? "test" : "skip" ]( "jQuery.readyException (original)", function( assert ) {
+QUnit[ includesModule( "deferred" ) && window.queueMicrotask ? "test" : "skip" ]( "jQuery.readyException (microtask)", function( assert ) {
+	assert.expect( 2 );
+
+	var done = assert.async();
+	var expected = "Error in jQuery ready #" + Math.random().toString( 36 ).slice( -7 );
+
+	this.sandbox.stub( jQuery, "readyException" ).callsFake( function( error ) {
+		assert.strictEqual( error.message, expected, "jQuery.readyException called with unexpected error" );
+		window.setTimeout( function() {
+			throw error;
+		} );
+	} );
+
+	this.sandbox.stub( window, "setTimeout" ).callsFake( function( fn ) {
+		var message;
+		try {
+			fn();
+		} catch ( error ) {
+			message = error.message;
+		}
+
+		assert.strictEqual( message, expected, "The error should have been caught" );
+		done();
+	} );
+
+	jQuery( function() {
+		throw new Error( expected );
+	} );
+} );
+
+QUnit[ includesModule( "deferred" ) && !window.queueMicrotask ? "test" : "skip" ]( "jQuery.readyException (timer)", function( assert ) {
 	assert.expect( 1 );
 
 	var message;


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Hi there, as you may know, Chrome/ium has been lately aggressively throttling background tabs, this may result in those setTimeout()-based promises/deferreds to never resolve until the tab becomes active again.

This PR is an attempt to prevent that, by using [queueMicrotask](https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask) under browsers supporting it. Also, the logic has been changed to dispatch those processes in bulk instead of individually, since the main reason for that throttling seems to be by having too many concurrent setTimeout()s running.

This implements a new `jQuery.asap()` function that will use either `queueMicrotask` or `setTimeout` for older browsers.

I've observed that around this whole codebase there are several other uses of that `window.setTimeout( func )` pattern so perhaps I should move this `jQuery.asap()` elsewhere to be used in place of those as well (as part of another PR) ?

Thanks!

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
