### PR TITLE
CSS: Make the reliableTrDimensions support test work with Bootstrap CSS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -89,6 +89,10 @@ module.exports = function( grunt ) {
 					destPrefix: "external"
 				},
 				files: {
+					"bootstrap/bootstrap.css": "bootstrap/dist/css/bootstrap.css",
+					"bootstrap/bootstrap.min.css": "bootstrap/dist/css/bootstrap.min.css",
+					"bootstrap/bootstrap.min.css.map": "bootstrap/dist/css/bootstrap.min.css.map",
+
 					"core-js-bundle/core-js-bundle.js": "core-js-bundle/minified.js",
 					"core-js-bundle/LICENSE": "core-js-bundle/LICENSE",
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@babel/core": "7.10.5",
     "@babel/plugin-transform-for-of": "7.10.4",
     "@swc/core": "1.3.66",
+    "bootstrap": "5.3.0",
     "colors": "1.4.0",
     "commitplease": "3.2.0",
     "core-js-bundle": "3.6.5",

--- a/src/css/support.js
+++ b/src/css/support.js
@@ -25,7 +25,7 @@ support.reliableTrDimensions = function() {
 		tr = document.createElement( "tr" );
 
 		table.style.cssText = "position:absolute;left:-11111px;border-collapse:separate";
-		tr.style.cssText = "border:1px solid";
+		tr.style.cssText = "box-sizing:content-box;border:1px solid";
 
 		// Support: Chrome 86+
 		// Height set through cssText does not get applied.
@@ -38,7 +38,7 @@ support.reliableTrDimensions = function() {
 		// display for all div elements is set to "inline",
 		// which causes a problem only in Android Chrome, but
 		// not consistently across all devices.
-		// Ensuring the div is display: block
+		// Ensuring the div is `display: block`
 		// gets around this issue.
 		div.style.display = "block";
 

--- a/test/data/support/bootstrap.html
+++ b/test/data/support/bootstrap.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8" />
+	<link rel="stylesheet" href="../../../external/bootstrap/bootstrap.min.css" class="stylesheet">
+</head>
+<body>
+<div>
+	<script src="../../jquery.js"></script>
+	<script src="../iframeTest.js"></script>
+	<script src="getComputedSupport.js"></script>
+</div>
+<script>
+	startIframeTest(
+		getComputedStyle( document.body ),
+		getComputedSupport( jQuery.support )
+	);
+</script>
+</body>
+</html>

--- a/test/unit/support.js
+++ b/test/unit/support.js
@@ -54,6 +54,18 @@ testIframe(
 	}
 );
 
+testIframe(
+	"Verify correctness of support tests with bootstrap CSS on the page",
+	"support/bootstrap.html",
+	function( assert, jQuery, window, document, bodyStyle, support ) {
+		assert.expect( 2 );
+		assert.strictEqual( bodyStyle.boxSizing, "border-box",
+			"border-box applied on body by Bootstrap" );
+		assert.deepEqual( jQuery.extend( {}, support ), computedSupport,
+			"Same support properties" );
+	}
+);
+
 ( function() {
 	var expected, browserKey,
 		userAgent = window.navigator.userAgent,


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Bootstrap 5 includes the following CSS on the page:

```css
*,
*::before,
*::after {
  box-sizing: border-box;
}
```

That threw our `reliableTrDimensions` support test off. This change fixes the support test and adds a unit test ensuring support test values on a page including Bootstrap 5 CSS are the same as on a page without it.

Fixes gh-5270

+10 bytes

3.x version: #5279

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
