### PR TITLE
Docs: Align CONTRIBUTING.md with `3.x-stable`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,43 +71,43 @@ We *love* when people contribute back to the project by patching the bugs they f
 
 Create a fork of the jQuery repo on GitHub at https://github.com/jquery/jquery
 
-Clone your jQuery fork to work locally
+Clone your jQuery fork to work locally:
 
 ```bash
 $ git clone git@github.com:username/jquery.git
 ```
 
-Change directory to the newly created dir jquery/
+Change directory to the newly created dir `jquery/`:
 
 ```bash
 $ cd jquery
 ```
 
-Add the jQuery main as a remote. I label mine "upstream"
+Add the jQuery `main` as a remote. I label mine `upstream`:
 
 ```bash
 $ git remote add upstream git@github.com:jquery/jquery.git
 ```
 
-Get in the habit of pulling in the "upstream" main to stay up to date as jQuery receives new commits
+Get in the habit of pulling in the "upstream" main to stay up to date as jQuery receives new commits:
 
 ```bash
 $ git pull upstream main
 ```
 
-Install the necessary dependencies
+Install the necessary dependencies:
 
 ```bash
 $ npm install
 ```
 
-Build all jQuery files
+Build all jQuery files:
 
 ```bash
 $ npm run build:all
 ```
 
-Start a test server
+Start a test server:
 
 ```bash
 $ npm run test:server


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

When backporting #5564 to `3.x-stable` I didn't notice I had some editorial changes locally that I accidentally copied. Therefore, `main` is now not aligned with `3.x-stable`. I think these changes make sense, so I'm proposing them here to align branches instead of reversing the `3.x-stable` parts.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
