### PR TITLE
Tests: Backport the `hidden="until-found"` attr tests from 3.x-stable

### DIFF
--- a/test/unit/attributes.js
+++ b/test/unit/attributes.js
@@ -479,6 +479,24 @@ QUnit.test( "attr(String, Object)", function( assert ) {
 	assert.equal( jQuery( "#name" ).attr( "nonexisting", undefined ).attr( "nonexisting" ), undefined, ".attr('attribute', undefined) does not create attribute (trac-5571)" );
 } );
 
+QUnit.test( "attr( previously-boolean-attr, non-boolean-value)", function( assert ) {
+	assert.expect( 3 );
+
+	var div = jQuery( "<div></div>" ).appendTo( "#qunit-fixture" );
+
+	div.attr( "hidden", "foo" );
+	assert.strictEqual( div.attr( "hidden" ), "foo",
+		"Values not normalized for previously-boolean hidden attribute" );
+
+	div.attr( "hidden", "until-found" );
+	assert.strictEqual( div.attr( "hidden" ), "until-found",
+		"`until-found` value preserved for hidden attribute" );
+
+	div.attr( "hiDdeN", "uNtil-fOund" );
+	assert.strictEqual( div.attr( "hidden" ), "uNtil-fOund",
+		"`uNtil-fOund` different casing preserved" );
+} );
+
 QUnit.test( "attr(non-ASCII)", function( assert ) {
 	assert.expect( 2 );
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The `hidden` attribute used to be a boolean one but it gained a new `until-found` eventually. This led us to change the way we handle boolean attributes in jQuery 4.0 in gh-5452 to avoid these issues in the future.

We haven't added an explicit test for the `"until-found"` value of the `hidden` attribute which triggered this decision so far, though. Backport the test from gh-5607 which landed on `3.x-stable` so that we do test it.

Ref gh-5452
Ref gh-5607

(cherry picked from commit 85290c59724db69a3967885892d4305d76de058f)

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
