### PR TITLE
Fix: Skip undefined values during serialization

### DIFF
--- a/src/serialize.js
+++ b/src/serialize.js
@@ -62,6 +62,11 @@ jQuery.param = function( a, traditional ) {
 				valueOrFunction() :
 				valueOrFunction;
 
+			// Skip undefined values
+			if (value === undefined) {
+					return;
+			}
+
 			s[ s.length ] = encodeURIComponent( key ) + "=" +
 				encodeURIComponent( value == null ? "" : value );
 		};


### PR DESCRIPTION
### Summary ###
This PR improves the `param` function by adding a check to skip `undefined` values during serialization. This ensures that `undefined` values are not included in the final query string.

### Checklist ###

* [x] New tests have been added to show the fix works
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com