### PR TITLE
Tests: Run tests on both real Firefox ESRs

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -37,7 +37,10 @@ jobs:
           - NAME: "Chrome"
             NODE_VERSION: "20.x"
             NPM_SCRIPT: "test:amd"
-          - NAME: "Firefox ESR"
+          - NAME: "Firefox ESR (new)"
+            NODE_VERSION: "20.x"
+            NPM_SCRIPT: "test:firefox"
+          - NAME: "Firefox ESR (old)"
             NODE_VERSION: "20.x"
             NPM_SCRIPT: "test:firefox"
     steps:
@@ -57,10 +60,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ matrix.NODE_VERSION }}-npm-lock-
 
-      - name: Install firefox ESR
+      - name: Set download URL for Firefox ESR (old)
         run: |
-          export FIREFOX_SOURCE_URL='https://download.mozilla.org/?product=firefox-esr-latest-ssl&lang=en-US&os=linux64'
+          echo "FIREFOX_SOURCE_URL=https://download.mozilla.org/?product=firefox-esr-latest-ssl&lang=en-US&os=linux64" >> "$GITHUB_ENV"
+        if: contains(matrix.NAME, 'Firefox ESR (old)')
+
+      - name: Set download URL for Firefox ESR (new)
+        run: |
+          echo "FIREFOX_SOURCE_URL=https://download.mozilla.org/?product=firefox-esr-next-latest-ssl&lang=en-US&os=linux64" >> "$GITHUB_ENV"
+        if: contains(matrix.NAME, 'Firefox ESR (new)')
+
+      - name: Install Firefox ESR
+        run: |
           wget --no-verbose $FIREFOX_SOURCE_URL -O - | tar -jx -C ${HOME}
+          echo "PATH=${HOME}/firefox:$PATH" >> "$GITHUB_ENV"
+          echo "FIREFOX_BIN=${HOME}/firefox/firefox" >> "$GITHUB_ENV"
         if: contains(matrix.NAME, 'Firefox ESR')
 
       - name: Install dependencies
@@ -71,10 +85,7 @@ jobs:
         if: contains(matrix.NPM_SCRIPT, 'lint')
 
       - name: Run tests
-        run: |
-          export PATH=${HOME}/firefox:$PATH
-          export FIREFOX_BIN=${HOME}/firefox/firefox
-          npm run ${{ matrix.NPM_SCRIPT }}
+        run: npm run ${{ matrix.NPM_SCRIPT }}
 
   safari:
     runs-on: macos-latest


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

A `3.x` version of #5547.

1. At the same time, there may be two supported versions of Firefox ESR. Run tests on both, installed locally.
2. Contrary to what we did in gh-5547, still run tests on Firefox 115 on BrowserStack - on `main`, we deleted it since we support only the versions supported upstream. In jQuery 3.x, we're testing on all versions matching ESR lines starting with Firefox 48, so for consistency let's keep Firefox 115 there as well.

Ref gh-5547

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
