### PR TITLE
Tests: Align `:has` selector tests with `3.x-stable`

### DIFF
--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -960,8 +960,8 @@ QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "pseudo - has", function( asse
 	// return no results. Make sure this is accounted for. (gh-5098)
 	// Note: Chrome 105 has this behavior only in 105.0.5195.125 or newer;
 	// initially it shipped with a fully forgiving parsing in `:has()`.
-	assert.t( "Nested with list arguments",
-		"#qunit-fixture div:has(faketag, div:has(faketag, div:not([id])))",
+	assert.selectInFixture( "Nested with list arguments",
+		"div:has(faketag, div:has(faketag, div:not([id])))",
 		[ "moretests", "t2037", "fx-test-group", "fx-queue" ] );
 } );
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Consistently use `assert.selectInFixture` instead of prepending the selector with `#qunit-fixture ` manually.

Ref gh-5497

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
