### PR TITLE
CSS:Tests: Fix tests & support tests under CSS Zoom

### DIFF
--- a/src/css/support.js
+++ b/src/css/support.js
@@ -54,9 +54,9 @@ support.reliableTrDimensions = function() {
 		}
 
 		trStyle = window.getComputedStyle( tr );
-		reliableTrDimensionsVal = ( parseInt( trStyle.height, 10 ) +
-				parseInt( trStyle.borderTopWidth, 10 ) +
-				parseInt( trStyle.borderBottomWidth, 10 ) ) === tr.offsetHeight;
+		reliableTrDimensionsVal = ( Math.round( parseFloat( trStyle.height ) ) +
+			Math.round( parseFloat( trStyle.borderTopWidth ) ) +
+			Math.round( parseFloat( trStyle.borderBottomWidth ) ) ) === tr.offsetHeight;
 
 		documentElement.removeChild( table );
 	}

--- a/test/data/support/zoom.html
+++ b/test/data/support/zoom.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8" />
+	<style>
+		html {
+			zoom: 2.1;
+		}
+	</style>
+</head>
+<body>
+	<div>
+		<script src="../../jquery.js"></script>
+		<script src="../iframeTest.js"></script>
+		<script src="getComputedSupport.js"></script>
+	</div>
+	<script>
+		startIframeTest(
+			getComputedStyle( document.documentElement ),
+			getComputedSupport( jQuery.support )
+		);
+	</script>
+</body>
+</html>

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -1381,8 +1381,12 @@ testIframe(
 	"css/cssWidthBrowserZoom.html",
 	function( assert, jQuery, window, document, widthBeforeSet, widthAfterSet ) {
 		assert.expect( 2 );
-		assert.strictEqual( widthBeforeSet, "100px", "elem.css('width') works correctly with browser zoom" );
-		assert.strictEqual( widthAfterSet, "100px", "elem.css('width', val) works correctly with browser zoom" );
+
+		// Support: Firefox 126+
+		// Newer Firefox implements CSS zoom in a way it affects
+		// those values slightly.
+		assert.ok( /^100(?:|\.0\d*)px$/.test( widthBeforeSet ), "elem.css('width') works correctly with browser zoom" );
+		assert.ok( /^100(?:|\.0\d*)px$/.test( widthAfterSet ), "elem.css('width', val) works correctly with browser zoom" );
 	}
 );
 

--- a/test/unit/support.js
+++ b/test/unit/support.js
@@ -66,6 +66,16 @@ testIframe(
 	}
 );
 
+testIframe(
+	"Verify correctness of support tests with CSS zoom on the root element",
+	"support/zoom.html",
+	function( assert, jQuery, window, document, htmlStyle, support ) {
+		assert.expect( 1 );
+		assert.deepEqual( jQuery.extend( {}, support ), computedSupport,
+			"Same support properties" );
+	}
+);
+
 ( function() {
 	var expected, browserKey,
 		userAgent = window.navigator.userAgent,


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Firefox 126+ implements CSS zoom in a way it affects width computed style
very slightly (`100.008px` instead of `100px`); accept that difference.

Add a test for support tests resolving the same under CSS zoom & without one.
That test uncovered Chrome failing the `reliableTrDimensions` support test
under zoom; the test has been fixed.

Fixes gh-5489
Closes gh-5495
Ref gh-5496

`3.x` version: gh-5496

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
