### PR TITLE
DOMEval make use of script nonce value for CSP nonce- validation

### DIFF
--- a/src/core/DOMEval.js
+++ b/src/core/DOMEval.js
@@ -20,6 +20,13 @@ export function DOMEval( code, node, doc ) {
 		}
 	}
 
+	if (!script.nonce) {
+		const currentNonce = doc.querySelector("script[nonce]")?.getAttribute("nonce");
+		if (currentNonce) {
+			script.setAttribute("nonce", currentNonce);
+		}
+	}
+
 	if ( doc.head.appendChild( script ).parentNode ) {
 		script.parentNode.removeChild( script );
 	}


### PR DESCRIPTION
### Summary ###
Enabling the use of script nonce tags in jquery which allowed to make a CSP Policy without unsafe-eval for jquery.
the nonce will be picked from the script tag if set.
Or if it is already set nothing will be done.

### Checklist ###

* [ ] New tests have been added to show the fix or feature works
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

