### PR TITLE
Ajax: Allow `processData: true` even for binary data

### DIFF
--- a/src/ajax/binary.js
+++ b/src/ajax/binary.js
@@ -2,10 +2,13 @@ import jQuery from "../core.js";
 
 import "../ajax.js";
 
-jQuery.ajaxPrefilter( function( s ) {
+jQuery.ajaxPrefilter( function( s, origOptions ) {
 
 	// Binary data needs to be passed to XHR as-is without stringification.
-	if ( typeof s.data !== "string" && !jQuery.isPlainObject( s.data ) ) {
+	if ( typeof s.data !== "string" && !jQuery.isPlainObject( s.data ) &&
+
+			// Don't disable data processing if explicitly set by the user.
+			!( "processData" in origOptions ) ) {
 		s.processData = false;
 	}
 

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -3148,4 +3148,27 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 		};
 	} );
 
+	ajaxTest( "jQuery.ajax() - non-plain object", 1, function( assert ) {
+		return {
+			url: url( "mock.php?action=name" ),
+			method: "post",
+			data: Object.create( { name: "peter" } ),
+			success: function( data ) {
+				assert.strictEqual( data, "ERROR", "Data correctly not sent" );
+			}
+		};
+	} );
+
+	ajaxTest( "jQuery.ajax() - non-plain object with processData: true", 1, function( assert ) {
+		return {
+			url: url( "mock.php?action=name" ),
+			method: "post",
+			processData: true,
+			data: Object.create( { name: "peter" } ),
+			success: function( data ) {
+				assert.strictEqual( data, "pan", "Data sent correctly" );
+			}
+		};
+	} );
+
 } )();


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The way gh-5197 implemented binary data handling, `processData` was being explicitly set to `false`. This is expected but it made it impossible to override it to `true`. The new logic will only set `processData` to `false` if it wasn't explicitly passed in original options.

Ref gh-5197

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
