### PR TITLE
Build: Switch the minifier from UglifyJS to Terser

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -329,25 +329,26 @@ module.exports = function( grunt ) {
 			files: [ "<%= eslint.dev.src %>" ],
 			tasks: [ "dev" ]
 		},
-		uglify: {
+		terser: {
 			all: {
 				files: {
 					"dist/<%= grunt.option('filename').replace('.js', '.min.js') %>":
 						"dist/<%= grunt.option('filename') %>"
 				},
 				options: {
-					preserveComments: false,
-					sourceMap: true,
-					sourceMapName:
-						"dist/<%= grunt.option('filename').replace('.js', '.min.map') %>",
-					report: "min",
-					output: {
-						"ascii_only": true
+					ecma: 5,
+					sourceMap: {
+						filename: "dist/<%= grunt.option('filename').replace('.js', '.min.map') %>"
 					},
-					banner: "/*! jQuery v<%= pkg.version %> | " +
-						"(c) OpenJS Foundation and other contributors | jquery.org/license */",
+					format: {
+						ascii_only: true,
+						comments: false,
+						preamble: "/*! jQuery v<%= pkg.version %> | " +
+							"(c) OpenJS Foundation and other contributors | " +
+							"jquery.org/license */"
+					},
 					compress: {
-						"hoist_funs": false,
+						hoist_funs: false,
 						loops: false
 					}
 				}
@@ -416,7 +417,7 @@ module.exports = function( grunt ) {
 	grunt.registerTask( "dev", [
 		"build:*:*",
 		runIfNewNode( "newer:eslint:dev" ),
-		"newer:uglify",
+		"newer:terser",
 		"remove_map_comment",
 		"dist:*",
 		"qunit_fixture",
@@ -427,7 +428,7 @@ module.exports = function( grunt ) {
 		runIfNewNode( "eslint:dev" ),
 		"build:*:*",
 		"amd",
-		"uglify",
+		"terser",
 		"remove_map_comment",
 		"dist:*",
 		"test:prepare",

--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -339,6 +339,6 @@ module.exports = function( grunt ) {
 			"";
 
 		grunt.log.writeln( "Creating custom build...\n" );
-		grunt.task.run( [ "build:*:*" + ( modules ? ":" + modules : "" ), "uglify", "dist" ] );
+		grunt.task.run( [ "build:*:*" + ( modules ? ":" + modules : "" ), "terser", "dist" ] );
 	} );
 };

--- a/build/tasks/sourcemap.js
+++ b/build/tasks/sourcemap.js
@@ -3,7 +3,7 @@
 var fs = require( "fs" );
 
 module.exports = function( grunt ) {
-	var config = grunt.config( "uglify.all.files" );
+	var config = grunt.config( "terser.all.files" );
 	grunt.registerTask( "remove_map_comment", function() {
 		var minLoc = grunt.config.process( Object.keys( config )[ 0 ] );
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "grunt-babel": "8.0.0",
     "grunt-cli": "1.4.3",
     "grunt-compare-size": "0.4.2",
-    "grunt-contrib-uglify": "3.4.0",
     "grunt-contrib-watch": "1.1.0",
     "grunt-eslint": "24.0.0",
     "grunt-git-authors": "3.2.0",
@@ -43,6 +42,7 @@
     "grunt-karma": "4.0.2",
     "grunt-newer": "1.3.0",
     "grunt-npmcopy": "0.2.0",
+    "grunt-terser": "2.0.0",
     "gzip-js": "0.3.2",
     "husky": "4.2.5",
     "jsdom": "19.0.0",
@@ -67,8 +67,8 @@
     "rollup": "2.21.0",
     "sinon": "7.3.1",
     "strip-json-comments": "3.1.1",
-    "testswarm": "1.1.2",
-    "uglify-js": "3.4.7"
+    "terser": "5.17.6",
+    "testswarm": "1.1.2"
   },
   "scripts": {
     "build": "npm install && grunt",


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

UglifyJS is ES5-only, while Terser supports newer ECMAScript versions. jQuery is authored in ES5 but jQuery 4.x will also have an ESM build that cannot be minified using UglifyJS directly.

We could strip the `export` statement, minify via UglifyJS and re-add one but that increases complexity & may not fully play nice with source maps.

On the other hand, switching to Terser increases the minfied size by just 324 bytes and the minified gzipped one by just 70 bytes. Such differences largely disappear among bigger size gains from the `3.x-stable` line - around 2.7 KB minified gzipped as of now.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* [x] Grunt build and unit tests pass locally with these changes
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
