### PR TITLE
Build: sort branches in compare_size; last run last

### DIFF
--- a/build/tasks/compare_size.mjs
+++ b/build/tasks/compare_size.mjs
@@ -81,7 +81,13 @@ function sortBranches( a, b ) {
 	if ( b === lastRunBranch ) {
 		return -1;
 	}
-	return a.localeCompare( b );
+	if ( a < b ) {
+		return -1;
+	}
+	if ( a > b ) {
+		return 1;
+	}
+	return 0;
 }
 
 export async function compareSize( { cache = ".sizecache.json", files } = {} ) {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
Sorts the branches and keep "last run" last.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
