### PR TITLE
Release: ensure builds have the proper version

### DIFF
--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -21,10 +21,10 @@ jobs:
       NODE_VERSION: 20.x
     steps:
       - name: Checkout
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.release-it.cjs
+++ b/.release-it.cjs
@@ -10,11 +10,11 @@ module.exports = {
 	preReleaseBase: 1,
 	hooks: {
 		"before:init": "bash ./build/release/pre-release.sh",
-		"before:git:release": "git add -f dist/ dist-module/ changelog.md",
 		"after:version:bump":
 			"sed -i 's/main\\/AUTHORS.txt/${version}\\/AUTHORS.txt/' package.json",
-		"after:release":
-			`bash ./build/release/post-release.sh \${version} ${ blogURL }`
+		"after:bump": "cross-env VERSION=${version} npm run build:all",
+		"before:git:release": "git add -f dist/ dist-module/ changelog.md",
+		"after:release": `bash ./build/release/post-release.sh \${version} ${ blogURL }`
 	},
 	git: {
 		changelog: "npm run release:changelog -- ${from} ${to}",

--- a/build/release/verify.js
+++ b/build/release/verify.js
@@ -24,12 +24,13 @@ const REGISTRY_URL = "https://registry.npmjs.org/jquery";
 
 const rstable = /^(\d+\.\d+\.\d+)$/;
 
-export async function verifyRelease( { version } = {} ) {
+async function verifyRelease( { version } = {} ) {
 	if ( !version ) {
 		version = process.env.VERSION || ( await getLatestVersion() );
 	}
-	console.log( `Checking jQuery ${ version }...` );
 	const release = await buildRelease( { version } );
+
+	console.log( `Verifying jQuery ${ version }...` );
 
 	let verified = true;
 
@@ -139,8 +140,8 @@ async function buildRelease( { version } ) {
 			.filter( ( dirent ) => dirent.isFile() )
 			.map( async( dirent ) => ( {
 				name: dirent.name,
-				path: path.basename( dirent.path ),
-				contents: await readFile( path.join( dirent.path, dirent.name ), "utf8" )
+				path: path.basename( dirent.parentPath ),
+				contents: await readFile( path.join( dirent.parentPath, dirent.name ), "utf8" )
 			} ) )
 	);
 
@@ -196,3 +197,5 @@ async function sumTarball( filepath ) {
 	const unzipped = await gunzip( contents );
 	return shasum( unzipped );
 }
+
+verifyRelease();

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "commitplease": "3.2.0",
         "concurrently": "8.2.2",
         "core-js-bundle": "3.37.1",
+        "cross-env": "7.0.3",
         "diff": "5.2.0",
         "eslint": "8.57.0",
         "eslint-config-jquery": "3.0.2",
@@ -3503,6 +3504,24 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "commitplease": "3.2.0",
     "concurrently": "8.2.2",
     "core-js-bundle": "3.37.1",
+    "cross-env": "7.0.3",
     "diff": "5.2.0",
     "eslint": "8.57.0",
     "eslint-config-jquery": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "release:changelog": "node build/release/changelog.js",
     "release:clean": "rimraf tmp --glob changelog.{md,html} contributors.html",
     "release:dist": "node build/release/dist.js",
-    "release:verify": "node -e \"(async () => { const { verifyRelease } = await import('./build/release/verify.js'); verifyRelease() })()\"",
+    "release:verify": "node build/release/verify.js",
     "start": "node -e \"(async () => { const { buildDefaultFiles } = await import('./build/tasks/build.js'); buildDefaultFiles({ watch: true }) })()\"",
     "test:bundlers": "npm run pretest && npm run build:all && node test/bundler_smoke_tests/run-jsdom-tests.js",
     "test:browser": "npm run pretest && npm run build:main && npm run test:unit -- -b chrome -b firefox -h",


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
I attempted the release this morning and noticed a couple things after the initial steps.

1. The version was not set in the built files. `VERSION` needed to be set in the environment. The `version` is not available in script contexts at the `init` stage. This adds a full build to `after:bump` with the new version, which happens just before publishing to npm. I added `cross-env` to do this so it works on Windows as well.
2. The last build to run in `npm test` was `selector-native`, so the main jquery.js file was not correct.

Also:

- order hooks in execution order
- upgrade actions in the new verify workflow
- verify.js did not need to export and could be run from the file

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
