### PR TITLE
Tests: Fix module/nomodule tests flakiness

### DIFF
--- a/test/data/inner_module.js
+++ b/test/data/inner_module.js
@@ -1,1 +1,3 @@
-QUnit.assert.ok( true, "evaluated: inner module with src" );
+/* global innerExternalCallback */
+
+innerExternalCallback( "evaluated: inner module with src" );

--- a/test/data/inner_nomodule.js
+++ b/test/data/inner_nomodule.js
@@ -1,1 +1,3 @@
-QUnit.assert.ok( QUnit.isIE, "evaluated: inner nomodule script with src" );
+/* global innerExternalCallback */
+
+innerExternalCallback( "evaluated: inner nomodule script with src" );

--- a/test/data/module.js
+++ b/test/data/module.js
@@ -1,1 +1,4 @@
-QUnit.assert.ok( true, "evaluated: module with src" );
+/* global outerExternalCallback */
+
+console.warn( "m_gol module.js window.outerExternalCallback", window.outerExternalCallback );
+outerExternalCallback( "evaluated: module with src" );

--- a/test/data/nomodule.js
+++ b/test/data/nomodule.js
@@ -1,1 +1,3 @@
-QUnit.assert.ok( QUnit.isIE, "evaluated: nomodule script with src" );
+/* global outerExternalCallback */
+
+outerExternalCallback( "evaluated: nomodule script with src" );

