### PR TITLE
Release: use buildDefaultFiles directly and pass version

### DIFF
--- a/build/release.js
+++ b/build/release.js
@@ -18,6 +18,7 @@ module.exports = function( Release ) {
 	];
 	const cdn = require( "./release/cdn" );
 	const dist = require( "./release/dist" );
+	const { buildDefaultFiles } = require( "./tasks/build" );
 
 	const npmTags = Release.npmTags;
 
@@ -41,8 +42,8 @@ module.exports = function( Release ) {
 		 * committed before creating the tag.
 		 * @param {Function} callback
 		 */
-		generateArtifacts: function( callback ) {
-			Release.exec( "npm run build:all" );
+		generateArtifacts: async function( callback ) {
+			await buildDefaultFiles( { version: Release.newVersion } );
 
 			cdn.makeReleaseCopies( Release );
 			Release._setSrcVersion();

--- a/build/release/dist.js
+++ b/build/release/dist.js
@@ -108,6 +108,7 @@ module.exports = function( Release, files, complete ) {
 		delete packageJson.devDependencies;
 		delete packageJson.dependencies;
 		delete packageJson.commitplease;
+		packageJson.version = Release.newVersion;
 		await fs.writeFile(
 			`${ Release.dir.dist }/package.json`,
 			JSON.stringify( packageJson, null, 2 )

--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -320,7 +320,9 @@ async function build( {
 	await minify( { filename, dir } );
 }
 
-async function buildDefaultFiles( { version } = {} ) {
+async function buildDefaultFiles( {
+	version = process.env.VERSION
+} = {} ) {
 	await Promise.all( [
 		build( { version } ),
 		build( { filename: "jquery.slim.js", slim: true, version } )

--- a/build/tasks/compare_size.mjs
+++ b/build/tasks/compare_size.mjs
@@ -109,7 +109,7 @@ export async function compareSize( { cache = ".sizecache.json", files } = {} ) {
 			// Remove the short SHA and .dirty from comparisons.
 			// The short SHA so commits can be compared against each other
 			// and .dirty to compare with the existing branch during development.
-			const sha = /jQuery v\d+.\d+.\d+(?:-\w+)?\+(?:slim.)?([^ \.]+(?:\.dirty)?)/.exec( contents )[ 1 ];
+			const sha = /jQuery v\d+.\d+.\d+(?:-\w+)?(?:\+|\+slim\.)?([^ \.]+(?:\.dirty)?)?/.exec( contents )[ 1 ];
 			contents = contents.replace( new RegExp( sha, "g" ), "" );
 
 			const size = Buffer.byteLength( contents, "utf8" );


### PR DESCRIPTION
- also add the ability to pass VERSION in env to test final builds
- adjust sha regex to account for lack of shas
- set the version on the dist package.json

Close gh-5408

### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
3.x version of #5408 

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
