### PR TITLE
Build: add commit SHAs and last runs to comparisons

### DIFF
--- a/build/tasks/compare_size.mjs
+++ b/build/tasks/compare_size.mjs
@@ -52,9 +52,9 @@ export async function compareSize( { cache = ".sizecache.json", files } = {} ) {
 
 			let contents = await fs.promises.readFile( filename, "utf8" );
 
-			// Remove the banner for size comparisons.
-			// The version string can vary widely by short SHA.
-			contents = contents.replace( /\/\*\! jQuery[^\n]+/, "" );
+			// Remove the short SHA and .dirty from comparisons
+			const sha = /\/\*\! jQuery v\d+.\d+.\d+(?:-\w+)?\+(?:slim.)?(\w{8}(?:\.dirty)?)/.exec( contents )[ 1 ];
+			contents = contents.replace( new RegExp( sha, "g" ), "" );
 
 			const size = Buffer.byteLength( contents, "utf8" );
 			const gzippedSize = ( await gzip( contents ) ).length;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -286,8 +286,12 @@ export default [
 		files: [
 			"dist/jquery.js",
 			"dist/jquery.slim.js",
+			"dist/jquery.factory.js",
+			"dist/jquery.factory.slim.js",
 			"dist-module/jquery.module.js",
-			"dist-module/jquery.slim.module.js"
+			"dist-module/jquery.slim.module.js",
+			"dist-module/jquery.factory.module.js",
+			"dist-module/jquery.factory.slim.module.js"
 		],
 
 		languageOptions: {


### PR DESCRIPTION
Fixes gh-5327

### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

- [BREAKING] changes the format of .sizecache.json. Delete your local .sizecache.json before running comparisons.

```json
{
  "branch": {
    "meta": {
      "commit": "87de182dada4df850a64f3f062fe656b7d589ed9"
    },
    "files": {
      "dist/jquery.min.js": {
        "raw": 79053,
        "gz": 27701
      }
    }
  }
}
```

- The commit SHA is now saved for branches and printed with comparisons in gray.
- every run is now saved as `" last run"`. The leading space is intentional to avoid any possible collisions.
- compare_size was removed the banner for comparisons, but @mgol made me realize all the exclusions can make a noticeable difference in the size so should be included. However, the short SHA varies by commit and we'd like to be able to compare exactly across commits. Also, `.dirty` is removed for comparisons because we'd like to be able to compare local changes (i.e. dirty git directory") to all branches and last runs that were clean.
- Added a version number check that will automatically rewrite the cache on version mismatch.

I can make another PR if preferred, but I tacked on another change here to add the factory files that were just added to the main branch to the dist eslint.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
