### PR TITLE
Tests: Make the beforeunload event tests work regardless of extensions

### DIFF
--- a/test/data/event/onbeforeunload.html
+++ b/test/data/event/onbeforeunload.html
@@ -4,17 +4,18 @@
 	<script>
 		function report( event ) {
 			var payload = {
+				source: "jQuery onbeforeunload iframe test",
 				event: event.type
 			};
-			return parent.postMessage( JSON.stringify(payload), "*" );
+			return parent.postMessage( JSON.stringify( payload ), "*" );
 		}
 
 		jQuery( window ).on( "beforeunload", function( event ) {
 			report( event );
-		}).on( "load", function( event ) {
-			setTimeout(function() {
+		} ).on( "load", function( event ) {
+			setTimeout( function() {
 				window.location.reload();
-			}, 50);
-		});
+			}, 50 );
+		} );
 	</script>
 </html>

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -1448,13 +1448,22 @@ QUnit[ /(ipad|iphone|ipod)/i.test( navigator.userAgent ) ? "skip" : "test" ](
 	var done = assert.async();
 
 	window.onmessage = function( event ) {
-		var payload = JSON.parse( event.data );
+		try {
+			var payload = JSON.parse( event.data );
 
-		assert.ok( payload.event, "beforeunload", "beforeunload event" );
+			// Ignore unrelated messages
+			if ( payload.source === "jQuery onbeforeunload iframe test" ) {
+				assert.ok( payload.event, "beforeunload", "beforeunload event" );
 
-		iframe.remove();
-		window.onmessage = null;
-		done();
+				iframe.remove();
+				window.onmessage = null;
+				done();
+			}
+		} catch ( e ) {
+
+			// Messages may come from other sources, like browser extensions;
+			// some may not be valid JSONs and thus cannot be `JSON.parse`d.
+		}
 	};
 
 	iframe.appendTo( "#qunit-fixture" );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Some browser extensions, like React DevTools, send messages to the content area. Since our beforeunload event test listens for all messages, it used to catch those as well, failing the test.

Add a `source` field to the payload JSON and check for it before treating the message as coming from our own test to make sure the test passes even with such browser extensions installed.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
