### PR TITLE
Build: Stop testing on iOS 10

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -48,9 +48,19 @@ jobs:
           - '__iOS_13'
           - '__iOS_12'
           - '__iOS_11'
-          - '__iOS_10'
+
+          # iOS 10 is a tier 4 device as of January 2025 and its availability
+          # is poor, leading to frequent test timeouts. Skip testing on it.
+          # See https://www.browserstack.com/device-tiers
+          # - '__iOS_10'
+
+          # Versions below are not officially supported by BrowserStack as
+          # they use emulators instead of real devices. We include them as
+          # long as they still work.
           - '__iOS_9'
           - '__iOS_8'
+          # iOS 7 emulators no longer work properly
+          # - '__iOS_7'
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

As of January 2025, iOS 10 is a tier 4 device on BrowserStack: https://www.browserstack.com/device-tiers
That leads to devices with this iOS version often not being available and failing our tests. Remove it from the test matrix. Also, add comments explaining the status of tests on various iOS versions, including iOS 7 that we stopped testing on a long time ago.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com: not API, but see https://github.com/jquery/jquery.com/pull/248

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
