### PR TITLE
Build: Make sure `*.cjs` & `*.mjs` files use UNIX line endings as well

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,7 @@
 * text=auto
 
 # JS files must always use LF for tools to work
+# JS files may have mjs or cjs extensions now as well
 *.js eol=lf
+*.cjs eol=lf
+*.mjs eol=lf


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

We've had this rule for `*.js` files so far but we now have two new JS extensions.

Another option is to set this for all text files, not just JS. Is there any downside? AFAIK most Windows editors/IDEs should handle LF line endings just fine nowadays?

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
