### PR TITLE
Build: Test on Safari 18 & 17 instead of "latest-1"

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -23,7 +23,13 @@ jobs:
         BROWSER:
           - 'IE_11'
           - 'Safari_latest'
-          - 'Safari_latest-1'
+          # JTR doesn't take into account the jump from Safari 18 to 26,
+          # so we need to specify versions explicitly. Also, while BrowserStack
+          # already added macOS Tahoe with Safari 26, it's not a stable release
+          # yet, so we need to test on Safari 17 as well.
+          # See https://github.com/jquery/jquery-test-runner/issues/17
+          - 'Safari_18'
+          - 'Safari_17'
           - 'Chrome_latest'
           - 'Chrome_latest-1'
           - 'Opera_latest'


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

JTR doesn't take into account the jump from Safari 18 to 26, so we need to specify versions explicitly. Also, while BrowserStack already added macOS Tahoe with Safari 26, it's not a stable release yet, so we need to test on Safari 17 as well.

Ref jquery/jquery-test-runner#17

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
