### PR TITLE
Build: Separate Node.js & Browser Tests, update tested Node.js versions

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -1,0 +1,102 @@
+name: Browser Tests
+
+on:
+  pull_request:
+  push:
+    branches-ignore: "dependabot/**"
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+env:
+  NODE_VERSION: 22.x
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    name: ${{ matrix.NPM_SCRIPT }} - ${{ matrix.NAME }}
+    strategy:
+      fail-fast: false
+      matrix:
+        NAME: ["Chrome"]
+        NPM_SCRIPT: ["test:slim", "test:no-deprecated", "test:selector-native", "test:esm"]
+        include:
+          - NAME: "Chrome/Firefox"
+            NPM_SCRIPT: "test:browser"
+          - NAME: "Firefox ESR (new)"
+            NPM_SCRIPT: "test:firefox"
+          - NAME: "Firefox ESR (old)"
+            NPM_SCRIPT: "test:firefox"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: Set download URL for Firefox ESR (old)
+        run: |
+          echo "FIREFOX_SOURCE_URL=https://download.mozilla.org/?product=firefox-esr-latest-ssl&lang=en-US&os=linux64" >> "$GITHUB_ENV"
+        if: contains(matrix.NAME, 'Firefox ESR (old)')
+
+      - name: Set download URL for Firefox ESR (new)
+        run: |
+          echo "FIREFOX_SOURCE_URL=https://download.mozilla.org/?product=firefox-esr-next-latest-ssl&lang=en-US&os=linux64" >> "$GITHUB_ENV"
+        if: contains(matrix.NAME, 'Firefox ESR (new)')
+
+      - name: Install Firefox ESR
+        run: |
+          wget --no-verbose "$FIREFOX_SOURCE_URL" -O - | tar -Jx -C "$HOME"
+          echo "PATH=${HOME}/firefox:$PATH" >> "$GITHUB_ENV"
+          echo "FIREFOX_BIN=${HOME}/firefox/firefox" >> "$GITHUB_ENV"
+        if: contains(matrix.NAME, 'Firefox ESR')
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm run ${{ matrix.NPM_SCRIPT }}
+
+  ie:
+    runs-on: windows-latest
+    name: test:ie - IE
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests in Edge in IE mode
+        run: npm run test:ie
+
+  safari:
+    runs-on: macos-latest
+    name: test:safari - Safari
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test:safari

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,33 +16,12 @@ jobs:
       fail-fast: false
       matrix:
         NAME: ["Node"]
-        NODE_VERSION: [18.x, 20.x, 22.x, 23.x]
+        NODE_VERSION: [20.x, 22.x, 24.x]
         NPM_SCRIPT: ["test:browserless"]
         include:
           - NAME: "Node"
             NODE_VERSION: "22.x"
             NPM_SCRIPT: "lint"
-          - NAME: "Chrome/Firefox"
-            NODE_VERSION: "22.x"
-            NPM_SCRIPT: "test:browser"
-          - NAME: "Chrome"
-            NODE_VERSION: "22.x"
-            NPM_SCRIPT: "test:slim"
-          - NAME: "Chrome"
-            NODE_VERSION: "22.x"
-            NPM_SCRIPT: "test:no-deprecated"
-          - NAME: "Chrome"
-            NODE_VERSION: "22.x"
-            NPM_SCRIPT: "test:selector-native"
-          - NAME: "Chrome"
-            NODE_VERSION: "22.x"
-            NPM_SCRIPT: "test:esm"
-          - NAME: "Firefox ESR (new)"
-            NODE_VERSION: "22.x"
-            NPM_SCRIPT: "test:firefox"
-          - NAME: "Firefox ESR (old)"
-            NODE_VERSION: "22.x"
-            NPM_SCRIPT: "test:firefox"
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -54,29 +33,6 @@ jobs:
           cache: npm
           cache-dependency-path: '**/package-lock.json'
 
-      - name: Set download URL for Firefox ESR (old)
-        run: |
-          echo "FIREFOX_SOURCE_URL=https://download.mozilla.org/?product=firefox-esr-latest-ssl&lang=en-US&os=linux64" >> "$GITHUB_ENV"
-        if: contains(matrix.NAME, 'Firefox ESR (old)')
-
-      - name: Set download URL for Firefox ESR (new)
-        run: |
-          echo "FIREFOX_SOURCE_URL=https://download.mozilla.org/?product=firefox-esr-next-latest-ssl&lang=en-US&os=linux64" >> "$GITHUB_ENV"
-        if: contains(matrix.NAME, 'Firefox ESR (new)')
-
-      - name: Install Firefox ESR
-        run: |
-          # Support: Firefox <135 only
-          # Older Firefox used to be compressed using bzip2, newer using xz. Try
-          # to uncompress using xz, fall back to bzip2 if that fails.
-          # Note: this will download the old Firefox ESR twice, but it will still work
-          # when the current ESR version starts to use xz with no changes to the code.
-          wget --no-verbose "$FIREFOX_SOURCE_URL" -O - | tar -Jx -C "$HOME" || \
-          wget --no-verbose "$FIREFOX_SOURCE_URL" -O - | tar -jx -C "$HOME"
-          echo "PATH=${HOME}/firefox:$PATH" >> "$GITHUB_ENV"
-          echo "FIREFOX_BIN=${HOME}/firefox/firefox" >> "$GITHUB_ENV"
-        if: contains(matrix.NAME, 'Firefox ESR')
-
       - name: Install dependencies
         run: npm ci
 
@@ -86,47 +42,3 @@ jobs:
 
       - name: Run tests
         run: npm run ${{ matrix.NPM_SCRIPT }}
-
-  ie:
-    runs-on: windows-latest
-    env:
-      NODE_VERSION: 22.x
-    name: test:ie - IE
-    steps:
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-          cache-dependency-path: '**/package-lock.json'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run tests in Edge in IE mode
-        run: npm run test:ie
-
-  safari:
-    runs-on: macos-latest
-    env:
-      NODE_VERSION: 22.x
-    name: test:safari - Safari
-    steps:
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-          cache-dependency-path: '**/package-lock.json'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run tests
-        run: npm run test:safari


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Changes:
1. Separate Browser Tests to its own workflow, simplifying the test matrix.
2. Update tested Node.js versions from 18/20/22/23 to 20/22/24.
3. Only use xz decompression method for Firefox ESR as Firefox ESR 128 is no longer supported and this was the last ESR to use bzip2.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
