### PR TITLE
Tests: Align `middleware-mockerver.js` with the `main` branch

### DIFF
--- a/test/middleware-mockserver.js
+++ b/test/middleware-mockserver.js
@@ -79,13 +79,7 @@ const mocks = {
 			headers[ "access-control-allow-origin" ] = "*";
 		}
 
-		if ( resp.set ) {
-			resp.set( headers );
-		} else {
-			for ( const key in headers ) {
-				resp.writeHead( 200, { [ key ]: headers[ key ] } );
-			}
-		}
+		resp.writeHead( 200, headers );
 
 		if ( req.query.callback ) {
 			resp.end( `${ cleanCallback( req.query.callback ) }(${ JSON.stringify( {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Remove a redundant Express-targeted `resp.set` call from the `script` handler in `middleware-mockserver.js` as was done on the `main` branch.

Ref gh-5397

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
