### PR TITLE
Deferred: Respect source maps in jQuery.Deferred.exceptionHook

### DIFF
--- a/src/deferred/exceptionHook.js
+++ b/src/deferred/exceptionHook.js
@@ -10,8 +10,8 @@ jQuery.Deferred.exceptionHook = function( error, stack ) {
 
 	if ( error && rerrorNames.test( error.name ) ) {
 		window.console.warn(
-			"jQuery.Deferred exception: " + error.message,
-			error.stack,
+			"jQuery.Deferred exception",
+			error,
 			stack
 		);
 	}

--- a/test/unit/deferred.js
+++ b/test/unit/deferred.js
@@ -575,9 +575,9 @@ QUnit.test( "jQuery.Deferred.exceptionHook", function( assert ) {
 		defer = jQuery.Deferred(),
 		oldWarn = window.console.warn;
 
-	window.console.warn = function() {
-		var msg = Array.prototype.join.call( arguments, " " );
-		assert.ok( /barf/.test( msg ), "Message: " + msg );
+	window.console.warn = function( _intro, error ) {
+		assert.ok( /barf/.test( error.message + "\n" + error.stack ),
+			"Error mentions the method: " + error.message + "\n" + error.stack );
 	};
 
 	jQuery.when(


### PR DESCRIPTION
## Summary
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

So far, `jQuery.Deferred.exceptionHook` used to log error message and stack separately. However, that breaks browser applying source maps against the stack trace - most browsers require logging an error instance. This change makes us do exactly that.

One drawback of the change is that in IE 11 previously stack was printed directly and now just the error summary; to get to the actual stack trace, three clicks are required. This seems to be a low price to pay for having source maps work in all the other browsers, though.

Safari with the new change requires one click to get to the stack trace which sounds manageable.

Fixes gh-3179
Ref https://crbug.com/622227

`-12 bytes`

I'd like to keep it a 4.x item only, for two reasons:
* this may be an edge case but some integrations may depend on our `console.warn` pattern and changing it would break them
* it degrades the debugging experience for all IE (especially 9-10 that have terrible DevTools) & Edge Legacy versions that we still support in v3; I also haven't tested other older browsers that we still test against with 3.x
* this improvement doesn't apply to running apps but to development only so I don't feel like it necessarily needs to make it to 3.x

I used a modified test case from gh-3179:
```coffee
c = ->
    foobar()

b = ->
    c()

a = ->
    b()

window.addEventListener 'DOMContentLoaded', ->
    console.log 'from dom content loaded'
    a()

$ ->
    console.log 'from jQuery ready'
    a()

$.when().then ->
    console.log 'from jQuery Deferred'
    a()
```

Screenshots comparing before & after below. One error coming from jQuery is available even in the "before" case as we still have [`jQuery.readyException`](https://github.com/jquery/jquery/blob/c66d4700dcf98efccb04061d575e242d28741223/src/core/readyException.js) that re-throws errors from jQuery ready.

### Chrome

#### Before

<img width="756" alt="jq-source-maps-chrome-jq3" src="https://user-images.githubusercontent.com/1758366/212088817-c6ea3f16-6430-4e99-b68c-1711a0d70951.png">

#### After

<img width="595" alt="jq-source-maps-chrome-jq4" src="https://user-images.githubusercontent.com/1758366/212065773-47bec6a8-a9a3-436d-964e-06bea12e79d9.png">

### Firefox

#### Before

<img width="761" alt="jq-source-maps-firefox-jq3" src="https://user-images.githubusercontent.com/1758366/212089152-043d1984-f3e0-4940-ba2c-307d7af06a06.png">

#### After

<img width="596" alt="jq-source-maps-firefox-jq4" src="https://user-images.githubusercontent.com/1758366/212065877-0169dc41-4a35-4796-a2d0-1e558854cb77.png">

### Safari

#### Before

<img width="499" alt="jq-source-maps-safari-jq3" src="https://user-images.githubusercontent.com/1758366/212066063-64e27f89-4980-4ab4-b8b5-18dd4cccaa82.png">

#### After

##### Initial view

<img width="498" alt="jq-source-maps-safari-jq4-1" src="https://user-images.githubusercontent.com/1758366/212066135-69a86047-fe21-44c7-9499-b3bb439c3dff.png">

##### After a single click on each exception

<img width="498" alt="jq-source-maps-safari-jq4-2" src="https://user-images.githubusercontent.com/1758366/212066217-25508b5f-88c0-481a-9193-7e3db3e5e7fc.png">

### IE 11

#### Before

<img width="612" alt="jq-source-maps-ie11-jq3" src="https://user-images.githubusercontent.com/1758366/212066278-318bfa9f-8e3b-400d-9a27-1f651f83734d.png">

#### After

##### Initial view

<img width="543" alt="jq-source-maps-ie11-jq4-1" src="https://user-images.githubusercontent.com/1758366/212066402-23fcfa12-cd95-4d6b-8d7f-9cc5f72c9994.png">

##### After the 1st click

<img width="1049" alt="jq-source-maps-ie11-jq4-2" src="https://user-images.githubusercontent.com/1758366/212066414-493ddb1b-dd10-4b0f-ba59-b0c2e79eab1f.png">

##### After the 2nd click

<img width="1055" alt="jq-source-maps-ie11-jq4-3" src="https://user-images.githubusercontent.com/1758366/212066421-8e3ec938-12ad-4ba8-94a3-b6379a6575b0.png">

##### After the 3rd click

<img width="1052" alt="jq-source-maps-ie11-jq4-4" src="https://user-images.githubusercontent.com/1758366/212066425-d9f53964-bdd3-4961-b794-f3cc9b2d9ddc.png">

## Checklist
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
