### PR TITLE
Tests: Make `:has` selector tests not vulnerable to unrelated failures

### DIFF
--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -986,10 +986,10 @@ QUnit.test( "pseudo - nth-last-of-type", function( assert ) {
 QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "pseudo - has", function( assert ) {
 	assert.expect( 4 );
 
-	assert.t( "Basic test", "p:has(a)", [ "firstp", "ap", "en", "sap" ] );
-	assert.t( "Basic test (irrelevant whitespace)", "p:has( a )", [ "firstp", "ap", "en", "sap" ] );
-	assert.t( "Nested with overlapping candidates",
-		"#qunit-fixture div:has(div:has(div:not([id])))",
+	assert.selectInFixture( "Basic test", "p:has(a)", [ "firstp", "ap", "en", "sap" ] );
+	assert.selectInFixture( "Basic test (irrelevant whitespace)", "p:has( a )", [ "firstp", "ap", "en", "sap" ] );
+	assert.selectInFixture( "Nested with overlapping candidates",
+		"div:has(div:has(div:not([id])))",
 		[ "moretests", "t2037", "fx-test-group", "fx-queue" ] );
 
 	// Support: Safari 15.4+, Chrome 105+
@@ -998,8 +998,8 @@ QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "pseudo - has", function( asse
 	// return no results. Make sure this is accounted for. (gh-5098)
 	// Note: Chrome 105 has this behavior only in 105.0.5195.125 or newer;
 	// initially it shipped with a fully forgiving parsing in `:has()`.
-	assert.t( "Nested with list arguments",
-		"#qunit-fixture div:has(faketag, div:has(faketag, div:not([id])))",
+	assert.selectInFixture( "Nested with list arguments",
+		"div:has(faketag, div:has(faketag, div:not([id])))",
 		[ "moretests", "t2037", "fx-test-group", "fx-queue" ] );
 } );
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Use `assert.selectInFixture` consistently in `:has` tests. Previously, any test failure that happened before this test run made it fail due to an additional paragraph with id `qunit-testresult` injected by QUnit.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
