### PR TITLE
Core: Formally deprecate push/sort/splice

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -121,13 +121,7 @@ jQuery.fn = jQuery.prototype = {
 
 	end: function() {
 		return this.prevObject || this.constructor();
-	},
-
-	// For internal use only.
-	// Behaves like an Array's method, not like a jQuery method.
-	push: push,
-	sort: arr.sort,
-	splice: arr.splice
+	}
 };
 
 jQuery.extend = jQuery.fn.extend = function() {

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -3,13 +3,16 @@ define( [
 	"./core/nodeName",
 	"./core/camelCase",
 	"./core/toType",
+	"./var/arr",
 	"./var/isFunction",
 	"./var/isWindow",
+	"./var/push",
 	"./var/slice",
 
 	"./deprecated/ajax-event-alias",
 	"./deprecated/event"
-], function( jQuery, nodeName, camelCase, toType, isFunction, isWindow, slice ) {
+], function( jQuery, nodeName, camelCase, toType, arr, isFunction, isWindow,
+	push, slice ) {
 
 "use strict";
 
@@ -89,5 +92,12 @@ jQuery.trim = function( text ) {
 
 jQuery.expr[ ":" ] = jQuery.expr.filters = jQuery.expr.pseudos;
 jQuery.unique = jQuery.uniqueSort;
+
+// Those methods behave like an Array's methods, not like jQuery ones.
+jQuery.fn.extend( {
+	push: push,
+	sort: arr.sort,
+	splice: arr.splice
+} );
 
 } );

--- a/test/unit/deprecated.js
+++ b/test/unit/deprecated.js
@@ -724,4 +724,33 @@ QUnit.test( "jQuery.unique", function( assert ) {
 		"jQuery.unique is an alias of jQuery.uniqueSort" );
 } );
 
+QUnit.test( "push/sort/splice", function( assert ) {
+	assert.expect( 4 );
+
+	var elem = jQuery( "<div id='2'></div>" ),
+		div1 = document.createElement( "div" ),
+		div3 = document.createElement( "div" ),
+		div4 = document.createElement( "div" );
+
+	div1.id = "1";
+	div3.id = "3";
+	div4.id = "4";
+
+	elem.push( div1 );
+	assert.strictEqual( elem.length, 2, "push works" );
+
+	elem.sort( function( a, b ) {
+		return Number( a.id ) - Number( b.id );
+	} );
+	assert.strictEqual( elem[ 0 ].id + "," + elem[ 1 ].id, "1,2", "sort works" );
+
+	elem.splice( 1, 1, div4, div3 );
+	assert.strictEqual( elem.length, 3, "splice works (length)" );
+	assert.strictEqual( [
+		elem[ 0 ].id,
+		elem[ 1 ].id,
+		elem[ 2 ].id
+	].join( "," ), "1,4,3", "splice works" );
+} );
+
 }


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Since we inlined Sizzle into jQuery, we haven't been actually using these three
methods internally. Therefore, we could add deprecation warnings in Migrate 3.x
for them with jQuery 3.7.0 or newer - both 3.7.0 & 3.7.1 pass all the tests
with them removed (while 3.6.4 does not).

Some basic tests were added as well.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
