### PR TITLE
Build: Update browsers tested in BrowserStack (3.x)

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -26,12 +26,9 @@ jobs:
           - 'IE_9'
           - 'Safari_latest'
           # JTR doesn't take into account the jump from Safari 18 to 26,
-          # so we need to specify versions explicitly. Also, while BrowserStack
-          # already added macOS Tahoe with Safari 26, it's not a stable release
-          # yet, so we need to test on Safari 17 as well.
+          # so we need to specify versions explicitly.
           # See https://github.com/jquery/jquery-test-runner/issues/17
           - 'Safari_18'
-          - 'Safari_17'
           - 'Chrome_latest'
           - 'Chrome_latest-1'
           - 'Opera_latest'
@@ -40,12 +37,14 @@ jobs:
           - 'Edge_18'
           - 'Firefox_latest'
           - 'Firefox_latest-1'
+          - 'Firefox_128'
           - 'Firefox_115'
           - 'Firefox_102'
           - 'Firefox_91'
           - 'Firefox_78'
           - 'Firefox_60'
           - 'Firefox_48'
+          - '__iOS_26'
           - '__iOS_18'
           - '__iOS_17'
           - '__iOS_16'


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Changes:
1. Remove Safari 17
2. Add iOS 26
3. Add Firefox 128 (due to there being Firefox 128 ESR in the past)

`main` version: #5705

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
