### PR TITLE
Selector: Make `selector.js` module depend on `attributes/attr.js`

### DIFF
--- a/src/attributes/attr.js
+++ b/src/attributes/attr.js
@@ -97,6 +97,11 @@ if ( isIE ) {
 	};
 }
 
+// HTML boolean attributes have special behavior:
+// we consider the lowercase name to be the only valid value, so
+// getting (if the attribute is present) normalizes to that, as does
+// setting to any non-`false` value (and setting to `false` removes the attribute).
+// See https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes
 jQuery.each( (
 	"checked selected async autofocus autoplay controls defer disabled " +
 	"hidden ismap loop multiple open readonly required scoped"

--- a/src/attributes/attr.js
+++ b/src/attributes/attr.js
@@ -97,7 +97,10 @@ if ( isIE ) {
 	};
 }
 
-jQuery.each( jQuery.expr.match.bool.source.match( /\w+/g ), function( _i, name ) {
+jQuery.each( (
+	"checked selected async autofocus autoplay controls defer disabled " +
+	"hidden ismap loop multiple open readonly required scoped"
+).split( " " ), function( _i, name ) {
 	jQuery.attrHooks[ name ] = {
 		get: function( elem ) {
 			var ret,

--- a/src/selector-native.js
+++ b/src/selector-native.js
@@ -25,7 +25,6 @@ import { jQuery } from "./core.js";
 import { document } from "./var/document.js";
 import { whitespace } from "./var/whitespace.js";
 import { isIE } from "./var/isIE.js";
-import { booleans } from "./selector/var/booleans.js";
 import { rleadingCombinator } from "./selector/var/rleadingCombinator.js";
 import { rdescend } from "./selector/var/rdescend.js";
 import { rsibling } from "./selector/var/rsibling.js";
@@ -41,7 +40,6 @@ import "./selector/escapeSelector.js";
 import "./selector/uniqueSort.js";
 
 var matchExpr = jQuery.extend( {
-	bool: new RegExp( "^(?:" + booleans + ")$", "i" ),
 	needsContext: new RegExp( "^" + whitespace + "*[>+~]" )
 }, filterMatchExpr );
 

--- a/src/selector.js
+++ b/src/selector.js
@@ -9,7 +9,6 @@ import { rbuggyQSA } from "./selector/rbuggyQSA.js";
 import { rtrimCSS } from "./var/rtrimCSS.js";
 import { isIE } from "./var/isIE.js";
 import { identifier } from "./selector/var/identifier.js";
-import { booleans } from "./selector/var/booleans.js";
 import { rleadingCombinator } from "./selector/var/rleadingCombinator.js";
 import { rdescend } from "./selector/var/rdescend.js";
 import { rsibling } from "./selector/var/rsibling.js";
@@ -24,6 +23,7 @@ import { tokenize } from "./selector/tokenize.js";
 import { toSelector } from "./selector/toSelector.js";
 
 // The following utils are attached directly to the jQuery object.
+import "./attributes/attr.js"; // jQuery.attr
 import "./selector/escapeSelector.js";
 import "./selector/uniqueSort.js";
 
@@ -50,7 +50,6 @@ var i,
 	ridentifier = new RegExp( "^" + identifier + "$" ),
 
 	matchExpr = jQuery.extend( {
-		bool: new RegExp( "^(?:" + booleans + ")$", "i" ),
 
 		// For use in libraries implementing .is()
 		// We use this for POS matching in `select`

--- a/src/selector/var/booleans.js
+++ b/src/selector/var/booleans.js
@@ -1,2 +1,0 @@
-export var booleans = "checked|selected|async|autofocus|autoplay|controls|" +
-	"defer|disabled|hidden|ismap|loop|multiple|open|readonly|required|scoped";


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

This fixes custom builds using the `--include` switch that don't include the `attributes` module.

Fixes gh-5379

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] New tests have been added to show the fix or feature works
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
