### PR TITLE
Build: Only install Playwright dependencies when needed

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -73,7 +73,7 @@ jobs:
 
     - name: Install Playwright dependencies
       run: npx playwright-webkit install-deps
-      if: "matrix.NPM_SCRIPT == 'test:browser'"
+      if: "matrix.NPM_SCRIPT == 'test:browser' && contains(matrix.BROWSERS, 'WebkitHeadless')"
 
     - name: Run tests
       env:


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

PR gh-5190 added support for running tests on Playwright WebKit in CI. For efficiency reasons, Playwright dependencies are only installed for the `test:browser` npm script. However, that same script is also used for Firefox ESR testing.

This change makes Playwright dependencies installed only for cases where `WebKitHeadless` exists on the list of tested browsers.

Ref gh-5190

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* [ ] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
