### PR TITLE
Tests: Fix tests for `jQuery.get( String, null-ish, null-ish, String )`

### DIFF
--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -2823,7 +2823,7 @@ if ( typeof window.ArrayBuffer === "undefined" || typeof new XMLHttpRequest().re
 					done();
 				} );
 
-			jQuery.get( url( "mock.php?action=json&header" ), null, "text" )
+			jQuery.get( url( "mock.php?action=json&header" ), data, success, "text" )
 				.then( function( text ) {
 					assert.strictEqual( text, "{\"data\":{\"lang\":\"en\",\"length\":25}}",
 						"`dataType: \"text\"` applied with `" + data + "` data & `" +


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The original test's `text` variant just repeated the previous test with 3 parameters; the goal was to use 4 ones. This fixes it.

Ref gh-5640
Ref gh-5645

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com - PR already at https://github.com/jquery/api.jquery.com/pull/1208

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
