### PR TITLE
Docs: Remove the "Grunt build" section from the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,6 @@ Mark an `[x]` for completed items, if you're not sure leave them unchecked and w
 -->
 
 * [ ] New tests have been added to show the fix or feature works
-* [ ] Grunt build and unit tests pass locally with these changes
 * [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com
 
 <!--


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Now that unit tests are run on GitHub Actions in all three major engines and for multiple custom jQuery builds, the request for PR authors to run unit tests locally and confirm they pass is needless overhead; let's drop the checkbox.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
