### PR TITLE
Tests: Fix Karma tests on Node.js 20

### DIFF
--- a/test/middleware-mockserver.cjs
+++ b/test/middleware-mockserver.cjs
@@ -83,9 +83,7 @@ const mocks = {
 		if ( resp.set ) {
 			resp.set( headers );
 		} else {
-			for ( const key in headers ) {
-				resp.writeHead( 200, { [ key ]: headers[ key ] } );
-			}
+			resp.writeHead( 200, headers );
 		}
 
 		if ( req.query.callback ) {
@@ -105,12 +103,14 @@ const mocks = {
 		);
 	},
 	json: function( req, resp ) {
+		const headers = {};
 		if ( req.query.header ) {
-			resp.writeHead( 200, { "content-type": "application/json" } );
+			headers[ "content-type" ] = "application/json";
 		}
 		if ( req.query.cors ) {
-			resp.writeHead( 200, { "access-control-allow-origin": "*" } );
+			headers[ "access-control-allow-origin" ] = "*";
 		}
+		resp.writeHead( 200, headers );
 		if ( req.query.array ) {
 			resp.end( JSON.stringify(
 				[ { name: "John", age: 21 }, { name: "Peter", age: 25 } ]

--- a/test/middleware-mockserver.cjs
+++ b/test/middleware-mockserver.cjs
@@ -80,11 +80,7 @@ const mocks = {
 			headers[ "access-control-allow-origin" ] = "*";
 		}
 
-		if ( resp.set ) {
-			resp.set( headers );
-		} else {
-			resp.writeHead( 200, headers );
-		}
+		resp.writeHead( 200, headers );
 
 		if ( req.query.callback ) {
 			resp.end( `${ cleanCallback( req.query.callback ) }(${ JSON.stringify( {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Node.js 20 started throwing errors when `writeHead` is called twice on a response. This might have already been invalid before but it wasn't throwing on Node.js 18.

Compute the headers object and call `writeHead` once to avoid the issue.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
