### PR TITLE
Core: Switch `$.parseHTML` from `document.implementation` to `DOMParser`

### DIFF
--- a/src/core/parseHTML.js
+++ b/src/core/parseHTML.js
@@ -1,5 +1,4 @@
 import { jQuery } from "../core.js";
-import { document } from "../var/document.js";
 import { rsingleTag } from "./var/rsingleTag.js";
 import { buildFragment } from "../manipulation/buildFragment.js";
 import { isObviousHtml } from "./isObviousHtml.js";
@@ -17,20 +16,14 @@ jQuery.parseHTML = function( data, context, keepScripts ) {
 		context = false;
 	}
 
-	var base, parsed, scripts;
+	var parsed, scripts;
 
 	if ( !context ) {
 
 		// Stop scripts or inline event handlers from being executed immediately
-		// by using document.implementation
-		context = document.implementation.createHTMLDocument( "" );
-
-		// Set the base href for the created document
-		// so any parsed elements with URLs
-		// are based on the document's URL (gh-2965)
-		base = context.createElement( "base" );
-		base.href = document.location.href;
-		context.head.appendChild( base );
+		// by using DOMParser
+		context = ( new window.DOMParser() )
+			.parseFromString( "", "text/html" );
 	}
 
 	parsed = rsingleTag.exec( data );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Using a document created via:
```js
document.implementation.createHTMLDocument( "" )
```
was needed in IE 9 which doesn't support `DOMParser#parseFromString` for `text/html`. We can switch to:
```js
( new window.DOMParser() ) .parseFromString( "", "text/html" )
```
now, saving some bytes.

Size comparison:
```
main @640d5825df5ff223560c5690f1a268681c32f9fa
   raw     gz     br Filename
   -42    -22     -3 dist/jquery.min.js
   -42    -22    -46 dist/jquery.slim.min.js
   -42    -22    -72 dist-module/jquery.module.min.js
   -42    -23    -19 dist-module/jquery.slim.module.min.js
```

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
