### PR TITLE
Attributes: Shave off a couple of bytes

### DIFF
--- a/src/attributes/attr.js
+++ b/src/attributes/attr.js
@@ -108,16 +108,9 @@ jQuery.each( (
 ).split( " " ), function( _i, name ) {
 	jQuery.attrHooks[ name ] = {
 		get: function( elem ) {
-			var ret,
-				isXML = jQuery.isXMLDoc( elem ),
-				lowercaseName = name.toLowerCase();
-
-			if ( !isXML ) {
-				ret = elem.getAttribute( name ) != null ?
-					lowercaseName :
-					null;
-			}
-			return ret;
+			return elem.getAttribute( name ) != null ?
+				name.toLowerCase() :
+				null;
 		},
 
 		set: function( elem, value, name ) {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The `attrHooks` entries for boolean attributes are only defined for jQuery 4+; jQuery 3.x used a separate mechanism - assigning them to `jQuery.expr.attrHandle`. That object used to be maintained by Sizzle, since jQuery 3.7.0 it's kept in the selector module. Because of that, the `isXMLDoc` check used to be require in this hook.

Now that standard `attrHooks` are used, the `isXMLDoc` check already happens inside of `jQuery.attr` and there's no need to repeat it in the test. Note that this repetition is even incorrect - while Sizzle's `jQuery.find.attr` used to treat an `undefined` output of the hooks from `jQuery.expr.attrHandle` as a way to opt out of the hook, jQuery's `attrHooks` use `null` to opt out of a getter hook.

Apart from the size, this patch also avoids unnecessary extra checks.

Size difference:
```
main @805cdb43fd02c3a5783c06b5ec2c9519be0682ab
   raw     gz Filename
   -35    -12 dist/jquery.min.js
   -35    -15 dist/jquery.slim.min.js
   -35    -15 dist-module/jquery.module.min.js
   -35    -15 dist-module/jquery.slim.module.min.js
```

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
