### PR TITLE
Tests: Workaround a tr width test issue in old iOS

### DIFF
--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -1402,7 +1402,7 @@ testIframe(
 );
 
 ( function() {
-	var supportsFractionalTrWidth,
+	var supportsFractionalTrWidth, trWidth,
 		epsilon = 0.1,
 		table = jQuery( "<table><tr></tr></table>" ),
 		tr = table.find( "tr" );
@@ -1429,12 +1429,16 @@ testIframe(
 			jQuery( "#test" ).width( 600 );
 			assert.strictEqual( jQuery( "#test" ).width(), 600, "width should be 600" );
 
+			trWidth = jQuery( "#test-tr" ).width();
 			if ( supportsFractionalTrWidth ) {
 				assert.ok(
-					Math.abs( jQuery( "#test-tr" ).width() - 100.7 ) < epsilon,
+					Math.abs( trWidth - 100.7 ) < epsilon,
 					"tr width should be fractional" );
 			} else {
-				assert.strictEqual( jQuery( "#test-tr" ).width(), 101, "tr width as expected" );
+
+				// Support: iOS <10
+				// Old iOS always rounds down.
+				assert.strictEqual( trWidth === 100 ? 101 : trWidth, 101, "tr width as expected" );
 			}
 		},
 		undefined,


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Old iOS (<10) always rounds widths down, account for this in tests.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
