### PR TITLE
Selector: Use loose document comparisons everywhere

### DIFF
--- a/src/selector-native.js
+++ b/src/selector-native.js
@@ -93,7 +93,11 @@ jQuery.extend( {
 
 				// Outside of IE, if we're not changing the context we can
 				// use :scope instead of an ID.
-				if ( newContext !== context || isIE ) {
+				// Support: IE 11+
+				// IE sometimes throws a "Permission denied" error when strict-comparing
+				// two documents; shallow comparisons work.
+				// eslint-disable-next-line eqeqeq
+				if ( newContext != context || isIE ) {
 
 					// Capture the context ID, setting it first if necessary
 					if ( ( nid = context.getAttribute( "id" ) ) ) {

--- a/src/selector/uniqueSort.js
+++ b/src/selector/uniqueSort.js
@@ -10,7 +10,11 @@ var hasDuplicate;
 function sortOrder( a, b ) {
 
 	// Flag for duplicate removal
-	if ( a === b ) {
+	// Support: IE 11+
+	// IE sometimes throws a "Permission denied" error when strict-comparing
+	// two documents; shallow comparisons work.
+	// eslint-disable-next-line eqeqeq
+	if ( a == b ) {
 		hasDuplicate = true;
 		return 0;
 	}


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

IE sometimes throw on strict document comparisons (using `===`). This does not happen for loose comparisons (using `==`). For this reason, we've switched a bunch of comparisons to weak ones a while ago, but there were a few leftovers. This change switches them to loose comparisons as well.

Ref gh-4441
Ref gh-4471
Ref gh-5769

3.x-version: gh-5769

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
