### PR TITLE
Selector: Wrap activeElement access in try-catch

### DIFF
--- a/src/selector.js
+++ b/src/selector.js
@@ -163,6 +163,15 @@ var i,
 		{ dir: "parentNode", next: "legend" }
 	);
 
+// Support: IE <=9 only
+// Accessing document.activeElement can throw unexpectedly
+// https://bugs.jquery.com/ticket/13393
+function safeActiveElement() {
+	try {
+		return document.activeElement;
+	} catch ( err ) { }
+}
+
 // Optimize for push.apply( _, NodeList )
 try {
 	push.apply(
@@ -1316,7 +1325,7 @@ Expr = jQuery.expr = {
 		},
 
 		focus: function( elem ) {
-			return elem === document.activeElement &&
+			return elem === safeActiveElement() &&
 				document.hasFocus() &&
 				!!( elem.type || elem.href || ~elem.tabIndex );
 		},

--- a/src/selector.js
+++ b/src/selector.js
@@ -166,6 +166,8 @@ var i,
 // Support: IE <=9 only
 // Accessing document.activeElement can throw unexpectedly
 // https://bugs.jquery.com/ticket/13393
+// An identical function exists in `src/event.js` but they use different
+// `documents` so it cannot be easily extracted.
 function safeActiveElement() {
 	try {
 		return document.activeElement;


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

In IE 9 accessing `document.activeElement` may throw; see https://bugs.jquery.com/ticket/13393. We've already guarded against this in `event` code but not in `selector`.

Due to gzip magic, this is +0 bytes.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
