### PR TITLE
CSS: Fix support test results for initially hidden iframes

### DIFF
--- a/src/css/support.js
+++ b/src/css/support.js
@@ -17,6 +17,10 @@ define( [
 		if ( !div ) {
 			return;
 		}
+		// Don't run until window is visible (gh-2176)
+		if ( documentElement.offsetHeight === 0 ) {
+			return;
+		}
 
 		container.style.cssText = "position:absolute;left:-11111px;width:60px;" +
 			"margin-top:1px;padding:0;border:0";

--- a/src/css/support.js
+++ b/src/css/support.js
@@ -17,7 +17,7 @@ define( [
 		if ( !div ) {
 			return;
 		}
-		// Don't run until window is visible (gh-2176)
+		// Don't run until window is visible (https://github.com/jquery/jquery-ui/issues/2176)
 		if ( documentElement.offsetHeight === 0 ) {
 			return;
 		}

--- a/src/css/support.js
+++ b/src/css/support.js
@@ -31,6 +31,7 @@ define( [
 
 		// Don't run until window is visible (https://github.com/jquery/jquery-ui/issues/2176)
 		if ( div.offsetWidth === 0 ) {
+			documentElement.removeChild( container );
 			return;
 		}
 

--- a/src/css/support.js
+++ b/src/css/support.js
@@ -18,11 +18,6 @@ define( [
 			return;
 		}
 
-		// Don't run until window is visible (https://github.com/jquery/jquery-ui/issues/2176)
-		if ( documentElement.offsetHeight === 0 ) {
-			return;
-		}
-
 		container.style.cssText = "position:absolute;left:-11111px;width:60px;" +
 			"margin-top:1px;padding:0;border:0";
 		div.style.cssText =
@@ -33,6 +28,11 @@ define( [
 
 		var divStyle = window.getComputedStyle( div );
 		pixelPositionVal = divStyle.top !== "1%";
+
+		// Don't run until window is visible (https://github.com/jquery/jquery-ui/issues/2176)
+		if ( div.offsetWidth === 0 ) {
+			return;
+		}
 
 		// Support: Android 4.0 - 4.3 only, Firefox <=3 - 44
 		reliableMarginLeftVal = roundPixelMeasures( divStyle.marginLeft ) === 12;

--- a/src/css/support.js
+++ b/src/css/support.js
@@ -17,6 +17,7 @@ define( [
 		if ( !div ) {
 			return;
 		}
+
 		// Don't run until window is visible (https://github.com/jquery/jquery-ui/issues/2176)
 		if ( documentElement.offsetHeight === 0 ) {
 			return;

--- a/test/data/css/cssComputeStyleTests.html
+++ b/test/data/css/cssComputeStyleTests.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style>
+		* {
+			box-sizing: border-box;
+		}
+		#test {
+			position: absolute;
+			border: 10px solid black;
+			width: 400px;
+		}
+	</style>
+</head>
+<body>
+<div id="test"></div>
+<script src="../../jquery.js"></script>
+<script src="../iframeTest.js"></script>
+<script>
+	var initialHeight = $('#test').outerHeight();
+	startIframeTest( initialHeight );
+</script>
+</body>
+</html>

--- a/test/data/testinit.js
+++ b/test/data/testinit.js
@@ -267,7 +267,7 @@ this.ajaxTest = function( title, expect, options ) {
 	} );
 };
 
-this.testIframe = function( title, fileName, func, wrapper ) {
+this.testIframe = function( title, fileName, func, wrapper, iframeStyles ) {
 	if ( !wrapper ) {
 		wrapper = QUnit.test;
 	}
@@ -276,6 +276,11 @@ this.testIframe = function( title, fileName, func, wrapper ) {
 			$iframe = supportjQuery( "<iframe></iframe>" )
 				.css( { position: "absolute", top: "0", left: "-600px", width: "500px" } )
 				.attr( { id: "qunit-fixture-iframe", src: url( fileName ) } );
+
+		// Add other iframe styles
+		if ( iframeStyles ) {
+			$iframe.css( iframeStyles );
+		}
 
 		// Test iframes are expected to invoke this via startIframeTest (cf. iframeTest.js)
 		window.iframeCallback = function() {

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -1406,7 +1406,8 @@ testIframe(
 	"css/cssComputeStyleTests.html",
 	function( assert, jQuery, window, document, initialHeight ) {
 		assert.expect( 2 );
-		assert.strictEqual( initialHeight, 0, "initial height should be undefined" );
+		assert.strictEqual( initialHeight === 0 ? 20 : initialHeight, 20,
+			"hidden-frame content sizes should be zero or accurate" );
 		window.parent.jQuery( "#qunit-fixture-iframe" ).css( { "display": "block" } );
 		jQuery( "#test" ).width( 600 );
 		assert.strictEqual( jQuery( "#test" ).width(), 600, "width should be 600" );

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -1401,6 +1401,20 @@ testIframe(
 	}
 );
 
+testIframe(
+	"Test computeStyleTests for hidden iframe",
+	"css/cssComputeStyleTests.html",
+	function( assert, jQuery, window, document, initialHeight ) {
+		assert.expect( 2 );
+		assert.strictEqual( initialHeight, 0, "initial height should be undefined" );
+		window.parent.jQuery( "#qunit-fixture-iframe" ).css( { "display": "block" } );
+		jQuery( "#test" ).width( 600 );
+		assert.strictEqual( jQuery( "#test" ).width(), 600, "width should be 600" );
+	},
+	undefined,
+	{ "display": "none" }
+);
+
 ( function() {
 	var supportsFractionalGBCR,
 		qunitFixture = document.getElementById( "qunit-fixture" ),


### PR DESCRIPTION
### Summary ###

If the iframe is not initially visible, `boxSizingReliableVal` gets set to false, which triggers this code to set the wrong dialog width here: https://github.com/jquery/jquery/blob/a7cc3a0f0418d168ff3818576161c5af24d0ca78/src/css.js#L418-L426

I think this should solve https://github.com/jquery/jquery-ui/issues/2176.

You can reproduce something similar to the original issue by creating the following two files in the top level of a website. Then go to `index.html`, click "Show Frame", then "Show Popup". The popup should be 600px, but is not.

## `index.html`
```html
<!DOCTYPE html>
<html>
	<body>
		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.js" integrity="sha512-+k1pnlgt4F1H8L7t3z95o3/KO+o78INEcXTbnoJQ/F2VqDVhWoaiVml/OEHv9HsVgxUaVW+IbiZPUJQfF/YxZw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
		<script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.13.2/jquery-ui.js" integrity="sha512-ynDTbjF5rUHsWBjz7nsljrrSWqLTPJaORzSe5aGCFxOigRZRmwM05y+kuCtxaoCSzVGB1Ky3XeRZsDhbSLdzXQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
		<div hidden="hidden" id="testFrame">
			<iframe src="/innerIframe.html" style="width: 100%; height: 500px"></iframe>
		</div>
		<button type="button" onclick="$('#testFrame').prop('hidden', false);this.hidden=true;">Show Frame</button>
	</body>
</html>
```

## `innerIframe.html`
```
<!DOCTYPE html>
<html>
	<head>
		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.13.2/themes/base/jquery-ui.min.css" integrity="sha512-ELV+xyi8IhEApPS/pSj66+Jiw+sOT1Mqkzlh8ExXihe4zfqbWkxPRi8wptXIO9g73FSlhmquFlUOuMSoXz5IRw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
		<style>
			* {
				box-sizing: border-box;
			}
			.ui-dialog {
				width: 400px;
			}
		</style>
	</head>
	<body>
		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.js" integrity="sha512-+k1pnlgt4F1H8L7t3z95o3/KO+o78INEcXTbnoJQ/F2VqDVhWoaiVml/OEHv9HsVgxUaVW+IbiZPUJQfF/YxZw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
		<script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.13.2/jquery-ui.js" integrity="sha512-ynDTbjF5rUHsWBjz7nsljrrSWqLTPJaORzSe5aGCFxOigRZRmwM05y+kuCtxaoCSzVGB1Ky3XeRZsDhbSLdzXQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
		<div id="testPopup" hidden="hidden" style="width: 800px;">
			Popup
		</div>
		<button type="button" onclick="$('#testPopup').dialog({width: 600});">Show Popup</button>
		<script>
			// Calling this triggers `computeStyleTests` to be called before the page is visible
			console.log($('#testPopup').outerHeight());
		</script>
	</body>
</html>
```

### Checklist ###

* [x] New tests have been added to show the fix or feature works
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

