### PR TITLE
Build: Verify release using dist repo tarball 

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 env:
-  NODE_VERSION: 22.x
+  NODE_VERSION: 24.x
 
 jobs:
   build-and-test:

--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
       BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-      NODE_VERSION: 22.x
+      NODE_VERSION: 24.x
     name: ${{ matrix.BROWSER }}
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.BROWSER }}

--- a/.github/workflows/filestash.yml
+++ b/.github/workflows/filestash.yml
@@ -16,7 +16,7 @@ jobs:
     if: ${{ github.repository == 'jquery/jquery' }}
     environment: filestash
     env:
-      NODE_VERSION: 22.x
+      NODE_VERSION: 24.x
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -20,7 +20,7 @@ jobs:
         NPM_SCRIPT: ["test:browserless"]
         include:
           - NAME: "Node"
-            NODE_VERSION: "22.x"
+            NODE_VERSION: "24.x"
             NPM_SCRIPT: "lint"
     steps:
       - name: Checkout

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -19,7 +19,7 @@ jobs:
     # skip on forks
     if: ${{ github.repository == 'jquery/jquery' }}
     env:
-      NODE_VERSION: 22.x
+      NODE_VERSION: 24.x
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -32,6 +32,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - run: npm run release:verify
+      - name: Verify release
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          retry_wait_seconds: 60
+          command: npm run release:verify
         env:
           VERSION: ${{ github.event.inputs.version || github.ref_name }}

--- a/.release-it.cjs
+++ b/.release-it.cjs
@@ -26,7 +26,13 @@ module.exports = {
 		getLatestTagFromAllRefs: true,
 		pushRepo: "git@github.com:jquery/jquery.git",
 		requireBranch: "main",
-		requireCleanWorkingDir: true
+		requireCleanWorkingDir: true,
+		commit: true,
+		commitArgs: [ "-S" ],
+		tag: true,
+		tagName: "${version}",
+		tagAnnotation: "Release: ${version}",
+		tagArgs: [ "-s" ]
 	},
 	github: {
 		pushRepo: "git@github.com:jquery/jquery.git",

--- a/build/release/post-release.sh
+++ b/build/release/post-release.sh
@@ -32,7 +32,7 @@ is_prerelease() {
 npm run release:cdn "$1"
 cd $cdn
 git add -A
-git commit -m "jquery: Add version $1"
+git commit -S -m "jquery: Add version $1"
 
 # Wait for confirmation from user to push changes to cdn repo
 read -p "Press enter to push changes to cdn repo"
@@ -44,7 +44,7 @@ cd -
 npm run release:dist "$1" "$2"
 cd $dist
 git add -A
-git commit -m "Release: $1"
+git commit -S -m "Release: $1"
 # -s to sign and annotate tag (recommended for releases)
 git tag -s "$1" -m "Release: $1"
 
@@ -69,7 +69,7 @@ git add package.json
 npm run build:clean
 git rm --cached -r dist/ dist-module/
 git add dist/package.json dist/wrappers dist-module/package.json dist-module/wrappers
-git commit -m "Release: remove dist files from main branch"
+git commit -S -m "Release: remove dist files from main branch"
 
 # Wait for confirmation from user to push changes
 read -p "Press enter to push changes to main branch"

--- a/build/release/verify.js
+++ b/build/release/verify.js
@@ -15,6 +15,7 @@ import { rimraf } from "rimraf";
 const exec = util.promisify( nodeExec );
 const gunzip = util.promisify( nodeGunzip );
 
+const DIST_REPO = "https://github.com/jquery/jquery-dist.git";
 const SRC_REPO = "https://github.com/jquery/jquery.git";
 const CDN_URL = "https://code.jquery.com";
 const REGISTRY_URL = "https://registry.npmjs.org/jquery";
@@ -25,11 +26,10 @@ const excludeFromCDN = [
 ];
 
 const rjquery = /^jquery/;
+const rblogUrl = /https:\/\/blog\.jquery\.com\/[^)]+/;
 
-async function verifyRelease( { version } = {} ) {
-	if ( !version ) {
-		version = process.env.VERSION || ( await getLatestVersion() );
-	}
+async function verifyRelease() {
+	const version = process.env.VERSION || ( await getLatestVersion() );
 	const release = await buildRelease( { version } );
 
 	console.log( `Verifying jQuery ${ version }...` );
@@ -119,6 +119,7 @@ async function verifyRelease( { version } = {} ) {
 
 async function buildRelease( { version } ) {
 	const releaseFolder = path.join( "tmp/verify", version );
+	const distFolder = path.join( releaseFolder, "tmp/release/dist" );
 
 	// Clone the release repo
 	console.log( `Cloning jQuery ${ version }...` );
@@ -155,9 +156,18 @@ async function buildRelease( { version } ) {
 	} );
 	console.log( buildOutput );
 
+	const blogUrl = await getBlogUrl( { distFolder, version } );
+
+	// Run the dist script to prepare files for packing
+	console.log( `Preparing jQuery ${ version } for packaging...` );
+	const { stdout: distOutput } = await exec( `npm run release:dist ${ version } ${ blogUrl }`, {
+		cwd: releaseFolder
+	} );
+	console.log( distOutput );
+
 	// Pack the npm tarball
 	console.log( `Packing jQuery ${ version }...` );
-	const { stdout: packOutput } = await exec( "npm pack", { cwd: releaseFolder } );
+	const { stdout: packOutput } = await exec( "npm pack", { cwd: distFolder } );
 	console.log( packOutput );
 
 	// Get all top-level /dist and /dist-module files
@@ -194,7 +204,7 @@ async function buildRelease( { version } ) {
 
 	// Get checksum of the tarball
 	const tgzFilename = `jquery-${ version }.tgz`;
-	const sum = await sumTarball( path.join( releaseFolder, tgzFilename ) );
+	const sum = await sumTarball( path.join( distFolder, tgzFilename ) );
 
 	return {
 		files,
@@ -204,6 +214,30 @@ async function buildRelease( { version } ) {
 		},
 		version
 	};
+}
+
+async function getBlogUrl( { distFolder, version } ) {
+
+	// Clone the dist repo
+	console.log( `Cloning jquery-dist ${ version }...` );
+	await rimraf( distFolder );
+	await mkdir( distFolder, { recursive: true } );
+	await exec( `git clone -q -b ${ version } ${ DIST_REPO } ${ distFolder }` );
+
+	// Read the README.md file
+	console.log( "Getting blog URL from README.md..." );
+	const readme = await readFile(
+		path.join( distFolder, "README.md" ),
+		"utf8"
+	);
+
+	const blogUrl = rblogUrl.exec( readme );
+	if ( !blogUrl ) {
+		throw new Error( "Invalid blog post URL" );
+	}
+
+	console.log( `Blog URL: ${ blogUrl[ 0 ] }` );
+	return blogUrl[ 0 ];
 }
 
 async function downloadFile( url, dest ) {


### PR DESCRIPTION
### Summary ###

- Builds the tarball using the dist repo after running `npm run release:dist` from the build.
- Pulls the blog URL from the dist repo README
- Update the default Node in workflows to 24.x, which is now in LTS
- Ensure all commits and tags are signed. This change was prompted when I noticed the tag on jquery/jquery for 4.0.0-rc.1 was not signed. We were already signing the tag for jquery-dist, and the team signs commits with global git config, but release-it does not sign tags by default.
- If the tag does not yet exist in the dist repo (which can happen as a race condition during the release), it falls back to cloning the main branch. That should still work.

Fixes gh-5693

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
