### PR TITLE
Tests: add --hard-retries option to test runner

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -77,4 +77,4 @@ jobs:
         run: npm run pretest
 
       - name: Run tests
-        run: npm run test:unit -- -v --browserstack "${{ matrix.BROWSER }}" --run-id ${{ github.run_id }} --isolate --retries 3
+        run: npm run test:unit -- -v --browserstack "${{ matrix.BROWSER }}" --run-id ${{ github.run_id }} --isolate --retries 3 --hard-retries 1

--- a/test/runner/browserstack/queue.js
+++ b/test/runner/browserstack/queue.js
@@ -56,7 +56,7 @@ export function retryTest( reportId, maxRetries ) {
 
 export async function hardRetryTest( reportId, maxHardRetries ) {
 	if ( !maxHardRetries ) {
-		return;
+		return false;
 	}
 	const test = queue.find( ( test ) => test.id === reportId );
 	if ( test ) {

--- a/test/runner/browserstack/queue.js
+++ b/test/runner/browserstack/queue.js
@@ -1,6 +1,11 @@
 import chalk from "chalk";
 import { getBrowserString } from "../lib/getBrowserString.js";
-import { checkLastTouches, createBrowserWorker, setBrowserWorkerUrl } from "./browsers.js";
+import {
+	checkLastTouches,
+	createBrowserWorker,
+	restartBrowser,
+	setBrowserWorkerUrl
+} from "./browsers.js";
 
 const TEST_POLL_TIMEOUT = 1000;
 
@@ -32,6 +37,9 @@ export function getNextBrowserTest( reportId ) {
 }
 
 export function retryTest( reportId, maxRetries ) {
+	if ( !maxRetries ) {
+		return;
+	}
 	const test = queue.find( ( test ) => test.id === reportId );
 	if ( test ) {
 		test.retries++;
@@ -46,10 +54,31 @@ export function retryTest( reportId, maxRetries ) {
 	}
 }
 
+export async function hardRetryTest( reportId, maxHardRetries ) {
+	if ( !maxHardRetries ) {
+		return;
+	}
+	const test = queue.find( ( test ) => test.id === reportId );
+	if ( test ) {
+		test.hardRetries++;
+		if ( test.hardRetries <= maxHardRetries ) {
+			console.log(
+				`Hard retrying test ${ reportId } for ${ chalk.yellow(
+					test.options.modules.join( ", " )
+				) }...${ test.hardRetries }`
+			);
+			await restartBrowser( test.browser );
+			return true;
+		}
+	}
+	return false;
+}
+
 export function addBrowserStackRun( url, browser, options ) {
 	queue.push( {
 		browser,
 		fullBrowser: getBrowserString( browser ),
+		hardRetries: 0,
 		id: options.reportId,
 		url,
 		options,
@@ -59,7 +88,7 @@ export function addBrowserStackRun( url, browser, options ) {
 }
 
 export async function runAllBrowserStack() {
-	return new Promise( async( resolve, reject )=> {
+	return new Promise( async( resolve, reject ) => {
 		while ( queue.length ) {
 			try {
 				await checkLastTouches();

--- a/test/runner/command.js
+++ b/test/runner/command.js
@@ -63,12 +63,6 @@ const argv = yargs( process.argv.slice( 2 ) )
 		type: "boolean",
 		description: "Log additional information."
 	} )
-	.option( "retries", {
-		alias: "r",
-		type: "number",
-		description: "Number of times to retry failed tests in BrowserStack.",
-		implies: [ "browserstack" ]
-	} )
 	.option( "run-id", {
 		type: "string",
 		description: "A unique identifier for this run."
@@ -88,6 +82,20 @@ const argv = yargs( process.argv.slice( 2 ) )
 			"The --browser option is ignored when --browserstack has a value.\n" +
 			"Otherwise, the --browser option will be used, " +
 			"with the latest version/device for that browser, on a matching OS."
+	} )
+	.option( "retries", {
+		alias: "r",
+		type: "number",
+		description: "Number of times to retry failed tests in BrowserStack.",
+		implies: [ "browserstack" ]
+	} )
+	.option( "hard-retries", {
+		type: "number",
+		description:
+			"Number of times to retry failed tests in BrowserStack " +
+			"by restarting the worker. This is in addition to the normal retries " +
+			"and are only used when the normal retries are exhausted.",
+		implies: [ "browserstack" ]
 	} )
 	.option( "list-browsers", {
 		type: "string",

--- a/test/runner/createTestServer.js
+++ b/test/runner/createTestServer.js
@@ -26,23 +26,29 @@ export async function createTestServer( report ) {
 
 	// Add a script tag to the index.html to load the QUnit listeners
 	app.use( /\/test(?:\/index.html)?\//, ( _req, res ) => {
-		res.send( indexHTML.replace(
-			"</head>",
-			"<script src=\"/test/runner/listeners.js\"></script></head>"
-		) );
+		res.send(
+			indexHTML.replace(
+				"</head>",
+				"<script src=\"/test/runner/listeners.js\"></script></head>"
+			)
+		);
 	} );
 
 	// Bind the reporter
-	app.post( "/api/report", bodyParser.json( { limit: "50mb" } ), ( req, res ) => {
-		if ( report ) {
-			const response = report( req.body );
-			if ( response ) {
-				res.json( response );
-				return;
+	app.post(
+		"/api/report",
+		bodyParser.json( { limit: "50mb" } ),
+		async( req, res ) => {
+			if ( report ) {
+				const response = await report( req.body );
+				if ( response ) {
+					res.json( response );
+					return;
+				}
 			}
+			res.sendStatus( 204 );
 		}
-		res.sendStatus( 204 );
-	} );
+	);
 
 	// Handle errors from the body parser
 	app.use( bodyParserErrorHandler() );

--- a/test/runner/run.js
+++ b/test/runner/run.js
@@ -14,6 +14,7 @@ import { cleanupAllBrowsers, touchBrowser } from "./browserstack/browsers.js";
 import {
 	addBrowserStackRun,
 	getNextBrowserTest,
+	hardRetryTest,
 	retryTest,
 	runAllBrowserStack
 } from "./browserstack/queue.js";
@@ -30,6 +31,7 @@ export async function run( {
 	browserstack,
 	concurrency,
 	debug,
+	hardRetries,
 	headless,
 	isolate,
 	modules = [],
@@ -72,7 +74,7 @@ export async function run( {
 	// Create the test app and
 	// hook it up to the reporter
 	const reports = Object.create( null );
-	const app = await createTestServer( ( message ) => {
+	const app = await createTestServer( async( message ) => {
 		switch ( message.type ) {
 			case "testEnd": {
 				const reportId = message.id;
@@ -119,6 +121,11 @@ export async function run( {
 					// Retry if retryTest returns a test
 					if ( retry ) {
 						return retry;
+					}
+
+					// Return early if hardRetryTest returns true
+					if ( await hardRetryTest( reportId, hardRetries ) ) {
+						return;
 					}
 					errorMessages.push( ...Object.values( pendingErrors[ reportId ] ) );
 				}


### PR DESCRIPTION
### Summary ###

3.x version of #5438 
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
Add the ability to retry by restarting the worker and getting a different browser instance, after all normal retries have been exhausted. This can sometimes be successful for flakey tests when a refresh is not.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
