### PR TITLE
Build: ESLint: Remove the `outerIIFEBody` exception to `indent`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -59,13 +59,7 @@ export default [
 			// 		ignoreExports: [ "{src/,}*.js" ]
 			// 	}
 			// ],
-			indent: [
-				"error",
-				"tab",
-				{
-					outerIIFEBody: 0
-				}
-			],
+			indent: [ "error", "tab" ],
 			"no-implicit-globals": "error",
 			"no-unused-vars": [
 				"error",


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

It used to be necessary when we still had the `selector` outer IIFE, but that got simplified.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
