### PR TITLE
Build: Add periodic tests on beta versions of browsers

### DIFF
--- a/.github/workflows/browser-tests-beta.yml
+++ b/.github/workflows/browser-tests-beta.yml
@@ -117,5 +117,5 @@ jobs:
 
       - name: Run Safari Technology Preview tests
         id: run-safari-tests
-        run: npm run test:safari_tp
+        run: npm run test:safari -- --safari-tp
         continue-on-error: true # Beta browsers may have bugs

--- a/.github/workflows/browser-tests-beta.yml
+++ b/.github/workflows/browser-tests-beta.yml
@@ -1,0 +1,121 @@
+name: Browser Tests (Beta)
+
+on:
+  schedule:
+    # Run weekly on Sunday at 3 AM UTC to catch beta browser updates
+    - cron: '0 3 * * 0'
+  workflow_dispatch:
+    # Allow manual triggering from the Actions tab
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+env:
+  NODE_VERSION: 24.x
+
+jobs:
+  chrome-beta:
+    runs-on: ubuntu-latest
+    name: Chrome Beta
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: Install Chrome Beta
+        run: |
+          wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+          echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list
+          sudo apt-get update
+          sudo apt-get install -y google-chrome-beta
+
+      - name: Set Chrome Beta as default
+        run: |
+          echo "CHROME_BIN=$(which google-chrome-beta)" >> "$GITHUB_ENV"
+          google-chrome-beta --version
+          echo "Chrome Beta installed at: $(which google-chrome-beta)"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Chrome Beta tests
+        id: run-chrome-tests
+        run: npm run test:chrome
+        continue-on-error: true # Beta browsers may have bugs
+
+  firefox-beta:
+    runs-on: ubuntu-latest
+    name: Firefox Beta
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: Install Firefox Beta
+        run: |
+          wget --no-verbose "https://download.mozilla.org/?product=firefox-beta-latest-ssl&lang=en-US&os=linux64" -O - | tar -Jx -C "$HOME"
+
+      - name: Set Firefox Beta as default
+        run: |
+          echo "PATH=${HOME}/firefox:$PATH" >> "$GITHUB_ENV"
+          echo "FIREFOX_BIN=${HOME}/firefox/firefox" >> "$GITHUB_ENV"
+          "$HOME/firefox/firefox" --version
+          echo "Firefox Beta installed at: $HOME/firefox/firefox"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Firefox Beta tests
+        id: run-firefox-tests
+        run: npm run test:firefox
+        continue-on-error: true # Beta browsers may have bugs
+
+  safari-tp:
+    runs-on: macos-latest
+    name: Safari Technology Preview
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: Install Safari Technology Preview
+        run: |
+          # Install Safari Technology Preview via Homebrew Cask
+          brew install --cask safari-technology-preview
+
+          # Verify installation
+          if [ -d "/Applications/Safari Technology Preview.app" ]; then
+            echo "Safari Technology Preview installed successfully"
+          else
+            echo "Safari TP installation verification failed"
+            exit 1
+          fi
+
+      - name: Enable Safari Technology Preview driver
+        run: sudo /Applications/Safari\ Technology\ Preview.app/Contents/MacOS/safaridriver --enable
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Safari Technology Preview tests
+        id: run-safari-tests
+        run: npm run test:safari_tp
+        continue-on-error: true # Beta browsers may have bugs

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "eslint-plugin-import": "2.32.0",
         "globals": "16.5.0",
         "husky": "9.1.7",
-        "jquery-test-runner": "0.2.8",
+        "jquery-test-runner": "0.3.0",
         "jsdom": "27.2.0",
         "marked": "17.0.0",
         "multiparty": "4.2.3",
@@ -5047,9 +5047,9 @@
       }
     },
     "node_modules/exit-hook": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-5.0.0.tgz",
-      "integrity": "sha512-Kz0x74pb0yYbEmcZ42QL5tPefRA/XqQKf2ZUD8isF6eOlpMB3F+HukHgdHVbFVB+k6DICCWnGS5qhynzxdXxqw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-5.0.1.tgz",
+      "integrity": "sha512-LHebYV6wSOObiWC894M36qqoWbGWFDZFJnCAch+JUYTyI5EJAlF3Lhv9sqLKoUDjTj3X6SsIxwy41mw2AqFfdA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6697,9 +6697,9 @@
       }
     },
     "node_modules/jquery-test-runner": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/jquery-test-runner/-/jquery-test-runner-0.2.8.tgz",
