### PR TITLE
Selector: Remove an obsolete comment

### DIFF
--- a/src/selector.js
+++ b/src/selector.js
@@ -166,8 +166,6 @@ var i,
 // Support: IE <=9 only
 // Accessing document.activeElement can throw unexpectedly
 // https://bugs.jquery.com/ticket/13393
-// An identical function exists in `src/event.js` but they use different
-// `documents` so it cannot be easily extracted.
 function safeActiveElement() {
 	try {
 		return document.activeElement;


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

There was a comment claiming that there are two implementations of `safeActiveElement`. However, the one in `event.js` got removed in gh-5224, even before the comment was added.

This commit removes this obsolete comment.

Ref gh-5224

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
