### PR TITLE
Tests: Run tests on both real Firefox ESRs

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -31,7 +31,6 @@ jobs:
           - 'Edge_latest-1'
           - 'Firefox_latest'
           - 'Firefox_latest-1'
-          - 'Firefox_115'
           - '__iOS_17'
           - '__iOS_16'
           - '__iOS_15'

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -37,7 +37,10 @@ jobs:
           - NAME: "Chrome"
             NODE_VERSION: "20.x"
             NPM_SCRIPT: "test:esm"
-          - NAME: "Firefox ESR"
+          - NAME: "Firefox ESR (new)"
+            NODE_VERSION: "20.x"
+            NPM_SCRIPT: "test:firefox"
+          - NAME: "Firefox ESR (old)"
             NODE_VERSION: "20.x"
             NPM_SCRIPT: "test:firefox"
     steps:
@@ -57,10 +60,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ matrix.NODE_VERSION }}-npm-lock-
 
-      - name: Install firefox ESR
+      - name: Set download URL for Firefox ESR (old)
         run: |
-          export FIREFOX_SOURCE_URL='https://download.mozilla.org/?product=firefox-esr-latest-ssl&lang=en-US&os=linux64'
+          echo "FIREFOX_SOURCE_URL=https://download.mozilla.org/?product=firefox-esr-latest-ssl&lang=en-US&os=linux64" >> "$GITHUB_ENV"
+        if: contains(matrix.NAME, 'Firefox ESR (old)')
+
+      - name: Set download URL for Firefox ESR (new)
+        run: |
+          echo "FIREFOX_SOURCE_URL=https://download.mozilla.org/?product=firefox-esr-next-latest-ssl&lang=en-US&os=linux64" >> "$GITHUB_ENV"
+        if: contains(matrix.NAME, 'Firefox ESR (new)')
+
+      - name: Install Firefox ESR
+        run: |
           wget --no-verbose $FIREFOX_SOURCE_URL -O - | tar -jx -C ${HOME}
+          echo "PATH=${HOME}/firefox:$PATH" >> "$GITHUB_ENV"
+          echo "FIREFOX_BIN=${HOME}/firefox/firefox" >> "$GITHUB_ENV"
         if: contains(matrix.NAME, 'Firefox ESR')
 
       - name: Install dependencies
@@ -71,10 +85,7 @@ jobs:
         if: contains(matrix.NPM_SCRIPT, 'lint')
 
       - name: Run tests
-        run: |
-          export PATH=${HOME}/firefox:$PATH
-          export FIREFOX_BIN=${HOME}/firefox/firefox
-          npm run ${{ matrix.NPM_SCRIPT }}
+        run: npm run ${{ matrix.NPM_SCRIPT }}
 
   safari:
     runs-on: macos-latest


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

1. At the same time, there may be two supported versions of Firefox ESR. Run tests on both, installed locally.
2. Don't run tests on Firefox 115 on BrowserStack - it was added as there's an ESR version of Firefox 115, but ESR versions may be different, e.g. for some time ServiceWorker was disabled on ESR versions: https://bugzilla.mozilla.org/show_bug.cgi?id=1547023

Example test runs:
* https://github.com/mgol/jquery/actions/runs/10710118685/job/29696215652
* https://github.com/mgol/jquery/actions/runs/10710118685/job/29696215823

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
