### PR TITLE
Build: Test on iOS 18, no longer test on iOS 15

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -31,9 +31,9 @@ jobs:
           - 'Edge_latest-1'
           - 'Firefox_latest'
           - 'Firefox_latest-1'
+          - '__iOS_18'
           - '__iOS_17'
           - '__iOS_16'
-          - '__iOS_15'
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

iOS 18 is out. It's already available in BrowserStack.

iOS is the last browser we need to bump manually in configs. It'd be cool to eventually compute the versions there as well.

3.x version of the PR: #5554

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
