### PR TITLE
Effects: Remove a redundant `!fn` check

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -446,7 +446,7 @@ jQuery.Animation = jQuery.extend( Animation, {
 
 jQuery.speed = function( speed, easing, fn ) {
 	var opt = speed && typeof speed === "object" ? jQuery.extend( {}, speed ) : {
-		complete: fn || !fn && easing ||
+		complete: fn || easing ||
 			typeof speed === "function" && speed,
 		duration: speed,
 		easing: fn && easing || easing && typeof easing !== "function" && easing


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

`fn || !fn && easing` is equivalent to `fn || easing`; simplify the code.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
