### PR TITLE
Build: Make middleware-mockserver not crash on reading nonexistent files

### DIFF
--- a/test/middleware-mockserver.cjs
+++ b/test/middleware-mockserver.cjs
@@ -8,6 +8,19 @@ const multiparty = require( "multiparty" );
 let cspLog = "";
 
 /**
+ * Like `readFileSync`, but on error returns "ERROR"
+ * without crashing.
+ * @param path
+ */
+function readFileSync( path ) {
+	try {
+		return fs.readFileSync( path );
+	} catch ( e ) {
+		return "ERROR";
+	}
+}
+
+/**
  * Keep in sync with /test/mock.php
  */
 function cleanCallback( callback ) {
@@ -143,7 +156,7 @@ const mocks = {
 	},
 	xmlOverJsonp: function( req, resp ) {
 		const callback = req.query.callback;
-		const body = fs.readFileSync( `${ __dirname }/data/with_fries.xml` ).toString();
+		const body = readFileSync( `${ __dirname }/data/with_fries.xml` ).toString();
 		resp.writeHead( 200 );
 		resp.end( `${ cleanCallback( callback ) }(${ JSON.stringify( body ) })\n` );
 	},
@@ -238,8 +251,9 @@ const mocks = {
 	},
 	testHTML: function( req, resp ) {
 		resp.writeHead( 200, { "Content-Type": "text/html" } );
-		const body = fs
-			.readFileSync( `${ __dirname }/data/test.include.html` )
+		const body = readFileSync(
+				`${ __dirname }/data/test.include.html`
+			)
 			.toString()
 			.replace( /{{baseURL}}/g, req.query.baseURL );
 		resp.end( body );
@@ -250,17 +264,19 @@ const mocks = {
 			"Content-Security-Policy": "default-src 'self'; require-trusted-types-for 'script'; " +
 				"report-uri /test/data/mock.php?action=cspLog"
 		} );
-		const body = fs.readFileSync( `${ __dirname }/data/csp.include.html` ).toString();
+		const body = readFileSync( `${ __dirname }/data/csp.include.html` ).toString();
 		resp.end( body );
 	},
 	cspNonce: function( req, resp ) {
-		const testParam = req.query.test ? `-${ req.query.test }` : "";
+		const testParam = req.query.test ?
+			`-${ req.query.test.replace( /[^a-z0-9]/gi, "" ) }` :
+			"";
 		resp.writeHead( 200, {
 			"Content-Type": "text/html",
 			"Content-Security-Policy": "script-src 'nonce-jquery+hardcoded+nonce'; " +
 				"report-uri /test/data/mock.php?action=cspLog"
 		} );
-		const body = fs.readFileSync(
+		const body = readFileSync(
 			`${ __dirname }/data/csp-nonce${ testParam }.html` ).toString();
 		resp.end( body );
 	},
@@ -270,7 +286,7 @@ const mocks = {
 			"Content-Security-Policy": "script-src 'self'; " +
 				"report-uri /test/data/mock.php?action=cspLog"
 		} );
-		const body = fs.readFileSync(
+		const body = readFileSync(
 			`${ __dirname }/data/csp-ajax-script.html` ).toString();
 		resp.end( body );
 	},
@@ -290,7 +306,7 @@ const mocks = {
 			"Content-Security-Policy": "require-trusted-types-for 'script'; " +
 				"report-uri /test/data/mock.php?action=cspLog"
 		} );
-		const body = fs.readFileSync( `${ __dirname }/data/trusted-html.html` ).toString();
+		const body = readFileSync( `${ __dirname }/data/trusted-html.html` ).toString();
 		resp.end( body );
 	},
 	trustedTypesAttributes: function( _req, resp ) {
@@ -299,7 +315,7 @@ const mocks = {
 			"Content-Security-Policy": "require-trusted-types-for 'script'; " +
 				"report-uri /test/data/mock.php?action=cspLog"
 		} );
-		const body = fs.readFileSync(
+		const body = readFileSync(
 			`${ __dirname }/data/trusted-types-attributes.html` ).toString();
 		resp.end( body );
 	},


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

`fs.readFileSync` crashes when a non-existing file is passed to it. Some APIs of `middleware-mockserver` read a file the path of which depends on query parameters, making it possible to crash it by providing such a parameter. The old PHP server doesn't have these issues.

To fix this, wrap all `fs.readFileSync` occurrences with a function that falls back to the string `"ERROR"`.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
