### PR TITLE
Build: add GitHub Actions workflow to update Filestash

### DIFF
--- a/.github/workflows/filestash.yml
+++ b/.github/workflows/filestash.yml
@@ -1,0 +1,56 @@
+name: Filestash
+
+on:
+  push:
+    branches:
+      - 3.x-stable
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    environment: filestash
+    env:
+      NODE_VERSION: 20.x
+    name: Update Filestash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Cache
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ env.NODE_VERSION }}-npm-lock-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ env.NODE_VERSION }}-npm-lock-
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build:all
+
+      - name: Set up SSH
+        run: |
+          install --directory ~/.ssh --mode 700
+          base64 --decode <<< "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -t ed25519 -H "${{ secrets.FILESTASH_SERVER }}" >> ~/.ssh/known_hosts
+
+      - name: Upload to Filestash
+        run: |
+          rsync dist/jquery.js filestash@"${{ secrets.FILESTASH_SERVER }}":jquery-3.x-git.js
+          rsync dist/jquery.min.js filestash@"${{ secrets.FILESTASH_SERVER }}":jquery-3.x-git.min.js
+          rsync dist/jquery.min.map filestash@"${{ secrets.FILESTASH_SERVER }}":jquery-3.x-git.min.map
+
+          rsync dist/jquery.slim.js filestash@"${{ secrets.FILESTASH_SERVER }}":jquery-3.x-git.slim.js
+          rsync dist/jquery.slim.min.js filestash@"${{ secrets.FILESTASH_SERVER }}":jquery-3.x-git.slim.min.js
+          rsync dist/jquery.slim.min.map filestash@"${{ secrets.FILESTASH_SERVER }}":jquery-3.x-git.slim.min.map


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

3.x companion of https://github.com/jquery/jquery/pull/5434

Replaces the jenkins workflow to update git versions of jQuery on the Filestash server. The filestash environment is already set up in the jQuery repo settings and includes the necessary SSH private key and filestash server URL.

Here's a sample of the 3.x workflow running as a dry run: 
https://github.com/timmywil/jquery/actions/runs/8205774067/job/22443405621

We should disable the jenkins workflow before merging.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
