### PR TITLE
Ajax: Support `headers` for script transport even when cross-domain

### DIFF
--- a/src/ajax/script.js
+++ b/src/ajax/script.js
@@ -6,20 +6,28 @@ import "../ajax.js";
 function canUseScriptTag( s ) {
 
 	// A script tag can only be used for async, cross domain or forced-by-attrs requests.
+	// Requests with headers cannot use a script tag. However, when both `scriptAttrs` &
+	// `headers` options are specified, both are impossible to satisfy together; we
+	// prefer `scriptAttrs` then.
 	// Sync requests remain handled differently to preserve strict script ordering.
-	return s.crossDomain || s.scriptAttrs ||
+	return s.scriptAttrs || (
+		!s.headers &&
+		(
+			s.crossDomain ||
 
-		// When dealing with JSONP (`s.dataTypes` include "json" then)
-		// don't use a script tag so that error responses still may have
-		// `responseJSON` set. Continue using a script tag for JSONP requests that:
-		//   * are cross-domain as AJAX requests won't work without a CORS setup
-		//   * have `scriptAttrs` set as that's a script-only functionality
-		// Note that this means JSONP requests violate strict CSP script-src settings.
-		// A proper solution is to migrate from using JSONP to a CORS setup.
-		( s.async && jQuery.inArray( "json", s.dataTypes ) < 0 );
+			// When dealing with JSONP (`s.dataTypes` include "json" then)
+			// don't use a script tag so that error responses still may have
+			// `responseJSON` set. Continue using a script tag for JSONP requests that:
+			//   * are cross-domain as AJAX requests won't work without a CORS setup
+			//   * have `scriptAttrs` set as that's a script-only functionality
+			// Note that this means JSONP requests violate strict CSP script-src settings.
+			// A proper solution is to migrate from using JSONP to a CORS setup.
+			( s.async && jQuery.inArray( "json", s.dataTypes ) < 0 )
+		)
+	);
 }
 
-// Install script dataType. Don't specify `content.script` so that an explicit
+// Install script dataType. Don't specify `contents.script` so that an explicit
 // `dataType: "script"` is required (see gh-2432, gh-4822)
 jQuery.ajaxSetup( {
 	accepts: {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The AJAX script transport has two versions: XHR + `jQuery.globalEval` or appending a script tag (note that `jQuery.globalEval` also appends a script tag now, but inline). The former cannot support the `headers` option which has so far not been taken into account.

For jQuery 3.x, the main consequence was the option not being respected for cross-domain requests. Since in 4.x we use the latter way more often, the option was being ignored in more cases.

The transport now checks whether the `headers` option is specified and uses the XHR way unless `scriptAttrs` are specified as well.

Fixes gh-5142

+5 bytes

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
