### PR TITLE
Event: Use `.preventDefault()` in beforeunload

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -485,12 +485,17 @@ jQuery.event = {
 
 		beforeunload: {
 			postDispatch: function( event ) {
+				if ( event.result !== undefined ) {
 
-				// Support: Chrome <=73+
-				// Chrome doesn't alert on `event.preventDefault()`
-				// as the standard mandates.
-				if ( event.result !== undefined && event.originalEvent ) {
-					event.originalEvent.returnValue = event.result;
+					// Setting `event.originalEvent.returnValue` in modern
+					// browsers does the same as just calling `preventDefault()`,
+					// the browsers ignore the value anyway.
+					// Incidentally, IE 11 is the only browser from our supported
+					// ones which respects the value returned from a `beforeunload`
+					// handler attached by `addEventListener`; other browsers do
+					// so only for inline handlers, so not setting the value
+					// directly shouldn't reduce any functionality.
+					event.preventDefault();
 				}
 			}
 		}


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

So far, a result of an event handler has been assigned to the `returnValue` of the original event by jQuery. Initially, one could pass a message the browser will then display to the user. Since that got abused a lot, every browser stopped using the provided string and they all now provide a generic message. From the browsers supported in v4, only IE 11 would still display the message.

Incidentally, IE 11 is the only browser from our supported ones which respects the value returned from a beforeunload handler attached by `addEventListener`; other browsers do so only for inline handlers, so not setting the value directly shouldn't reduce any functionality.

This looks like a good moment to stop passing the message through and just call `event.preventDefault()` without extra checks which is shorter. This used to not work in Chrome but it got implemented in Chrome 119.

Unfortunately, it's hard to test this event in unit tests since it blocks page dismissal.

Size difference:
```
main @667321eb2d1c4328b993c25fbe2342a01ec4f87f
   raw     gz     br Filename
   -37    -17    +15 dist/jquery.min.js
   -37    -18     -7 dist/jquery.slim.min.js
   -37    -17    +31 dist-module/jquery.module.min.js
   -37    -19    -10 dist-module/jquery.slim.module.min.js
```

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] New tests have been added to show the fix or feature works
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
