### PR TITLE
Fix: remove redundant check in parseXML.js

### DIFF
--- a/src/core/parseXML.js
+++ b/src/core/parseXML.js
@@ -13,8 +13,7 @@ jQuery.parseXML = function( data ) {
 		xml = ( new window.DOMParser() ).parseFromString( data, "text/xml" );
 	} catch ( e ) {}
 
-	parserErrorElem = xml && xml.getElementsByTagName( "parsererror" )[ 0 ];
-	if ( !xml || parserErrorElem ) {
+	if ( !xml || (parserErrorElem = xml.getElementsByTagName( "parsererror" )[ 0 ]) ) {
 		jQuery.error( "Invalid XML: " + (
 			parserErrorElem ?
 				jQuery.map( parserErrorElem.childNodes, function( el ) {


### PR DESCRIPTION

This PR addresses the issue where we do redundant check.

Changes Made:

Removed redundant operation xml && .. and do assign to parserErrorElem after check xml

Impact:

No breaking changes.

### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