--- a/test/data/testrunner.js
+++ b/test/data/testrunner.js
@@ -79,6 +79,7 @@ window.Globals = ( function() {
 		},
 
 		cleanup: function() {
+			console.warn( "m_gol Globals.cleanup", globals );
 			var name;
 
 			for ( name in globals ) {

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -1771,53 +1771,148 @@ QUnit.test( "html(Function)", function( assert ) {
 	testHtml( manipulationFunctionReturningObj, assert  );
 } );
 
-// Support: IE 9 - 11+
-// IE doesn't support modules.
-QUnit.testUnlessIE( "html(script type module)", function( assert ) {
-	assert.expect( 4 );
-	var done = assert.async(),
-		$fixture = jQuery( "#qunit-fixture" );
+( function() {
+	function setup( options ) {
+		var timeoutId,
+			assert = options.assert,
+			done = options.done,
+			expectedCount = options.expectedCount == null ? 1 : options.expectedCount,
+			timeout = options.timeout,
+			verified = false,
+			calls = {
+				outerExternal: 0,
+				innerExternal: 0,
+				outerInline: 0,
+				innerInline: 0
+			};
 
-	$fixture.html(
-		[
-			"<script type='module'>QUnit.assert.ok( true, 'evaluated: module' );</script>",
-			"<script type='module' src='" + url( "module.js" ) + "'></script>",
-			"<div>",
-				"<script type='module'>QUnit.assert.ok( true, 'evaluated: inner module' );</script>",
-				"<script type='module' src='" + url( "inner_module.js" ) + "'></script>",
-			"</div>"
-		].join( "" )
-	);
+		function verify( force ) {
+			console.warn( "m_gol verify", force );
+			var i;
+			if ( verified ) {
+				return;
+			}
 
-	// Allow asynchronous script execution to generate assertions
-	setTimeout( function() {
-		done();
-	}, 1000 );
-} );
+			if ( !force ) {
+				for ( i in calls ) {
 
-QUnit.test( "html(script nomodule)", function( assert ) {
+					// Not ready yet, we'll check later.
+					// If we're checking for 0, we don't know when to check, so
+					// wait until we force it.
+					if ( calls[ i ] !== expectedCount || calls[ i ] === 0 ) {
+						return;
+					}
+				}
+			}
 
-	// `nomodule` scripts should be executed by legacy browsers only.
-	assert.expect( QUnit.isIE ? 4 : 0 );
-	var done = assert.async(),
-		$fixture = jQuery( "#qunit-fixture" );
+			verified = true;
+			console.warn( "m_gol verify: proceeding", force );
 
-	$fixture.html(
-		[
-			"<script nomodule>QUnit.assert.ok( QUnit.isIE, 'evaluated: nomodule script' );</script>",
-			"<script nomodule src='" + url( "nomodule.js" ) + "'></script>",
-			"<div>",
-				"<script nomodule>QUnit.assert.ok( QUnit.isIE, 'evaluated: inner nomodule script' );</script>",
-				"<script nomodule src='" + url( "inner_nomodule.js" ) + "'></script>",
-			"</div>"
-		].join( "" )
-	);
+			assert.strictEqual( calls.outerExternal, expectedCount,
+				"Expected number of outer external calls: " + expectedCount );
+			assert.strictEqual( calls.innerExternal, expectedCount,
+				"Expected number of inner external calls: " + expectedCount );
+			assert.strictEqual( calls.outerInline, expectedCount,
+				"Expected number of outer inline calls: " + expectedCount );
+			assert.strictEqual( calls.innerInline, expectedCount,
+			"Expected number of inner inline calls: " + expectedCount );
 
-	// Allow asynchronous script execution to generate assertions
-	setTimeout( function() {
-		done();
-	}, 1000 );
-} );
+			clearInterval( timeoutId );
+			done();
+		}
+
+		Globals.register( "outerExternalCallback" );
+		Globals.register( "innerExternalCallback" );
+		Globals.register( "outerInlineCallback" );
+		Globals.register( "innerInlineCallback" );
+
+		window.outerExternalCallback = function( message ) {
+			if ( message ) {
+				assert.ok( true, message );
+			}
+			calls.outerExternal++;
+			verify();
+		};
+		window.innerExternalCallback = function( message ) {
+			if ( message ) {
+				assert.ok( true, message );
+			}
+			calls.innerExternal++;
+			verify();
+		};
+		window.outerInlineCallback = function( message ) {
+			if ( message ) {
+				assert.ok( true, message );
+			}
+			calls.outerInline++;
+			verify();
+		};
+		window.innerInlineCallback = function( message ) {
+			if ( message ) {
+				assert.ok( true, message );
+			}
+			calls.innerInline++;
+			verify();
+		};
+		console.warn( "m_gol window.outerExternalCallback", window.outerExternalCallback );
+
+		// Give some time for async script execution before forcing verification.
+		timeoutId = setTimeout( function() {
+			verify( true );
+		}, timeout );
+	}
+
+	// Support: IE 9 - 11+
+	// IE doesn't support modules.
+	QUnit.testUnlessIE( "html(script type module)", function( assert ) {
+		assert.expect( 8 );
+		var done = assert.async(),
+			$fixture = jQuery( "#qunit-fixture" );
+
+		setup( {
+			assert: assert,
+			done: done,
+			timeout: 5000
+		} );
+
+		$fixture.html(
+			[
+				"<script type='module'>outerInlineCallback( 'evaluated: module' );</script>",
+				"<script type='module' src='" + url( "module.js" ) + "'></script>",
+				"<div>",
+					"<script type='module'>innerInlineCallback( 'evaluated: inner module' );</script>",
+					"<script type='module' src='" + url( "inner_module.js" ) + "'></script>",
+				"</div>"
+			].join( "" )
+		);
+	} );
+
+	QUnit.test( "html(script nomodule)", function( assert ) {
+
+		// `nomodule` scripts should be executed by legacy browsers only.
+		assert.expect( QUnit.isIE ? 8 : 4 );
+		var done = assert.async(),
+			$fixture = jQuery( "#qunit-fixture" );
+
+		setup( {
+			assert: assert,
+			done: done,
+			timeout: 1000,
+			expectedCount: QUnit.isIE ? 1 : 0
+		} );
+
+		$fixture.html(
+			[
+				"<script nomodule>outerInlineCallback( 'evaluated: nomodule script' );</script>",
+				"<script nomodule src='" + url( "nomodule.js" ) + "'></script>",
+				"<div>",
+					"<script nomodule>innerInlineCallback( 'evaluated: inner nomodule script' );</script>",
+					"<script nomodule src='" + url( "inner_nomodule.js" ) + "'></script>",
+				"</div>"
+			].join( "" )
+		);
+	} );
+} )();
 
 QUnit.test( "html(self-removing script) (gh-5377)", function( assert ) {
 	assert.expect( 2 );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The module/nomodule tests are the most flaky ones, contributing significantly to increase number of test failures (somewhat mitigated by auto-retries).

Fix flakiness of module/nomodule tests:
1. For module tests, increase the timeout to 5 seconds. In order for most tests to not wait that long, change callbacks called by module scripts to verify the results as soon as all scripts have run.
2. For nomodule tests, run the check in 1 second. All modern browsers will need to wait that long, hence a smaller timeout, and if occasionally the check runs too quickly, the test will still pass.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
