### PR TITLE
Serialize: Support form-associated custom elements

### DIFF
--- a/src/serialize.js
+++ b/src/serialize.js
@@ -100,13 +100,24 @@ jQuery.fn.extend( {
 
 			// Can add propHook for "elements" to filter or add form elements
 			var elements = jQuery.prop( this, "elements" );
-			return elements ? jQuery.makeArray( elements ) : this;
+			if ( elements ) {
+				return jQuery.makeArray( elements );
+			}
+
+			// Only ensure a submittable nodeName for individual elements.
+			// Don't run this check when running `serializeArray` on a form
+			// so that form-associated custom elements can be reported.
+			if ( rsubmittable.test( this.nodeName ) ) {
+				return this;
+			}
+
+			return [];
 		} ).filter( function() {
 			var type = this.type;
 
 			// Use .is( ":disabled" ) so that fieldset[disabled] works
 			return this.name && !jQuery( this ).is( ":disabled" ) &&
-				rsubmittable.test( this.nodeName ) && !rsubmitterTypes.test( type ) &&
+				!rsubmitterTypes.test( type ) &&
 				( this.checked || !rcheckableType.test( type ) );
 		} ).map( function( _i, elem ) {
 			var val = jQuery( this ).val();


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Skip the `rsubmittable` check for elements coming from `form.elements`.

Fixes gh-5245
Ref gh-5773

~~I added tests for existing behavior in gh-5773. That's the first commit, so ignore it when reviewing this PR.~~

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
