### PR TITLE
Tests: revert concurrency group change

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -15,7 +15,7 @@ jobs:
       NODE_VERSION: 20.x
     name: ${{ matrix.BROWSER }}
     concurrency:
-      group: ${{ matrix.BROWSER }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ matrix.BROWSER }}
     timeout-minutes: 30
     strategy:
       fail-fast: false


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
It's common for us to merge to main and cherry pick to 3.x-stable, so it's best if concurrency is shared between branches, which is effectively what we had already as it matches on workflow name and browser. Ideally, it could also match on the corresponding commit, but it seems the commit message is not available in the github context.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
