### PR TITLE
Manipulation: Support $el.html(selfRemovingScript)

### DIFF
--- a/src/core/DOMEval.js
+++ b/src/core/DOMEval.js
@@ -14,16 +14,13 @@ export function DOMEval( code, node, doc ) {
 		script = doc.createElement( "script" );
 
 	script.text = code;
-	if ( node ) {
-		for ( i in preservedScriptAttributes ) {
-			if ( node[ i ] ) {
-				script[ i ] = node[ i ];
-			}
+	for ( i in preservedScriptAttributes ) {
+		if ( node && node[ i ] ) {
+			script[ i ] = node[ i ];
 		}
 	}
 
-	doc.head.appendChild( script );
-	if ( script.parentNode ) {
+	if ( doc.head.appendChild( script ).parentNode ) {
 		script.parentNode.removeChild( script );
 	}
 }

--- a/src/core/DOMEval.js
+++ b/src/core/DOMEval.js
@@ -21,5 +21,9 @@ export function DOMEval( code, node, doc ) {
 			}
 		}
 	}
-	doc.head.appendChild( script ).parentNode.removeChild( script );
+
+	doc.head.appendChild( script );
+	if ( script.parentNode ) {
+		script.parentNode.removeChild( script );
+	}
 }

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -1819,6 +1819,21 @@ QUnit.test( "html(script nomodule)", function( assert ) {
 	}, 1000 );
 } );
 
+QUnit.test( "html(self-removing script) (gh-5377)", function( assert ) {
+	assert.expect( 2 );
+
+	var $fixture = jQuery( "#qunit-fixture" );
+
+	$fixture.html(
+		[
+			"<script>document.currentScript.parentNode.removeChild( document.currentScript ); QUnit.assert.ok( true, 'removed document.currentScript' );</script>",
+			"<div>",
+				"<script>document.currentScript.parentNode.removeChild( document.currentScript ); QUnit.assert.ok( true, 'removed inner document.currentScript' );</script>",
+			"</div>"
+		].join( "" )
+	);
+} );
+
 QUnit.test( "html(Function) with incoming value -- direct selection", function( assert ) {
 
 	assert.expect( 4 );


### PR DESCRIPTION
Fixes gh-5377

### Summary ###
Don't try to remove a script element that has already removed itself.

With nearby improvements, +12 bytes to jquery.min.js (+1 gzipped).

### Checklist ###
* [x] New tests have been added to show the fix or feature works
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com