### PR TITLE
Build: Don't run CI push workflows for dependabot branches

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,8 +1,9 @@
 name: "Code scanning - action"
 
 on:
-  push:
   pull_request:
+  push:
+    branches-ignore: "dependabot/**"
   schedule:
     - cron: '0 4 * * 6'
 
@@ -30,7 +31,7 @@ jobs:
     # the head of the pull request instead of the merge commit.
     - run: git checkout HEAD^2
       if: ${{ github.event_name == 'pull_request' }}
-      
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@00e563ead9f72a8461b24876bee2d0c2e8bd2ee8 # v2.21.5

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches-ignore: "dependabot/**"
 
 permissions:
   contents: read # to fetch code (actions/checkout)


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Without this change, dependabot PRs run double checks - one set for the `push` part and one for the `pull_request` part.

I tested it on my fork.

PR against `jquery/jquery` (i.e. without this fix):
<img width="927" alt="Screenshot 2023-10-30 at 18 45 12" src="https://github.com/jquery/jquery/assets/1758366/bd3356c8-b9b7-4b41-bfd0-feb8d5e11c3f">

PR against `mgol/jquery` with this fix applied:
<img width="919" alt="Screenshot 2023-10-30 at 18 44 10" src="https://github.com/jquery/jquery/assets/1758366/22313e2f-186f-4d7f-8d46-97533531a68c">

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
