### PR TITLE
Release: add support for md5 sums in windows

### DIFF
--- a/build/release/cdn.js
+++ b/build/release/cdn.js
@@ -69,9 +69,7 @@ function makeArchives( Release, callback ) {
 
 		console.log( "Creating production archive for " + cdn );
 
-		var i,
-			sum,
-			result,
+		var i, sum, result,
 			archiver = require( "archiver" )( "zip" ),
 			md5file = cdnFolder + "/" + cdn + "-md5.txt",
 			output = fs.createWriteStream(

--- a/build/release/cdn.js
+++ b/build/release/cdn.js
@@ -4,6 +4,7 @@ var
 	fs = require( "fs" ),
 	shell = require( "shelljs" ),
 	path = require( "path" ),
+	os = require( "os" ),
 
 	cdnFolder = "dist/cdn",
 
@@ -68,12 +69,15 @@ function makeArchives( Release, callback ) {
 
 		console.log( "Creating production archive for " + cdn );
 
-		var sum,
+		var i,
+			sum,
+			result,
 			archiver = require( "archiver" )( "zip" ),
 			md5file = cdnFolder + "/" + cdn + "-md5.txt",
 			output = fs.createWriteStream(
 				cdnFolder + "/" + cdn + "-jquery-" + Release.newVersion + ".zip"
 			),
+			rmd5 = /[a-f0-9]{32}/,
 			rver = /VER/;
 
 		output.on( "close", callback );
@@ -89,7 +93,18 @@ function makeArchives( Release, callback ) {
 				item.replace( rver, Release.newVersion );
 		} );
 
-		sum = Release.exec( "md5 -r " + files.join( " " ), "Error retrieving md5sum" );
+		if ( os.platform() === "win32" ) {
+			sum = [];
+			for ( i = 0; i < files.length; i++ ) {
+				result = Release.exec(
+					"certutil -hashfile " + files[ i ] + " MD5", "Error retrieving md5sum"
+				);
+				sum.push( rmd5.exec( result )[ 0 ] + " " + files[ i ] );
+			}
+			sum = sum.join( "\n" );
+		} else {
+			sum = Release.exec( "md5 -r " + files.join( " " ), "Error retrieving md5sum" );
+		}
 		fs.writeFileSync( md5file, sum );
 		files.push( md5file );
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
I wanted to see if the release could be run on Windows. To my surprise, the md5 hash was the only thing that didn't work.

This checks the OS and switches up the command used for the md5 sums and formats it the same way as default mac/linux.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
