### PR TITLE
Tests: Indicate Chrome 112 & Safari 16.4 pass the cssHas support test (3.x version)

### DIFF
--- a/src/selector.js
+++ b/src/selector.js
@@ -558,8 +558,8 @@ function setDocument( node ) {
 		return document.querySelectorAll( ":scope" );
 	} );
 
-	// Support: Chrome 105 - 110+, Safari 15.4 - 16.3+
-	// Make sure the the `:has()` argument is parsed unforgivingly.
+	// Support: Chrome 105 - 111 only, Safari 15.4 - 16.3 only
+	// Make sure the `:has()` argument is parsed unforgivingly.
 	// We include `*` in the test to detect buggy implementations that are
 	// _selectively_ forgiving (specifically when the list includes at least
 	// one valid selector).

--- a/test/unit/support.js
+++ b/test/unit/support.js
@@ -130,7 +130,55 @@ testIframe(
 				sortDetached: true,
 				sortStable: true
 			},
+			chrome_111: {
+				ajax: true,
+				boxSizingReliable: true,
+				checkClone: true,
+				checkOn: true,
+				clearCloneStyle: true,
+				cssHas: false,
+				cors: true,
+				createHTMLDocument: true,
+				disconnectedMatch: true,
+				getById: true,
+				noCloneChecked: true,
+				option: true,
+				optSelected: true,
+				pixelBoxStyles: true,
+				pixelPosition: true,
+				radioValue: true,
+				reliableMarginLeft: true,
+				reliableTrDimensions: true,
+				scope: true,
+				scrollboxSize: true,
+				sortDetached: true,
+				sortStable: true
+			},
 			chrome: {
+				ajax: true,
+				boxSizingReliable: true,
+				checkClone: true,
+				checkOn: true,
+				clearCloneStyle: true,
+				cssHas: true,
+				cors: true,
+				createHTMLDocument: true,
+				disconnectedMatch: true,
+				getById: true,
+				noCloneChecked: true,
+				option: true,
+				optSelected: true,
+				pixelBoxStyles: true,
+				pixelPosition: true,
+				radioValue: true,
+				reliableMarginLeft: true,
+				reliableTrDimensions: true,
+				scope: true,
+				scrollboxSize: true,
+				sortDetached: true,
+				sortStable: true
+			},
+			safari_16_3: {
 				ajax: true,
 				boxSizingReliable: true,
 				checkClone: true,
@@ -160,7 +208,7 @@ testIframe(
 				checkClone: true,
 				checkOn: true,
 				clearCloneStyle: true,
-				cssHas: false,
+				cssHas: true,
 				cors: true,
 				createHTMLDocument: true,
 				disconnectedMatch: true,
@@ -221,30 +269,6 @@ testIframe(
 				radioValue: true,
 				reliableMarginLeft: false,
 				reliableTrDimensions: true,
-				scope: true,
-				scrollboxSize: true,
-				sortDetached: true,
-				sortStable: true
-			},
-			firefox_102: {
-				ajax: true,
-				boxSizingReliable: true,
-				checkClone: true,
-				checkOn: true,
-				clearCloneStyle: true,
-				cssHas: true,
-				cors: true,
-				createHTMLDocument: true,
-				disconnectedMatch: true,
-				getById: true,
-				noCloneChecked: true,
-				option: true,
-				optSelected: true,
-				pixelBoxStyles: true,
-				pixelPosition: true,
-				radioValue: true,
-				reliableMarginLeft: true,
-				reliableTrDimensions: false,
 				scope: true,
 				scrollboxSize: true,
 				sortDetached: true,
@@ -370,13 +394,37 @@ testIframe(
 				sortDetached: true,
 				sortStable: true
 			},
-			ios: {
+			ios_15_4_16_3: {
 				ajax: true,
 				boxSizingReliable: true,
 				checkClone: true,
 				checkOn: true,
 				clearCloneStyle: true,
 				cssHas: false,
+				cors: true,
+				createHTMLDocument: true,
+				disconnectedMatch: true,
+				getById: true,
+				noCloneChecked: true,
+				option: true,
+				optSelected: true,
+				pixelBoxStyles: true,
+				pixelPosition: true,
+				radioValue: true,
+				reliableMarginLeft: true,
+				reliableTrDimensions: true,
+				scope: true,
+				scrollboxSize: true,
+				sortDetached: true,
+				sortStable: true
+			},
+			ios: {
+				ajax: true,
+				boxSizingReliable: true,
+				checkClone: true,
+				checkOn: true,
+				clearCloneStyle: true,
+				cssHas: true,
 				cors: true,
 				createHTMLDocument: true,
 				disconnectedMatch: true,
@@ -440,36 +488,36 @@ testIframe(
 		}
 	}
 
-	if ( /edge\//i.test( userAgent ) ) {
+	if ( /\bedge\//i.test( userAgent ) ) {
 		expected = expectedMap.edge;
-	} else if ( /msie 9\.0/i.test( userAgent ) ) {
+	} else if ( /\bmsie 9\.0/i.test( userAgent ) ) {
 		expected = expectedMap.ie_9;
-	} else if ( /(msie 10\.0|trident\/7\.0)/i.test( userAgent ) ) {
+	} else if ( /\b(?:msie 10\.0|trident\/7\.0)/i.test( userAgent ) ) {
 		expected = expectedMap.ie_10_11;
-	} else if ( /chrome/i.test( userAgent ) ) {
+	} else if ( /\b(?:headless)?chrome\/(?:10\d|11[01])\b/i.test( userAgent ) ) {
+		expected = expectedMap.chrome_111;
+	} else if ( /\b(?:headless)?chrome\//i.test( userAgent ) ) {
 
 		// Catches Chrome on Android as well (i.e. the default
 		// Android browser on Android >= 4.4).
 		expected = expectedMap.chrome;
-	} else if ( /\b(?:9|10)\.\d+(\.\d+)* safari/i.test( userAgent ) ) {
-		expected = expectedMap.safari_9_10;
-	} else if ( /firefox\/[456]\d\b/i.test( userAgent ) ) {
+	} else if ( /\bfirefox\/[456]\d\b/i.test( userAgent ) ) {
 		expected = expectedMap.firefox_60;
-	} else if ( /firefox\/(?:[789]\d|102)\b/i.test( userAgent ) ) {
-		expected = expectedMap.firefox_102;
-	} else if ( /firefox/i.test( userAgent ) ) {
+	} else if ( /\bfirefox\//i.test( userAgent ) ) {
 		expected = expectedMap.firefox;
-	} else if ( /android 4\.[0-3]/i.test( userAgent ) ) {
+	} else if ( /\bandroid 4\.[0-3]/i.test( userAgent ) ) {
 		expected = expectedMap.android;
-	} else if ( /iphone os 7_/i.test( userAgent ) ) {
+	} else if ( /\biphone os 7_/i.test( userAgent ) ) {
 		expected = expectedMap.ios_7;
-	} else if ( /iphone os 8_/i.test( userAgent ) ) {
+	} else if ( /\biphone os 8_/i.test( userAgent ) ) {
 		expected = expectedMap.ios_8;
-	} else if ( /iphone os (?:9|10)_/i.test( userAgent ) ) {
+	} else if ( /\biphone os (?:9|10)_/i.test( userAgent ) ) {
 		expected = expectedMap.ios_9_10;
-	} else if ( /iphone os (?:1[1234]_|15_[0123])/i.test( userAgent ) ) {
+	} else if ( /\biphone os (?:1[1234]_|15_[0123])/i.test( userAgent ) ) {
 		expected = expectedMap.ios_11_15_3;
-	} else if ( /(?:iphone|ipad);.*(?:iphone)? os \d+_/i.test( userAgent ) ) {
+	} else if ( /\biphone os (?:15_|16_[0123])/i.test( userAgent ) ) {
+		expected = expectedMap.ios_15_4_16_3;
+	} else if ( /\b(?:iphone|ipad);.*(?:iphone)? os \d+_/i.test( userAgent ) ) {
 		expected = expectedMap.ios;
 	} else if ( typeof URLSearchParams !== "undefined" &&
 
@@ -483,7 +531,9 @@ testIframe(
 		) === "Playwright"
 	) {
 		expected = expectedMap.webkit;
-	} else if ( /\b\d+(\.\d+)+ safari/i.test( userAgent ) ) {
+	} else if ( /\bversion\/(?:15|16\.[0123])(?:\.\d+)* safari/i.test( userAgent ) ) {
+		expected = expectedMap.safari_16_3;
+	} else if ( /\bversion\/\d+(?:\.\d+)+ safari/i.test( userAgent ) ) {
 		expected = expectedMap.safari;
 	}
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Chrome 112 & Safari 16.4 introduce two changes:
* `:has()` is non-forgiving
* `CSS.supports( "selector(...)" )` parses everything in a non-forgiving way

We no longer care about the latter but the former means the `cssHas` support test now passes.

`main` version: #5225

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
