### PR TITLE
Ajax: Support `null` as success functions in `jQuery.get`

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -846,8 +846,9 @@ jQuery.extend( {
 jQuery.each( [ "get", "post" ], function( _i, method ) {
 	jQuery[ method ] = function( url, data, callback, type ) {
 
-		// Shift arguments if data argument was omitted
-		if ( typeof data === "function" ) {
+		// Shift arguments if data argument was omitted.
+		// Handle the null callback placeholder.
+		if ( typeof data === "function" || data === null ) {
 			type = type || callback;
 			callback = data;
 			data = undefined;

--- a/src/ajax/xhr.js
+++ b/src/ajax/xhr.js
@@ -15,7 +15,6 @@ var xhrSuccessStatus = {
 jQuery.ajaxTransport( function( options ) {
 	var callback;
 
-	// Cross domain only allowed if supported through XMLHttpRequest
 	return {
 		send: function( headers, complete ) {
 			var i,

--- a/test/data/mock.php
+++ b/test/data/mock.php
@@ -95,9 +95,9 @@ QUnit.assert.ok( true, "mock executed");';
 		}
 
 		if ( isset( $req->query['array'] ) ) {
-			echo '[ {"name": "John", "age": 21}, {"name": "Peter", "age": 25 } ]';
+			echo '[{"name":"John","age":21},{"name":"Peter","age":25}]';
 		} else {
-			echo '{ "data": {"lang": "en", "length": 25} }';
+			echo '{"data":{"lang":"en","length":25}}';
 		}
 	}
 
@@ -112,8 +112,8 @@ QUnit.assert.ok( true, "mock executed");';
 			$callback = $_POST['callback'];
 		}
 		$json = isset( $req->query['array'] ) ?
-			'[ { "name": "John", "age": 21 }, { "name": "Peter", "age": 25 } ]' :
-			'{ "data": { "lang": "en", "length": 25 } }';
+			'[{"name":"John","age":21},{"name":"Peter","age":25}]' :
+			'{"data":{"lang":"en","length":25}}';
 		echo cleanCallback( $callback ) . '(' . $json . ')';
 	}
 

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -2593,6 +2593,26 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 		} );
 	} );
 
+	QUnit.test( "jQuery.get( String, null-ish, String ) - dataType with null callback (gh-4989)",
+			function( assert ) {
+		assert.expect( 2 );
+		var done = assert.async( 2 );
+
+		jQuery.get( url( "mock.php?action=json&header" ), null, "json" )
+			.then( function( json ) {
+				assert.deepEqual( json, { data: { lang: "en", length: 25 } },
+					"`dataType: \"json\"` applied with a `null` callback" );
+				done();
+			} );
+
+		jQuery.get( url( "mock.php?action=json&header" ), null, "text" )
+			.then( function( text ) {
+				assert.strictEqual( text, "{\"data\":{\"lang\":\"en\",\"length\":25}}",
+					"`dataType: \"text\"` applied with a `null` callback" );
+				done();
+			} );
+	} );
+
 //----------- jQuery.getJSON()
 
 	QUnit.test( "jQuery.getJSON( String, Hash, Function ) - JSON array", function( assert ) {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

According to the docs, one can use `null` as a success function in `jQuery.get`
of `jQuery.post` so the following:

```js
await jQuery.get( "https://httpbin.org/json", null, "text" )
```

should get the text result. However, this shortcut hasn't been working so far.

Fixes gh-4989

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com - API PR: https://github.com/jquery/api.jquery.com/pull/1208

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
