### PR TITLE
Data: Unset hasDataAttrs when calling removeData

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -80,6 +80,9 @@ jQuery.extend( {
 
 	removeData: function( elem, name ) {
 		dataUser.remove( elem, name );
+		if ( name === undefined ) {
+			dataPriv.remove( elem, "hasDataAttrs" );
+		}
 	},
 
 	// TODO: Now that all calls to _data and _removeData have been replaced
@@ -172,6 +175,9 @@ jQuery.fn.extend( {
 	removeData: function( key ) {
 		return this.each( function() {
 			dataUser.remove( this, key );
+			if ( key === undefined ) {
+				dataPriv.remove( this, "hasDataAttrs" );
+			}
 		} );
 	}
 } );

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -875,6 +875,19 @@ QUnit.test( "data-* with JSON value can have newlines", function( assert ) {
 	x.remove();
 } );
 
+QUnit.test( "element attributes are repopulated after calling .removeData", function( assert ) {
+	assert.expect( 1 );
+
+	var testing = {
+		"test": "testing"
+		},
+		element = jQuery( "<div data-test='testing'>" );
+
+	element.data();
+	element.removeData();
+	assert.deepEqual( element.data(), testing, "data- attributes not repopulated" );
+} );
+
 QUnit.test( ".data doesn't throw when calling selection is empty. trac-13551", function( assert ) {
 	assert.expect( 1 );
 


### PR DESCRIPTION
### Summary ###
Fixes https://github.com/jquery/jquery/issues/5751
Unsets hasDataAttrs when calling `$.removeData()` or `$.fn.removeData()` with no key, so that subsequent calls to `.data()` will know to reread data- attributes.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

You could make the case that the documentation is wrong and removeData() as it is now is correct. The data is removed, for sure. But the documentation is how I hoped and intuitively expected it would work.