### PR TITLE
Build: Add `C:\SeleniumWebDrivers\IEDriver` to PATH to fix IE tests

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -78,6 +78,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Add IE Driver to PATH
+        run: echo "C:\SeleniumWebDrivers\IEDriver" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        shell: pwsh
+
       - name: Run tests in Edge in IE mode
         run: npm run test:ie
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9205,9 +9205,9 @@
       }
     },
     "node_modules/selenium-webdriver": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.28.1.tgz",
-      "integrity": "sha512-TwbTpu/NUQkorBODGAkGowJ8sar63bvqi66/tjqhS05rBl34HkVp8DoRg1cOv2iSnNonVSbkxazS3wjbc+NRtg==",
+      "version": "4.38.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.38.0.tgz",
+      "integrity": "sha512-5/UXXFSQmn7FGQkbcpAqvfhzflUdMWtT7QqpEgkFD6Q6rDucxB5EUfzgjmr6JbUj30QodcW3mDXehzoeS/Vy5w==",
       "dev": true,
       "funding": [
         {
@@ -9223,11 +9223,11 @@
       "dependencies": {
         "@bazel/runfiles": "^6.3.1",
         "jszip": "^3.10.1",
-        "tmp": "^0.2.3",
-        "ws": "^8.18.0"
+        "tmp": "^0.2.5",
+        "ws": "^8.18.3"
       },
       "engines": {
-        "node": ">= 18.20.5"
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/semver": {
@@ -10998,9 +10998,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

For some reason, recent GitHub Action tests on Edge in IE Mode started
failing with:
```
D:\a\jquery\jquery\node_modules\selenium-webdriver\bin\windows\selenium-manager.exe with --browser,internet explorer,--language-binding,javascript,--output,json: IEDriverServer release not available
```

Adding `C:\SeleniumWebDrivers\IEDriver` to PATH resolves the issue.

Also, update selenium-webdriver to the latest version.
### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
