### PR TITLE
Tests: Fix the "outside view position" test in Headless Chrome (3.x)

### DIFF
--- a/test/unit/dimensions.js
+++ b/test/unit/dimensions.js
@@ -663,7 +663,7 @@ QUnit.test( "outside view position (gh-2836)", function( assert ) {
 	// This test ported from gh-2836 example
 	assert.expect( 1 );
 
-	var parent,
+	var parent, pos,
 		html = [
 		"<div id=div-gh-2836>",
 			"<div></div>",
@@ -672,20 +672,15 @@ QUnit.test( "outside view position (gh-2836)", function( assert ) {
 			"<div></div>",
 			"<div></div>",
 		"</div>"
-	].join( "" ),
-	stop = assert.async();
+	].join( "" );
 
 	parent = jQuery( html );
 	parent.appendTo( "#qunit-fixture" );
 
-	parent.one( "scroll", function() {
-		var pos = parent.find( "div" ).eq( 3 ).position();
-
-		assert.strictEqual( pos.top, -100 );
-		stop();
-	} );
-
 	parent.scrollTop( 400 );
+
+	pos = parent.find( "div" ).eq( 3 ).position();
+	assert.strictEqual( pos.top, -100 );
 } );
 
 QUnit.test( "width/height on element with transform (gh-3193)", function( assert ) {


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

In Headless Chrome, when run locally on macOS together with a few other modules, the scroll handler for the appended element in the "outside view position" dimensions test doesn't fire, timing out the test & failing it as a result.

While the scroll handler may not fire, the new position data is available immediately, so just do the checks directly, without relying on scroll handlers.

`main` version: gh-5728

Ref gh-5728

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
