### PR TITLE
Tests: Indicate Chrome 112 & Safari 16.4 pass the cssHas support test

### DIFF
--- a/src/selector/support.js
+++ b/src/selector/support.js
@@ -1,7 +1,7 @@
 import document from "../var/document.js";
 import support from "../var/support.js";
 
-// Support: Chrome 105 - 110+, Safari 15.4 - 16.3+
+// Support: Chrome 105 - 111 only, Safari 15.4 - 16.3+
 // Make sure the the `:has()` argument is parsed unforgivingly.
 // We include `*` in the test to detect buggy implementations that are
 // _selectively_ forgiving (specifically when the list includes at least

--- a/test/unit/support.js
+++ b/test/unit/support.js
@@ -62,21 +62,25 @@ testIframe(
 				cssHas: true,
 				reliableTrDimensions: false
 			},
+			chrome_111: {
+				cssHas: false,
+				reliableTrDimensions: true
+			},
 			chrome: {
+				cssHas: true,
+				reliableTrDimensions: true
+			},
+			safari_16_3: {
 				cssHas: false,
 				reliableTrDimensions: true
 			},
 			safari: {
-				cssHas: false,
+				cssHas: true,
 				reliableTrDimensions: true
 			},
 			webkit: {
 				cssHas: true,
 				reliableTrDimensions: true
-			},
-			firefox_102: {
-				cssHas: true,
-				reliableTrDimensions: false
 			},
 			firefox: {
 				cssHas: true,
@@ -86,8 +90,12 @@ testIframe(
 				cssHas: true,
 				reliableTrDimensions: true
 			},
-			ios: {
+			ios_15_4_16_3: {
 				cssHas: false,
+				reliableTrDimensions: true
+			},
+			ios: {
+				cssHas: true,
 				reliableTrDimensions: true
 			}
 		};
@@ -101,17 +109,19 @@ testIframe(
 
 	if ( document.documentMode ) {
 		expected = expectedMap.ie_11;
-	} else if ( /chrome/i.test( userAgent ) ) {
+	} else if ( /\b(?:headless)?chrome\/(?:10\d|11[01])\b/i.test( userAgent ) ) {
+		expected = expectedMap.chrome_111;
+	} else if ( /\b(?:headless)?chrome\//i.test( userAgent ) ) {
 
 		// Catches Edge, Chrome on Android & Opera as well.
 		expected = expectedMap.chrome;
-	} else if ( /firefox\/102\./i.test( userAgent ) ) {
-		expected = expectedMap.firefox_102;
-	} else if ( /firefox/i.test( userAgent ) ) {
+	} else if ( /\bfirefox\//i.test( userAgent ) ) {
 		expected = expectedMap.firefox;
-	} else if ( /iphone os (?:14_|15_[0123])/i.test( userAgent ) ) {
+	} else if ( /\biphone os (?:14_|15_[0123])/i.test( userAgent ) ) {
 		expected = expectedMap.ios_14_15_3;
-	} else if ( /(?:iphone|ipad);.*(?:iphone)? os \d+_/i.test( userAgent ) ) {
+	} else if ( /\biphone os (?:15_|16_[0123])/i.test( userAgent ) ) {
+		expected = expectedMap.ios_15_4_16_3;
+	} else if ( /\b(?:iphone|ipad);.*(?:iphone)? os \d+_/i.test( userAgent ) ) {
 		expected = expectedMap.ios;
 	} else if ( typeof URLSearchParams !== "undefined" &&
 
@@ -125,7 +135,9 @@ testIframe(
 		) === "Playwright"
 	) {
 		expected = expectedMap.webkit;
-	} else if ( /\b\d+(\.\d+)+ safari/i.test( userAgent ) ) {
+	} else if ( /\bversion\/(?:15|16\.[0123])(?:\.\d+)* safari/i.test( userAgent ) ) {
+		expected = expectedMap.safari_16_3;
+	} else if ( /\bversion\/\d+(?:\.\d+)+ safari/i.test( userAgent ) ) {
 		expected = expectedMap.safari;
 	}
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Chrome 112 & Safari 16.4 introduce two changes:
* `:has()` is non-forgiving
* `CSS.supports( "selector(...)" )` parses everything in a non-forgiving way

We no longer care about the latter but the former means the `cssHas` support test now passes.

`3.x-stable` version: #5226

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
