### PR TITLE
Docs: Fix module links in the package README

### DIFF
--- a/build/fixtures/README.md
+++ b/build/fixtures/README.md
@@ -23,7 +23,7 @@ or, to use the jQuery ECMAScript module:
 
 ```html
 <script type="module">
-	import { $ } from "https://code.jquery.com/jquery-@VERSION.min.js";
+	import { $ } from "https://code.jquery.com/jquery-@VERSION.module.min.js";
 </script>
 ```
 
@@ -31,7 +31,7 @@ or:
 
 ```html
 <script type="module">
-	import { jQuery } from "https://code.jquery.com/jquery-@VERSION.min.js";
+	import { jQuery } from "https://code.jquery.com/jquery-@VERSION.module.min.js";
 </script>
 ```
 
@@ -39,7 +39,7 @@ All jQuery modules export named `$` & `jQuery` tokens; the further examples will
 
 ```html
 <script type="module">
-	import $ from "https://code.jquery.com/jquery-@VERSION.min.js";
+	import $ from "https://code.jquery.com/jquery-@VERSION.module.min.js";
 </script>
 ```
 
@@ -55,7 +55,7 @@ or as a module:
 
 ```html
 <script type="module">
-	import { $ } from "https://code.jquery.com/jquery-@VERSION.slim.min.js";
+	import { $ } from "https://code.jquery.com/jquery-@VERSION.module.slim.min.js";
 </script>
 ```
 
@@ -67,8 +67,8 @@ To avoid repeating long import paths that change on each jQuery release, you can
 <script type="importmap">
 	{
 		"imports": {
-			"jquery": "https://code.jquery.com/jquery-@VERSION.min.js",
-			"jquery/slim": "https://code.jquery.com/jquery-@VERSION.slim.min.js"
+			"jquery": "https://code.jquery.com/jquery-@VERSION.module.min.js",
+			"jquery/slim": "https://code.jquery.com/jquery-@VERSION.module.slim.min.js"
 		}
 	}
 </script>


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The package README used to show examples importing from a regular jQuery file; this won't work natively. Instead, use module versions of jQuery in these examples.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
