### PR TITLE
Build: add --reset-compare and --clear-compare options to build command

### DIFF
--- a/build/command.js
+++ b/build/command.js
@@ -13,8 +13,7 @@ const argv = yargs( process.argv.slice( 2 ) )
 	.option( "filename", {
 		alias: "f",
 		type: "string",
-		description:
-			"Set the filename of the built file. Defaults to jquery.js."
+		description: "Set the filename of the built file. Defaults to jquery.js."
 	} )
 	.option( "dir", {
 		alias: "d",
@@ -33,8 +32,7 @@ const argv = yargs( process.argv.slice( 2 ) )
 	.option( "watch", {
 		alias: "w",
 		type: "boolean",
-		description:
-			"Watch the source files and rebuild when they change."
+		description: "Watch the source files and rebuild when they change."
 	} )
 	.option( "exclude", {
 		alias: "e",
@@ -61,21 +59,28 @@ const argv = yargs( process.argv.slice( 2 ) )
 	.option( "factory", {
 		type: "boolean",
 		description:
-			"Build the factory bundle. " +
-			"By default, a UMD bundle is built."
+			"Build the factory bundle. By default, a UMD bundle is built."
 	} )
 	.option( "slim", {
 		alias: "s",
 		type: "boolean",
-		description: "Build a slim bundle, which excludes " +
-			slimExclude.join( ", " )
+		description:
+			"Build a slim bundle, which excludes " + slimExclude.join( ", " )
 	} )
 	.option( "amd", {
 		type: "string",
 		description:
 			"Set the name of the AMD module. Leave blank to make an anonymous module."
 	} )
-	.help()
-	.argv;
+	.option( "reset-compare", {
+		type: "boolean",
+		description:
+			"Reset the size comparison cache to only include the main branch and last run."
+	} )
+	.option( "clear-compare", {
+		type: "boolean",
+		description: "Clear the size comparison cache."
+	} )
+	.help().argv;
 
 build( argv );

--- a/build/command.js
+++ b/build/command.js
@@ -75,11 +75,13 @@ const argv = yargs( process.argv.slice( 2 ) )
 	.option( "reset-compare", {
 		type: "boolean",
 		description:
-			"Reset the size comparison cache to only include the main branch and last run."
+			"Reset the size comparison cache to only include the main branch and last run.",
+		conflicts: [ "clear-compare" ]
 	} )
 	.option( "clear-compare", {
 		type: "boolean",
-		description: "Clear the size comparison cache."
+		description: "Clear the size comparison cache.",
+		conflicts: [ "reset-compare" ]
 	} )
 	.help().argv;
 

--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -158,16 +158,29 @@ async function writeCompiled( { code, dir, filename, version } ) {
 // Build jQuery ECMAScript modules
 async function build( {
 	amd,
+	clearCompare = false,
 	dir = "dist",
+	esm = false,
 	exclude = [],
+	factory = false,
 	filename = "jquery.js",
 	include = [],
-	esm = false,
-	factory = false,
+	resetCompare = false,
 	slim = false,
 	version,
 	watch = false
 } = {} ) {
+
+	if ( resetCompare ) {
+		const { resetCache } = await import( "./compare_size.mjs" );
+		return resetCache();
+	}
+
+	if ( clearCompare ) {
+		const { clearCache } = await import( "./compare_size.mjs" );
+		return clearCache();
+	}
+
 	const pureSlim = slim && !exclude.length && !include.length;
 
 	const fileOverrides = new Map();

--- a/build/tasks/compare_size.mjs
+++ b/build/tasks/compare_size.mjs
@@ -90,6 +90,25 @@ function sortBranches( a, b ) {
 	return 0;
 }
 
+export async function resetCache( { cache = ".sizecache.json" } = {} ) {
+	const sizeCache = await getCache( cache );
+
+	// Keep main and last run
+	Object.keys( sizeCache ).forEach( function( branch ) {
+		if ( branch !== "main" && branch !== lastRunBranch ) {
+			delete sizeCache[ branch ];
+		}
+	} );
+
+	await saveCache( cache, sizeCache );
+	console.log( "Compare cache reset." );
+}
+
+export async function clearCache( { cache = ".sizecache.json" } = {} ) {
+	await fs.promises.unlink( cache );
+	console.log( "Compare cache cleared." );
+}
+
 export async function compareSize( { cache = ".sizecache.json", files } = {} ) {
 	if ( !files || !files.length ) {
 		throw new Error( "No files specified" );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
This adds 2 options to the build command.

My compare-size cache was getting a little big with all my branches. Rather than manually editing or deleting the file, I would prefer a command that kept the `main` branch and `last run` in there (`npm run build -- --reset-compare`).

I also added `--clear-compare` in case there's ever a need for starting over completely. It just deletes the cache file.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
