### PR TITLE
Release: use buildDefaultFiles directly and pass version

### DIFF
--- a/build/release.js
+++ b/build/release.js
@@ -24,6 +24,7 @@ module.exports = function( Release ) {
 	];
 	const cdn = require( "./release/cdn" );
 	const dist = require( "./release/dist" );
+	const { buildDefaultFiles } = require( "./tasks/build" );
 
 	const npmTags = Release.npmTags;
 
@@ -53,8 +54,8 @@ module.exports = function( Release ) {
 		 * committed before creating the tag.
 		 * @param {Function} callback
 		 */
-		generateArtifacts: function( callback ) {
-			Release.exec( "npm run build:all" );
+		generateArtifacts: async function( callback ) {
+			await buildDefaultFiles( { version: Release.newVersion } );
 
 			cdn.makeReleaseCopies( Release );
 			Release._setSrcVersion();
@@ -77,7 +78,7 @@ module.exports = function( Release ) {
 		 * Publish to distribution repo and npm
 		 * @param {Function} callback
 		 */
-		dist: async callback => {
+		dist: async function( callback ) {
 			await cdn.makeArchives( Release );
 			dist( Release, distFiles, callback );
 		}

--- a/build/release/dist.js
+++ b/build/release/dist.js
@@ -119,6 +119,7 @@ module.exports = function( Release, files, complete ) {
 		delete packageJson.devDependencies;
 		delete packageJson.dependencies;
 		delete packageJson.commitplease;
+		packageJson.version = Release.newVersion;
 		await fs.writeFile(
 			`${ Release.dir.dist }/package.json`,
 			JSON.stringify( packageJson, null, 2 )

--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -353,6 +353,10 @@ async function build( {
 }
 
 async function buildDefaultFiles( { version, watch } = {} ) {
+	if ( !version ) {
+		version = process.env.VERSION;
+	}
+
 	await Promise.all( [
 		build( { version, watch } ),
 		build( { filename: "jquery.slim.js", slim: true, version, watch } ),

--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -352,11 +352,10 @@ async function build( {
 	}
 }
 
-async function buildDefaultFiles( { version, watch } = {} ) {
-	if ( !version ) {
-		version = process.env.VERSION;
-	}
-
+async function buildDefaultFiles( {
+	version = process.env.VERSION,
+	watch
+} = {} ) {
 	await Promise.all( [
 		build( { version, watch } ),
 		build( { filename: "jquery.slim.js", slim: true, version, watch } ),

--- a/build/tasks/compare_size.mjs
+++ b/build/tasks/compare_size.mjs
@@ -109,7 +109,7 @@ export async function compareSize( { cache = ".sizecache.json", files } = {} ) {
 			// Remove the short SHA and .dirty from comparisons.
 			// The short SHA so commits can be compared against each other
 			// and .dirty to compare with the existing branch during development.
-			const sha = /jQuery v\d+.\d+.\d+(?:-\w+)?\+(?:slim.)?([^ \.]+(?:\.dirty)?)/.exec( contents )[ 1 ];
+			const sha = /jQuery v\d+.\d+.\d+(?:-\w+)?(?:\+|\+slim\.)?([^ \.]+(?:\.dirty)?)?/.exec( contents )[ 1 ];
 			contents = contents.replace( new RegExp( sha, "g" ), "" );
 
 			const size = Buffer.byteLength( contents, "utf8" );


### PR DESCRIPTION
- also add the ability to pass VERSION in env to test final builds
- adjust sha regex to account for lack of shas
- set the version on the dist package.json

### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
