### PR TITLE
Selector: Properly deprecate `jQuery.expr[ ":" ]`/`jQuery.expr.filters`

### DIFF
--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -43,4 +43,6 @@ jQuery.holdReady = function( hold ) {
 	}
 };
 
+jQuery.expr[ ":" ] = jQuery.expr.filters = jQuery.expr.pseudos;
+
 export { jQuery, jQuery as $ };

--- a/src/selector.js
+++ b/src/selector.js
@@ -846,7 +846,7 @@ for ( i in { submit: true, reset: true } ) {
 
 // Easy API for creating new setFilters
 function setFilters() {}
-setFilters.prototype = jQuery.expr.filters = jQuery.expr.pseudos;
+setFilters.prototype = jQuery.expr.pseudos;
 jQuery.expr.setFilters = new setFilters();
 
 function addCombinator( matcher, combinator, base ) {

--- a/test/unit/deprecated.js
+++ b/test/unit/deprecated.js
@@ -205,4 +205,17 @@ QUnit.test( "jQuery.proxy", function( assert ) {
 	cb.call( thisObject, "arg3" );
 } );
 
+if ( includesModule( "selector" ) ) {
+	QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ](
+		"jQuery.expr[ \":\" ], jQuery.expr.filters",
+		function( assert ) {
+			assert.expect( 2 );
+
+			assert.strictEqual( jQuery.expr[ ":" ], jQuery.expr.pseudos,
+				"jQuery.expr[ \":\" ] is an alias of jQuery.expr.pseudos" );
+			assert.strictEqual( jQuery.expr.filters, jQuery.expr.pseudos,
+				"jQuery.expr.filters is an alias of jQuery.expr.pseudos" );
+		} );
+}
+
 }

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -2167,10 +2167,10 @@ QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "custom pseudos", function( as
 	assert.expect( 6 );
 
 	try {
-		jQuery.expr.filters.foundation = jQuery.expr.filters.root;
+		jQuery.expr.pseudos.foundation = jQuery.expr.pseudos.root;
 		assert.deepEqual( jQuery.find( ":foundation" ), [ document.documentElement ], "Copy element filter with new name" );
 	} finally {
-		delete jQuery.expr.filters.foundation;
+		delete jQuery.expr.pseudos.foundation;
 	}
 
 	try {
@@ -2181,25 +2181,25 @@ QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "custom pseudos", function( as
 	}
 
 	try {
-		jQuery.expr.filters.aristotlean = jQuery.expr.createPseudo( function() {
+		jQuery.expr.pseudos.aristotlean = jQuery.expr.createPseudo( function() {
 			return function( elem ) {
 				return !!elem.id;
 			};
 		} );
 		assert.t( "Custom element filter", "#foo :aristotlean", [ "sndp", "en", "yahoo", "sap", "anchor2", "timmy" ] );
 	} finally {
-		delete jQuery.expr.filters.aristotlean;
+		delete jQuery.expr.pseudos.aristotlean;
 	}
 
 	try {
-		jQuery.expr.filters.endswith = jQuery.expr.createPseudo( function( text ) {
+		jQuery.expr.pseudos.endswith = jQuery.expr.createPseudo( function( text ) {
 			return function( elem ) {
 				return jQuery.text( elem ).slice( -text.length ) === text;
 			};
 		} );
 		assert.t( "Custom element filter with argument", "a:endswith(ogle)", [ "google" ] );
 	} finally {
-		delete jQuery.expr.filters.endswith;
+		delete jQuery.expr.pseudos.endswith;
 	}
 
 	try {
@@ -2213,7 +2213,7 @@ QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "custom pseudos", function( as
 		} );
 		assert.t( "Custom set filter", "#qunit-fixture p:second", [ "ap" ] );
 	} finally {
-		delete jQuery.expr.filters.second;
+		delete jQuery.expr.setFilters.second;
 	}
 
 	try {
@@ -2233,7 +2233,7 @@ QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "custom pseudos", function( as
 		} );
 		assert.t( "Custom set filter with argument", "#qunit-fixture p:slice(1:3)", [ "ap", "sndp" ] );
 	} finally {
-		delete jQuery.expr.filters.slice;
+		delete jQuery.expr.setFilters.slice;
 	}
 } );
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Those APIs have formally been deprecated since `3.0.0`, but they never made its way into the deprecated module.

`jQuery.expr[ ":" ]` has been removed when Sizzle got inlined into Core in gh-4395; this change restores it.

Ref gh-5570
Ref gh-4395

PR for `3.x-stable`: #5570

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
