### PR TITLE
Docs: remove stale gitter badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 [jQuery](https://jquery.com/) — New Wave JavaScript
 ==================================================
 
-[![Gitter](https://badges.gitter.im/jquery/jquery.svg)](https://gitter.im/jquery/jquery?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+Meetings are currently held on the [matrix.org platform](https://matrix.to/#/#jquery_meeting:gitter.im).
+
+Meeting minutes can be found at [meetings.jquery.org](https://meetings.jquery.org/category/core/).
 
 Contribution Guides
 --------------------------------------


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
This removes the gitter badge and adds a link to the current meeting place and meeting minutes.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
