### PR TITLE
Selector: Make selector lists work with `qSA` again

### DIFF
--- a/src/selector.js
+++ b/src/selector.js
@@ -255,15 +255,20 @@ function find( selector, context, results, seed ) {
 
 					// `qSA` may not throw for unrecognized parts using forgiving parsing:
 					// https://drafts.csswg.org/selectors/#forgiving-selector
-					// like the `:has()` pseudo-class:
-					// https://drafts.csswg.org/selectors/#relational
+					// like the `:is()` pseudo-class:
+					// https://drafts.csswg.org/selectors/#matches
 					// `CSS.supports` is still expected to return `false` then:
 					// https://drafts.csswg.org/css-conditional-4/#typedef-supports-selector-fn
 					// https://drafts.csswg.org/css-conditional-4/#dfn-support-selector
 					if ( support.cssSupportsSelector &&
 
+						// `CSS.supports( "selector(...)" )` requires the argument to the
+						// `selector` function to be a `<complex-selector>`, not
+						// a `<complex-selector-list>` which our selector may be. Wrapping with
+						// `:is` works around the issue and is supported by all browsers
+						// we support except for IE which will fail the support test anyway.
 						// eslint-disable-next-line no-undef
-						!CSS.supports( "selector(" + newSelector + ")" ) ) {
+						!CSS.supports( "selector(:is(" + newSelector + "))" ) ) {
 
 						// Support: IE 11+
 						// Throw to get to the same code path as an error directly in qSA.

--- a/src/selector/rbuggyQSA.js
+++ b/src/selector/rbuggyQSA.js
@@ -27,9 +27,8 @@ if ( !support.cssSupportsSelector ) {
 	// `:has()` uses a forgiving selector list as an argument so our regular
 	// `try-catch` mechanism fails to catch `:has()` with arguments not supported
 	// natively like `:has(:contains("Foo"))`. Where supported & spec-compliant,
-	// we now use `CSS.supports("selector(:is(SELECTOR_TO_BE_TESTED))")` but,
-	// outside that, let's mark `:has` as buggy to always use jQuery traversal
-	// for `:has()`.
+		// we now use `CSS.supports("selector(:is(SELECTOR_TO_BE_TESTED))")`, but
+		// outside that we mark `:has` as buggy.
 	rbuggyQSA.push( ":has" );
 }
 

--- a/src/selector/rbuggyQSA.js
+++ b/src/selector/rbuggyQSA.js
@@ -27,9 +27,9 @@ if ( !support.cssSupportsSelector ) {
 	// `:has()` uses a forgiving selector list as an argument so our regular
 	// `try-catch` mechanism fails to catch `:has()` with arguments not supported
 	// natively like `:has(:contains("Foo"))`. Where supported & spec-compliant,
-	// we now use `CSS.supports("selector(SELECTOR_TO_BE_TESTED)")` but outside
-	// that, let's mark `:has` as buggy to always use jQuery traversal for
-	// `:has()`.
+	// we now use `CSS.supports("selector(:is(SELECTOR_TO_BE_TESTED))")` but,
+	// outside that, let's mark `:has` as buggy to always use jQuery traversal
+	// for `:has()`.
 	rbuggyQSA.push( ":has" );
 }
 

--- a/src/selector/rbuggyQSA.js
+++ b/src/selector/rbuggyQSA.js
@@ -27,8 +27,8 @@ if ( !support.cssSupportsSelector ) {
 	// `:has()` uses a forgiving selector list as an argument so our regular
 	// `try-catch` mechanism fails to catch `:has()` with arguments not supported
 	// natively like `:has(:contains("Foo"))`. Where supported & spec-compliant,
-		// we now use `CSS.supports("selector(:is(SELECTOR_TO_BE_TESTED))")`, but
-		// outside that we mark `:has` as buggy.
+	// we now use `CSS.supports("selector(:is(SELECTOR_TO_BE_TESTED))")`, but
+	// outside that we mark `:has` as buggy.
 	rbuggyQSA.push( ":has" );
 }
 

--- a/src/selector/support.js
+++ b/src/selector/support.js
@@ -1,5 +1,8 @@
 import support from "../var/support.js";
 
+// Support: IE 11+
+// IE doesn't support `CSS.supports( "selector(...)" )`; it will throw
+// in this support test.
 try {
 	/* eslint-disable no-undef */
 

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -400,7 +400,7 @@ QUnit.test( "name", function( assert ) {
 } );
 
 QUnit.test( "comma-separated", function( assert ) {
-	assert.expect( 4 );
+	assert.expect( 10 );
 
 	var fixture = jQuery( "<div><h2><span></span></h2><div><p><span></span></p><p></p></div></div>" );
 
@@ -408,6 +408,26 @@ QUnit.test( "comma-separated", function( assert ) {
 	assert.equal( fixture.find( "h2, div p" ).filter( "h2" ).length, 1, "has to find one <h2>" );
 	assert.equal( fixture.find( "h2 , div p" ).filter( "p" ).length, 2, "has to find two <p>" );
 	assert.equal( fixture.find( "h2 , div p" ).filter( "h2" ).length, 1, "has to find one <h2>" );
+	assert.equal( fixture.find( "h2 ,div p" ).filter( "p" ).length, 2, "has to find two <p>" );
+	assert.equal( fixture.find( "h2 ,div p" ).filter( "h2" ).length, 1, "has to find one <h2>" );
+	assert.equal( fixture.find( "h2,div p" ).filter( "p" ).length, 2, "has to find two <p>" );
+	assert.equal( fixture.find( "h2,div p" ).filter( "h2" ).length, 1, "has to find one <h2>" );
+	assert.equal( fixture.find( "h2\t,\rdiv p" ).filter( "p" ).length, 2, "has to find two <p>" );
+	assert.equal( fixture.find( "h2\t,\rdiv p" ).filter( "h2" ).length, 1, "has to find one <h2>" );
+} );
+
+QUnit.test( "comma-separated, only supported natively (gh-5177)", function( assert ) {
+	assert.expect( 5 );
+
+	var fixture = jQuery( "<div><input/><span></span></div>" );
+
+	fixture.appendTo( "#qunit-fixture" );
+
+	assert.equal( fixture.find( "input:valid, span" ).length, 2, "has to find two elements" );
+	assert.equal( fixture.find( "input:valid , span" ).length, 2, "has to find two elements" );
+	assert.equal( fixture.find( "input:valid ,span" ).length, 2, "has to find two elements" );
+	assert.equal( fixture.find( "input:valid,span" ).length, 2, "has to find two elements" );
+	assert.equal( fixture.find( "input:valid\t,\rspan" ).length, 2, "has to find two elements" );
 } );
 
 QUnit.test( "child and adjacent", function( assert ) {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

jQuery 3.6.2 started using `CSS.supports( "selector(SELECTOR)" )` before using `querySelectorAll` on the selector. This was to solve gh-5098 - some selectors, like `:has()`, now have their parameters parsed in a forgiving way, meaning that `:has(:fakepseudo)` no longer throws but just returns 0 results, breaking that jQuery mechanism.

A recent spec change]() made `CSS.supports( "selector(SELECTOR)" )` always use non-forgiving parsing, allowing us to use this API for what we've used `try-catch` before.

To solve the issue on the spec side for older jQuery versions, `:has()` parameters are no longer using forgiving parsing in the latest spec update but our new mechanism is more future-proof anyway.

However, the jQuery implementation has a bug - in
`CSS.supports( "selector(SELECTOR)" )`, `SELECTOR` needs to be a `<complex-selector>` and not a `<complex-selector-list>`. Which means that selector lists now skip `qSA` and go to the jQuery custom traversal:
```js
CSS.supports("selector(div:valid, span)"); // false
CSS.supports("selector(div:valid)"); // true
CSS.supports("selector(span)"); // true
```

To solve this, this commit wraps the selector list passed to `CSS.supports( "selector(:is(SELECTOR))" )` with `:is`, making it a single selector again.

See:
* https://w3c.github.io/csswg-drafts/css-conditional-4/#at-supports-ext
* https://w3c.github.io/csswg-drafts/selectors-4/#typedef-complex-selector
* https://w3c.github.io/csswg-drafts/selectors-4/#typedef-complex-selector-list

Fixes gh-5177
Ref w3c/csswg-drafts#7280

+2 bytes

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
