### PR TITLE
Build: Fix pre release matching in compare size regex

### DIFF
--- a/build/tasks/lib/compareSize.js
+++ b/build/tasks/lib/compareSize.js
@@ -111,7 +111,7 @@ export async function compareSize( { cache = ".sizecache.json", files } = {} ) {
 			// Remove the short SHA and .dirty from comparisons.
 			// The short SHA so commits can be compared against each other
 			// and .dirty to compare with the existing branch during development.
-			const sha = /jQuery v\d+.\d+.\d+(?:-\w+)?(?:\+slim\.|\+)?([^ \.]+(?:\.dirty)?)?/.exec( contents )[ 1 ];
+			const sha = /jQuery v\d+.\d+.\d+(?:-[\w\.]+)?(?:\+slim\.|\+)?(\w+(?:\.dirty)?)?/.exec( contents )[ 1 ];
 			contents = contents.replace( new RegExp( sha, "g" ), "" );
 
 			const size = Buffer.byteLength( contents, "utf8" );

--- a/build/tasks/lib/compareSize.js
+++ b/build/tasks/lib/compareSize.js
@@ -5,7 +5,7 @@ import { exec as nodeExec } from "node:child_process";
 import chalk from "chalk";
 import isCleanWorkingDir from "./isCleanWorkingDir.js";
 
-const VERSION = 1;
+const VERSION = 2;
 const lastRunBranch = " last run";
 
 const gzip = promisify( zlib.gzip );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->
@mgol noticed this in https://github.com/jquery/jquery/pull/5583#issuecomment-2487006240

- The regex wasn't accounting for the added `.2` in `beta.2`.
- Incremented the version number in compareSize.js so that all existing caches automatically reset.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
