### PR TITLE
Event: Avoid collisions between jQuery.event.special & Object.prototype

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -429,7 +429,7 @@ jQuery.event = {
 			new jQuery.Event( originalEvent );
 	},
 
-	special: {
+	special: jQuery.extend( Object.create( null ), {
 		load: {
 
 			// Prevent triggered image.load events from bubbling to window.load
@@ -494,7 +494,7 @@ jQuery.event = {
 				}
 			}
 		}
-	}
+	} )
 };
 
 // Ensure the presence of an event listener that handles manually-triggered

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -2428,6 +2428,26 @@ QUnit.test( ".on and .off, selective mixed removal (trac-10705)", function( asse
 		.trigger( "click" );	// 0
 } );
 
+QUnit.test( "special interference with Object.prototype", function( assert ) {
+	assert.expect( 1 );
+
+	var triggered = false;
+
+	Object.prototype.jqfake = {
+		trigger: function() {
+			triggered = true;
+		}
+	};
+
+	jQuery( "<div></div>" )
+		.appendTo( "#qunit-fixture" )
+		.trigger( "jqfake" );
+
+	delete Object.prototype.jqfake;
+
+	assert.ok( !triggered, "Object.prototype.jqfake.trigger not called" );
+} );
+
 QUnit.test( ".on( event-map, null-selector, data ) trac-11130", function( assert ) {
 
 	assert.expect( 1 );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

This is a follow-up to similar changes to data & event storages from gh-4603.

This is a breaking change as there may be code like:
```js
jQuery.event.special.hasOwnProperty( "something" )
```
in the wild.

Ref gh-4603

+3 bytes

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
