### PR TITLE
Release: remove scripts and dev deps from dist package.json

### DIFF
--- a/build/release/dist.js
+++ b/build/release/dist.js
@@ -15,8 +15,7 @@ module.exports = function( Release, files, complete ) {
 	const extras = [
 		"src",
 		"LICENSE.txt",
-		"AUTHORS.txt",
-		"package.json"
+		"AUTHORS.txt"
 	];
 
 	/**
@@ -100,6 +99,17 @@ module.exports = function( Release, files, complete ) {
 		// Remove the wrapper & the ESLint config from the dist repo
 		shell.rm( "-f", `${ Release.dir.dist }/src/wrapper.js` );
 		shell.rm( "-f", `${ Release.dir.dist }/src/.eslintrc.json` );
+
+		// Write package.json
+		const packageJson = Object.assign( {}, pkg );
+		delete packageJson.scripts;
+		delete packageJson.devDependencies;
+		delete packageJson.dependencies;
+		delete packageJson.commitplease;
+		await fs.writeFile(
+			`${ Release.dir.dist }/package.json`,
+			JSON.stringify( packageJson, null, 2 )
+		);
 
 		// Write generated bower file
 		await fs.writeFile( `${ Release.dir.dist }/bower.json`, generateBower() );

--- a/build/release/dist.js
+++ b/build/release/dist.js
@@ -101,6 +101,8 @@ module.exports = function( Release, files, complete ) {
 		shell.rm( "-f", `${ Release.dir.dist }/src/.eslintrc.json` );
 
 		// Write package.json
+		// Remove scripts and other superfluous properties,
+		// especially the prepare script, which fails on the dist repo
 		const packageJson = Object.assign( {}, pkg );
 		delete packageJson.scripts;
 		delete packageJson.devDependencies;


### PR DESCRIPTION
- this became necessary due to the addition of the prepare script
- scripts aren't needed and don't work in the dist repo

### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
Hit this snag on the last step testing npm publish in the dist repo, which tried to run the new `prepare` script, which of course failed.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
