### PR TITLE
Tests: Make Ajax tests pass in iOS 9

### DIFF
--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -1640,8 +1640,14 @@ QUnit.module( "ajax", {
 		var done = assert.async();
 		jQuery.ajax( url( "mock.php?action=status&code=200&text=Hello" ) ).done( function( _, statusText, jqXHR ) {
 			assert.strictEqual( statusText, "success", "callback status text ok for success" );
-			assert.ok( [ "Hello", "OK", "success" ].indexOf( jqXHR.statusText ) > -1,
+
+			// Support: iOS 9 only
+			// Some versions of iOS 9 return the "HTTP/2.0 200" status text
+			// in this case; accept it.
+			assert.ok(
+				[ "Hello", "OK", "success", "HTTP/2.0 200" ].indexOf( jqXHR.statusText ) > -1,
 				"jqXHR status text ok for success (" + jqXHR.statusText + ")" );
+
 			jQuery.ajax( url( "mock.php?action=status&code=404&text=World" ) ).fail( function( jqXHR, statusText ) {
 				assert.strictEqual( statusText, "error", "callback status text ok for error" );
 				done();


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Accept "HTTP/2.0 200" as a valid `statusText` for successful requests to make ajax tests pass in iOS 9. At this point, normalizing this in code doesn't seem to make a lot of sense.

Screenshot of the current test failure:
<img width="1153" alt="Screen Shot 2022-09-21 at 14 18 29" src="https://user-images.githubusercontent.com/1758366/191501788-92992dc9-0de0-4319-90eb-99894e298065.png">

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
