### PR TITLE
Tests: Indicate Firefox 106+ passes the `cssSupportsSelector` test

### DIFF
--- a/src/selector/support.js
+++ b/src/selector/support.js
@@ -3,7 +3,7 @@ import support from "../var/support.js";
 try {
 	/* eslint-disable no-undef */
 
-	// Support: Chrome 105+, Firefox 104+, Safari 15.4+
+	// Support: Chrome 105+, Firefox <106, Safari 15.4+
 	// Make sure forgiving mode is not used in `CSS.supports( "selector(...)" )`.
 	//
 	// `:is()` uses a forgiving selector list as an argument and is widely

--- a/test/unit/support.js
+++ b/test/unit/support.js
@@ -70,8 +70,12 @@ testIframe(
 				cssSupportsSelector: false,
 				reliableTrDimensions: true
 			},
-			firefox: {
+			firefox_102: {
 				cssSupportsSelector: false,
+				reliableTrDimensions: false
+			},
+			firefox: {
+				cssSupportsSelector: true,
 				reliableTrDimensions: false
 			},
 			ios: {
@@ -88,6 +92,8 @@ testIframe(
 		expected = expectedMap.chrome;
 	} else if ( /\b\d+(\.\d+)+ safari/i.test( userAgent ) ) {
 		expected = expectedMap.safari;
+	} else if ( /firefox\/102\./i.test( userAgent ) ) {
+		expected = expectedMap.firefox_102;
 	} else if ( /firefox/i.test( userAgent ) ) {
 		expected = expectedMap.firefox;
 	} else if ( /(?:iphone|ipad);.*(?:iphone)? os \d+_/i.test( userAgent ) ) {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Firefox 106 adjusted to the spec mandating that `CSS.supports("selector(...)")` uses non-forgiving parsing which makes it pass the relevant support test.

Note: I only check for Fx 102 in the test as it's just a support test and Fx 102 is an ESR version; the other tested ones will soon go out of support. This means the test will only start passing tomorrow once Firefox 106 gets released.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* [ ] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
