### PR TITLE
Core: Add New Feature - entries Function

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -265,9 +265,15 @@ jQuery.extend( {
 		for ( ; i < length; i++ ) {
 			propertyNames = Object.getOwnPropertyNames( obj[ i ] );
 
-			for ( ; b < propertyNames.length; b++ ) {
-				if ( callback.call( obj[ i ], propertyNames[ b ],
-					obj[ i ][ propertyNames[ b ] ] ) ) {
+			if ( propertyNames.length > 0 ) {
+				for ( ; b < propertyNames.length; b++ ) {
+					if ( callback.call( obj[ i ], propertyNames[ b ],
+						obj[ i ][ propertyNames[ b ] ] ) ) {
+						break;
+					}
+				}
+			} else {
+				if ( callback.call( obj[ i ], i, obj[ i ] ) ) {
 					break;
 				}
 			}

--- a/src/core.js
+++ b/src/core.js
@@ -71,6 +71,10 @@ jQuery.fn = jQuery.prototype = {
 		return jQuery.each( this, callback );
 	},
 
+	entries: function( callback ) {
+		return jQuery.entries( this, callback );
+	},
+
 	map: function( callback ) {
 		return this.pushStack( jQuery.map( this, function( elem, i ) {
 			return callback.call( elem, i, elem );
@@ -247,6 +251,23 @@ jQuery.extend( {
 		} else {
 			for ( i in obj ) {
 				if ( callback.call( obj[ i ], i, obj[ i ] ) === false ) {
+					break;
+				}
+			}
+		}
+
+		return obj;
+	},
+
+	entries: function( obj, callback ) {
+		var length = obj.length, i = 0, propertyNames = [], b = 0;
+
+		for ( ; i < length; i++ ) {
+			propertyNames = Object.getOwnPropertyNames( obj[ i ] );
+
+			for ( ; b < propertyNames.length; b++ ) {
+				if ( callback.call( obj[ i ], propertyNames[ b ],
+					obj[ i ][ propertyNames[ b ] ] ) ) {
 					break;
 				}
 			}

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -644,6 +644,21 @@ QUnit.test( "each(Function)", function( assert ) {
 	assert.ok( pass, "Execute a function, Relative" );
 } );
 
+QUnit.test( "entries(Function)", function( assert ) {
+	assert.expect( 1 );
+	var object, pass, i;
+
+	object = jQuery( { name: "john" } );
+	object.entries( function( field, value ) {this.foo = field; this.bar = value; } );
+	pass = true;
+	for ( i = 0; i < object.length; i++ ) {
+		if ( object.get( i ).foo !== "name" || object.get( i ).bar !== "john" ) {
+			pass = false;
+		}
+	}
+	assert.ok( pass, "Execute a function, Relative" );
+} );
+
 QUnit.test( "slice()", function( assert ) {
 	assert.expect( 7 );
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Returns an enumerated string key and value of an object. 
Old method of object entries with jQuery:
`var response = {
            "status": "success",
            "data": {
                "id": 1,
                "name": "John Doe",
                "email": "john.doe@website.com",
                "phone": "1234567890"
            }
        };
        
        var propertyNames = Object.getOwnPropertyNames(response.data)
        
        $(propertyNames).each(function (index, value) {
            console.log('Field: ' + value + ' Value: ' + response.data[value]);
        });`

With New entries Function:

`var response = {
            "status": "success",
            "data": {
                "id": 1,
                "name": "John Doe",
                "email": "john.doe@website.com",
                "phone": "1234567890"
            }
        };

$(response.data).entries(function (field, value) {
            console.log('Field: ' + field + ', Value: ' + value);
        });
`


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [ x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
