### PR TITLE
Tests: Fix selector tests in Chrome 141

### DIFF
--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -1537,7 +1537,17 @@ QUnit.test( "pseudo - :lang", function( assert ) {
 			assert.ok( jQuery( elem ).is( selector ), text + " match " + selector );
 		},
 		assertNoMatch = function( text, elem, selector ) {
-			assert.ok( !jQuery( elem ).is( selector ), text + " fail " + selector );
+
+			// Support: Chrome 141 only
+			// Chrome 141 incorrectly matches `:lang()` selectors with values with a trailing `-`.
+			// This is fixed in Chrome 142, so just skip these tests in v141.
+			// See https://issues.chromium.org/issues/451355198
+			if ( /\b(?:headless)?chrome\/141\./i.test( navigator.userAgent ) &&
+				selector.slice( -2 ) === "-)" ) {
+				assert.ok( true, "Broken handling in Chrome 141: " + text + " fail " + selector );
+			} else {
+				assert.ok( !jQuery( elem ).is( selector ), text + " fail " + selector );
+			}
 		};
 
 	// Prefixing and inheritance


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Chrome 141 incorrectly matches `:lang()` selectors with values with a trailing `-`. This is fixed in Chrome 142, so just skip these tests in v141. See https://issues.chromium.org/issues/451355198

`main` version of #5717

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
