### PR TITLE
Attributes: Make `.attr( name, false )` remove for all non-ARIA attrs

### DIFF
--- a/src/attributes/attr.js
+++ b/src/attributes/attr.js
@@ -38,7 +38,14 @@ jQuery.extend( {
 		}
 
 		if ( value !== undefined ) {
-			if ( value === null ) {
+			if ( value === null ||
+
+				// For compat with previous handling of boolean attributes,
+				// remove when `false` passed. For ARIA attributes -
+				// many of which recognize a `"false"` value - continue to
+				// set the `"false"` value as jQuery <4 did.
+				( value === false && name.toLowerCase().indexOf( "aria-" ) !== 0 ) ) {
+
 				jQuery.removeAttr( elem, name );
 				return;
 			}
@@ -96,32 +103,3 @@ if ( isIE ) {
 		}
 	};
 }
-
-// HTML boolean attributes have special behavior:
-// we consider the lowercase name to be the only valid value, so
-// getting (if the attribute is present) normalizes to that, as does
-// setting to any non-`false` value (and setting to `false` removes the attribute).
-// See https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes
-jQuery.each( (
-	"checked selected async autofocus autoplay controls defer disabled " +
-	"hidden ismap loop multiple open readonly required scoped"
-).split( " " ), function( _i, name ) {
-	jQuery.attrHooks[ name ] = {
-		get: function( elem ) {
-			return elem.getAttribute( name ) != null ?
-				name.toLowerCase() :
-				null;
-		},
-
-		set: function( elem, value, name ) {
-			if ( value === false ) {
-
-				// Remove boolean attributes when set to false
-				jQuery.removeAttr( elem, name );
-			} else {
-				elem.setAttribute( name, name );
-			}
-			return name;
-		}
-	};
-} );

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -948,10 +948,10 @@ QUnit.test( "pseudo - nth-last-of-type", function( assert ) {
 QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "pseudo - has", function( assert ) {
 	assert.expect( 4 );
 
-	assert.t( "Basic test", "p:has(a)", [ "firstp", "ap", "en", "sap" ] );
-	assert.t( "Basic test (irrelevant whitespace)", "p:has( a )", [ "firstp", "ap", "en", "sap" ] );
-	assert.t( "Nested with overlapping candidates",
-		"#qunit-fixture div:has(div:has(div:not([id])))",
+	assert.selectInFixture( "Basic test", "p:has(a)", [ "firstp", "ap", "en", "sap" ] );
+	assert.selectInFixture( "Basic test (irrelevant whitespace)", "p:has( a )", [ "firstp", "ap", "en", "sap" ] );
+	assert.selectInFixture( "Nested with overlapping candidates",
+		"div:has(div:has(div:not([id])))",
 		[ "moretests", "t2037", "fx-test-group", "fx-queue" ] );
 
 	// Support: Safari 15.4+, Chrome 105+


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The HTML spec defines boolean attributes:
https://html.spec.whatwg.org/#boolean-attributes
that often correlate with boolean properties. If the attribute is missing, it correlates with the `false` property value, if it's present - the `true` property value. The only valid values are an empty string or the attribute name.

jQuery tried to be helpful here and treated boolean attributes in a special way in the `.attr()` API:
1. For the getter, as long as the attribute was present, it was returning the attribute name lowercased, ignoring the value.
2. For the setter, it was removing the attribute when `false` was passed; otherwise, it was ignoring the passed value and set the attribute - interestingly, in jQuery `>=3` not lowercased anymore.

The problem is the spec occasionally converts boolean attributes into ones with additional attribute values with special behavior - one such example is the new `"until-found"` value for the `hidden` attribute. Our setter normalization means passing those values is impossible with jQuery. Also, new boolean attributes are introduced occasionally and jQuery cannot easily add them to the list without incurring breaking changes.

This patch removes any special handling of boolean attributes - the getter returns the value as-is and the setter sets the provided value.

To provide better backwards compatibility with the very frequent `false` value provided to remove the attribute, this patch makes `false` trigger attribute removal for ALL non-ARIA attributes. ARIA attributes are exempt from the rule since many of them recognize `"false"` as a valid value with semantics different than the attribute missing. To remove an ARIA attribute, use `.removeAttr()` or pass `null` as the value to `.attr()` which doesn't have this exception.

Fixes gh-5388

Richard Gibson is added as a co-author.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com: https://github.com/jquery/api.jquery.com/issues/1243
* [x] If needed, a Migrate issue/PR was created at https://github.com/jquery/jquery-migrate: https://github.com/jquery/jquery-migrate/issues/504

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
