### PR TITLE
Build: Migrate middleware-mockserver to modern JS

### DIFF
--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -60,6 +60,14 @@
 	"overrides": [
 		{
 			"files": [
+				"middleware-mockserver.js"
+			],
+
+			"extends": "../.eslintrc-node.json"
+		},
+
+		{
+			"files": [
 				"data/core/jquery-iterability-transpiled-es6.js",
 				"data/testinit-jsdom.js"
 			],


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The `test/middleware-mockserver.js` file used to have the same ESLint settings applied as other test files that are directly run in tested browsers. Now it shares settings of other Node.js files.

The file is now also written using modern JS, leveraging ES2018.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* [ ] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
