### PR TITLE
Event: Simplify the check for saved data in leverageNative

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -556,7 +556,7 @@ function leverageNative( el, type, isSetup ) {
 
 			// If this is a native event triggered above, everything is now in order
 			// Fire an inner synthetic event with the original arguments
-			} else if ( saved.length ) {
+			} else if ( saved ) {
 
 				// ...and capture the result
 				dataPriv.set( this, type, jQuery.event.trigger(


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Previously, when `leverageNative` handled async events, there was a case where an empty placeholder object was set as a result. Covering both such an object and `false` required a `length` check. However, this is not necessary since gh-5223 and the check was already simplified in other places; this one was missed.

Ref gh-5223

-1 byte

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
