### PR TITLE
Tests: fix flakey message logs; ignore delete worker failures

### DIFF
--- a/test/runner/browserstack/browsers.js
+++ b/test/runner/browserstack/browsers.js
@@ -187,13 +187,19 @@ export async function cleanupAllBrowsers( { verbose } ) {
 	const workersRemaining = Object.values( workers );
 	const numRemaining = workersRemaining.length;
 	if ( numRemaining ) {
-		await Promise.all(
-			workersRemaining.map( ( worker ) => deleteWorker( worker.id ) )
-		);
-		if ( verbose ) {
-			console.log(
-				`Stopped ${ numRemaining } browser${ numRemaining > 1 ? "s" : "" }.`
+		try {
+			await Promise.all(
+				workersRemaining.map( ( worker ) => deleteWorker( worker.id ) )
 			);
+			if ( verbose ) {
+				console.log(
+					`Stopped ${ numRemaining } browser${ numRemaining > 1 ? "s" : "" }.`
+				);
+			}
+		} catch ( error ) {
+
+			// Log the error, but do not consider the test run failed
+			console.error( error );
 		}
 	}
 }

--- a/test/runner/browserstack/queue.js
+++ b/test/runner/browserstack/queue.js
@@ -39,7 +39,7 @@ export function retryTest( reportId, maxRetries ) {
 			console.log(
 				`Retrying test ${ reportId } for ${ chalk.yellow(
 					test.options.modules.join( ", " )
-				) }...`
+				) }...${ test.retries }`
 			);
 			return test;
 		}


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Companion PR for #5431 

Add some minor improvements after watching the recent first run on 3.x-stable, including:

- fix the flakey message for when a test fails and then passes on retry.
- ignore worker delete failures. We hit this in one browser. The tests all passed and the worker had stopped, but BrowserStack returned a 502.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
