### PR TITLE
Modified exports in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
       "node": {
         "module": "./dist-module/jquery.module.js",
         "import": "./dist-module/jquery.node-module-wrapper.js",
-        "require": "./dist/jquery.js"
       },
+      "require": "./dist/jquery.js"
       "production": "./dist-module/jquery.module.min.js",
       "development": "./dist-module/jquery.module.js",
       "script": "./dist/jquery.min.js",
@@ -20,8 +20,8 @@
       "node": {
         "module": "./dist-module/jquery.slim.module.js",
         "import": "./dist-module/jquery.node-module-wrapper.slim.js",
-        "require": "./dist/jquery.slim.js"
       },
+      "require": "./dist/jquery.slim.js"
       "production": "./dist-module/jquery.slim.module.min.js",
       "development": "./dist-module/jquery.slim.module.js",
       "script": "./dist/jquery.slim.min.js",


### PR DESCRIPTION
### Summary ###
Proposal to change exports settings in package.json
Use case: webpack with target `browser`, the export proposed will be always `development` /`production` (so *jquery-module*).
But if someone uses *require('jquery')*  for example in old CJS packages, is more correct and compatible loading *jquery.js*, as it is for node target.

### Checklist ###

* [ ] New tests have been added to show the fix or feature works
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com
