### PR TITLE
Selector: Use loose document comparisons everywhere (3.x)

### DIFF
--- a/src/selector-native.js
+++ b/src/selector-native.js
@@ -48,7 +48,11 @@ var hasDuplicate, sortInput,
 function sortOrder( a, b ) {
 
 	// Flag for duplicate removal
-	if ( a === b ) {
+	// Support: IE 11+, Edge 17 - 18+
+	// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
+	// two documents; shallow comparisons work.
+	// eslint-disable-next-line eqeqeq
+	if ( a == b ) {
 		hasDuplicate = true;
 		return 0;
 	}
@@ -60,7 +64,11 @@ function sortOrder( a, b ) {
 	}
 
 	// Calculate position if both inputs belong to the same document
-	compare = ( a.ownerDocument || a ) === ( b.ownerDocument || b ) ?
+	// Support: IE 11+, Edge 17 - 18+
+	// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
+	// two documents; shallow comparisons work.
+	// eslint-disable-next-line eqeqeq
+	compare = ( a.ownerDocument || a ) == ( b.ownerDocument || b ) ?
 		a.compareDocumentPosition( b ) :
 
 		// Otherwise we know they are disconnected
@@ -70,11 +78,20 @@ function sortOrder( a, b ) {
 	if ( compare & 1 ) {
 
 		// Choose the first element that is related to our preferred document
-		if ( a === document || a.ownerDocument === document &&
+		// Support: IE 11+, Edge 17 - 18+
+		// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
+		// two documents; shallow comparisons work.
+		// eslint-disable-next-line eqeqeq
+		if ( a == document || a.ownerDocument == document &&
 			jQuery.contains( document, a ) ) {
 			return -1;
 		}
-		if ( b === document || b.ownerDocument === document &&
+
+		// Support: IE 11+, Edge 17 - 18+
+		// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
+		// two documents; shallow comparisons work.
+		// eslint-disable-next-line eqeqeq
+		if ( b == document || b.ownerDocument == document &&
 			jQuery.contains( document, b ) ) {
 			return 1;
 		}

--- a/src/selector.js
+++ b/src/selector.js
@@ -749,7 +749,11 @@ function setDocument( node ) {
 	sortOrder = function( a, b ) {
 
 		// Flag for duplicate removal
-		if ( a === b ) {
+		// Support: IE 11+, Edge 17 - 18+
+		// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
+		// two documents; shallow comparisons work.
+		// eslint-disable-next-line eqeqeq
+		if ( a == b ) {
 			hasDuplicate = true;
 			return 0;
 		}
@@ -780,7 +784,7 @@ function setDocument( node ) {
 			// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
 			// two documents; shallow comparisons work.
 			// eslint-disable-next-line eqeqeq
-			if ( a === document || a.ownerDocument == preferredDoc &&
+			if ( a == document || a.ownerDocument == preferredDoc &&
 				find.contains( preferredDoc, a ) ) {
 				return -1;
 			}
@@ -789,7 +793,7 @@ function setDocument( node ) {
 			// IE/Edge sometimes throw a "Permission denied" error when strict-comparing
 			// two documents; shallow comparisons work.
 			// eslint-disable-next-line eqeqeq
-			if ( b === document || b.ownerDocument == preferredDoc &&
+			if ( b == document || b.ownerDocument == preferredDoc &&
 				find.contains( preferredDoc, b ) ) {
 				return 1;
 			}


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

IE & Edge Legacy sometimes throw on strict document comparisons (using `===`). This does not happen for loose comparisons (using `==`). For this reason, we've switched a bunch of comparisons to weak ones a while ago, but there were a few leftovers. This change switches them to loose comparisons as well.

Ref gh-4441
Ref gh-4471
Ref gh-5770

`main` version: gh-5770

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
