### PR TITLE
Release: Fix release issues uncovered during the 4.0.0-rc.1 release

### DIFF
--- a/.release-it.cjs
+++ b/.release-it.cjs
@@ -9,7 +9,7 @@ if ( !blogURL || !blogURL.startsWith( "https://blog.jquery.com/" ) ) {
 module.exports = {
 	preReleaseBase: 1,
 	hooks: {
-		"before:init": "bash ./build/release/pre-release.sh",
+		"before:init": "./build/release/pre-release.sh",
 		"after:version:bump":
 			"sed -i '' -e 's|main/AUTHORS.txt|${version}/AUTHORS.txt|' package.json",
 		"after:bump": "cross-env VERSION=${version} npm run build:all",

--- a/build/release/pre-release.sh
+++ b/build/release/pre-release.sh
@@ -1,6 +1,11 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -euo pipefail
+
+if (( $(echo "$BASH_VERSION" | cut -f1 -d.) < 5 )); then
+	echo "Bash 5 or newer required. If you're on macOS, the built-in Bash is too old; install a newer one from Homebrew."
+	exit 1
+fi
 
 # Install dependencies
 npm ci

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jquery/jquery.git"
+    "url": "git+https://github.com/jquery/jquery.git"
   },
   "keywords": [
     "jquery",


### PR DESCRIPTION
Changes:
* Run `pre-release.sh` & `post-release.sh` scripts directly; make them executable
* Fix the hashbang to specify the default bash installation; note: `/bin/bash` would be a wrong choice as that would use an ancient 3.x version on macOS
* Make sure Bash 5 or newer is used
* Run `npm publish --tag beta` when a pre-release is being published
* Fix the `repository.url` field in `package.json` as reported by `npm publish`
* Fix a few issues reported by shellcheck

### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
