### PR TITLE
Manipulation: Make jQuery.cleanData not skip elements during cleanup

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -133,51 +133,46 @@ jQuery.extend( {
 		return clone;
 	},
 
-	cleanData: function( elems ) {
-	    var data, elem, type,
-	        special = jQuery.event.special,
-	        i = 0;
+	cleanData: function(elems) {
+		var data, elem, type,
+		    special = jQuery.event.special,
+		    i = 0;
 
-	    // Convert elems to a native array if it is not already
-	    elems = jQuery.makeArray(elems);
+		// Convert elems to a native array if it is not already
+		elems = jQuery.makeArray(elems);
 
-	    while (i < elems.length) {
-	        elem = elems[i];
+		while (i < elems.length) {
+		  elem = elems[i];
 
-	        if (acceptData(elem)) {
-	            if ((data = elem[dataPriv.expando])) {
-	                if (data.events) {
-	                    for (type in data.events) {
-	                        if (special[type]) {
-	                            jQuery.event.remove(elem, type);
+		  if (acceptData(elem)) {
+		    if ((data = elem[dataPriv.expando])) {
+		      if (data.events) {
+		        for (type in data.events) {
+		          if (special[type]) {
+		            jQuery.event.remove(elem, type);
+		          // This is a shortcut to avoid jQuery.event.remove's overhead
+		          } else {
+		            jQuery.removeEvent(elem, type, data.handle);
+		          }
+		        }
+		      }
 
-	                        // This is a shortcut to avoid jQuery.event.remove's overhead
-	                        } else {
-	                            jQuery.removeEvent(elem, type, data.handle);
-	                        }
-	                    }
-	                }
+		      // Support: Chrome <=35 - 45+
+		      // Assign undefined instead of using delete, see Data#remove
+		      elem[dataPriv.expando] = undefined;
+		    }
+		    if (elem[dataUser.expando]) {
+		      // Support: Chrome <=35 - 45+
+		      // Assign undefined instead of using delete, see Data#remove
+		      elem[dataUser.expando] = undefined;
+		    }
 
-	                // Support: Chrome <=35 - 45+
-	                // Assign undefined instead of using delete, see Data#remove
-	                elem[dataPriv.expando] = undefined;
-	            }
-	            if (elem[dataUser.expando]) {
-
-	                // Support: Chrome <=35 - 45+
-	                // Assign undefined instead of using delete, see Data#remove
-	                elem[dataUser.expando] = undefined;
-	            }
-
-	            // Remove the element from the array while preserving the index positions
-	            elems.splice(i, 1);
-	        } else {
-	            i++;
-	        }
-	    }
-	}
-
-
+		    // Remove the element from the array while preserving the index positions
+		    elems.splice(i, 1);
+		  } else {
+		    i++;
+		  }
+		}
 } );
 
 jQuery.fn.extend( {

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -133,46 +133,49 @@ jQuery.extend( {
 		return clone;
 	},
 
-	cleanData: function(elems) {
+	cleanData: function( elems ) {
 		var data, elem, type,
-		    special = jQuery.event.special,
-		    i = 0;
+			special = jQuery.event.special,
+			i = 0;
 
 		// Convert elems to a native array if it is not already
-		elems = jQuery.makeArray(elems);
+		elems = jQuery.makeArray( elems );
 
-		while (i < elems.length) {
-		  elem = elems[i];
+		while ( i < elems.length ) {
+			elem = elems[ i ];
 
-		  if (acceptData(elem)) {
-		    if ((data = elem[dataPriv.expando])) {
-		      if (data.events) {
-		        for (type in data.events) {
-		          if (special[type]) {
-		            jQuery.event.remove(elem, type);
-		          // This is a shortcut to avoid jQuery.event.remove's overhead
-		          } else {
-		            jQuery.removeEvent(elem, type, data.handle);
-		          }
-		        }
-		      }
+			if ( acceptData( elem ) ) {
+				if ( ( data = elem[ dataPriv.expando ] ) ) {
+					if ( data.events ) {
+						for ( type in data.events ) {
+							if ( special[ type ] ) {
+								jQuery.event.remove( elem, type );
 
-		      // Support: Chrome <=35 - 45+
-		      // Assign undefined instead of using delete, see Data#remove
-		      elem[dataPriv.expando] = undefined;
-		    }
-		    if (elem[dataUser.expando]) {
-		      // Support: Chrome <=35 - 45+
-		      // Assign undefined instead of using delete, see Data#remove
-		      elem[dataUser.expando] = undefined;
-		    }
+								// This is a shortcut to avoid jQuery.event.remove's overhead
+							} else {
+								jQuery.removeEvent( elem, type, data.handle );
+							}
+						}
+					}
 
-		    // Remove the element from the array while preserving the index positions
-		    elems.splice(i, 1);
-		  } else {
-		    i++;
-		  }
+					// Support: Chrome <=35 - 45+
+					// Assign undefined instead of using delete, see Data#remove
+					elem[ dataPriv.expando ] = undefined;
+				}
+				if ( elem[ dataUser.expando ] ) {
+
+					// Support: Chrome <=35 - 45+
+					// Assign undefined instead of using delete, see Data#remove
+					elem[ dataUser.expando ] = undefined;
+				}
+
+				// Remove the element from the array while preserving the index positions
+				elems.splice( i, 1 );
+			} else {
+				i++;
+			}
 		}
+	}
 } );
 
 jQuery.fn.extend( {

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -141,32 +141,32 @@ jQuery.extend( {
 	    // Convert elems to a native array if it is not already
 	    elems = jQuery.makeArray(elems);
 
-	    while ( i < elems.length ) {
-	        elem = elems[ i ];
+	    while (i < elems.length) {
+	        elem = elems[i];
 
-	        if ( acceptData( elem ) ) {
-	            if ( ( data = elem[ dataPriv.expando ] ) ) {
-	                if ( data.events ) {
-	                    for ( type in data.events ) {
-	                        if ( special[ type ] ) {
-	                            jQuery.event.remove( elem, type );
+	        if (acceptData(elem)) {
+	            if ((data = elem[dataPriv.expando])) {
+	                if (data.events) {
+	                    for (type in data.events) {
+	                        if (special[type]) {
+	                            jQuery.event.remove(elem, type);
 
 	                        // This is a shortcut to avoid jQuery.event.remove's overhead
 	                        } else {
-	                            jQuery.removeEvent( elem, type, data.handle );
+	                            jQuery.removeEvent(elem, type, data.handle);
 	                        }
 	                    }
 	                }
 
 	                // Support: Chrome <=35 - 45+
 	                // Assign undefined instead of using delete, see Data#remove
-	                elem[ dataPriv.expando ] = undefined;
+	                elem[dataPriv.expando] = undefined;
 	            }
-	            if ( elem[ dataUser.expando ] ) {
+	            if (elem[dataUser.expando]) {
 
 	                // Support: Chrome <=35 - 45+
 	                // Assign undefined instead of using delete, see Data#remove
-	                elem[ dataUser.expando ] = undefined;
+	                elem[dataUser.expando] = undefined;
 	            }
 
 	            // Remove the element from the array while preserving the index positions
@@ -176,6 +176,7 @@ jQuery.extend( {
 	        }
 	    }
 	}
+
 
 } );
 

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -138,12 +138,7 @@ jQuery.extend( {
 			special = jQuery.event.special,
 			i = 0;
 
-		// Convert elems to a native array if it is not already
-		elems = jQuery.makeArray( elems );
-
-		while ( i < elems.length ) {
-			elem = elems[ i ];
-
+		for ( ; ( elem = elems[ i ] ) !== undefined; i++ ) {
 			if ( acceptData( elem ) ) {
 				if ( ( data = elem[ dataPriv.expando ] ) ) {
 					if ( data.events ) {
@@ -151,7 +146,7 @@ jQuery.extend( {
 							if ( special[ type ] ) {
 								jQuery.event.remove( elem, type );
 
-								// This is a shortcut to avoid jQuery.event.remove's overhead
+							// This is a shortcut to avoid jQuery.event.remove's overhead
 							} else {
 								jQuery.removeEvent( elem, type, data.handle );
 							}
@@ -168,11 +163,6 @@ jQuery.extend( {
 					// Assign undefined instead of using delete, see Data#remove
 					elem[ dataUser.expando ] = undefined;
 				}
-
-				// Remove the element from the array while preserving the index positions
-				elems.splice( i, 1 );
-			} else {
-				i++;
 			}
 		}
 	}

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -134,38 +134,46 @@ jQuery.extend( {
 	},
 
 	cleanData: function( elems ) {
-		var data, elem, type,
-			special = jQuery.event.special,
-			i = 0;
+    var data, elem, type,
+        special = jQuery.event.special,
+        i = 0;
+    
+     elems = jQuery.makeArray(elems);
+    while ( i < elems.length ) {
+        elem = elems[ i ];
 
-		for ( ; ( elem = elems[ i ] ) !== undefined; i++ ) {
-			if ( acceptData( elem ) ) {
-				if ( ( data = elem[ dataPriv.expando ] ) ) {
-					if ( data.events ) {
-						for ( type in data.events ) {
-							if ( special[ type ] ) {
-								jQuery.event.remove( elem, type );
+        if ( acceptData( elem ) ) {
+            if ( ( data = elem[ dataPriv.expando ] ) ) {
+                if ( data.events ) {
+                    for ( type in data.events ) {
+                        if ( special[ type ] ) {
+                            jQuery.event.remove( elem, type );
 
-							// This is a shortcut to avoid jQuery.event.remove's overhead
-							} else {
-								jQuery.removeEvent( elem, type, data.handle );
-							}
-						}
-					}
+                        // This is a shortcut to avoid jQuery.event.remove's overhead
+                        } else {
+                            jQuery.removeEvent( elem, type, data.handle );
+                        }
+                    }
+                }
 
-					// Support: Chrome <=35 - 45+
-					// Assign undefined instead of using delete, see Data#remove
-					elem[ dataPriv.expando ] = undefined;
-				}
-				if ( elem[ dataUser.expando ] ) {
+                // Support: Chrome <=35 - 45+
+                // Assign undefined instead of using delete, see Data#remove
+                elem[ dataPriv.expando ] = undefined;
+            }
+            if ( elem[ dataUser.expando ] ) {
 
-					// Support: Chrome <=35 - 45+
-					// Assign undefined instead of using delete, see Data#remove
-					elem[ dataUser.expando ] = undefined;
-				}
-			}
-		}
-	}
+                // Support: Chrome <=35 - 45+
+                // Assign undefined instead of using delete, see Data#remove
+                elem[ dataUser.expando ] = undefined;
+            }
+
+            // Remove the element from the array while preserving the index positions
+            elems.splice(i, 1);
+        } else {
+            i++;
+        }
+    }
+}
 } );
 
 jQuery.fn.extend( {

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -134,46 +134,49 @@ jQuery.extend( {
 	},
 
 	cleanData: function( elems ) {
-    var data, elem, type,
-        special = jQuery.event.special,
-        i = 0;
-    
-     elems = jQuery.makeArray(elems);
-    while ( i < elems.length ) {
-        elem = elems[ i ];
+	    var data, elem, type,
+	        special = jQuery.event.special,
+	        i = 0;
 
-        if ( acceptData( elem ) ) {
-            if ( ( data = elem[ dataPriv.expando ] ) ) {
-                if ( data.events ) {
-                    for ( type in data.events ) {
-                        if ( special[ type ] ) {
-                            jQuery.event.remove( elem, type );
+	    // Convert elems to a native array if it is not already
+	    elems = jQuery.makeArray(elems);
 
-                        // This is a shortcut to avoid jQuery.event.remove's overhead
-                        } else {
-                            jQuery.removeEvent( elem, type, data.handle );
-                        }
-                    }
-                }
+	    while ( i < elems.length ) {
+	        elem = elems[ i ];
 
-                // Support: Chrome <=35 - 45+
-                // Assign undefined instead of using delete, see Data#remove
-                elem[ dataPriv.expando ] = undefined;
-            }
-            if ( elem[ dataUser.expando ] ) {
+	        if ( acceptData( elem ) ) {
+	            if ( ( data = elem[ dataPriv.expando ] ) ) {
+	                if ( data.events ) {
+	                    for ( type in data.events ) {
+	                        if ( special[ type ] ) {
+	                            jQuery.event.remove( elem, type );
 
-                // Support: Chrome <=35 - 45+
-                // Assign undefined instead of using delete, see Data#remove
-                elem[ dataUser.expando ] = undefined;
-            }
+	                        // This is a shortcut to avoid jQuery.event.remove's overhead
+	                        } else {
+	                            jQuery.removeEvent( elem, type, data.handle );
+	                        }
+	                    }
+	                }
 
-            // Remove the element from the array while preserving the index positions
-            elems.splice(i, 1);
-        } else {
-            i++;
-        }
-    }
-}
+	                // Support: Chrome <=35 - 45+
+	                // Assign undefined instead of using delete, see Data#remove
+	                elem[ dataPriv.expando ] = undefined;
+	            }
+	            if ( elem[ dataUser.expando ] ) {
+
+	                // Support: Chrome <=35 - 45+
+	                // Assign undefined instead of using delete, see Data#remove
+	                elem[ dataUser.expando ] = undefined;
+	            }
+
+	            // Remove the element from the array while preserving the index positions
+	            elems.splice(i, 1);
+	        } else {
+	            i++;
+	        }
+	    }
+	}
+
 } );
 
 jQuery.fn.extend( {

--- a/src/manipulation/getAll.js
+++ b/src/manipulation/getAll.js
@@ -9,6 +9,7 @@ export function getAll( context, tag ) {
 	var ret;
 
 	if ( typeof context.getElementsByTagName !== "undefined" ) {
+		// Use slice to snapshot the live collection from gEBTN
 		ret = arr.slice.call( context.getElementsByTagName( tag || "*" ) );
 
 	} else if ( typeof context.querySelectorAll !== "undefined" ) {

--- a/src/manipulation/getAll.js
+++ b/src/manipulation/getAll.js
@@ -1,5 +1,6 @@
 import { jQuery } from "../core.js";
 import { nodeName } from "../core/nodeName.js";
+import { arr } from "../var/arr.js";
 
 export function getAll( context, tag ) {
 
@@ -7,7 +8,10 @@ export function getAll( context, tag ) {
 	// Use typeof to avoid zero-argument method invocation on host objects (trac-15151)
 	var ret;
 
-	if ( typeof context.querySelectorAll !== "undefined" ) {
+	if ( typeof context.getElementsByTagName !== "undefined" ) {
+		ret = arr.slice.call( context.getElementsByTagName( tag || "*" ) );
+
+	} else if ( typeof context.querySelectorAll !== "undefined" ) {
 		ret = context.querySelectorAll( tag || "*" );
 
 	} else {

--- a/src/manipulation/getAll.js
+++ b/src/manipulation/getAll.js
@@ -9,6 +9,7 @@ export function getAll( context, tag ) {
 	var ret;
 
 	if ( typeof context.getElementsByTagName !== "undefined" ) {
+
 		// Use slice to snapshot the live collection from gEBTN
 		ret = arr.slice.call( context.getElementsByTagName( tag || "*" ) );
 

--- a/src/manipulation/getAll.js
+++ b/src/manipulation/getAll.js
@@ -7,10 +7,7 @@ export function getAll( context, tag ) {
 	// Use typeof to avoid zero-argument method invocation on host objects (trac-15151)
 	var ret;
 
-	if ( typeof context.getElementsByTagName !== "undefined" ) {
-		ret = context.getElementsByTagName( tag || "*" );
-
-	} else if ( typeof context.querySelectorAll !== "undefined" ) {
+	if ( typeof context.querySelectorAll !== "undefined" ) {
 		ret = context.querySelectorAll( tag || "*" );
 
 	} else {

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -3104,23 +3104,23 @@ QUnit.test( "should handle custom 'removeondestroy' event correctly", function( 
 
 	assert.expect( 4 );
 
-	jQuery( `
-	<div id="container">
-		<div class="guarded removeself" data-elt="one">
-			Guarded 1
-		</div>
-		<div class="guarded" data-elt="two">
-			Guarded 2
-		</div>
-		<div class="guarded" data-elt="three">
-			Guarded 3
-		</div>
-	</div>
-	` ).appendTo( "#qunit-fixture" );
+	jQuery(
+		"<div id='container'>" +
+			"<div class='guarded removeself' data-elt='one'>" +
+				"Guarded 1" +
+			"</div>" +
+			"<div class='guarded' data-elt='two'>" +
+				"Guarded 2" +
+			"</div>" +
+			"<div class='guarded' data-elt='three'>" +
+				"Guarded 3" +
+			"</div>" +
+		"</div>"
+	).appendTo( "#qunit-fixture" );
 
 	// Define the custom event handler
 	jQuery.event.special.removeondestroy = {
-	remove: function( _handleObj ) {
+	remove: function( ) {
 		var $t = jQuery( this );
 		assert.step( $t.data( "elt" ) );
 		if ( $t.is( ".removeself" ) ) {

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -3106,15 +3106,15 @@ QUnit.test( "should handle node removal in event's remove hook (gh-5214)", funct
 
 	jQuery(
 		"<div id='container'>" +
-			"<div class='guarded removeself' data-elt='one'>" +
-				"Guarded 1" +
-			"</div>" +
-			"<div class='guarded' data-elt='two'>" +
-				"Guarded 2" +
-			"</div>" +
-			"<div class='guarded' data-elt='three'>" +
-				"Guarded 3" +
-			"</div>" +
+		"	<div class='guarded removeself' data-elt='one'>" +
+		"		Guarded 1" +
+		"	</div>" +
+		"	<div class='guarded' data-elt='two'>" +
+		"		Guarded 2" +
+		"	</div>" +
+		"	<div class='guarded' data-elt='three'>" +
+		"		Guarded 3" +
+		"	</div>" +
 		"</div>"
 	).appendTo( "#qunit-fixture" );
 

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -3099,3 +3099,66 @@ testIframe(
 		} );
 	}
 );
+
+
+// new test cases
+
+function nodeName( elem, name ) {
+	return elem.nodeName && elem.nodeName.toLowerCase() === name.toLowerCase();
+}
+
+function getAll( context, tag ) {
+
+	// Support: IE <=9 - 11+
+	// Use typeof to avoid zero-argument method invocation on host objects (trac-15151)
+	var ret;
+
+	if ( typeof context.querySelectorAll !== "undefined" ) {
+		ret = context.querySelectorAll( tag || "*" );
+
+	} else {
+		ret = [];
+	}
+
+	if ( tag === undefined || tag && nodeName( context, tag ) ) {
+		return jQuery.merge( [ context ], ret );
+	}
+
+	return ret;
+}
+
+QUnit.test( "should retrieve all elements with a specific tag", function( assert ) {
+    assert.expect( 1 );
+    var context = document.createElement( "div" );
+    context.innerHTML = "<span></span><span></span>";
+
+    var result = getAll( context, "span" );
+    assert.equal( result.length, 2, "Found two span elements" );
+} );
+
+QUnit.test( "should retrieve all elements if no tag is specified", function( assert ) {
+    assert.expect( 1 );
+    var context = document.createElement( "div" );
+    context.innerHTML = "<span></span><span></span>";
+
+    var result = getAll( context );
+    assert.equal( result.length, 3, "Found three elements including the context itself" );
+} );
+
+QUnit.test( "should retrieve elements including the context if it matches the tag", function( assert ) {
+    assert.expect( 1 );
+    var context = document.createElement( "div" );
+    context.innerHTML = "<div></div><span></span>";
+
+    var result = getAll( context, "div" );
+    assert.equal( result.length, 2, "Found two div elements including the context itself" );
+} );
+
+QUnit.test( "should return an empty array if no matching elements are found", function( assert ) {
+    assert.expect( 1 );
+    var context = document.createElement( "div" );
+    context.innerHTML = "<span></span><span></span>";
+
+    var result = getAll( context, "p" );
+    assert.equal( result.length, 0, "Found no p elements" );
+} );

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -3100,34 +3100,26 @@ testIframe(
 	}
 );
 
-// Custom event handler test case
-
-QUnit.test( "should handle custom '_se-custom-destroy' event correctly", function( assert ) {
-
-	// Define the expected number of assertions
+QUnit.test( "should handle custom 'removeondestroy' event correctly", function( assert ) {
 
 	assert.expect( 4 );
 
-	// Set up the HTML structure by appending to the existing fixture
-
-	var fixture = jQuery( "#qunit-fixture" );
-
-	fixture.append( `
+	jQuery( `
 	<div id="container">
-	  <div class="guarded removeself" data-elt="one">
-	    Guarded 1
-	  </div>
-	  <div class="guarded" data-elt="two">
-	    Guarded 2
-	  </div>
-	  <div class="guarded" data-elt="three">
-	    Guarded 3
-	  </div>
+		<div class="guarded removeself" data-elt="one">
+			Guarded 1
+		</div>
+		<div class="guarded" data-elt="two">
+			Guarded 2
+		</div>
+		<div class="guarded" data-elt="three">
+			Guarded 3
+		</div>
 	</div>
-	` );
+	` ).appendTo( "#qunit-fixture" );
 
 	// Define the custom event handler
-	jQuery.event.special[ "_se-custom-destroy" ] = {
+	jQuery.event.special.removeondestroy = {
 	remove: function( _handleObj ) {
 		var $t = jQuery( this );
 		assert.step( $t.data( "elt" ) );
@@ -3139,15 +3131,11 @@ QUnit.test( "should handle custom '_se-custom-destroy' event correctly", functio
 
 	// Attach an empty handler to trigger the `remove`
 	// logic for the custom event when the element is removed.
+	jQuery( ".guarded" ).on( "removeondestroy", function( ) { } );
 
-	jQuery( ".guarded" ).on( "_se-custom-destroy", function( ) { } );
-
-	// Trigger the event by emptying the container
-
+	// Trigger the event's removal logic by emptying the container
 	jQuery( "#container" ).empty();
 
-	// Verify the steps to ensure the expected elements were processed
-
-	assert.verifySteps( [ "one", "two", "three" ], "Steps should match the data-elt attributes" );
+	assert.verifySteps( [ "one", "two", "three" ], "All elements were processed in order" );
 } );
 

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -3104,66 +3104,50 @@ testIframe(
 
 QUnit.test( "should handle custom '_se-custom-destroy' event correctly", function( assert ) {
 
-	// Set up the HTML structure using innerHTML within #qunit-fixture
+	// Define the expected number of assertions
 
-	assert.expect( 2 );
+	assert.expect( 4 );
+
+	// Set up the HTML structure by appending to the existing fixture
 
 	var fixture = jQuery( "#qunit-fixture" );
 
-	fixture.html( `
-    <div id="container">
-      <div class="guarded removeself" data-elt="one">
-        Guarded 1
-      </div>
-      <div class="guarded" data-elt="two">
-        Guarded 2
-      </div>
-      <div class="guarded" data-elt="three">
-        Guarded 3
-      </div>
-    </div>
-  ` );
+	fixture.append( `
+	<div id="container">
+	  <div class="guarded removeself" data-elt="one">
+	    Guarded 1
+	  </div>
+	  <div class="guarded" data-elt="two">
+	    Guarded 2
+	  </div>
+	  <div class="guarded" data-elt="three">
+	    Guarded 3
+	  </div>
+	</div>
+	` );
 
-	// JavaScript code to be tested
-
-  jQuery.event.special[ "_se-custom-destroy" ] = {
-    remove: function( _handleObj ) {
+	// Define the custom event handler
+	jQuery.event.special[ "_se-custom-destroy" ] = {
+	remove: function( _handleObj ) {
 		var $t = jQuery( this );
-		console.log( $t.data( "elt" ) );
+		assert.step( $t.data( "elt" ) );
 		if ( $t.is( ".removeself" ) ) {
 			$t.remove();
-			}
 		}
+	}
 	};
 
-	// Attach the custom event handler
+	// Attach an empty handler to trigger the `remove`
+	// logic for the custom event when the element is removed.
 
 	jQuery( ".guarded" ).on( "_se-custom-destroy", function( ) { } );
 
-	// Spy on console.log
-
-	var consoleLog = console.log;
-
-	var logMessages = [];
-
-	console.log = function( message ) {
-	logMessages.push( message );
-	};
-
 	// Trigger the event by emptying the container
 
-	jQuery( "#container" ).empty( );
+	jQuery( "#container" ).empty();
 
-	// Verify that the elements with class 'removeself' were removed
+	// Verify the steps to ensure the expected elements were processed
 
-	assert.equal( jQuery( ".removeself" ).length, 0, "Elements with class 'removeself' should be removed" );
-
-	// Verify console logs
-
-	assert.deepEqual( logMessages, [ "one", "two", "three" ], "Console logs should match the data-elt attributes" );
-
-	// Restore console.log
-
-	console.log = consoleLog;
-
+	assert.verifySteps( [ "one", "two", "three" ], "Steps should match the data-elt attributes" );
 } );
+

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -3100,7 +3100,7 @@ testIframe(
 	}
 );
 
-QUnit.test( "should handle custom 'removeondestroy' event correctly", function( assert ) {
+QUnit.test( "should handle node removal in event's remove hook (gh-5214)", function( assert ) {
 
 	assert.expect( 4 );
 
@@ -3120,13 +3120,13 @@ QUnit.test( "should handle custom 'removeondestroy' event correctly", function( 
 
 	// Define the custom event handler
 	jQuery.event.special.removeondestroy = {
-	remove: function( ) {
-		var $t = jQuery( this );
-		assert.step( $t.data( "elt" ) );
-		if ( $t.is( ".removeself" ) ) {
-			$t.remove();
+		remove: function( ) {
+			var $t = jQuery( this );
+			assert.step( $t.data( "elt" ) );
+			if ( $t.is( ".removeself" ) ) {
+				$t.remove();
+			}
 		}
-	}
 	};
 
 	// Attach an empty handler to trigger the `remove`


### PR DESCRIPTION
This pull request addresses [#5214](https://github.com/jquery/jquery/issues/5214) issue in jQuery.cleanData where certain elements were being skipped during the cleanup process. The problem occurred when an element removed itself from the DOM during its own cleanup, causing subsequent elements in the list to be missed.
