### PR TITLE
CSS: `showOnlyWhen()`

### DIFF
--- a/src/css/showHide.js
+++ b/src/css/showHide.js
@@ -82,6 +82,9 @@ jQuery.fn.extend( {
 	hide: function() {
 		return showHide( this );
 	},
+	showOnlyWhen: function( condition ) {
+		return showHide( this, condition );
+	},
 	toggle: function( state ) {
 		if ( typeof state === "boolean" ) {
 			return state ? this.show() : this.hide();

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -546,6 +546,56 @@ QUnit.test( "show()", function( assert ) {
 	jQuery( "<div>test</div> text <span>test</span>" ).hide().remove();
 } );
 
+QUnit.test( "showOnlyWhen() shows when condition is true", function( assert ) {
+
+	assert.expect( 3 );
+
+	var hiddendiv, div, pass;
+		hiddendiv = jQuery( "div.hidden" );
+
+	hiddendiv.hide();
+	assert.equal( jQuery.css( hiddendiv[ 0 ], "display" ), "none", "hiddendiv is display: none" );
+
+	hiddendiv.showOnlyWhen( true );
+	assert.equal( jQuery.css( hiddendiv[ 0 ], "display" ), "block", "hiddendiv is display: block" );
+
+	hiddendiv.css( "display", "" );
+
+	pass = true;
+	div = jQuery( "#qunit-fixture div" );
+	div.showOnlyWhen( true ).each( function() {
+		if ( this.style.display === "none" ) {
+			pass = false;
+		}
+	} );
+	assert.ok( pass, "Show" );
+} );
+
+QUnit.test( "showOnlyWhen() hides when condition is false", function( assert ) {
+
+	assert.expect( 3 );
+
+	var hiddendiv, div, pass;
+		hiddendiv = jQuery( "div.hidden" );
+
+	hiddendiv.show();
+	assert.equal( jQuery.css( hiddendiv[ 0 ], "display" ), "block", "hiddendiv is display: block" );
+
+	hiddendiv.showOnlyWhen( false );
+	assert.equal( jQuery.css( hiddendiv[ 0 ], "display" ), "none", "hiddendiv is display: none" );
+
+	hiddendiv.css( "display", "" );
+
+	pass = true;
+	div = jQuery( "#qunit-fixture div" );
+	div.showOnlyWhen( false ).each( function() {
+		if ( this.style.display === "block" ) {
+			pass = false;
+		}
+	} );
+	assert.ok( pass, "Hide" );
+} );
+
 QUnit.test( "show/hide detached nodes", function( assert ) {
 	assert.expect( 19 );
 


### PR DESCRIPTION
Helloooo 👋🏻 

### Summary ###
Since we usually on the case where we show/hide elements depending on some condition. In this PR I have added a new method `showOnlyWhen()` that will simplify this more.

### Example ###
#### Before ####
```javascript
const checkbox = $("#the-checkbox");
const otherElem = $("#the-other-element");

if (checkbox.attr("checked")) {
    otherElem.show();
} else {
    otherElem.hide();
}
```
#### After ####
```javascript
const checkbox = $("#the-checkbox");
const otherElem = $("#the-other-element");

otherElem.showOnlyWhen(checkbox.attr("checked"));
```

### Checklist ###
* [x] New tests have been added to show the fix or feature works
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

If approved I'll be happy to add documentation for it.
