### PR TITLE
Core: Fix regression in jQuery.text() on HTMLDocument objects

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -289,9 +289,14 @@ jQuery.extend( {
 				// Do not traverse comment nodes
 				ret += jQuery.text( node );
 			}
-		} else if ( nodeType === 1 || nodeType === 9 || nodeType === 11 ) {
+		}
+		if ( nodeType === 1 || nodeType === 11 ) {
 			return elem.textContent;
-		} else if ( nodeType === 3 || nodeType === 4 ) {
+		}
+		if ( nodeType === 9 ) {
+			return elem.documentElement.textContent;
+		}
+		if ( nodeType === 3 || nodeType === 4 ) {
 			return elem.nodeValue;
 		}
 

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -30,9 +30,9 @@ function manipulationFunctionReturningObj( value ) {
 
 QUnit.test( "text()", function( assert ) {
 
-	assert.expect( 5 );
+	assert.expect( 6 );
 
-	var expected, frag, $newLineTest;
+	var expected, frag, $newLineTest, doc;
 
 	expected = "This link has class=\"blog\": Simon Willison's Weblog";
 	assert.equal( jQuery( "#sap" ).text(), expected, "Check for merged text of more then one element." );
@@ -52,6 +52,9 @@ QUnit.test( "text()", function( assert ) {
 	assert.equal( $newLineTest.text(), "test\ntesty", "text() does not remove new lines (trac-11153)" );
 
 	$newLineTest.remove();
+
+	doc = new DOMParser().parseFromString( "<span>example</span>", "text/html" );
+	assert.equal( jQuery( doc ).text(), "example", "text() on HTMLDocument (gh-5264)" );
 } );
 
 QUnit.test( "text(undefined)", function( assert ) {


### PR DESCRIPTION
Fixes https://github.com/jquery/jquery/issues/5264.

Size comparison, if written as minimal diff (add conditional branch):
```                              
   +54     +8 dist/jquery.js                                                   
   +19     +5 dist/jquery.min.js   
```

Size comparison, as submitted (rewritten without "else if"):
```
   raw     gz Compared to 3.x-stable @ 992a66538b535d24c9ba46c3a4492665943b40c7
   +50     +4 dist/jquery.js                                                   
    +4     +1 dist/jquery.min.js  
```

### Checklist ###
* [x] New tests have been added to show the fix or feature works
