### PR TITLE
CSS: Fix reliableTrDimensions support test for initially hidden iframes

### DIFF
--- a/src/css/support.js
+++ b/src/css/support.js
@@ -47,6 +47,12 @@ support.reliableTrDimensions = function() {
 			.appendChild( tr )
 			.appendChild( div );
 
+		// Don't run until window is visible
+		if ( table.offsetWidth === 0 ) {
+			documentElement.removeChild( table );
+			return;
+		}
+
 		trStyle = window.getComputedStyle( tr );
 		reliableTrDimensionsVal = ( parseInt( trStyle.height, 10 ) +
 				parseInt( trStyle.borderTopWidth, 10 ) +

--- a/test/data/css/cssComputeStyleTests.html
+++ b/test/data/css/cssComputeStyleTests.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Test computeStyleTests for hidden iframe</title>
+	<meta charset="utf-8">
+	<style>
+		* {
+			box-sizing: border-box;
+		}
+		#test {
+			position: absolute;
+			border: 10px solid black;
+			width: 400px;
+		}
+		#test-table {
+			position: absolute;
+			width: 100.7px;
+			border-spacing: 0;
+		}
+	</style>
+</head>
+<body>
+<div id="test"></div>
+<table id="test-table">
+	<tr id="test-tr"></tr>
+</table>
+<script src="../../jquery.js"></script>
+<script src="../iframeTest.js"></script>
+<script>
+	var initialHeight = $( "#test" ).outerHeight();
+	startIframeTest( initialHeight );
+</script>
+</body>
+</html>

--- a/test/data/testinit.js
+++ b/test/data/testinit.js
@@ -243,7 +243,7 @@ this.ajaxTest = function( title, expect, options, wrapper ) {
 	} );
 };
 
-this.testIframe = function( title, fileName, func, wrapper ) {
+this.testIframe = function( title, fileName, func, wrapper, iframeStyles ) {
 	if ( !wrapper ) {
 		wrapper = QUnit.test;
 	}
@@ -252,6 +252,11 @@ this.testIframe = function( title, fileName, func, wrapper ) {
 			$iframe = supportjQuery( "<iframe></iframe>" )
 				.css( { position: "absolute", top: "0", left: "-600px", width: "500px" } )
 				.attr( { id: "qunit-fixture-iframe", src: url( fileName ) } );
+
+		// Add other iframe styles
+		if ( iframeStyles ) {
+			$iframe.css( iframeStyles );
+		}
 
 		// Test iframes are expected to invoke this via startIframeTest (cf. iframeTest.js)
 		window.iframeCallback = function() {

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -1386,6 +1386,47 @@ testIframe(
 	}
 );
 
+( function() {
+	var supportsFractionalTrWidth,
+		epsilon = 0.1,
+		table = jQuery( "<table><tr></tr></table>" ),
+		tr = table.find( "tr" );
+
+	table
+		.appendTo( "#qunit-fixture" )
+		.css( {
+			width: "100.7px",
+			borderSpacing: 0
+		} );
+
+	supportsFractionalTrWidth = Math.abs( tr.width() - 100.7 ) < epsilon;
+
+	testIframe(
+		"Test computeStyleTests for hidden iframe",
+		"css/cssComputeStyleTests.html",
+		function( assert, jQuery, window, document, initialHeight ) {
+			assert.expect( 3 );
+
+			assert.strictEqual( initialHeight === 0 ? 20 : initialHeight, 20,
+				"hidden-frame content sizes should be zero or accurate" );
+
+			window.parent.jQuery( "#qunit-fixture-iframe" ).css( { "display": "block" } );
+			jQuery( "#test" ).width( 600 );
+			assert.strictEqual( jQuery( "#test" ).width(), 600, "width should be 600" );
+
+			if ( supportsFractionalTrWidth ) {
+				assert.ok(
+					Math.abs( jQuery( "#test-tr" ).width() - 100.7 ) < epsilon,
+					"tr width should be fractional" );
+			} else {
+				assert.strictEqual( jQuery( "#test-tr" ).width(), 101, "tr width as expected" );
+			}
+		},
+		undefined,
+		{ "display": "none" }
+	);
+} )();
+
 QUnit.testUnlessIE( "css('width') and css('height') should return fractional values for nodes in the document", function( assert ) {
 	assert.expect( 2 );
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Followup to gh-5317 - that PR didn't apply to the reliableTrDimensions support test.

`3.x-stable` version of this PR: #5359

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
