### PR TITLE
Tests: replace dead links in qunit fixture

### DIFF
--- a/test/data/qunit-fixture.html
+++ b/test/data/qunit-fixture.html
@@ -1,15 +1,15 @@
-<p id="firstp">See <a id="simon1" href="https://simon.incutio.com/archive/2003/03/25/#getElementsBySelector" rel="bookmark">this blog entry</a> for more information.</p>
+<p id="firstp">See <a id="john1" href="https://johnresig.com/blog/10th-anniversary-of-jquery/#body" rel="bookmark">this blog entry</a> for more information.</p>
 <p id="ap">
 	Here are some [links] in a normal paragraph: <a id="google" href="https://www.google.com/" title="Google!">Google</a>,
 	<a id="groups" href="https://groups.google.com/" class="GROUPS">Google Groups (Link)</a>.
-	This link has <code id="code1"><a href="https://smin" id="anchor1">class="blog"</a></code>:
-	<a href="https://diveintomark.org/" class="blog" hreflang="en" id="mark">diveintomark</a>
+	This link has <code id="code1"><a href="https://blog" id="anchor1">class="blog"</a></code>:
+	<a href="https://mozilla.org/" class="blog" hreflang="en" id="mozilla">mozilla</a>
 
 </p>
 <div id="foo">
 	<p id="sndp">Everything inside the red border is inside a div with <code>id="foo"</code>.</p>
 	<p lang="en" id="en">This is a normal link: <a id="yahoo" href="https://www.yahoo.com/" class="blogTest">Yahoo</a></p>
