### PR TITLE
Build: Make the `eslint:dev` task not lint the `dist/` folder

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -136,7 +136,11 @@ module.exports = function( grunt ) {
 						.map( filePath => filePath[ 0 ] === "!" ?
 							filePath.slice( 1 ) :
 							`!${ filePath }`
-						)
+						),
+
+					// Explicitly ignore `dist/` as it could be unignored by
+					// the above `.eslintignore` parsing.
+					"!dist/**/*.js"
 				]
 			}
 		},


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

There was a mistake in paths logic that made the `dist/` folder linted even in the `eslint:dev` task which is run before the build. Fix that by explicitly ignoring the `dist/` folder at the end of the file list.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
