### PR TITLE
Build: remove stale Insight package from custom builds

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -12,8 +12,6 @@ module.exports = function( grunt ) {
 	const rollup = require( "rollup" );
 	const slimBuildFlags = require( "./lib/slim-build-flags" );
 	const rollupFileOverrides = require( "./lib/rollup-plugin-file-overrides" );
-	const Insight = require( "insight" );
-	const pkg = require( "../../package.json" );
 	const srcFolder = path.resolve( `${ __dirname }/../../src` );
 	const read = function( fileName ) {
 		return grunt.file.read( `${ srcFolder }/${ fileName }` );
@@ -339,46 +337,8 @@ module.exports = function( grunt ) {
 		const modules = args.length ?
 			args[ 0 ].split( "," ).join( ":" ) :
 			"";
-		const done = this.async();
-		const insight = new Insight( {
-			trackingCode: "UA-1076265-4",
-			pkg: pkg
-		} );
-
-		function exec( trackingAllowed ) {
-			let tracks = args.length ? args[ 0 ].split( "," ) : [];
-			const defaultPath = [ "build", "custom" ];
-
-			tracks = tracks.map( function( track ) {
-				return track.replace( /\//g, "+" );
-			} );
-
-			if ( trackingAllowed ) {
-
-				// Track individuals
-				tracks.forEach( function( module ) {
-					const path = defaultPath.concat( [ "individual" ], module );
-
-					insight.track.apply( insight, path );
-				} );
-
-				// Track full command
-				insight.track.apply( insight, defaultPath.concat( [ "full" ], tracks ) );
-			}
-
-			grunt.task.run( [ "build:*:*" + ( modules ? ":" + modules : "" ), "uglify", "dist" ] );
-			done();
-		}
 
 		grunt.log.writeln( "Creating custom build...\n" );
-
-		// Ask for permission the first time
-		if ( insight.optOut === undefined ) {
-			insight.askPermission( null, function( _error, result ) {
-				exec( result );
-			} );
-		} else {
-			exec( !insight.optOut );
-		}
+		grunt.task.run( [ "build:*:*" + ( modules ? ":" + modules : "" ), "uglify", "dist" ] );
 	} );
 };

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "grunt-npmcopy": "0.2.0",
     "gzip-js": "0.3.2",
     "husky": "4.2.5",
-    "insight": "0.10.3",
     "jsdom": "19.0.0",
     "karma": "^6.3.17",
     "karma-browserstack-launcher": "1.6.0",


### PR DESCRIPTION
### Summary ###

When trying to run a test release, I learned that the Insight package is no longer maintained and no longer works on a fresh install. This PR removes it from the main branch.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
