### PR TITLE
Tests: Test AJAX deprecated event aliases properly

### DIFF
--- a/test/unit/deprecated.js
+++ b/test/unit/deprecated.js
@@ -97,7 +97,7 @@ QUnit.test( "trigger() shortcuts", function( assert ) {
 } );
 
 if ( includesModule( "ajax" ) ) {
-	ajaxTest( "jQuery.ajax() - events with context", 12, function( assert ) {
+	ajaxTest( "Ajax events aliases (with context)", 12, function( assert ) {
 		var context = document.createElement( "div" );
 
 		function event( e ) {
@@ -113,10 +113,10 @@ if ( includesModule( "ajax" ) ) {
 		return {
 			setup: function() {
 				jQuery( context ).appendTo( "#foo" )
-					.on( "ajaxSend", event )
-					.on( "ajaxComplete", event )
-					.on( "ajaxError", event )
-					.on( "ajaxSuccess", event );
+					.ajaxSend( event )
+					.ajaxComplete( event )
+					.ajaxError( event )
+					.ajaxSuccess( event );
 			},
 			requests: [ {
 				url: url( "name.html" ),


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

PR gh-5046 erroneously changed AJAX deprecated event alias usage in deprecated tests to `.on()` calls. This change reverses this mistake.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
