### PR TITLE
Build: replace CRLF with LF during minify

### DIFF
--- a/build/tasks/minify.js
+++ b/build/tasks/minify.js
@@ -34,7 +34,8 @@ module.exports = ( grunt ) => {
 					}
 				);
 
-				grunt.file.write( dest, code );
+				// Can't seem to get SWC to not use CRLF on Windows, so replace them with LF.
+				grunt.file.write( dest, code.replace( /\r\n/g, "\n" ) );
 
 				if ( sourceMapFilename ) {
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

SWC is not respecting the git setting and does not have an option to force LF. This fixes the build on Windows.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
