### PR TITLE
Build: Update the jQuery license link in comment headers

### DIFF
--- a/build/tasks/minify.js
+++ b/build/tasks/minify.js
@@ -12,7 +12,7 @@ export default async function minify( { dir, filename } ) {
 	const version = /jQuery JavaScript Library ([^\n]+)/.exec( contents )[ 1 ];
 	const banner = `/*! jQuery ${ version }` +
 		" | (c) OpenJS Foundation and other contributors" +
-		" | jquery.org/license */";
+		" | jquery.com/license */";
 
 	const minFilename = filename.replace( rjs, ".min.js" );
 	const mapFilename = filename.replace( rjs, ".min.map" );

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -4,7 +4,7 @@
  *
  * Copyright OpenJS Foundation and other contributors
  * Released under the MIT license
- * https://jquery.org/license
+ * https://jquery.com/license/
  *
  * Date: @DATE
  */


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Switch https://jquery.org/license to https://jquery.com/license/, note the trailing slash. Leave the trailing slash from the minified version to save size.

4.x version: #5685

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
