### PR TITLE
CSS: Drop the cache in finalPropName

### DIFF
--- a/src/css/finalPropName.js
+++ b/src/css/finalPropName.js
@@ -1,8 +1,7 @@
 import { document } from "../var/document.js";
 
 var cssPrefixes = [ "Webkit", "Moz", "ms" ],
-	emptyStyle = document.createElement( "div" ).style,
-	vendorProps = {};
+	emptyStyle = document.createElement( "div" ).style;
 
 // Return a vendor-prefixed property or undefined
 function vendorPropName( name ) {
@@ -21,13 +20,8 @@ function vendorPropName( name ) {
 
 // Return a potentially-mapped vendor prefixed property
 export function finalPropName( name ) {
-	var final = vendorProps[ name ];
-
-	if ( final ) {
-		return final;
-	}
 	if ( name in emptyStyle ) {
 		return name;
 	}
-	return vendorProps[ name ] = vendorPropName( name ) || name;
+	return vendorPropName( name ) || name;
 }

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -1705,7 +1705,7 @@ QUnit.test( "Do not throw on frame elements from css method (trac-15098)", funct
 ( function() {
 	var vendorPrefixes = [ "Webkit", "Moz", "ms" ];
 
-	QUnit.test( "Don't default to a cached previously used wrong prefixed name (gh-2015)", function( assert ) {
+	QUnit.test( "Don't default to a previously used wrong prefixed name (gh-2015)", function( assert ) {
 
 		// Note: this test needs a property we know is only supported in a prefixed version
 		// by at least one of our main supported browsers. This may get out of date so let's
@@ -1761,7 +1761,7 @@ QUnit.test( "Do not throw on frame elements from css method (trac-15098)", funct
 
 } )();
 
-QUnit.test( "Don't detect fake set properties on a node when caching the prefixed version", function( assert ) {
+QUnit.test( "Don't update existing unsupported prefixed properties", function( assert ) {
 	assert.expect( 1 );
 
 	var elem = jQuery( "<div></div>" ),
@@ -1769,7 +1769,7 @@ QUnit.test( "Don't detect fake set properties on a node when caching the prefixe
 	style.MozFakeProperty = "old value";
 	elem.css( "fakeProperty", "new value" );
 
-	assert.equal( style.MozFakeProperty, "old value", "Fake prefixed property is not cached" );
+	assert.equal( style.MozFakeProperty, "old value", "Fake prefixed property is not set" );
 } );
 
 QUnit.test( "Don't set fake prefixed properties when a regular one is missing", function( assert ) {

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -1759,18 +1759,32 @@ QUnit.test( "Do not throw on frame elements from css method (trac-15098)", funct
 		assert.equal( elemStyle.undefined, undefined, "Nothing writes to node.style.undefined" );
 	} );
 
-	QUnit.test( "Don't detect fake set properties on a node when caching the prefixed version", function( assert ) {
-		assert.expect( 1 );
-
-		var elem = jQuery( "<div></div>" ),
-			style = elem[ 0 ].style;
-		style.MozFakeProperty = "old value";
-		elem.css( "fakeProperty", "new value" );
-
-		assert.equal( style.MozFakeProperty, "old value", "Fake prefixed property is not cached" );
-	} );
-
 } )();
+
+QUnit.test( "Don't detect fake set properties on a node when caching the prefixed version", function( assert ) {
+	assert.expect( 1 );
+
+	var elem = jQuery( "<div></div>" ),
+		style = elem[ 0 ].style;
+	style.MozFakeProperty = "old value";
+	elem.css( "fakeProperty", "new value" );
+
+	assert.equal( style.MozFakeProperty, "old value", "Fake prefixed property is not cached" );
+} );
+
+QUnit.test( "Don't set fake prefixed properties when a regular one is missing", function( assert ) {
+	assert.expect( 5 );
+
+	var elem = jQuery( "<div></div>" ),
+		style = elem[ 0 ].style;
+	elem.css( "fakeProperty", "fake value" );
+
+	assert.strictEqual( style.fakeProperty, "fake value", "Fake unprefixed property is set" );
+	assert.strictEqual( style.webkitFakeProperty, undefined, "Fake prefixed property is not set (webkit)" );
+	assert.strictEqual( style.WebkitFakeProperty, undefined, "Fake prefixed property is not set (Webkit)" );
+	assert.strictEqual( style.MozFakeProperty, undefined, "Fake prefixed property is not set (Moz)" );
+	assert.strictEqual( style.msFakeProperty, undefined, "Fake prefixed property is not set (ms)" );
+} );
 
 // IE doesn't support CSS variables.
 QUnit.testUnlessIE( "css(--customProperty)", function( assert ) {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The `finalPropName` util caches properties detected to require a vendor prefix. This used to cache unprefixed properties as well, but it was reported that this logic broke accidentally during a refactor. Since fewer & fewer properties require a vendor prefix and caching a few basic checks likely has negligible perf benefits, opt to saving a few bytes and remove the cache.

Ref gh-5582

Size comparison:
```
main @d5ebb464debab6ac39fe065e93c8a7ae1de8547e
   raw     gz Filename
    -9     -3 dist/jquery.min.js
    -9     -7 dist/jquery.slim.min.js
    -9     -4 dist-module/jquery.module.min.js
    -9     -7 dist-module/jquery.slim.module.min.js
```

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
