### PR TITLE
Attributes: Support the `until-found` value for the `hidden` attribute

### DIFF
--- a/src/attributes/attr.js
+++ b/src/attributes/attr.js
@@ -106,17 +106,19 @@ jQuery.extend( {
 // Hooks for boolean attributes
 boolHook = {
 	set: function( elem, value, name ) {
+		var strValue = String( value );
+
 		if ( value === false ) {
 
 			// Remove boolean attributes when set to false
 			jQuery.removeAttr( elem, name );
-		} else if (
-			name.toLowerCase() !== "hidden" ||
-				String( value ).toLowerCase() !== "until-found"
-		) {
-			elem.setAttribute( name, name );
 		} else {
-			elem.setAttribute( name, value );
+			elem.setAttribute( name,
+				name.toLowerCase() === "hidden" &&
+						strValue.toLowerCase() === "until-found" ?
+					strValue :
+					name
+			);
 		}
 		return name;
 	}
@@ -136,13 +138,10 @@ jQuery.each( jQuery.expr.match.bool.source.match( /\w+/g ), function( _i, name )
 			attrHandle[ lowercaseName ] = ret;
 
 			ret = getter( elem, name, isXML );
-			if ( ret != null ) {
-				if ( lowercaseName !== "hidden" ||
-					ret.toLowerCase() !== "until-found"
-				) {
-					ret = lowercaseName;
-				}
-			}
+			ret = ret == null ||
+					( lowercaseName === "hidden" && ret.toLowerCase() === "until-found" ) ?
+				ret :
+				lowercaseName;
 
 			attrHandle[ lowercaseName ] = handle;
 		}

--- a/src/attributes/attr.js
+++ b/src/attributes/attr.js
@@ -10,13 +10,7 @@ define( [
 "use strict";
 
 var boolHook,
-	attrHandle = jQuery.expr.attrHandle,
-
-	// Some formerly boolean attributes gained new values with special meaning.
-	// Skip the old boolean attr logic for those values.
-	extraBoolAttrValues = {
-		hidden: [ "until-found" ]
-	};
+	attrHandle = jQuery.expr.attrHandle;
 
 jQuery.fn.extend( {
 	attr: function( name, value ) {
@@ -117,8 +111,8 @@ boolHook = {
 			// Remove boolean attributes when set to false
 			jQuery.removeAttr( elem, name );
 		} else if (
-			( extraBoolAttrValues[ name.toLowerCase() ] || [] )
-				.indexOf( String( value ).toLowerCase() ) === -1
+			name.toLowerCase() !== "hidden" ||
+				String( value ).toLowerCase() !== "until-found"
 		) {
 			elem.setAttribute( name, name );
 		} else {
@@ -143,8 +137,8 @@ jQuery.each( jQuery.expr.match.bool.source.match( /\w+/g ), function( _i, name )
 
 			ret = getter( elem, name, isXML );
 			if ( ret != null ) {
-				if ( ( extraBoolAttrValues[ lowercaseName ] || [] )
-					.indexOf( ret.toLowerCase() ) === -1
+				if ( lowercaseName !== "hidden" ||
+					ret.toLowerCase() !== "until-found"
 				) {
 					ret = lowercaseName;
 				}

--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -479,6 +479,24 @@ QUnit.test( "attr(String, Object)", function( assert ) {
 	assert.equal( jQuery( "#name" ).attr( "nonexisting", undefined ).attr( "nonexisting" ), undefined, ".attr('attribute', undefined) does not create attribute (trac-5571)" );
 } );
 
+QUnit.test( "attr( previously-boolean-attr, non-boolean-value)", function( assert ) {
+	assert.expect( 3 );
+
+	var div = jQuery( "<div></div>" ).appendTo( "#qunit-fixture" );
+
+	div.attr( "hidden", "foo" );
+	assert.strictEqual( div.attr( "hidden" ), "hidden",
+		"Values normalized for previously-boolean hidden attribute" );
+
+	div.attr( "hidden", "until-found" );
+	assert.strictEqual( div.attr( "hidden" ), "until-found",
+		"`until-found` value preserved for hidden attribute" );
+
+	div.attr( "hiDdeN", "uNtil-fOund" );
+	assert.strictEqual( div.attr( "hidden" ), "uNtil-fOund",
+		"`uNtil-fOund` different casing preserved" );
+} );
+
 QUnit.test( "attr(non-ASCII)", function( assert ) {
 	assert.expect( 2 );
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The `hidden` attribute used to be a boolean one but it gained a new `until-found` eventually. This led us to change the way we handle boolean attributes in jQuery 4.0 in gh-5452 to avoid these issues in the future.

That said, currently from the attributes we treat as boolean only `hidden` has gained an extra value, let's support it.

Ref gh-5388
Ref gh-5452

The cost is currently quite high:
```
3.x-stable @fc874a0e125b01c2d91b4a8a06213bf1f1e5bfb6
   raw     gz     br Filename
  +157    +66    +58 dist/jquery.min.js
  +157    +52    +36 dist/jquery.slim.min.js
```

It's possible it could be lowered if we removed the infra for adding future attributes to the list and just mentioned `hidden` & `until-found` explicitly in both the getter & setter.

Another alternative is to avoid changing the `3.x` line and instead add a note to the docs, showing how to define an attrHook for `hidden` that will achieve the same result.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
