### PR TITLE
Build: Enforce ECMAScript 5 in tests via ESLint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -159,7 +159,7 @@ export default [
 			"test/data/core/jquery-iterability-transpiled.js"
 		],
 		languageOptions: {
-			ecmaVersion: 2015,
+			ecmaVersion: 5,
 			sourceType: "script",
 			globals: {
 				...globals.browser,
@@ -187,7 +187,9 @@ export default [
 				originaljQuery: false,
 				original$: false,
 				baseURL: false,
-				externalHost: false
+				externalHost: false,
+				Promise: false,
+				Symbol: false
 			}
 		},
 		rules: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -164,6 +164,8 @@ export default [
 			globals: {
 				...globals.browser,
 				require: false,
+				Promise: false,
+				Symbol: false,
 				trustedTypes: false,
 				QUnit: false,
 				ajaxTest: false,
@@ -187,9 +189,7 @@ export default [
 				originaljQuery: false,
 				original$: false,
 				baseURL: false,
-				externalHost: false,
-				Promise: false,
-				Symbol: false
+				externalHost: false
 			}
 		},
 		rules: {


### PR DESCRIPTION
### Summary ###

#5542 Changed the `ecmaVersion`  for unit tests to ES5 from ES2015. Added **Promise** and **Symbol** keyword in `globals ` and given them the value `false` to   ignore them while linting tests. Polyfill added for this as well as per @mgol.


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] New tests have been added to show the fix or feature works
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
