### PR TITLE
Selector: Drop support for legacy pseudos, test custom pseudos

### DIFF
--- a/src/selector.js
+++ b/src/selector.js
@@ -804,33 +804,14 @@ Expr = jQuery.expr = {
 			// https://www.w3.org/TR/selectors/#pseudo-classes
 			// Prioritize by case sensitivity in case custom pseudos are added with uppercase letters
 			// Remember that setFilters inherits from pseudos
-			var args,
-				fn = Expr.pseudos[ pseudo ] || Expr.setFilters[ pseudo.toLowerCase() ] ||
-					selectorError( "unsupported pseudo: " + pseudo );
+			var fn = Expr.pseudos[ pseudo ] || Expr.setFilters[ pseudo.toLowerCase() ] ||
+				selectorError( "unsupported pseudo: " + pseudo );
 
 			// The user may use createPseudo to indicate that
 			// arguments are needed to create the filter function
 			// just as jQuery does
 			if ( fn[ expando ] ) {
 				return fn( argument );
-			}
-
-			// But maintain support for old signatures
-			if ( fn.length > 1 ) {
-				args = [ pseudo, pseudo, "", argument ];
-				return Expr.setFilters.hasOwnProperty( pseudo.toLowerCase() ) ?
-					markFunction( function( seed, matches ) {
-						var idx,
-							matched = fn( seed, argument ),
-							i = matched.length;
-						while ( i-- ) {
-							idx = indexOf.call( seed, matched[ i ] );
-							seed[ idx ] = !( matches[ idx ] = matched[ i ] );
-						}
-					} ) :
-					function( elem ) {
-						return fn( elem, 0, args );
-					};
 			}
 
 			return fn;

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -2142,3 +2142,59 @@ QUnit.test( "jQuery.escapeSelector", function( assert ) {
 	assert.equal( jQuery.escapeSelector( "\uDF06" ), "\uDF06", "Doesn't escape lone low surrogate" );
 	assert.equal( jQuery.escapeSelector( "\uD834" ), "\uD834", "Doesn't escape lone high surrogate" );
 } );
+
+QUnit.test( "custom pseudos", function( assert ) {
+	assert.expect( 6 );
+
+	jQuery.expr.filters.foundation = jQuery.expr.filters.root;
+	assert.deepEqual( jQuery.find( ":foundation" ), [ document.documentElement ], "Copy element filter with new name" );
+	delete jQuery.expr.filters.foundation;
+
+	jQuery.expr.setFilters.primary = jQuery.expr.setFilters.first;
+	assert.t( "Copy set filter with new name", "div#qunit-fixture :primary", [ "firstp" ] );
+	delete jQuery.expr.setFilters.primary;
+
+	jQuery.expr.filters.aristotlean = jQuery.expr.createPseudo( function() {
+		return function( elem ) {
+			return !!elem.id;
+		};
+	} );
+	assert.t( "Custom element filter", "#foo :aristotlean", [ "sndp", "en", "yahoo", "sap", "anchor2", "simon" ] );
+	delete jQuery.expr.filters.aristotlean;
+
+	jQuery.expr.filters.endswith = jQuery.expr.createPseudo( function( text ) {
+		return function( elem ) {
+			return jQuery.text( elem ).slice( -text.length ) === text;
+		};
+	} );
+	assert.t( "Custom element filter with argument", "a:endswith(ogle)", [ "google" ] );
+	delete jQuery.expr.filters.endswith;
+
+	jQuery.expr.setFilters.second = jQuery.expr.createPseudo( function() {
+		return jQuery.expr.createPseudo( function( seed, matches ) {
+			if ( seed[ 1 ] ) {
+				matches[ 1 ] = seed[ 1 ];
+				seed[ 1 ] = false;
+			}
+		} );
+	} );
+	assert.t( "Custom set filter", "#qunit-fixture p:second", [ "ap" ] );
+	delete jQuery.expr.filters.second;
+
+	jQuery.expr.setFilters.slice = jQuery.expr.createPseudo( function( argument ) {
+		var bounds = argument.split( ":" );
+		return jQuery.expr.createPseudo( function( seed, matches ) {
+			var i = bounds[ 1 ];
+
+			// Match elements found at the specified indexes
+			while ( --i >= bounds[ 0 ] ) {
+				if ( seed[ i ] ) {
+					matches[ i ] = seed[ i ];
+					seed[ i ] = false;
+				}
+			}
+		} );
+	} );
+	assert.t( "Custom set filter with argument", "#qunit-fixture p:slice(1:3)", [ "ap", "sndp" ] );
+	delete jQuery.expr.filters.slice;
+} );

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -2146,55 +2146,73 @@ QUnit.test( "jQuery.escapeSelector", function( assert ) {
 QUnit.test( "custom pseudos", function( assert ) {
 	assert.expect( 6 );
 
-	jQuery.expr.filters.foundation = jQuery.expr.filters.root;
-	assert.deepEqual( jQuery.find( ":foundation" ), [ document.documentElement ], "Copy element filter with new name" );
-	delete jQuery.expr.filters.foundation;
+	try {
+		jQuery.expr.filters.foundation = jQuery.expr.filters.root;
+		assert.deepEqual( jQuery.find( ":foundation" ), [ document.documentElement ], "Copy element filter with new name" );
+	} finally {
+		delete jQuery.expr.filters.foundation;
+	}
 
-	jQuery.expr.setFilters.primary = jQuery.expr.setFilters.first;
-	assert.t( "Copy set filter with new name", "div#qunit-fixture :primary", [ "firstp" ] );
-	delete jQuery.expr.setFilters.primary;
+	try {
+		jQuery.expr.setFilters.primary = jQuery.expr.setFilters.first;
+		assert.t( "Copy set filter with new name", "div#qunit-fixture :primary", [ "firstp" ] );
+	} finally {
+		delete jQuery.expr.setFilters.primary;
+	}
 
-	jQuery.expr.filters.aristotlean = jQuery.expr.createPseudo( function() {
-		return function( elem ) {
-			return !!elem.id;
-		};
-	} );
-	assert.t( "Custom element filter", "#foo :aristotlean", [ "sndp", "en", "yahoo", "sap", "anchor2", "simon" ] );
-	delete jQuery.expr.filters.aristotlean;
-
-	jQuery.expr.filters.endswith = jQuery.expr.createPseudo( function( text ) {
-		return function( elem ) {
-			return jQuery.text( elem ).slice( -text.length ) === text;
-		};
-	} );
-	assert.t( "Custom element filter with argument", "a:endswith(ogle)", [ "google" ] );
-	delete jQuery.expr.filters.endswith;
-
-	jQuery.expr.setFilters.second = jQuery.expr.createPseudo( function() {
-		return jQuery.expr.createPseudo( function( seed, matches ) {
-			if ( seed[ 1 ] ) {
-				matches[ 1 ] = seed[ 1 ];
-				seed[ 1 ] = false;
-			}
+	try {
+		jQuery.expr.filters.aristotlean = jQuery.expr.createPseudo( function() {
+			return function( elem ) {
+				return !!elem.id;
+			};
 		} );
-	} );
-	assert.t( "Custom set filter", "#qunit-fixture p:second", [ "ap" ] );
-	delete jQuery.expr.filters.second;
+		assert.t( "Custom element filter", "#foo :aristotlean", [ "sndp", "en", "yahoo", "sap", "anchor2", "simon" ] );
+	} finally {
+		delete jQuery.expr.filters.aristotlean;
+	}
 
-	jQuery.expr.setFilters.slice = jQuery.expr.createPseudo( function( argument ) {
-		var bounds = argument.split( ":" );
-		return jQuery.expr.createPseudo( function( seed, matches ) {
-			var i = bounds[ 1 ];
+	try {
+		jQuery.expr.filters.endswith = jQuery.expr.createPseudo( function( text ) {
+			return function( elem ) {
+				return jQuery.text( elem ).slice( -text.length ) === text;
+			};
+		} );
+		assert.t( "Custom element filter with argument", "a:endswith(ogle)", [ "google" ] );
+	} finally {
+		delete jQuery.expr.filters.endswith;
+	}
 
-			// Match elements found at the specified indexes
-			while ( --i >= bounds[ 0 ] ) {
-				if ( seed[ i ] ) {
-					matches[ i ] = seed[ i ];
-					seed[ i ] = false;
+	try {
+		jQuery.expr.setFilters.second = jQuery.expr.createPseudo( function() {
+			return jQuery.expr.createPseudo( function( seed, matches ) {
+				if ( seed[ 1 ] ) {
+					matches[ 1 ] = seed[ 1 ];
+					seed[ 1 ] = false;
 				}
-			}
+			} );
 		} );
-	} );
-	assert.t( "Custom set filter with argument", "#qunit-fixture p:slice(1:3)", [ "ap", "sndp" ] );
-	delete jQuery.expr.filters.slice;
+		assert.t( "Custom set filter", "#qunit-fixture p:second", [ "ap" ] );
+	} finally {
+		delete jQuery.expr.filters.second;
+	}
+
+	try {
+		jQuery.expr.setFilters.slice = jQuery.expr.createPseudo( function( argument ) {
+			var bounds = argument.split( ":" );
+			return jQuery.expr.createPseudo( function( seed, matches ) {
+				var i = bounds[ 1 ];
+
+				// Match elements found at the specified indexes
+				while ( --i >= bounds[ 0 ] ) {
+					if ( seed[ i ] ) {
+						matches[ i ] = seed[ i ];
+						seed[ i ] = false;
+					}
+				}
+			} );
+		} );
+		assert.t( "Custom set filter with argument", "#qunit-fixture p:slice(1:3)", [ "ap", "sndp" ] );
+	} finally {
+		delete jQuery.expr.filters.slice;
+	}
 } );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

This backports custom pseudos tests from Sizzle; they were missed in original test backports. Also, the support for legacy custom pseudos has been dropped.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
