### PR TITLE
Tests: Add custom attribute getter tests to the selector module

### DIFF
--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -2237,6 +2237,37 @@ QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "custom pseudos", function( as
 	}
 } );
 
+QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "custom attribute getters", function( assert ) {
+	assert.expect( 2 );
+
+	var original = jQuery.attrHooks.hreflang,
+		selector = "a:contains('mozilla')[hreflang='https://mozilla.org/en']";
+
+	try {
+		jQuery.attrHooks.hreflang = {
+			get: function( elem, name ) {
+				var href = elem.getAttribute( "href" ),
+					lang = elem.getAttribute( name );
+				return lang && ( href + lang );
+			}
+		};
+
+		assert.deepEqual(
+			jQuery.find( selector, createWithFriesXML() ),
+			[],
+			"Custom attrHooks (preferred document)"
+		);
+		assert.t( "Custom attrHooks (preferred document)", selector, [ "mozilla" ] );
+	} finally {
+		jQuery.attrHooks.hreflang = original;
+	}
+} );
+QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "Ensure no 'undefined' handler is added", function( assert ) {
+	assert.expect( 1 );
+	assert.ok( !jQuery.attrHooks.hasOwnProperty( "undefined" ),
+		"Extra attr handlers are not added to jQuery.attrHooks (https://github.com/jquery/sizzle/issues/353)" );
+} );
+
 QUnit.test( "jQuery.find.matchesSelector", function( assert ) {
 	assert.expect( 15 );
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Sizzle & the `3.x-stable` branch have tests adding a custom attribute getter to `attrHandle` and checking if selection takes it into account. `attrHandle` was removed from the `4.x` line so the tests were not ported to the `main` branch, but the `4.x` line takes standard jQuery attribute getters into account instead and we should test for that.

Backport the `3.x-stable` selector tests for custom attribute getters, changing `jQuery.expr.attrHandle` to `jQuery.attrHooks`.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
