### PR TITLE
Build: Group dependabot PRs updating GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
+
+    # Group all dependabot version update PRs into one
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

We have monthly automatic dependabot PRs for GitHub Actions. Unfortunately, as of now we get a separate PR for every dependency which is a bit spammy compared to regular commits updating source.

Thankfully, there's now a way to tell dependabot to submit a single PR per a defined group. This change defines a single group to have a single dependabot PR for all action updates.

Example PR: https://github.com/mgol/jquery/pull/12

PR title: "Build: Bump the github-actions group with 2 updates". I thought using `GitHub Actions` as the group name (which is a Yaml key in `dependabot.yml`) would be more readable but the title is the same; it must be normalizing this name.

Screenshot:
<img width="931" alt="Screenshot 2024-06-05 at 00 31 37" src="https://github.com/jquery/jquery/assets/1758366/cc766c06-a89f-4602-9240-24560d0648c8">


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
