### PR TITLE
Tests: add support for latest and latest-\d+ in test runner

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -21,19 +21,19 @@ jobs:
       matrix:
         BROWSER:
           - 'IE_11'
-          - 'Safari_17'
-          - 'Safari_16'
-          - 'Chrome_120'
-          - 'Chrome_119'
-          - 'Edge_120'
-          - 'Edge_119'
-          - 'Firefox_121'
-          - 'Firefox_120'
+          - 'Safari_latest'
+          - 'Safari_latest-1'
+          - 'Chrome_latest'
+          - 'Chrome_latest-1'
+          - 'Edge_latest'
+          - 'Edge_latest-1'
+          - 'Firefox_latest'
+          - 'Firefox_latest-1'
+          - 'Opera_latest'
           - 'Firefox_115'
           - '__iOS_17'
           - '__iOS_16'
           - '__iOS_15'
-          - 'Opera_106'
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/test/runner/browserstack/api.js
+++ b/test/runner/browserstack/api.js
@@ -14,6 +14,7 @@ const accessKey = process.env.BROWSERSTACK_ACCESS_KEY;
 // iOS has null for version numbers,
 // and we do not need a similar check for OS versions.
 const rfinalVersion = /(?:^[0-9\.]+$)|(?:^null$)/;
+const rlatest = /^latest-(\d+)$/;
 
 const rnonDigits = /(?:[^\d\.]+)|(?:20\d{2})/g;
 
@@ -137,6 +138,15 @@ function matchVersion( browserVersion, version ) {
 	return regex.test( browserVersion );
 }
 