-	<p id="sap">This link has <code><a href="#2" id="anchor2">class="blog"</a></code>: <a href="https://simon.incutio.com/" class="blog link" id="simon">Simon Willison's Weblog</a></p>
+	<p id="sap">This link has <code><a href="#2" id="anchor2">class="blog"</a></code>: <a href="https://timmywil.com/" class="blog link" id="timmy">Timmy Willison's Weblog</a></p>
 
 </div>
 <div id="nothiddendiv" style="height:1px;background:white;" class="nothiddendiv">

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -63,11 +63,11 @@ QUnit.test( "attr(String)", function( assert ) {
 	assert.equal( jQuery( "#text1" ).attr( "type" ), "text", "Check for type attribute" );
 	assert.equal( jQuery( "#radio1" ).attr( "type" ), "radio", "Check for type attribute" );
 	assert.equal( jQuery( "#check1" ).attr( "type" ), "checkbox", "Check for type attribute" );
-	assert.equal( jQuery( "#simon1" ).attr( "rel" ), "bookmark", "Check for rel attribute" );
+	assert.equal( jQuery( "#john1" ).attr( "rel" ), "bookmark", "Check for rel attribute" );
 	assert.equal( jQuery( "#google" ).attr( "title" ), "Google!", "Check for title attribute" );
-	assert.equal( jQuery( "#mark" ).attr( "hreflang" ), "en", "Check for hreflang attribute" );
+	assert.equal( jQuery( "#mozilla" ).attr( "hreflang" ), "en", "Check for hreflang attribute" );
 	assert.equal( jQuery( "#en" ).attr( "lang" ), "en", "Check for lang attribute" );
-	assert.equal( jQuery( "#simon" ).attr( "class" ), "blog link", "Check for class attribute" );
+	assert.equal( jQuery( "#timmy" ).attr( "class" ), "blog link", "Check for class attribute" );
 	assert.equal( jQuery( "#name" ).attr( "name" ), "name", "Check for name attribute" );
 	assert.equal( jQuery( "#text1" ).attr( "name" ), "action", "Check for name attribute" );
 	assert.ok( jQuery( "#form" ).attr( "action" ).indexOf( "formaction" ) >= 0, "Check for action attribute" );

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -589,14 +589,14 @@ QUnit.test( "inArray()", function( assert ) {
 		p: q( "firstp", "sap", "ap", "first" ),
 		em: q( "siblingnext", "siblingfirst" ),
 		div: q( "qunit-testrunner-toolbar", "nothiddendiv", "nothiddendivchild", "foo" ),
-		a: q( "mark", "groups", "google", "simon1" ),
+		a: q( "mozilla", "groups", "google", "john1" ),
 		empty: []
 	},
 	tests = {
 		p: { elem: jQuery( "#ap" )[ 0 ], index: 2 },
 		em: { elem: jQuery( "#siblingfirst" )[ 0 ], index: 1 },
 		div: { elem: jQuery( "#nothiddendiv" )[ 0 ], index: 1 },
-		a: { elem: jQuery( "#simon1" )[ 0 ], index: 3 }
+		a: { elem: jQuery( "#john1" )[ 0 ], index: 3 }
 	},
 	falseTests = {
 		p: jQuery( "#liveSpan1" )[ 0 ],
@@ -654,13 +654,13 @@ QUnit.test( "slice()", function( assert ) {
 	var $links = jQuery( "#ap a" );
 
 	assert.deepEqual( $links.slice( 1, 2 ).get(), q( "groups" ), "slice(1,2)" );
-	assert.deepEqual( $links.slice( 1 ).get(), q( "groups", "anchor1", "mark" ), "slice(1)" );
+	assert.deepEqual( $links.slice( 1 ).get(), q( "groups", "anchor1", "mozilla" ), "slice(1)" );
 	assert.deepEqual( $links.slice( 0, 3 ).get(), q( "google", "groups", "anchor1" ), "slice(0,3)" );
-	assert.deepEqual( $links.slice( -1 ).get(), q( "mark" ), "slice(-1)" );
+	assert.deepEqual( $links.slice( -1 ).get(), q( "mozilla" ), "slice(-1)" );
 
 	assert.deepEqual( $links.eq( 1 ).get(), q( "groups" ), "eq(1)" );
 	assert.deepEqual( $links.eq( "2" ).get(), q( "anchor1" ), "eq('2')" );
-	assert.deepEqual( $links.eq( -1 ).get(), q( "mark" ), "eq(-1)" );
+	assert.deepEqual( $links.eq( -1 ).get(), q( "mozilla" ), "eq(-1)" );
 } );
 
 QUnit.test( "first()/last()", function( assert ) {
@@ -669,7 +669,7 @@ QUnit.test( "first()/last()", function( assert ) {
 	var $links = jQuery( "#ap a" ), $none = jQuery( "asdf" );
 
 	assert.deepEqual( $links.first().get(), q( "google" ), "first()" );
-	assert.deepEqual( $links.last().get(), q( "mark" ), "last()" );
+	assert.deepEqual( $links.last().get(), q( "mozilla" ), "last()" );
 
 	assert.deepEqual( $none.first().get(), [], "first() none" );
 	assert.deepEqual( $none.last().get(), [], "last() none" );
@@ -681,7 +681,7 @@ QUnit.test( "even()/odd()", function( assert ) {
 	var $links = jQuery( "#ap a" ), $none = jQuery( "asdf" );
 
 	assert.deepEqual( $links.even().get(), q( "google", "anchor1" ), "even()" );
-	assert.deepEqual( $links.odd().get(), q( "groups", "mark" ), "odd()" );
+	assert.deepEqual( $links.odd().get(), q( "groups", "mozilla" ), "odd()" );
 
 	assert.deepEqual( $none.even().get(), [], "even() none" );
 	assert.deepEqual( $none.odd().get(), [], "odd() none" );
@@ -694,7 +694,7 @@ QUnit.test( "map()", function( assert ) {
 		jQuery( "#ap" ).map( function() {
 			return jQuery( this ).find( "a" ).get();
 		} ).get(),
-		q( "google", "groups", "anchor1", "mark" ),
+		q( "google", "groups", "anchor1", "mozilla" ),
 		"Array Map"
 	);
 

--- a/test/unit/deprecated.js
+++ b/test/unit/deprecated.js
@@ -93,10 +93,10 @@ QUnit.test( "trigger() shortcuts", function( assert ) {
 	assert.equal( counter, 1, "Check that click, triggers onclick event handler also" );
 
 	clickCounter = 0;
-	jQuery( "#simon1" )[ 0 ].onclick = function() {
+	jQuery( "#john1" )[ 0 ].onclick = function() {
 		clickCounter++;
 	};
-	jQuery( "#simon1" ).click();
+	jQuery( "#john1" ).click();
 	assert.equal( clickCounter, 1, "Check that click, triggers onclick event handler on an a tag also" );
 } );
 

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -1708,7 +1708,7 @@ QUnit.test( "hide, fadeOut and slideUp called on element width height and width 
 QUnit.test( "hide should not leave hidden inline elements visible (trac-14848)", function( assert ) {
 	assert.expect( 2 );
 
-	var el = jQuery( "#simon1" );
+	var el = jQuery( "#john1" );
 
 	el.hide( 1, function() {
 		assert.equal( el.css( "display" ), "none", "hidden" );

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -34,8 +34,8 @@ QUnit.test( "text()", function( assert ) {
 
 	var expected, frag, $newLineTest, doc;
 
-	expected = "This link has class=\"blog\": Simon Willison's Weblog";
-	assert.equal( jQuery( "#sap" ).text(), expected, "Check for merged text of more then one element." );
+	expected = "This link has class=\"blog\": Timmy Willison's Weblog";
+	assert.equal( jQuery( "#sap" ).text(), expected, "Check for merged text of more than one element." );
 
 	// Check serialization of text values
 	assert.equal( jQuery( document.createTextNode( "foo" ) ).text(), "foo", "Text node was retrieved from .text()." );
@@ -110,7 +110,7 @@ QUnit.test( "text(Function) with incoming value", function( assert ) {
 
 	assert.expect( 2 );
 
-	var old = "This link has class=\"blog\": Simon Willison's Weblog";
+	var old = "This link has class=\"blog\": Timmy Willison's Weblog";
 
 	jQuery( "#sap" ).text( function( i, val ) {
 		assert.equal( val, old, "Make sure the incoming value is correct." );
@@ -123,7 +123,7 @@ QUnit.test( "text(Function) with incoming value", function( assert ) {
 function testAppendForObject( valueObj, isFragment, assert ) {
 	var $base,
 		type = isFragment ? " (DocumentFragment)" : " (Element)",
-		text = "This link has class=\"blog\": Simon Willison's Weblog",
+		text = "This link has class=\"blog\": Timmy Willison's Weblog",
 		el = document.getElementById( "sap" ).cloneNode( true ),
 		first = document.getElementById( "first" ),
 		yahoo = document.getElementById( "yahoo" );
@@ -357,7 +357,7 @@ QUnit.test( "append(Function) returns String", function( assert ) {
 QUnit.test( "append(Function) returns Element", function( assert ) {
 
 	assert.expect( 2 );
-	var expected = "This link has class=\"blog\": Simon Willison's WeblogTry them out:",
+	var expected = "This link has class=\"blog\": Timmy Willison's WeblogTry them out:",
 		old = jQuery( "#sap" ).html();
 
 	jQuery( "#sap" ).append( function( i, val ) {
@@ -370,7 +370,7 @@ QUnit.test( "append(Function) returns Element", function( assert ) {
 QUnit.test( "append(Function) returns Array<Element>", function( assert ) {
 
 	assert.expect( 2 );
-	var expected = "This link has class=\"blog\": Simon Willison's WeblogTry them out:Yahoo",
+	var expected = "This link has class=\"blog\": Timmy Willison's WeblogTry them out:Yahoo",
 		old = jQuery( "#sap" ).html();
 
 	jQuery( "#sap" ).append( function( i, val ) {
@@ -383,7 +383,7 @@ QUnit.test( "append(Function) returns Array<Element>", function( assert ) {
 QUnit.test( "append(Function) returns jQuery", function( assert ) {
 
 	assert.expect( 2 );
-	var expected = "This link has class=\"blog\": Simon Willison's WeblogYahooTry them out:",
+	var expected = "This link has class=\"blog\": Timmy Willison's WeblogYahooTry them out:",
 		old = jQuery( "#sap" ).html();
 
 	jQuery( "#sap" ).append( function( i, val ) {
@@ -616,11 +616,11 @@ QUnit.test( "appendTo(Element|Array<Element>)", function( assert ) {
 
 	assert.expect( 2 );
 
-	var expected = "This link has class=\"blog\": Simon Willison's WeblogTry them out:";
+	var expected = "This link has class=\"blog\": Timmy Willison's WeblogTry them out:";
 	jQuery( document.getElementById( "first" ) ).appendTo( "#sap" );
 	assert.equal( jQuery( "#sap" ).text(), expected, "Check for appending of element" );
 
-	expected = "This link has class=\"blog\": Simon Willison's WeblogTry them out:Yahoo";
+	expected = "This link has class=\"blog\": Timmy Willison's WeblogTry them out:Yahoo";
 	jQuery( [ document.getElementById( "first" ), document.getElementById( "yahoo" ) ] ).appendTo( "#sap" );
 	assert.equal( jQuery( "#sap" ).text(), expected, "Check for appending of array of elements" );
 
@@ -633,7 +633,7 @@ QUnit.test( "appendTo(jQuery)", function( assert ) {
 	var expected, num, div;
 	assert.ok( jQuery( document.createElement( "script" ) ).appendTo( "body" ).length, "Make sure a disconnected script can be appended." );
 
-	expected = "This link has class=\"blog\": Simon Willison's WeblogYahooTry them out:";
+	expected = "This link has class=\"blog\": Timmy Willison's WeblogYahooTry them out:";
 	jQuery( "#yahoo, #first" ).appendTo( "#sap" );
 	assert.equal( jQuery( "#sap" ).text(), expected, "Check for appending of jQuery object" );
 
@@ -686,7 +686,7 @@ QUnit.test( "prepend(Element)", function( assert ) {
 	assert.expect( 1 );
 
 	var expected;
-	expected = "Try them out:This link has class=\"blog\": Simon Willison's Weblog";
+	expected = "Try them out:This link has class=\"blog\": Timmy Willison's Weblog";
 	jQuery( "#sap" ).prepend( document.getElementById( "first" ) );
 	assert.equal( jQuery( "#sap" ).text(), expected, "Check for prepending of element" );
 } );
@@ -696,7 +696,7 @@ QUnit.test( "prepend(Array<Element>)", function( assert ) {
 	assert.expect( 1 );
 
 	var expected;
-	expected = "Try them out:YahooThis link has class=\"blog\": Simon Willison's Weblog";
+	expected = "Try them out:YahooThis link has class=\"blog\": Timmy Willison's Weblog";
 	jQuery( "#sap" ).prepend( [ document.getElementById( "first" ), document.getElementById( "yahoo" ) ] );
 	assert.equal( jQuery( "#sap" ).text(), expected, "Check for prepending of array of elements" );
 } );
@@ -706,7 +706,7 @@ QUnit.test( "prepend(jQuery)", function( assert ) {
 	assert.expect( 1 );
 
 	var expected;
-	expected = "YahooTry them out:This link has class=\"blog\": Simon Willison's Weblog";
+	expected = "YahooTry them out:This link has class=\"blog\": Timmy Willison's Weblog";
 	jQuery( "#sap" ).prepend( jQuery( "#yahoo, #first" ) );
 	assert.equal( jQuery( "#sap" ).text(), expected, "Check for prepending of jQuery object" );
 } );
@@ -716,7 +716,7 @@ QUnit.test( "prepend(Array<jQuery>)", function( assert ) {
 	assert.expect( 1 );
 
 	var expected;
-	expected = "Try them out:GoogleYahooThis link has class=\"blog\": Simon Willison's Weblog";
+	expected = "Try them out:GoogleYahooThis link has class=\"blog\": Timmy Willison's Weblog";
 	jQuery( "#sap" ).prepend( [ jQuery( "#first" ), jQuery( "#yahoo, #google" ) ] );
 	assert.equal( jQuery( "#sap" ).text(), expected, "Check for prepending of array of jQuery objects" );
 } );
@@ -749,7 +749,7 @@ QUnit.test( "prepend(Function) with incoming value -- Element", function( assert
 	assert.expect( 2 );
 
 	var old, expected;
-	expected = "Try them out:This link has class=\"blog\": Simon Willison's Weblog";
+	expected = "Try them out:This link has class=\"blog\": Timmy Willison's Weblog";
 	old = jQuery( "#sap" ).html();
 
 	jQuery( "#sap" ).prepend( function( i, val ) {
@@ -765,7 +765,7 @@ QUnit.test( "prepend(Function) with incoming value -- Array<Element>", function(
 	assert.expect( 2 );
 
 	var old, expected;
-	expected = "Try them out:YahooThis link has class=\"blog\": Simon Willison's Weblog";
+	expected = "Try them out:YahooThis link has class=\"blog\": Timmy Willison's Weblog";
 	old = jQuery( "#sap" ).html();
 
 	jQuery( "#sap" ).prepend( function( i, val ) {
@@ -781,7 +781,7 @@ QUnit.test( "prepend(Function) with incoming value -- jQuery", function( assert 
 	assert.expect( 2 );
 
 	var old, expected;
-	expected = "YahooTry them out:This link has class=\"blog\": Simon Willison's Weblog";
+	expected = "YahooTry them out:This link has class=\"blog\": Timmy Willison's Weblog";
 	old = jQuery( "#sap" ).html();
 
 	jQuery( "#sap" ).prepend( function( i, val ) {
@@ -811,7 +811,7 @@ QUnit.test( "prependTo(Element)", function( assert ) {
 
 	var expected;
 
-	expected = "Try them out:This link has class=\"blog\": Simon Willison's Weblog";
+	expected = "Try them out:This link has class=\"blog\": Timmy Willison's Weblog";
 	jQuery( document.getElementById( "first" ) ).prependTo( "#sap" );
 	assert.equal( jQuery( "#sap" ).text(), expected, "Check for prepending of element" );
 } );
@@ -822,7 +822,7 @@ QUnit.test( "prependTo(Array<Element>)", function( assert ) {
 
 	var expected;
 
-	expected = "Try them out:YahooThis link has class=\"blog\": Simon Willison's Weblog";
+	expected = "Try them out:YahooThis link has class=\"blog\": Timmy Willison's Weblog";
 	jQuery( [ document.getElementById( "first" ), document.getElementById( "yahoo" ) ] ).prependTo( "#sap" );
 	assert.equal( jQuery( "#sap" ).text(), expected, "Check for prepending of array of elements" );
 } );
@@ -833,7 +833,7 @@ QUnit.test( "prependTo(jQuery)", function( assert ) {
 
 	var expected;
 
-	expected = "YahooTry them out:This link has class=\"blog\": Simon Willison's Weblog";
+	expected = "YahooTry them out:This link has class=\"blog\": Timmy Willison's Weblog";
 	jQuery( "#yahoo, #first" ).prependTo( "#sap" );
 	assert.equal( jQuery( "#sap" ).text(), expected, "Check for prepending of jQuery object" );
 } );
@@ -875,8 +875,8 @@ QUnit.test( "before(Array<Element>)", function( assert ) {
 	assert.expect( 1 );
 
 	var expected;
-	expected = "This is a normal link: Try them out:diveintomarkYahoo";
-	jQuery( "#yahoo" ).before( manipulationBareObj( [ document.getElementById( "first" ), document.getElementById( "mark" ) ] ) );
+	expected = "This is a normal link: Try them out:mozillaYahoo";
+	jQuery( "#yahoo" ).before( manipulationBareObj( [ document.getElementById( "first" ), document.getElementById( "mozilla" ) ] ) );
 	assert.equal( jQuery( "#en" ).text(), expected, "Insert array of elements before" );
 } );
 
@@ -885,8 +885,8 @@ QUnit.test( "before(jQuery)", function( assert ) {
 	assert.expect( 1 );
 
 	var expected;
-	expected = "This is a normal link: diveintomarkTry them out:Yahoo";
-	jQuery( "#yahoo" ).before( manipulationBareObj( jQuery( "#mark, #first" ) ) );
+	expected = "This is a normal link: mozillaTry them out:Yahoo";
+	jQuery( "#yahoo" ).before( manipulationBareObj( jQuery( "#mozilla, #first" ) ) );
 	assert.equal( jQuery( "#en" ).text(), expected, "Insert jQuery before" );
 } );
 
@@ -895,8 +895,8 @@ QUnit.test( "before(Array<jQuery>)", function( assert ) {
 	assert.expect( 1 );
 
 	var expected;
-	expected = "This is a normal link: Try them out:GooglediveintomarkYahoo";
-	jQuery( "#yahoo" ).before( manipulationBareObj( [ jQuery( "#first" ), jQuery( "#mark, #google" ) ] ) );
+	expected = "This is a normal link: Try them out:GooglemozillaYahoo";
+	jQuery( "#yahoo" ).before( manipulationBareObj( [ jQuery( "#first" ), jQuery( "#mozilla, #google" ) ] ) );
 	assert.equal( jQuery( "#en" ).text(), expected, "Insert array of jQuery objects before" );
 } );
 
@@ -927,8 +927,8 @@ QUnit.test( "before(Function) -- Returns Array<Element>", function( assert ) {
 	assert.expect( 1 );
 
 	var expected;
-	expected = "This is a normal link: Try them out:diveintomarkYahoo";
-	jQuery( "#yahoo" ).before( manipulationFunctionReturningObj( [ document.getElementById( "first" ), document.getElementById( "mark" ) ] ) );
+	expected = "This is a normal link: Try them out:mozillaYahoo";
+	jQuery( "#yahoo" ).before( manipulationFunctionReturningObj( [ document.getElementById( "first" ), document.getElementById( "mozilla" ) ] ) );
 	assert.equal( jQuery( "#en" ).text(), expected, "Insert array of elements before" );
 } );
 
@@ -937,8 +937,8 @@ QUnit.test( "before(Function) -- Returns jQuery", function( assert ) {
 	assert.expect( 1 );
 
 	var expected;
-	expected = "This is a normal link: diveintomarkTry them out:Yahoo";
-	jQuery( "#yahoo" ).before( manipulationFunctionReturningObj( jQuery( "#mark, #first" ) ) );
+	expected = "This is a normal link: mozillaTry them out:Yahoo";
+	jQuery( "#yahoo" ).before( manipulationFunctionReturningObj( jQuery( "#mozilla, #first" ) ) );
 	assert.equal( jQuery( "#en" ).text(), expected, "Insert jQuery before" );
 } );
 
@@ -947,8 +947,8 @@ QUnit.test( "before(Function) -- Returns Array<jQuery>", function( assert ) {
 	assert.expect( 1 );
 
 	var expected;
-	expected = "This is a normal link: Try them out:GooglediveintomarkYahoo";
-	jQuery( "#yahoo" ).before( manipulationFunctionReturningObj( [ jQuery( "#first" ), jQuery( "#mark, #google" ) ] ) );
+	expected = "This is a normal link: Try them out:GooglemozillaYahoo";
+	jQuery( "#yahoo" ).before( manipulationFunctionReturningObj( [ jQuery( "#first" ), jQuery( "#mozilla, #google" ) ] ) );
 	assert.equal( jQuery( "#en" ).text(), expected, "Insert array of jQuery objects before" );
 } );
 
@@ -1042,8 +1042,8 @@ QUnit.test( "insertBefore(Array<Element>)", function( assert ) {
 
 	assert.expect( 1 );
 
-	var expected = "This is a normal link: Try them out:diveintomarkYahoo";
-	jQuery( [ document.getElementById( "first" ), document.getElementById( "mark" ) ] ).insertBefore( "#yahoo" );
+	var expected = "This is a normal link: Try them out:mozillaYahoo";
+	jQuery( [ document.getElementById( "first" ), document.getElementById( "mozilla" ) ] ).insertBefore( "#yahoo" );
 	assert.equal( jQuery( "#en" ).text(), expected, "Insert array of elements before" );
 } );
 
@@ -1051,8 +1051,8 @@ QUnit.test( "insertBefore(jQuery)", function( assert ) {
 
 	assert.expect( 1 );
 
-	var expected = "This is a normal link: diveintomarkTry them out:Yahoo";
-	jQuery( "#mark, #first" ).insertBefore( "#yahoo" );
+	var expected = "This is a normal link: mozillaTry them out:Yahoo";
+	jQuery( "#mozilla, #first" ).insertBefore( "#yahoo" );
 	assert.equal( jQuery( "#en" ).text(), expected, "Insert jQuery before" );
 } );
 
@@ -1078,8 +1078,8 @@ QUnit.test( ".after(Array<Element>)", function( assert ) {
 
 	assert.expect( 1 );
 
-	var expected = "This is a normal link: YahooTry them out:diveintomark";
-	jQuery( "#yahoo" ).after( [ document.getElementById( "first" ), document.getElementById( "mark" ) ] );
+	var expected = "This is a normal link: YahooTry them out:mozilla";
+	jQuery( "#yahoo" ).after( [ document.getElementById( "first" ), document.getElementById( "mozilla" ) ] );
 	assert.equal( jQuery( "#en" ).text(), expected, "Insert array of elements after" );
 } );
 
@@ -1087,8 +1087,8 @@ QUnit.test( ".after(jQuery)", function( assert ) {
 
 	assert.expect( 1 );
 
-	var expected = "This is a normal link: YahooTry them out:Googlediveintomark";
-	jQuery( "#yahoo" ).after( [ jQuery( "#first" ), jQuery( "#mark, #google" ) ] );
+	var expected = "This is a normal link: YahooTry them out:Googlemozilla";
+	jQuery( "#yahoo" ).after( [ jQuery( "#first" ), jQuery( "#mozilla, #google" ) ] );
 	assert.equal( jQuery( "#en" ).text(), expected, "Insert array of jQuery objects after" );
 } );
 
@@ -1116,9 +1116,9 @@ QUnit.test( ".after(Function) returns Array<Element>", function( assert ) {
 
 	assert.expect( 1 );
 
-	var expected = "This is a normal link: YahooTry them out:diveintomark",
+	var expected = "This is a normal link: YahooTry them out:mozilla",
 		val = manipulationFunctionReturningObj;
-	jQuery( "#yahoo" ).after( val( [ document.getElementById( "first" ), document.getElementById( "mark" ) ] ) );
+	jQuery( "#yahoo" ).after( val( [ document.getElementById( "first" ), document.getElementById( "mozilla" ) ] ) );
 	assert.equal( jQuery( "#en" ).text(), expected, "Insert array of elements after" );
 } );
 
@@ -1126,9 +1126,9 @@ QUnit.test( ".after(Function) returns jQuery", function( assert ) {
 
 	assert.expect( 1 );
 
-	var expected = "This is a normal link: YahooTry them out:Googlediveintomark",
+	var expected = "This is a normal link: YahooTry them out:Googlemozilla",
 		val = manipulationFunctionReturningObj;
-	jQuery( "#yahoo" ).after( val( [ jQuery( "#first" ), jQuery( "#mark, #google" ) ] ) );
+	jQuery( "#yahoo" ).after( val( [ jQuery( "#first" ), jQuery( "#mozilla, #google" ) ] ) );
 	assert.equal( jQuery( "#en" ).text(), expected, "Insert array of jQuery objects after" );
 } );
 
@@ -1163,8 +1163,8 @@ QUnit.test( "insertAfter(Array<Element>)", function( assert ) {
 
 	assert.expect( 1 );
 
-	var expected = "This is a normal link: YahooTry them out:diveintomark";
-	jQuery( [ document.getElementById( "first" ), document.getElementById( "mark" ) ] ).insertAfter( "#yahoo" );
+	var expected = "This is a normal link: YahooTry them out:mozilla";
+	jQuery( [ document.getElementById( "first" ), document.getElementById( "mozilla" ) ] ).insertAfter( "#yahoo" );
 	assert.equal( jQuery( "#en" ).text(), expected, "Insert array of elements after" );
 } );
 
@@ -1172,8 +1172,8 @@ QUnit.test( "insertAfter(jQuery)", function( assert ) {
 
 	assert.expect( 1 );
 
-	var expected = "This is a normal link: YahoodiveintomarkTry them out:";
-	jQuery( "#mark, #first" ).insertAfter( "#yahoo" );
+	var expected = "This is a normal link: YahoomozillaTry them out:";
+	jQuery( "#mozilla, #first" ).insertAfter( "#yahoo" );
 	assert.equal( jQuery( "#en" ).text(), expected, "Insert jQuery after" );
 } );
 
@@ -1202,17 +1202,17 @@ function testReplaceWith( val, assert ) {
 	assert.strictEqual( jQuery( "#yahoo" )[ 0 ].nextSibling, jQuery( "#baz" )[ 0 ].previousSibling, "Argument order preserved" );
 	assert.deepEqual( jQuery( "#bar" ).get(), [], "Verify that original element is gone, after multiple arguments" );
 
-	jQuery( "#google" ).replaceWith( val( [ document.getElementById( "first" ), document.getElementById( "mark" ) ] ) );
-	assert.deepEqual( jQuery( "#mark, #first" ).get(), q( "first", "mark" ),  "Replace element with array of elements" );
+	jQuery( "#google" ).replaceWith( val( [ document.getElementById( "first" ), document.getElementById( "mozilla" ) ] ) );
+	assert.deepEqual( jQuery( "#mozilla, #first" ).get(), q( "first", "mozilla" ),  "Replace element with array of elements" );
 	assert.ok( !jQuery( "#google" )[ 0 ], "Verify that original element is gone, after array of elements" );
 
-	jQuery( "#groups" ).replaceWith( val( jQuery( "#mark, #first" ) ) );
-	assert.deepEqual( jQuery( "#mark, #first" ).get(), q( "first", "mark" ),  "Replace element with jQuery collection" );
+	jQuery( "#groups" ).replaceWith( val( jQuery( "#mozilla, #first" ) ) );
+	assert.deepEqual( jQuery( "#mozilla, #first" ).get(), q( "first", "mozilla" ),  "Replace element with jQuery collection" );
 	assert.ok( !jQuery( "#groups" )[ 0 ], "Verify that original element is gone, after jQuery collection" );
 
-	jQuery( "#mark, #first" ).replaceWith( val( "<span class='replacement'></span><span class='replacement'></span>" ) );
+	jQuery( "#mozilla, #first" ).replaceWith( val( "<span class='replacement'></span><span class='replacement'></span>" ) );
 	assert.equal( jQuery( "#qunit-fixture .replacement" ).length, 4, "Replace multiple elements (trac-12449)" );
-	assert.deepEqual( jQuery( "#mark, #first" ).get(), [], "Verify that original elements are gone, after replace multiple" );
+	assert.deepEqual( jQuery( "#mozilla, #first" ).get(), [], "Verify that original elements are gone, after replace multiple" );
 
 	tmp = jQuery( "<b>content</b>" )[ 0 ];
 	jQuery( "#anchor1" ).contents().replaceWith( val( tmp ) );
@@ -1367,9 +1367,9 @@ QUnit.test( "replaceAll(Array<Element>)", function( assert ) {
 
 	assert.expect( 3 );
 
-	jQuery( [ document.getElementById( "first" ), document.getElementById( "mark" ) ] ).replaceAll( "#yahoo" );
+	jQuery( [ document.getElementById( "first" ), document.getElementById( "mozilla" ) ] ).replaceAll( "#yahoo" );
 	assert.ok( jQuery( "#first" )[ 0 ], "Replace element with array of elements" );
-	assert.ok( jQuery( "#mark" )[ 0 ], "Replace element with array of elements" );
+	assert.ok( jQuery( "#mozilla" )[ 0 ], "Replace element with array of elements" );
 	assert.ok( !jQuery( "#yahoo" )[ 0 ], "Verify that original element is gone, after array of elements" );
 } );
 
@@ -1377,9 +1377,9 @@ QUnit.test( "replaceAll(jQuery)", function( assert ) {
 
 	assert.expect( 3 );
 
-	jQuery( "#mark, #first" ).replaceAll( "#yahoo" );
+	jQuery( "#mozilla, #first" ).replaceAll( "#yahoo" );
 	assert.ok( jQuery( "#first" )[ 0 ], "Replace element with set of elements" );
-	assert.ok( jQuery( "#mark" )[ 0 ], "Replace element with set of elements" );
+	assert.ok( jQuery( "#mozilla" )[ 0 ], "Replace element with set of elements" );
 	assert.ok( !jQuery( "#yahoo" )[ 0 ], "Verify that original element is gone, after set of elements" );
 } );
 

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -109,8 +109,8 @@ QUnit.test( "element", function( assert ) {
 	}
 
 	assert.t( "Checking sort order", "#qunit-fixture p, #qunit-fixture p a",
-		[ "firstp", "simon1", "ap", "google", "groups", "anchor1", "mark", "sndp", "en", "yahoo",
-			"sap", "anchor2", "simon", "first" ] );
+		[ "firstp", "john1", "ap", "google", "groups", "anchor1", "mozilla", "sndp", "en", "yahoo",
+			"sap", "anchor2", "timmy", "first" ] );
 
 	// Test Conflict ID
 	lengthtest = document.getElementById( "lengthtest" );
@@ -233,7 +233,7 @@ QUnit.test( "id", function( assert ) {
 	assert.t( "ID Selector", "#body", [ "body" ] );
 	assert.t( "ID Selector w/ Element", "body#body", [ "body" ] );
 	assert.t( "ID Selector w/ Element", "ul#first", [] );
-	assert.t( "ID selector with existing ID descendant", "#firstp #simon1", [ "simon1" ] );
+	assert.t( "ID selector with existing ID descendant", "#firstp #john1", [ "john1" ] );
 	assert.t( "ID selector with non-existent descendant", "#firstp #foobar", [] );
 	assert.t( "ID selector using UTF8", "#台北Táiběi", [ "台北Táiběi" ] );
 	assert.t( "Multiple ID selectors using UTF8", "#台北Táiběi, #台北", [ "台北Táiběi", "台北" ] );
@@ -307,19 +307,19 @@ QUnit.test( "class", function( assert ) {
 	assert.expect( 32 );
 
 	assert.deepEqual( jQuery( ".blog", document.getElementsByTagName( "p" ) ).get(),
-		q( "mark", "simon" ), "Finding elements with a context." );
+		q( "mozilla", "timmy" ), "Finding elements with a context." );
 	assert.deepEqual( jQuery( ".blog", "p" ).get(),
-		q( "mark", "simon" ), "Finding elements with a context." );
+		q( "mozilla", "timmy" ), "Finding elements with a context." );
 	assert.deepEqual( jQuery( ".blog", jQuery( "p" ) ).get(),
-		q( "mark", "simon" ), "Finding elements with a context." );
+		q( "mozilla", "timmy" ), "Finding elements with a context." );
 	assert.deepEqual( jQuery( "p" ).find( ".blog" ).get(),
-		q( "mark", "simon" ), "Finding elements with a context." );
+		q( "mozilla", "timmy" ), "Finding elements with a context." );
 
-	assert.t( "Class Selector", ".blog", [ "mark", "simon" ] );
+	assert.t( "Class Selector", ".blog", [ "mozilla", "timmy" ] );
 	assert.t( "Class Selector", ".GROUPS", [ "groups" ] );
-	assert.t( "Class Selector", ".blog.link", [ "simon" ] );
-	assert.t( "Class Selector w/ Element", "a.blog", [ "mark", "simon" ] );
-	assert.t( "Parent Class Selector", "p .blog", [ "mark", "simon" ] );
+	assert.t( "Class Selector", ".blog.link", [ "timmy" ] );
+	assert.t( "Class Selector w/ Element", "a.blog", [ "mozilla", "timmy" ] );
+	assert.t( "Parent Class Selector", "p .blog", [ "mozilla", "timmy" ] );
 
 	assert.t( "Class selector using UTF8", ".台北Táiběi", [ "utf8class1" ] );
 	assert.t( "Class selector using UTF8", ".台北", [ "utf8class1", "utf8class2" ] );
@@ -438,11 +438,11 @@ QUnit.test( "child and adjacent", function( assert ) {
 
 	var siblingFirst, en, nothiddendiv;
 
-	assert.t( "Child", "p > a", [ "simon1", "google", "groups", "mark", "yahoo", "simon" ] );
-	assert.t( "Child minus leading whitespace", "p> a", [ "simon1", "google", "groups", "mark", "yahoo", "simon" ] );
-	assert.t( "Child minus trailing whitespace", "p >a", [ "simon1", "google", "groups", "mark", "yahoo", "simon" ] );
-	assert.t( "Child minus whitespace", "p>a", [ "simon1", "google", "groups", "mark", "yahoo", "simon" ] );
-	assert.t( "Child w/ Class", "p > a.blog", [ "mark", "simon" ] );
+	assert.t( "Child", "p > a", [ "john1", "google", "groups", "mozilla", "yahoo", "timmy" ] );
+	assert.t( "Child minus leading whitespace", "p> a", [ "john1", "google", "groups", "mozilla", "yahoo", "timmy" ] );
+	assert.t( "Child minus trailing whitespace", "p >a", [ "john1", "google", "groups", "mozilla", "yahoo", "timmy" ] );
+	assert.t( "Child minus whitespace", "p>a", [ "john1", "google", "groups", "mozilla", "yahoo", "timmy" ] );
+	assert.t( "Child w/ Class", "p > a.blog", [ "mozilla", "timmy" ] );
 	assert.t( "All Children", "code > *", [ "anchor1", "anchor2" ] );
 	assert.selectInFixture( "All Grandchildren", "p > * > *", [ "anchor1", "anchor2" ] );
 
@@ -457,7 +457,7 @@ QUnit.test( "child and adjacent", function( assert ) {
 	assert.t( "#id adjacent", "#firstp + p", [ "ap" ] );
 	assert.t( "Tag#id adjacent", "p#firstp + p", [ "ap" ] );
 	assert.t( "Tag[attr] adjacent", "p[lang=en] + p", [ "sap" ] );
-	assert.t( "Tag.class adjacent", "a.GROUPS + code + a", [ "mark" ] );
+	assert.t( "Tag.class adjacent", "a.GROUPS + code + a", [ "mozilla" ] );
 	assert.t( "Comma, Child, and Adjacent", "#qunit-fixture a + a, code > a",
 		[ "groups", "anchor1", "anchor2", "tName2ID" ] );
 
@@ -465,7 +465,7 @@ QUnit.test( "child and adjacent", function( assert ) {
 		[ "foo", "nothiddendiv", "moretests", "tabindex-tests", "liveHandlerOrder", "siblingTest", "fx-test-group" ] );
 	assert.t( "Element Preceded By", "#first ~ div",
 		[ "moretests", "tabindex-tests", "liveHandlerOrder", "siblingTest", "fx-test-group" ] );
-	assert.t( "Element Preceded By", "#groups ~ a", [ "mark" ] );
+	assert.t( "Element Preceded By", "#groups ~ a", [ "mozilla" ] );
 	assert.t( "Element Preceded By", "#length ~ input", [ "idTest" ] );
 	assert.t( "Element Preceded By", "#siblingfirst ~ em", [ "siblingnext", "siblingthird" ] );
 	assert.t( "Element Preceded By (multiple)", "#siblingTest em ~ em ~ em ~ span", [ "siblingspan" ] );
@@ -545,10 +545,10 @@ QUnit.test( "attributes - equals", function( assert ) {
 
 	var withScript;
 
-	assert.t( "Identifier", "#qunit-fixture a[rel=bookmark]", [ "simon1" ] );
+	assert.t( "Identifier", "#qunit-fixture a[rel=bookmark]", [ "john1" ] );
 	assert.t( "Identifier with underscore", "input[id=types_all]", [ "types_all" ] );
-	assert.t( "String", "#qunit-fixture a[rel='bookmark']", [ "simon1" ] );
-	assert.t( "String (whitespace ignored)", "#qunit-fixture a[ rel = 'bookmark' ]", [ "simon1" ] );
+	assert.t( "String", "#qunit-fixture a[rel='bookmark']", [ "john1" ] );
+	assert.t( "String (whitespace ignored)", "#qunit-fixture a[ rel = 'bookmark' ]", [ "john1" ] );
 	assert.t( "Non-identifier string", "#qunit-fixture a[href='https://www.google.com/']", [ "google" ] );
 	assert.t( "Empty string", "#select1 option[value='']", [ "option1a" ] );
 
@@ -616,13 +616,13 @@ QUnit.test( "attributes - contains", function( assert ) {
 	assert.t( "string (whitespace ignored)", "a[href *= 'google']", [ "google", "groups" ] );
 	assert.t( "string like '[' ... ']']", "input[name*='[bar]']", [ "hidden2" ] );
 	assert.t( "string containing '['...']", "input[name*='foo[bar]']", [ "hidden2" ] );
-	assert.t( "href contains hash", "p a[href*='#']", [ "simon1", "anchor2" ] );
+	assert.t( "href contains hash", "p a[href*='#']", [ "john1", "anchor2" ] );
 } );
 
 QUnit.test( "attributes - ends with", function( assert ) {
 	assert.expect( 4 );
 
-	assert.t( "string (whitespace ignored)", "a[href $= 'org/']", [ "mark" ] );
+	assert.t( "string (whitespace ignored)", "a[href $= 'org/']", [ "mozilla" ] );
 	assert.t( "string ending with ']'", "input[name$='bar]']", [ "hidden2" ] );
 	assert.t( "string like '[' ... ']'", "input[name$='[bar]']", [ "hidden2" ] );
 	assert.t( "Attribute containing []", "input[name$='foo[bar]']", [ "hidden2" ] );
@@ -797,9 +797,9 @@ QUnit.test( "pseudo - (first|last|only)-(child|of-type)", function( assert ) {
 	assert.t( "First Child (case-insensitive)", "#qunit-fixture p:FIRST-CHILD", [ "firstp", "sndp" ] );
 
 	assert.t( "Last Child", "#qunit-fixture p:last-child", [ "sap" ] );
-	assert.t( "Last Child (leading id)", "#qunit-fixture a:last-child", [ "simon1", "anchor1", "mark", "yahoo", "anchor2", "simon", "liveLink1", "liveLink2" ] );
+	assert.t( "Last Child (leading id)", "#qunit-fixture a:last-child", [ "john1", "anchor1", "mozilla", "yahoo", "anchor2", "timmy", "liveLink1", "liveLink2" ] );
 
-	assert.t( "Only Child", "#qunit-fixture a:only-child", [ "simon1", "anchor1", "yahoo", "anchor2", "liveLink1", "liveLink2" ] );
+	assert.t( "Only Child", "#qunit-fixture a:only-child", [ "john1", "anchor1", "yahoo", "anchor2", "liveLink1", "liveLink2" ] );
 
 	assert.t( "First-of-type", "#qunit-fixture > p:first-of-type", [ "firstp" ] );
 	assert.t( "Last-of-type", "#qunit-fixture > p:last-of-type", [ "first" ] );
@@ -922,13 +922,13 @@ QUnit.test( "pseudo - nth-last-child", function( assert ) {
 QUnit.test( "pseudo - nth-of-type", function( assert ) {
 	assert.expect( 9 );
 	assert.t( "Nth-of-type(-1)", ":nth-of-type(-1)", [] );
-	assert.t( "Nth-of-type(3)", "#ap :nth-of-type(3)", [ "mark" ] );
-	assert.t( "Nth-of-type(n)", "#ap :nth-of-type(n)", [ "google", "groups", "code1", "anchor1", "mark" ] );
-	assert.t( "Nth-of-type(0n+3)", "#ap :nth-of-type(0n+3)", [ "mark" ] );
+	assert.t( "Nth-of-type(3)", "#ap :nth-of-type(3)", [ "mozilla" ] );
+	assert.t( "Nth-of-type(n)", "#ap :nth-of-type(n)", [ "google", "groups", "code1", "anchor1", "mozilla" ] );
+	assert.t( "Nth-of-type(0n+3)", "#ap :nth-of-type(0n+3)", [ "mozilla" ] );
 	assert.t( "Nth-of-type(2n)", "#ap :nth-of-type(2n)", [ "groups" ] );
 	assert.t( "Nth-of-type(even)", "#ap :nth-of-type(even)", [ "groups" ] );
-	assert.t( "Nth-of-type(2n+1)", "#ap :nth-of-type(2n+1)", [ "google", "code1", "anchor1", "mark" ] );
-	assert.t( "Nth-of-type(odd)", "#ap :nth-of-type(odd)", [ "google", "code1", "anchor1", "mark" ] );
+	assert.t( "Nth-of-type(2n+1)", "#ap :nth-of-type(2n+1)", [ "google", "code1", "anchor1", "mozilla" ] );
+	assert.t( "Nth-of-type(odd)", "#ap :nth-of-type(odd)", [ "google", "code1", "anchor1", "mozilla" ] );
 	assert.t( "Nth-of-type(-n+2)", "#qunit-fixture > :nth-of-type(-n+2)", [ "firstp", "ap", "foo", "nothiddendiv", "name+value", "firstUL", "empty", "form", "floatTest", "iframe", "lengthtest", "table", "last" ] );
 } );
 
@@ -936,12 +936,12 @@ QUnit.test( "pseudo - nth-last-of-type", function( assert ) {
 	assert.expect( 9 );
 	assert.t( "Nth-last-of-type(-1)", ":nth-last-of-type(-1)", [] );
 	assert.t( "Nth-last-of-type(3)", "#ap :nth-last-of-type(3)", [ "google" ] );
-	assert.t( "Nth-last-of-type(n)", "#ap :nth-last-of-type(n)", [ "google", "groups", "code1", "anchor1", "mark" ] );
+	assert.t( "Nth-last-of-type(n)", "#ap :nth-last-of-type(n)", [ "google", "groups", "code1", "anchor1", "mozilla" ] );
 	assert.t( "Nth-last-of-type(0n+3)", "#ap :nth-last-of-type(0n+3)", [ "google" ] );
 	assert.t( "Nth-last-of-type(2n)", "#ap :nth-last-of-type(2n)", [ "groups" ] );
 	assert.t( "Nth-last-of-type(even)", "#ap :nth-last-of-type(even)", [ "groups" ] );
-	assert.t( "Nth-last-of-type(2n+1)", "#ap :nth-last-of-type(2n+1)", [ "google", "code1", "anchor1", "mark" ] );
-	assert.t( "Nth-last-of-type(odd)", "#ap :nth-last-of-type(odd)", [ "google", "code1", "anchor1", "mark" ] );
+	assert.t( "Nth-last-of-type(2n+1)", "#ap :nth-last-of-type(2n+1)", [ "google", "code1", "anchor1", "mozilla" ] );
+	assert.t( "Nth-last-of-type(odd)", "#ap :nth-last-of-type(odd)", [ "google", "code1", "anchor1", "mozilla" ] );
 	assert.t( "Nth-last-of-type(-n+2)", "#qunit-fixture > :nth-last-of-type(-n+2)", [ "ap", "name+value", "first", "firstUL", "empty", "floatTest", "iframe", "table", "testForm", "disabled-tests", "siblingTest", "fx-test-group", "last" ] );
 } );
 
@@ -969,7 +969,7 @@ QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "pseudo - contains", function(
 	assert.expect( 9 );
 
 	var gh335 = document.getElementById( "qunit-fixture" ).appendChild(
-		document.createElement( "mark" ) );
+		document.createElement( "mozilla" ) );
 	gh335.id = "gh-335";
 	gh335.appendChild( document.createTextNode( "raw line 1\nline 2" ) );
 
@@ -987,7 +987,7 @@ QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "pseudo - contains", function(
 		"span:contains(\"\\\"'\\53F0 \\5317 Ta\\301 ibe\\30C i\")",
 		[ "utf8class1" ] );
 
-	assert.t( "collapsed whitespace", "mark:contains('line 1\\A line')", [ "gh-335" ] );
+	assert.t( "collapsed whitespace", "mozilla:contains('line 1\\A line')", [ "gh-335" ] );
 } );
 
 QUnit.test( "pseudo - misc", function( assert ) {
@@ -1107,8 +1107,8 @@ QUnit.test( "pseudo - misc", function( assert ) {
 	if ( QUnit.jQuerySelectors ) {
 
 		// Tokenization edge cases
-		assert.t( "Sequential pseudos", "#qunit-fixture p:has(:contains(mark)):has(code)", [ "ap" ] );
-		assert.t( "Sequential pseudos", "#qunit-fixture p:has(:contains(mark)):has(code):contains(This link)", [ "ap" ] );
+		assert.t( "Sequential pseudos", "#qunit-fixture p:has(:contains(mozilla)):has(code)", [ "ap" ] );
+		assert.t( "Sequential pseudos", "#qunit-fixture p:has(:contains(mozilla)):has(code):contains(This link)", [ "ap" ] );
 
 		assert.t( "Pseudo argument containing ')'", "p:has(>a.GROUPS[src!=')'])", [ "ap" ] );
 		assert.t( "Pseudo argument containing ')'", "p:has(>a.GROUPS[src!=')'])", [ "ap" ] );
@@ -1118,7 +1118,7 @@ QUnit.test( "pseudo - misc", function( assert ) {
 		assert.t( "Multi-pseudo", "#ap:has(*), #ap:has(*)", [ "ap" ] );
 		assert.t( "Multi-pseudo with leading nonexistent id", "#nonexistent:has(*), #ap:has(*)", [ "ap" ] );
 
-		assert.t( "Tokenization stressor", "a[class*=blog]:not(:has(*, :contains(!)), :contains(!)), br:contains(]), p:contains(]):not(.qunit-source), :not(:empty):not(:parent):not(.qunit-source)", [ "ap", "mark", "yahoo", "simon" ] );
+		assert.t( "Tokenization stressor", "a[class*=blog]:not(:has(*, :contains(!)), :contains(!)), br:contains(]), p:contains(]):not(.qunit-source), :not(:empty):not(:parent):not(.qunit-source)", [ "ap", "mozilla", "yahoo", "timmy" ] );
 	} else {
 		assert.ok( "skip", ":has not supported in selector-native" );
 		assert.ok( "skip", ":has not supported in selector-native" );
@@ -1146,7 +1146,7 @@ QUnit.test( "pseudo - misc", function( assert ) {
 QUnit.test( "pseudo - :not", function( assert ) {
 	assert.expect( 43 );
 
-	assert.t( "Not", "a.blog:not(.link)", [ "mark" ] );
+	assert.t( "Not", "a.blog:not(.link)", [ "mozilla" ] );
 
 	if ( QUnit.jQuerySelectors ) {
 		assert.t( "Not - multiple", "#form option:not(:contains(Nothing),#option1b,:selected)", [ "option1c", "option1d", "option2b", "option2c", "option3d", "option3e", "option4e", "option5b", "option5c" ] );
@@ -1157,7 +1157,7 @@ QUnit.test( "pseudo - :not", function( assert ) {
 	}
 
 	if ( QUnit.jQuerySelectorsPos ) {
-		assert.t( ":not() with :first", "#foo p:not(:first) .link", [ "simon" ] );
+		assert.t( ":not() with :first", "#foo p:not(:first) .link", [ "timmy" ] );
 	} else {
 		assert.ok( "skip", "Positional selectors are not supported" );
 	}
@@ -1607,7 +1607,7 @@ QUnit.test( "context", function( assert ) {
 
 	var context,
 		selector = ".blog",
-		expected = q( "mark", "simon" ),
+		expected = q( "mozilla", "timmy" ),
 		iframe = document.getElementById( "iframe" ),
 		iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
 
@@ -1725,15 +1725,15 @@ QUnit.test( "caching does not introduce bugs", function( assert ) {
 
 	jQuery( ":not(code)", document.getElementById( "ap" ) );
 	assert.deepEqual(
-		jQuery( ":not(code)", document.getElementById( "foo" ) ).get(),
-		q( "sndp", "en", "yahoo", "sap", "anchor2", "simon" ),
+		jQuery.find( ":not(code)", document.getElementById( "foo" ) ),
+		q( "sndp", "en", "yahoo", "sap", "anchor2", "timmy" ),
 		"Reusing selector with new context"
 	);
 
 	if ( QUnit.jQuerySelectorsPos ) {
 		assert.t( "Deep ancestry caching in post-positional element matcher (jQuery trac-14657)",
 			"#qunit-fixture a:lt(3):parent",
-			[ "simon1", "google", "groups" ] );
+			[ "john1", "google", "groups" ] );
 	} else {
 		assert.ok( "skip", "Positional selectors are not supported" );
 	}
@@ -2186,7 +2186,7 @@ QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "custom pseudos", function( as
 				return !!elem.id;
 			};
 		} );
-		assert.t( "Custom element filter", "#foo :aristotlean", [ "sndp", "en", "yahoo", "sap", "anchor2", "simon" ] );
+		assert.t( "Custom element filter", "#foo :aristotlean", [ "sndp", "en", "yahoo", "sap", "anchor2", "timmy" ] );
 	} finally {
 		delete jQuery.expr.filters.aristotlean;
 	}
@@ -2240,7 +2240,7 @@ QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "custom pseudos", function( as
 QUnit.test( "jQuery.find.matchesSelector", function( assert ) {
 	assert.expect( 15 );
 
-	var link = document.getElementById( "simon1" ),
+	var link = document.getElementById( "john1" ),
 		input = document.getElementById( "text1" ),
 		option = document.getElementById( "option1a" ),
 		disconnected = document.createElement( "div" );

--- a/test/unit/traversing.js
+++ b/test/unit/traversing.js
@@ -63,17 +63,17 @@ QUnit.test( "is(falsy|invalid)", function( assert ) {
 QUnit.test( "is(String)", function( assert ) {
 	assert.expect( 33 );
 
-	var link = document.getElementById( "simon1" ),
+	var link = document.getElementById( "john1" ),
 		input = document.getElementById( "text1" ),
 		option = document.getElementById( "option1a" ),
 		disconnected = document.createElement( "div" );
 
 	assert.ok( jQuery( "#form" ).is( "form" ), "Check for element: A form must be a form" );
 	assert.ok( !jQuery( "#form" ).is( "div" ), "Check for element: A form is not a div" );
-	assert.ok( jQuery( "#mark" ).is( ".blog" ), "Check for class: Expected class 'blog'" );
-	assert.ok( !jQuery( "#mark" ).is( ".link" ), "Check for class: Did not expect class 'link'" );
-	assert.ok( jQuery( "#simon" ).is( ".blog.link" ), "Check for multiple classes: Expected classes 'blog' and 'link'" );
-	assert.ok( !jQuery( "#simon" ).is( ".blogTest" ), "Check for multiple classes: Expected classes 'blog' and 'link', but not 'blogTest'" );
+	assert.ok( jQuery( "#mozilla" ).is( ".blog" ), "Check for class: Expected class 'blog'" );
+	assert.ok( !jQuery( "#mozilla" ).is( ".link" ), "Check for class: Did not expect class 'link'" );
+	assert.ok( jQuery( "#timmy" ).is( ".blog.link" ), "Check for multiple classes: Expected classes 'blog' and 'link'" );
+	assert.ok( !jQuery( "#timmy" ).is( ".blogTest" ), "Check for multiple classes: Expected classes 'blog' and 'link', but not 'blogTest'" );
 	assert.ok( jQuery( "#en" ).is( "[lang=\"en\"]" ), "Check for attribute: Expected attribute lang to be 'en'" );
 	assert.ok( !jQuery( "#en" ).is( "[lang=\"de\"]" ), "Check for attribute: Expected attribute lang to be 'en', not 'de'" );
 	assert.ok( jQuery( "#text1" ).is( "[type=\"text\"]" ), "Check for attribute: Expected attribute type to be 'text'" );
@@ -164,10 +164,10 @@ QUnit.test( "is(jQuery)", function( assert ) {
 	assert.expect( 19 );
 	assert.ok( jQuery( "#form" ).is( jQuery( "form" ) ), "Check for element: A form is a form" );
 	assert.ok( !jQuery( "#form" ).is( jQuery( "div" ) ), "Check for element: A form is not a div" );
-	assert.ok( jQuery( "#mark" ).is( jQuery( ".blog" ) ), "Check for class: Expected class 'blog'" );
-	assert.ok( !jQuery( "#mark" ).is( jQuery( ".link" ) ), "Check for class: Did not expect class 'link'" );
-	assert.ok( jQuery( "#simon" ).is( jQuery( ".blog.link" ) ), "Check for multiple classes: Expected classes 'blog' and 'link'" );
-	assert.ok( !jQuery( "#simon" ).is( jQuery( ".blogTest" ) ), "Check for multiple classes: Expected classes 'blog' and 'link', but not 'blogTest'" );
+	assert.ok( jQuery( "#mozilla" ).is( jQuery( ".blog" ) ), "Check for class: Expected class 'blog'" );
+	assert.ok( !jQuery( "#mozilla" ).is( jQuery( ".link" ) ), "Check for class: Did not expect class 'link'" );
+	assert.ok( jQuery( "#timmy" ).is( jQuery( ".blog.link" ) ), "Check for multiple classes: Expected classes 'blog' and 'link'" );
+	assert.ok( !jQuery( "#timmy" ).is( jQuery( ".blogTest" ) ), "Check for multiple classes: Expected classes 'blog' and 'link', but not 'blogTest'" );
 	assert.ok( jQuery( "#en" ).is( jQuery( "[lang=\"en\"]" ) ), "Check for attribute: Expected attribute lang to be 'en'" );
 	assert.ok( !jQuery( "#en" ).is( jQuery( "[lang=\"de\"]" ) ), "Check for attribute: Expected attribute lang to be 'en', not 'de'" );
 	assert.ok( jQuery( "#text1" ).is( jQuery( "[type=\"text\"]" ) ), "Check for attribute: Expected attribute type to be 'text'" );
@@ -179,10 +179,10 @@ QUnit.test( "is(jQuery)", function( assert ) {
 	// Some raw elements
 	assert.ok( jQuery( "#form" ).is( jQuery( "#qunit-fixture form" )[ 0 ] ), "Check for element: A form is a form" );
 	assert.ok( !jQuery( "#form" ).is( jQuery( "div" )[ 0 ] ), "Check for element: A form is not a div" );
-	assert.ok( jQuery( "#mark" ).is( jQuery( ".blog" )[ 0 ] ), "Check for class: Expected class 'blog'" );
-	assert.ok( !jQuery( "#mark" ).is( jQuery( ".link" )[ 0 ] ), "Check for class: Did not expect class 'link'" );
-	assert.ok( jQuery( "#simon" ).is( jQuery( ".blog.link" )[ 0 ] ), "Check for multiple classes: Expected classes 'blog' and 'link'" );
-	assert.ok( !jQuery( "#simon" ).is( jQuery( ".blogTest" )[ 0 ] ), "Check for multiple classes: Expected classes 'blog' and 'link', but not 'blogTest'" );
+	assert.ok( jQuery( "#mozilla" ).is( jQuery( ".blog" )[ 0 ] ), "Check for class: Expected class 'blog'" );
+	assert.ok( !jQuery( "#mozilla" ).is( jQuery( ".link" )[ 0 ] ), "Check for class: Did not expect class 'link'" );
+	assert.ok( jQuery( "#timmy" ).is( jQuery( ".blog.link" )[ 0 ] ), "Check for multiple classes: Expected classes 'blog' and 'link'" );
+	assert.ok( !jQuery( "#timmy" ).is( jQuery( ".blogTest" )[ 0 ] ), "Check for multiple classes: Expected classes 'blog' and 'link', but not 'blogTest'" );
 } );
 
 QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "is() with :has() selectors", function( assert ) {
@@ -478,9 +478,9 @@ QUnit.testUnlessIE( "not(Selector)", function( assert ) {
 		"not('selector, selector')"
 	);
 
-	assert.deepEqual( jQuery( "#ap *" ).not( "code" ).get(), q( "google", "groups", "anchor1", "mark" ), "not('tag selector')" );
-	assert.deepEqual( jQuery( "#ap *" ).not( "code, #mark" ).get(), q( "google", "groups", "anchor1" ), "not('tag, ID selector')" );
-	assert.deepEqual( jQuery( "#ap *" ).not( "#mark, code" ).get(), q( "google", "groups", "anchor1" ), "not('ID, tag selector')" );
+	assert.deepEqual( jQuery( "#ap *" ).not( "code" ).get(), q( "google", "groups", "anchor1", "mozilla" ), "not('tag selector')" );
+	assert.deepEqual( jQuery( "#ap *" ).not( "code, #mozilla" ).get(), q( "google", "groups", "anchor1" ), "not('tag, ID selector')" );
+	assert.deepEqual( jQuery( "#ap *" ).not( "#mozilla, code" ).get(), q( "google", "groups", "anchor1" ), "not('ID, tag selector')" );
 
 	if ( QUnit.jQuerySelectors ) {
 		assert.deepEqual(


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
Looks like we had already converted links to https, but they were still dead links (or were not what they used to be). This is the 4.x version of my [3.x commit](https://github.com/jquery/jquery/pull/5531/commits/250ad48e51b3d6a5b1bc71ad03424e8cb82c9cfc) to replace these links with ones that should last long into the future.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
