### PR TITLE
Build: remove stale Insight package from custom builds

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -10,8 +10,6 @@ module.exports = function( grunt ) {
 	var fs = require( "fs" ),
 		requirejs = require( "requirejs" ),
 		slimBuildFlags = require( "./lib/slim-build-flags" ),
-		Insight = require( "insight" ),
-		pkg = require( "../../package.json" ),
 		srcFolder = __dirname + "/../../src/",
 		rdefineEnd = /\}\s*?\);[^}\w]*$/,
 		read = function( fileName ) {
@@ -357,47 +355,9 @@ module.exports = function( grunt ) {
 					), [] )
 
 					.join( ":" ) :
-				"",
-			done = this.async(),
-			insight = new Insight( {
-				trackingCode: "UA-1076265-4",
-				pkg: pkg
-			} );
-
-		function exec( trackingAllowed ) {
-			var tracks = args.length ? args[ 0 ].split( "," ) : [];
-			var defaultPath = [ "build", "custom" ];
-
-			tracks = tracks.map( function( track ) {
-				return track.replace( /\//g, "+" );
-			} );
-
-			if ( trackingAllowed ) {
-
-				// Track individuals
-				tracks.forEach( function( module ) {
-					var path = defaultPath.concat( [ "individual" ], module );
-
-					insight.track.apply( insight, path );
-				} );
-
-				// Track full command
-				insight.track.apply( insight, defaultPath.concat( [ "full" ], tracks ) );
-			}
-
-			grunt.task.run( [ "build:*:*" + ( modules ? ":" + modules : "" ), "uglify", "dist" ] );
-			done();
-		}
+				"";
 
 		grunt.log.writeln( "Creating custom build...\n" );
-
-		// Ask for permission the first time
-		if ( insight.optOut === undefined ) {
-			insight.askPermission( null, function( _error, result ) {
-				exec( result );
-			} );
-		} else {
-			exec( !insight.optOut );
-		}
+		grunt.task.run( [ "build:*:*" + ( modules ? ":" + modules : "" ), "uglify", "dist" ] );
 	} );
 };

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "grunt-npmcopy": "0.2.0",
     "gzip-js": "0.3.2",
     "husky": "4.2.5",
-    "insight": "0.10.3",
     "jsdom": "19.0.0",
     "karma": "^6.3.17",
     "karma-browserstack-launcher": "1.6.0",


### PR DESCRIPTION
### Summary ###
When trying to run a test release, I learned that the Insight package is no longer maintained and no longer works on a fresh install. This PR removes it from the 3.x-stable branch.


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