+function findLatest( browsers ) {
+
+	// The list is sorted in ascending order,
+	// so the last item is the latest.
+	return browsers.findLast( ( browser ) =>
+		rfinalVersion.test( browser.browser_version )
+	);
+}
+
 export async function filterBrowsers( filter ) {
 	const browsers = await getBrowsers( { flat: true } );
 	if ( !filter ) {
@@ -148,16 +158,49 @@ export async function filterBrowsers( filter ) {
 	const filterOsVersion = ( filter.os_version ?? "" ).toLowerCase();
 	const filterDevice = ( filter.device ?? "" ).toLowerCase();
 
-	return browsers.filter( ( browser ) => {
+	const filteredWithoutVersion = browsers.filter( ( browser ) => {
 		return (
 			( !filterBrowser || filterBrowser === browser.browser.toLowerCase() ) &&
-			( !filterVersion ||
-				matchVersion( browser.browser_version, filterVersion ) ) &&
 			( !filterOs || filterOs === browser.os.toLowerCase() ) &&
 			( !filterOsVersion ||
 				filterOsVersion === browser.os_version.toLowerCase() ) &&
 			( !filterDevice || filterDevice === ( browser.device || "" ).toLowerCase() )
 		);
+	} );
+
+	if ( !filterVersion ) {
+		return filteredWithoutVersion;
+	}
+
+	if ( filterVersion.startsWith( "latest" ) ) {
+		const groupedByName = filteredWithoutVersion
+			.filter( ( b ) => rfinalVersion.test( b.browser_version ) )
+			.reduce( ( acc, browser ) => {
+				acc[ browser.browser ] = acc[ browser.browser ] || [];
+				acc[ browser.browser ].push( browser );
+				return acc;
+			}, {} );
+
+		const filtered = [];
+		for ( const group of Object.values( groupedByName ) ) {
+			const num = rlatest.exec( filterVersion );
+			const latest = findLatest( group );
+
+			// Get the latest version and subtract the number from the filter,
+			// ignoring any patch versions, which may differ between major versions.
+			const version = parseInt( latest.browser_version ) - ( num ? num[ 1 ] : 0 );
+			const match = group.findLast( ( browser ) => {
+				return matchVersion( browser.browser_version, version.toString() );
+			} );
+			if ( match ) {
+				filtered.push( match );
+			}
+		}
+		return filtered;
+	}
+
+	return filteredWithoutVersion.filter( ( browser ) => {
+		return matchVersion( browser.browser_version, filterVersion );
 	} );
 }
 
@@ -179,11 +222,7 @@ export async function listBrowsers( filter ) {
 export async function getLatestBrowser( filter ) {
 	const browsers = await filterBrowsers( filter );
 
-	// The list is sorted in ascending order,
-	// so the last item is the latest.
-	return browsers.findLast( ( browser ) =>
-		rfinalVersion.test( browser.browser_version )
-	);
+	return findLatest( browsers );
 }
 
 /**

--- a/test/runner/browserstack/buildBrowserFromString.js
+++ b/test/runner/browserstack/buildBrowserFromString.js
@@ -3,8 +3,18 @@ export function buildBrowserFromString( str ) {
 
 	// If the version starts with a colon, it's a device
 	if ( versionOrDevice && versionOrDevice.startsWith( ":" ) ) {
-		return { browser, device: versionOrDevice.slice( 1 ), os, os_version: osVersion };
+		return {
+			browser,
+			device: versionOrDevice.slice( 1 ),
+			os,
+			os_version: osVersion
+		};
 	}
 
-	return { browser, browser_version: versionOrDevice, os, os_version: osVersion };
+	return {
+		browser,
+		browser_version: versionOrDevice,
+		os,
+		os_version: osVersion
+	};
 }

--- a/test/runner/command.js
+++ b/test/runner/command.js
@@ -65,8 +65,8 @@ const argv = yargs( process.argv.slice( 2 ) )
 	.option( "retries", {
 		alias: "r",
 		type: "number",
-		description: "Number of times to retry failed tests.",
-		default: 0
+		description: "Number of times to retry failed tests in BrowserStack.",
+		implies: [ "browserstack" ]
 	} )
 	.option( "no-isolate", {
 		type: "boolean",
@@ -88,8 +88,10 @@ const argv = yargs( process.argv.slice( 2 ) )
 			"Leave blank to view all browsers or pass " +
 			"\"browser_[browserVersion | :device]_os_osVersion\" with each parameter " +
 			"separated by an underscore to filter the list (any can be omitted).\n" +
+			"\"latest\" can be used in place of \"browserVersion\" to find the latest version.\n" +
+			"\"latest-n\" can be used to find the nth latest browser version.\n" +
 			"Use a colon to indicate a device.\n" +
-			"Examples: \"chrome__windows_10\", \"Mobile Safari\", \"Android Browser_:Google Pixel 8 Pro\".\n" +
+			"Examples: \"chrome__windows_10\", \"safari_latest\", \"Mobile Safari\", \"Android Browser_:Google Pixel 8 Pro\".\n" +
 			"Use quotes if spaces are necessary."
 	} )
 	.option( "stop-workers", {

--- a/test/runner/run.js
+++ b/test/runner/run.js
@@ -211,7 +211,8 @@ export async function run( {
 
 				const latestMatch = await getLatestBrowser( browser );
 				if ( !latestMatch ) {
-					throw new Error( `Browser not found: ${ getBrowserString( browser ) }.` );
+					console.error( chalk.red( `Browser not found: ${ getBrowserString( browser ) }.` ) );
+					gracefulExit( 1 );
 				}
 				return latestMatch;
 			} )

--- a/test/runner/run.js
+++ b/test/runner/run.js
@@ -98,6 +98,7 @@ export async function run( {
 							debugWorker( reportId );
 						}
 						errorMessages.push( ...Object.values( pendingErrors[ reportId ] ) );
+						await cleanupWorker( reportId, verbose );
 					}
 				} else {
 					if ( Object.keys( pendingErrors[ reportId ] ).length ) {
@@ -107,8 +108,8 @@ export async function run( {
 						}
 						delete pendingErrors[ reportId ];
 					}
+					await cleanupWorker( reportId, verbose );
 				}
-				await cleanupWorker( reportId, verbose );
 				cleanupJSDOM( reportId, verbose );
 				break;
 			}

--- a/test/runner/run.js
+++ b/test/runner/run.js
@@ -33,7 +33,7 @@ export async function run( {
 	headless,
 	isolate = true,
 	modules = [],
-	retries = 3,
+	retries = 0,
 	verbose
 } = {} ) {
 	if ( !browserNames || !browserNames.length ) {


### PR DESCRIPTION
Adds support for filtering browser version by "latest" and "latest-n", which we can now use in the browserstack.yml.

I also made it so `npm run test:unit -- --list-browsers=_latest` lists the latest version of all browsers, rather than matching on the last browser in the sorted list.

I considered adding support for "latest" to OS versions, but didn't want to spend too much time on it since OS versions don't get updated nearly as often as browser versions.

I looked into setting browser versions using the environment, but workflows do not support environment variables at the matrix level, only in steps. There were a couple ways around that, but they were convoluted.

- also fix an issue with retries. It was starting each retry the first time, but closing the worker immediately afterward, so any failures were getting ignored. Fortunately, retries were not actually common and we still have all green: https://github.com/timmywil/jquery/actions/runs/8075030746. In the process, I edited the CLI documentation for `--retries` to make it clear it only applies on BrowserStack runs.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
