### PR TITLE
Selector:Manipulation: Fix DOM manip within template contents

### DIFF
--- a/src/selector/contains.js
+++ b/src/selector/contains.js
@@ -2,15 +2,14 @@ import jQuery from "../core.js";
 
 // Note: an element does not contain itself
 jQuery.contains = function( a, b ) {
-	var adown = a.nodeType === 9 ? a.documentElement : a,
-		bup = b && b.parentNode;
+	var bup = b && b.parentNode;
 
 	return a === bup || !!( bup && bup.nodeType === 1 && (
 
 		// Support: IE 9 - 11+
 		// IE doesn't have `contains` on SVG.
-		adown.contains ?
-			adown.contains( bup ) :
+		a.contains ?
+			a.contains( bup ) :
 			a.compareDocumentPosition && a.compareDocumentPosition( bup ) & 16
 	) );
 };

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -2830,6 +2830,47 @@ QUnit.test( "Make sure tr is not appended to the wrong tbody (gh-3439)", functio
 	assert.strictEqual( htmlOut, htmlExpected );
 } );
 
+[ true, false ].forEach( function( adoptedCase ) {
+	QUnit.testUnlessIE(
+		"Manip within <template /> content moved back & forth doesn't throw - " + (
+			adoptedCase ? "explicitly adopted" : "not explicitly adopted"
+		),
+		function( assert ) {
+			assert.expect( 1 );
+
+			var fragment, diva, divb,
+				div = jQuery( "<div></div>" ),
+				template = jQuery( "" +
+					"<template>\n" +
+					"	<div><div class='a'></div></div>\n" +
+					"	<div><div class='b'></div></div>\n" +
+					"</template>" +
+					"" );
+
+			jQuery( "#qunit-fixture" )
+				.append( div )
+				.append( template );
+
+			fragment = template[ 0 ].content;
+			diva = jQuery( fragment ).find( ".a" );
+			divb = jQuery( fragment ).find( ".b" );
+
+			if ( adoptedCase ) {
+				document.adoptNode( fragment );
+			}
+			div.append( fragment );
+
+			fragment.appendChild( div.children()[ 0 ] );
+			fragment.appendChild( div.children()[ 0 ] );
+
+			diva.insertBefore( divb );
+
+			assert.strictEqual( diva.siblings( ".b" ).length, 1,
+				"Insertion worked" );
+		}
+	);
+} );
+
 QUnit.test( "Make sure tags with single-character names are found (gh-4124)", function( assert ) {
 	assert.expect( 1 );
 

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -2834,31 +2834,30 @@ QUnit.test( "Make sure tr is not appended to the wrong tbody (gh-3439)", functio
 	QUnit.testUnlessIE(
 		"Manip within <template /> content moved back & forth doesn't throw - " + (
 			adoptedCase ? "explicitly adopted" : "not explicitly adopted"
-		),
+		) + " (gh-5147)",
 		function( assert ) {
 			assert.expect( 1 );
 
 			var fragment, diva, divb,
-				div = jQuery( "<div></div>" ),
-				template = jQuery( "" +
-					"<template>\n" +
+				div = jQuery( "" +
+					"<div>\n" +
 					"	<div><div class='a'></div></div>\n" +
 					"	<div><div class='b'></div></div>\n" +
-					"</template>" +
-					"" );
+					"</div>" +
+					"" ),
+				template = jQuery( "<template></template>" );
 
 			jQuery( "#qunit-fixture" )
 				.append( div )
 				.append( template );
 
 			fragment = template[ 0 ].content;
-			diva = jQuery( fragment ).find( ".a" );
-			divb = jQuery( fragment ).find( ".b" );
+			diva = div.find( ".a" );
+			divb = div.find( ".b" );
 
 			if ( adoptedCase ) {
 				document.adoptNode( fragment );
 			}
-			div.append( fragment );
 
 			fragment.appendChild( div.children()[ 0 ] );
 			fragment.appendChild( div.children()[ 0 ] );

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -1895,6 +1895,19 @@ QUnit.test( "jQuery.contains in SVG (jQuery trac-10832)", function( assert ) {
 		"parent (negative)" );
 } );
 
+QUnit.test( "jQuery.contains within <template/> doesn't throw (gh-5147)", function( assert ) {
+	assert.expect( 1 );
+
+	var template = jQuery( "<template><div><div class='a'></div></div></template>" ),
+		a = jQuery( template[ 0 ].content ).find( ".a" );
+
+	template.appendTo( "#qunit-fixture" );
+
+	jQuery.contains( a[ 0 ].ownerDocument, a[ 0 ] );
+
+	assert.ok( true, "Didn't throw" );
+} );
+
 QUnit.test( "jQuery.uniqueSort", function( assert ) {
 	assert.expect( 14 );
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The `<template/>` element `contents` property is a document fragment that may
have a `null` `documentElement`. In Safari 16 this happens in more cases due
to recent spec changes - in particular, even if that document fragment is
explicitly adopted into an outer document. We're testing both of those cases
now.

The crash used to happen in `jQuery.contains`. As it turns out, we don't need
to query the supposed container `documentElement` if it has the
`Node.DOCUMENT_NODE` (9) `nodeType`; we can call `.contains()` directly on
the `document`. That avoids the crash.

Fixes gh-5147

-18 bytes

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