-      "integrity": "sha512-grXJ2h3/mpBOP0ne3m+/XyA3iMX16MccDOVwYXr9+HcE0+4U6ar+jC1bxMocRGmgiPlSfH9NG3O0fyBvgR/Tuw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/jquery-test-runner/-/jquery-test-runner-0.3.0.tgz",
+      "integrity": "sha512-p2hr+94JxQYN/csjhPny/go0vWgUHcWsvpJV5TwYx9iNqFmVw6BXmMy9AOsFxg3mVkLaU2o44mhRegMhJBkb2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6707,7 +6707,7 @@
         "chalk": "^5.6.2",
         "commander": "^14.0.2",
         "diff": "^8.0.2",
-        "exit-hook": "^5.0.0",
+        "exit-hook": "^5.0.1",
         "jsdom": "^27.2.0",
         "raw-body": "^3.0.1",
         "selenium-webdriver": "^4.38.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "test:firefox": "npm run pretest && npm run build:main && npm run test:unit -- -v -b firefox --headless",
     "test:ie": "npm run pretest && npm run build:main && npm run test:unit -- -v -b ie",
     "test:safari": "npm run pretest && npm run build:main && npm run test:unit -- -b safari",
-    "test:safari_tp": "npm run pretest && npm run build:main && npm run test:unit -- -b safari_tp",
     "test:server": "jtr serve -m test/middleware-mockserver.cjs",
     "test:esm": "npm run pretest && npm run build:main && npm run test:unit -- -f esmodules --headless",
     "test:no-deprecated": "npm run pretest && npm run build -- -e deprecated && npm run test:unit -- --headless",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "eslint-plugin-import": "2.32.0",
     "globals": "16.5.0",
     "husky": "9.1.7",
-    "jquery-test-runner": "0.2.8",
+    "jquery-test-runner": "0.3.0",
     "jsdom": "27.2.0",
     "marked": "17.0.0",
     "multiparty": "4.2.3",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "test:firefox": "npm run pretest && npm run build:main && npm run test:unit -- -v -b firefox --headless",
     "test:ie": "npm run pretest && npm run build:main && npm run test:unit -- -v -b ie",
     "test:safari": "npm run pretest && npm run build:main && npm run test:unit -- -b safari",
+    "test:safari_tp": "npm run pretest && npm run build:main && npm run test:unit -- -b safari_tp",
     "test:server": "jtr serve -m test/middleware-mockserver.cjs",
     "test:esm": "npm run pretest && npm run build:main && npm run test:unit -- -f esmodules --headless",
     "test:no-deprecated": "npm run pretest && npm run build -- -e deprecated && npm run test:unit -- --headless",


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Run weekly tests on the following browsers:
* Chrome beta
* Firefox beta
* Safari Technology Preview

Don't fail the job in case of failures to avoid jQuery being marked as failing CI in case of a beta browser bug. In such cases, print a summary about errors to the job.

The current implementation exposes the errors if you visit the workflow run page - in the list view, it's just green (run https://github.com/mgol/jquery/actions/runs/19712307177):
<img width="999" height="739" alt="Screenshot 2025-11-28 at 11 16 40" src="https://github.com/user-attachments/assets/83c659ca-aafa-4221-983e-6a68ca2bd09c" />

It's possible to have more output there by writing to the `"$GITHUB_STEP_SUMMARY"` file; example workflow step:
```
- name: Report Safari TP failure
  if: ${{ steps.run-safari-tests.outcome == 'failure' }}
  run: |
    echo "## ❗ Safari Technology Preview tests failed" >> "$GITHUB_STEP_SUMMARY"
    echo "" >> "$GITHUB_STEP_SUMMARY"
    echo "The Safari Technology Preview job encountered failures; see logs above." >> "$GITHUB_STEP_SUMMARY"
    echo "This workflow remains green because the browsers are beta." >> "$GITHUB_STEP_SUMMARY"
```
Example output for the code above (run https://github.com/mgol/jquery/actions/runs/19712123581):
<img width="990" height="965" alt="Screenshot 2025-11-28 at 11 16 43" src="https://github.com/user-attachments/assets/e91d9b4e-1cf8-44e0-9a07-2008dce88fa5" />

If we wanted, we could e.g. expose which tests failed there. But for now I opted for a simpler implementation.

The job is set to run weekly on Sundays; we could make looking at it a part of our weekly meetings.

One gotcha - while manually this workflow can be triggered on any branch, the scheduled run will always be against the default branch - here: `main`. To avoid that, we'd have to manually checkout a proper branch during the test run. But if we wanted to do that for both branches, it'd make harder to run the workflow manually just against one. Again, I opted for a simple implementation for now; if we want, we can expand in the future.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
