### PR TITLE
Build: Update the jQuery license link in comment headers

### DIFF
--- a/build/tasks/minify.js
+++ b/build/tasks/minify.js
@@ -24,7 +24,7 @@ export default async function minify( { filename, dir, esm } ) {
 				comments: false,
 				preamble: `/*! jQuery ${ version }` +
 					" | (c) OpenJS Foundation and other contributors" +
-					" | jquery.org/license */\n"
+					" | jquery.com/license */\n"
 			},
 			inlineSourcesContent: false,
 			mangle: true,

--- a/src/wrapper-esm.js
+++ b/src/wrapper-esm.js
@@ -4,7 +4,7 @@
  *
  * Copyright OpenJS Foundation and other contributors
  * Released under the MIT license
- * https://jquery.org/license
+ * https://jquery.com/license/
  *
  * Date: @DATE
  */

--- a/src/wrapper-factory-esm.js
+++ b/src/wrapper-factory-esm.js
@@ -4,7 +4,7 @@
  *
  * Copyright OpenJS Foundation and other contributors
  * Released under the MIT license
- * https://jquery.org/license
+ * https://jquery.com/license/
  *
  * Date: @DATE
  */

--- a/src/wrapper-factory.js
+++ b/src/wrapper-factory.js
@@ -4,7 +4,7 @@
  *
  * Copyright OpenJS Foundation and other contributors
  * Released under the MIT license
- * https://jquery.org/license
+ * https://jquery.com/license/
  *
  * Date: @DATE
  */

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -4,7 +4,7 @@
  *
  * Copyright OpenJS Foundation and other contributors
  * Released under the MIT license
- * https://jquery.org/license
+ * https://jquery.com/license/
  *
  * Date: @DATE
  */


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Switch https://jquery.org/license to https://jquery.com/license/, note the trailing slash. Leave the trailing slash from the minified version to save size.

3.x version: #5686

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
