### PR TITLE
Build: Try to unpack Firefox ESR via xz, fall back to bzip2 (3.x)

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -72,7 +72,13 @@ jobs:
 
       - name: Install Firefox ESR
         run: |
-          wget --no-verbose $FIREFOX_SOURCE_URL -O - | tar -jx -C ${HOME}
+          # Support: Firefox <135 only
+          # Older Firefox used to be compressed using bzip2, newer using xz. Try
+          # to uncompress using xz, fall back to bzip2 if that fails.
+          # Note: this will download the old Firefox ESR twice, but it will still work
+          # when the current ESR version starts to use xz with no changes to the code.
+          wget --no-verbose "$FIREFOX_SOURCE_URL" -O - | tar -Jx -C "$HOME" || \
+          wget --no-verbose "$FIREFOX_SOURCE_URL" -O - | tar -jx -C "$HOME"
           echo "PATH=${HOME}/firefox:$PATH" >> "$GITHUB_ENV"
           echo "FIREFOX_BIN=${HOME}/firefox/firefox" >> "$GITHUB_ENV"
         if: contains(matrix.NAME, 'Firefox ESR')


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

This is a 3.x version of gh-5682.

The `-j` switch passed to `tar` indicates the archive is compressed using the bzip2 format (`bz2` extension). That was how Firefox used to be compressed until recently, but the new ESR release now uses xz. Ubuntu `tar` doesn't auto-guess the encryption algorithm, so to support both, first try with xz and fall back to bzip2 if that fails.

Note: this will download the old Firefox ESR twice, but it will still work when the current ESR version starts to use xz with no changes to the code

Ref gh-5682

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
