### PR TITLE
Update buildFragment.js DOM text reinterpreted as HTML

### DIFF
--- a/src/manipulation/buildFragment.js
+++ b/src/manipulation/buildFragment.js
@@ -45,7 +45,7 @@ export function buildFragment( elems, context, scripts, selection, ignored ) {
 					tmp = tmp.appendChild( context.createElement( wrap[ j ] ) );
 				}
 
-				tmp.innerHTML = jQuery.htmlPrefilter( elem );
+				tmp.textContent = jQuery.htmlPrefilter( elem );
 
 				jQuery.merge( nodes, tmp.childNodes );
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
By using textContent, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.



### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] New tests have been added to show the fix or feature works
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
