### PR TITLE
Docs: remove stale badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 [jQuery](https://jquery.com/) — New Wave JavaScript
 ==================================================
 
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fjquery%2Fjquery.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fjquery%2Fjquery?ref=badge_shield)
-
 [![Gitter](https://badges.gitter.im/jquery/jquery.svg)](https://gitter.im/jquery/jquery?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 Contribution Guides


### PR DESCRIPTION
### Summary ###
This removes the stale badge on the README from Fossa. It may be a temporary loss of service, but I'd prefer not to have badges that don't load.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

