### PR TITLE
Selector: Properly deprecate `jQuery.expr[ ":" ]`/`jQuery.expr.filters`

### DIFF
--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -86,4 +86,8 @@ jQuery.trim = function( text ) {
 		"" :
 		( text + "" ).replace( rtrim, "$1" );
 };
+
+jQuery.expr[ ":" ] = jQuery.expr.filters = jQuery.expr.pseudos;
+jQuery.unique = jQuery.uniqueSort;
+
 } );

--- a/src/selector-native.js
+++ b/src/selector-native.js
@@ -124,7 +124,6 @@ jQuery.extend( {
 	// elements in the full selector module. This will be a minor
 	// breaking change in 4.0.0.
 	uniqueSort: uniqueSort,
-	unique: uniqueSort,
 
 	find: function( selector, context, results, seed ) {
 		var elem, nodeType,

--- a/src/selector.js
+++ b/src/selector.js
@@ -1473,7 +1473,7 @@ for ( i in { submit: true, reset: true } ) {
 
 // Easy API for creating new setFilters
 function setFilters() {}
-setFilters.prototype = Expr.filters = Expr.pseudos;
+setFilters.prototype = Expr.pseudos;
 Expr.setFilters = new setFilters();
 
 function tokenize( selector, parseOnly ) {
@@ -2091,10 +2091,6 @@ support.sortDetached = assert( function( el ) {
 } );
 
 jQuery.find = find;
-
-// Deprecated
-jQuery.expr[ ":" ] = jQuery.expr.pseudos;
-jQuery.unique = jQuery.uniqueSort;
 
 // These have always been private, but they used to be documented as part of
 // Sizzle so let's maintain them for now for backwards compatibility purposes.

--- a/test/unit/deprecated.js
+++ b/test/unit/deprecated.js
@@ -704,4 +704,24 @@ if ( includesModule( "deferred" ) ) {
 	} );
 }
 
+if ( includesModule( "selector" ) ) {
+	QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ](
+		"jQuery.expr[ \":\" ], jQuery.expr.filters",
+		function( assert ) {
+			assert.expect( 2 );
+
+			assert.strictEqual( jQuery.expr[ ":" ], jQuery.expr.pseudos,
+				"jQuery.expr[ \":\" ] is an alias of jQuery.expr.pseudos" );
+			assert.strictEqual( jQuery.expr.filters, jQuery.expr.pseudos,
+				"jQuery.expr.filters is an alias of jQuery.expr.pseudos" );
+		} );
+}
+
+QUnit.test( "jQuery.unique", function( assert ) {
+	assert.expect( 1 );
+
+	assert.strictEqual( jQuery.unique, jQuery.uniqueSort,
+		"jQuery.unique is an alias of jQuery.uniqueSort" );
+} );
+
 }

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -2346,10 +2346,10 @@ QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "custom pseudos", function( as
 	assert.expect( 6 );
 
 	try {
-		jQuery.expr.filters.foundation = jQuery.expr.filters.root;
+		jQuery.expr.pseudos.foundation = jQuery.expr.pseudos.root;
 		assert.deepEqual( jQuery.find( ":foundation" ), [ document.documentElement ], "Copy element filter with new name" );
 	} finally {
-		delete jQuery.expr.filters.foundation;
+		delete jQuery.expr.pseudos.foundation;
 	}
 
 	try {
@@ -2360,25 +2360,25 @@ QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "custom pseudos", function( as
 	}
 
 	try {
-		jQuery.expr.filters.aristotlean = jQuery.expr.createPseudo( function() {
+		jQuery.expr.pseudos.aristotlean = jQuery.expr.createPseudo( function() {
 			return function( elem ) {
 				return !!elem.id;
 			};
 		} );
 		assert.t( "Custom element filter", "#foo :aristotlean", [ "sndp", "en", "yahoo", "sap", "anchor2", "timmy" ] );
 	} finally {
-		delete jQuery.expr.filters.aristotlean;
+		delete jQuery.expr.pseudos.aristotlean;
 	}
 
 	try {
-		jQuery.expr.filters.endswith = jQuery.expr.createPseudo( function( text ) {
+		jQuery.expr.pseudos.endswith = jQuery.expr.createPseudo( function( text ) {
 			return function( elem ) {
 				return jQuery.text( elem ).slice( -text.length ) === text;
 			};
 		} );
 		assert.t( "Custom element filter with argument", "a:endswith(ogle)", [ "google" ] );
 	} finally {
-		delete jQuery.expr.filters.endswith;
+		delete jQuery.expr.pseudos.endswith;
 	}
 
 	try {
@@ -2392,7 +2392,7 @@ QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "custom pseudos", function( as
 		} );
 		assert.t( "Custom set filter", "#qunit-fixture p:second", [ "ap" ] );
 	} finally {
-		delete jQuery.expr.filters.second;
+		delete jQuery.expr.setFilters.second;
 	}
 
 	try {
@@ -2412,7 +2412,7 @@ QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "custom pseudos", function( as
 		} );
 		assert.t( "Custom set filter with argument", "#qunit-fixture p:slice(1:3)", [ "ap", "sndp" ] );
 	} finally {
-		delete jQuery.expr.filters.slice;
+		delete jQuery.expr.setFilters.slice;
 	}
 } );
 
@@ -2420,12 +2420,12 @@ QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "backwards-compatible custom p
 	assert.expect( 3 );
 
 	try {
-		jQuery.expr.filters.icontains = function( elem, i, match ) {
+		jQuery.expr.pseudos.icontains = function( elem, i, match ) {
 			return jQuery.text( elem ).toLowerCase().indexOf( ( match[ 3 ] || "" ).toLowerCase() ) > -1;
 		};
 		assert.t( "Custom element filter with argument", "a:icontains(THIS BLOG ENTRY)", [ "john1" ] );
 	} finally {
-		delete jQuery.expr.filters.icontains;
+		delete jQuery.expr.pseudos.icontains;
 	}
 
 	try {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Those APIs have formally been deprecated since `3.0.0`, but they never made its way into the deprecated module.

Ref gh-5580

PR for `main`: #5580

~~Note: this PR only makes sense in its form if we decide to release it as `3.8.0`; otherwise, we should avoid moving stuff between modules.~~

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
