### PR TITLE
Tests: improve diffing for values of different types

### DIFF
--- a/test/runner/listeners.js
+++ b/test/runner/listeners.js
@@ -57,6 +57,7 @@
 			// Serialize Symbols as string representations so they are
 			// sent over the wire after being stringified.
 			if ( typeof value === "symbol" ) {
+
 				// We can *describe* unique symbols, but note that their identity
 				// (e.g., `Symbol() !== Symbol()`) is lost
 				var ctor = Symbol.keyFor( value ) !== undefined ? "Symbol.for" : "Symbol";

--- a/test/runner/listeners.js
+++ b/test/runner/listeners.js
@@ -53,6 +53,14 @@
 					return nu;
 				}
 			}
+
+			// Serialize Symbols as string representations so they are
+			// sent over the wire after being stringified.
+			if ( typeof value === "symbol" ) {
+				var ctor = Symbol.keyFor( value ) !== undefined ? "Symbol.for" : "Symbol";
+				return ctor + "(" + JSON.stringify( value.description ) + ")";
+			}
+
 			return value;
 		}
 		return derez( object );

--- a/test/runner/listeners.js
+++ b/test/runner/listeners.js
@@ -57,6 +57,8 @@
 			// Serialize Symbols as string representations so they are
 			// sent over the wire after being stringified.
 			if ( typeof value === "symbol" ) {
+				// We can *describe* unique symbols, but note that their identity
+				// (e.g., `Symbol() !== Symbol()`) is lost
 				var ctor = Symbol.keyFor( value ) !== undefined ? "Symbol.for" : "Symbol";
 				return ctor + "(" + JSON.stringify( value.description ) + ")";
 			}

--- a/test/runner/reporter.js
+++ b/test/runner/reporter.js
@@ -3,11 +3,14 @@ import { getBrowserString } from "./lib/getBrowserString.js";
 import { prettyMs } from "./lib/prettyMs.js";
 import * as Diff from "diff";
 
-const rdquo = /"/g;
+function serializeForDiff( value ) {
 
-function quoteWrap( value ) {
+	// Use naive serialization for everything except types with confusable values
 	if ( typeof value === "string" ) {
-		return `"${ value.replace( rdquo, "\\\"" ) }"`;
+		return JSON.stringify( value );
+	}
+	if ( typeof value === "bigint" ) {
+		return `${ value }n`;
 	}
 	return `${ value }`;
 }
@@ -76,12 +79,12 @@ export function reportTest( test, reportId, { browser, headless } ) {
 
 					// Diff the characters of strings
 					diff = Diff.diffChars( error.expected, error.actual );
-				} else if ( error.expected != null && error.actual != null ) {
+				} else {
 
 					// Diff everything else as words
 					diff = Diff.diffWords(
-						quoteWrap( error.expected ),
-						quoteWrap( error.actual )
+						serializeForDiff( error.expected ),
+						serializeForDiff( error.actual )
 					);
 				}
 

--- a/test/runner/reporter.js
+++ b/test/runner/reporter.js
@@ -3,9 +3,11 @@ import { getBrowserString } from "./lib/getBrowserString.js";
 import { prettyMs } from "./lib/prettyMs.js";
 import * as Diff from "diff";
 
+const rdquo = /"/g;
+
 function quoteWrap( value ) {
 	if ( typeof value === "string" ) {
-		return `"${ value }"`;
+		return `"${ value.replace( rdquo, "\\\"" ) }"`;
 	}
 	return `${ value }`;
 }
@@ -57,7 +59,7 @@ export function reportTest( test, reportId, { browser, headless } ) {
 					diff = Diff.diffJson( error.expected, error.actual );
 				} else if (
 					typeof error.expected === "number" &&
-					typeof error.expected === "number"
+					typeof error.actual === "number"
 				) {
 
 					// Diff numbers directly

--- a/test/runner/reporter.js
+++ b/test/runner/reporter.js
@@ -3,6 +3,13 @@ import { getBrowserString } from "./lib/getBrowserString.js";
 import { prettyMs } from "./lib/prettyMs.js";
 import * as Diff from "diff";
 
+function quoteWrap( value ) {
+	if ( typeof value === "string" ) {
+		return `"${ value }"`;
+	}
+	return `${ value }`;
+}
+
 export function reportTest( test, reportId, { browser, headless } ) {
 	if ( test.status === "passed" ) {
 
@@ -25,15 +32,19 @@ export function reportTest( test, reportId, { browser, headless } ) {
 				message += `\n${ error.message }`;
 			}
 			message += `\n${ chalk.gray( error.stack ) }`;
-			if ( "expected" in error && "actual" in error ) {
-				message += `\nexpected: ${ JSON.stringify( error.expected ) }`;
-				message += `\nactual: ${ JSON.stringify( error.actual ) }`;
+
+			// Show expected and actual values
+			// if either is defined and non-null.
+			// error.actual is set to null for failed
+			// assert.expect() assertions, so skip those as well.
+			// This should be fine because error.expected would
+			// have to also be null for this to be skipped.
+			if ( error.expected != null || error.actual != null ) {
+				message += `\nexpected: ${ chalk.red( JSON.stringify( error.expected ) ) }`;
+				message += `\nactual: ${ chalk.green( JSON.stringify( error.actual ) ) }`;
 				let diff;
 
-				if (
-					Array.isArray( error.expected ) &&
-					Array.isArray( error.actual )
-				) {
+				if ( Array.isArray( error.expected ) && Array.isArray( error.actual ) ) {
 
 					// Diff arrays
 					diff = Diff.diffArrays( error.expected, error.actual );
@@ -57,30 +68,35 @@ export function reportTest( test, reportId, { browser, headless } ) {
 						diff = [ { removed: true, value: `${ value }` } ];
 					}
 				} else if (
-					typeof error.expected === "boolean" &&
-					typeof error.actual === "boolean"
+					typeof error.expected === "string" &&
+					typeof error.actual === "string"
 				) {
 
-					// Show the actual boolean in red
-					diff = [ { removed: true, value: `${ error.actual }` } ];
-				} else {
+					// Diff the characters of strings
+					diff = Diff.diffChars( error.expected, error.actual );
+				} else if ( error.expected != null && error.actual != null ) {
 
-					// Diff everything else as characters
-					diff = Diff.diffChars( `${ error.expected }`, `${ error.actual }` );
+					// Diff everything else as words
+					diff = Diff.diffWords(
+						quoteWrap( error.expected ),
+						quoteWrap( error.actual )
+					);
 				}
 
-				message += "\n";
-				message += diff
-					.map( ( part ) => {
-						if ( part.added ) {
-							return chalk.green( part.value );
-						}
-						if ( part.removed ) {
-							return chalk.red( part.value );
-						}
-						return chalk.gray( part.value );
-					} )
-					.join( "" );
+				if ( diff ) {
+					message += "\n";
+					message += diff
+						.map( ( part ) => {
+							if ( part.added ) {
+								return chalk.green( part.value );
+							}
+							if ( part.removed ) {
+								return chalk.red( part.value );
+							}
+							return chalk.gray( part.value );
+						} )
+						.join( "" );
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Summary ###

3.x version of #5454

<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
Differences are:
- use `diffChars` when both expected and actual are strings
- use `diffWords` for everything after that

Objects, arrays, and numbers are diffed as before.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
