### PR TITLE
Selector: Eliminate `selector.js` depenencies from various modules

### DIFF
--- a/src/attributes/attr.js
+++ b/src/attributes/attr.js
@@ -4,8 +4,6 @@ import { nodeName } from "../core/nodeName.js";
 import { rnothtmlwhite } from "../var/rnothtmlwhite.js";
 import { isIE } from "../var/isIE.js";
 
-import "../selector.js";
-
 jQuery.fn.extend( {
 	attr: function( name, value ) {
 		return access( this, jQuery.attr, name, value, arguments.length > 1 );

--- a/src/attributes/prop.js
+++ b/src/attributes/prop.js
@@ -2,8 +2,6 @@ import { jQuery } from "../core.js";
 import { access } from "../core/access.js";
 import { isIE } from "../var/isIE.js";
 
-import "../selector.js";
-
 var rfocusable = /^(?:input|select|textarea|button)$/i,
 	rclickable = /^(?:a|area)$/i;
 

--- a/src/css.js
+++ b/src/css.js
@@ -17,7 +17,6 @@ import { support } from "./css/support.js";
 
 import "./core/init.js";
 import "./core/ready.js";
-import "./selector.js"; // contains
 
 var
 

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -15,7 +15,6 @@ import { nodeName } from "./core/nodeName.js";
 
 import "./core/init.js";
 import "./traversing.js";
-import "./selector.js";
 import "./event.js";
 
 var

--- a/src/offset.js
+++ b/src/offset.js
@@ -5,7 +5,6 @@ import { isWindow } from "./var/isWindow.js";
 
 import "./core/init.js";
 import "./css.js";
-import "./selector.js"; // contains
 
 jQuery.offset = {
 	setOffset: function( elem, options, i ) {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

There are two main reasons for why some of those dependencies are no longer needed:
1. `jQuery.contains` which is now a part of `core`.
2. `jQuery.find.attr` no longer exists, native `getAttribute` is used instead.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] New tests have been added to show the fix or feature works
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
