### PR TITLE
Tests: Fix manipulation tests on iPad on iOS 12.

### DIFF
--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -3152,7 +3152,7 @@ QUnit.test( "Sanitized HTML doesn't get unsanitized", function( assert ) {
 
 	var container,
 		counter = 0,
-		oldIos = /iphone os (?:8|9|10|11|12)_/i.test( navigator.userAgent ),
+		oldIos = /(?:ipad.* os|iphone os) (?:8|9|10|11|12)_/i.test( navigator.userAgent ),
 		assertCount = oldIos ? 12 : 13,
 		done = assert.async( assertCount );
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

iPad's iOS 12.2 User Agent contains the following string:

    (iPad; CPU OS 12_2 like Mac OS X)

while iPhone on iOS 12_2 uses:

    (iPhone; CPU iPhone OS 12_2 like Mac OS X)

The iPad version was not caught by a regex used to exclude one manipulation test in old iOS, making tests in iOS 12 fail on an iPad. Our CI started running iOS 12 test on an iPad, making them fail.

This change adjusts the regex for iPads as well.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
