### PR TITLE
Tests: Add unit tests for callback-only animation signatures

### DIFF
--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -801,7 +801,7 @@ QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "toggle()", function( assert )
 } );
 
 QUnit.test( "show/hide/toggle(callback) - animate with default duration (gh-1738)", function( assert ) {
-	assert.expect( 12 );
+	assert.expect( 9 );
 
 	var div = jQuery( "<div>" ).appendTo( "#qunit-fixture" ),
 		hideCb = this.sandbox.spy(),
@@ -834,7 +834,7 @@ QUnit.test( "show/hide/toggle(callback) - animate with default duration (gh-1738
 } );
 
 QUnit.test( "slideDown/slideUp/slideToggle(callback) - animate with default duration (gh-1738)", function( assert ) {
-	assert.expect( 9 );
+	assert.expect( 6 );
 
 	var div = jQuery( "<div>" ).appendTo( "#qunit-fixture" ).hide(),
 		slideDownCb = this.sandbox.spy(),
@@ -863,7 +863,7 @@ QUnit.test( "slideDown/slideUp/slideToggle(callback) - animate with default dura
 } );
 
 QUnit.test( "fadeIn/fadeOut/fadeToggle(callback) - animate with default duration (gh-1738)", function( assert ) {
-	assert.expect( 9 );
+	assert.expect( 6 );
 
 	var div = jQuery( "<div>" ).appendTo( "#qunit-fixture" ).hide(),
 		fadeInCb = this.sandbox.spy(),

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -800,6 +800,97 @@ QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "toggle()", function( assert )
 	assert.ok( x.is( ":visible" ), "is visible again" );
 } );
 
+QUnit.test( "show/hide/toggle(callback) - animate with default duration (gh-1738)", function( assert ) {
+	assert.expect( 12 );
+
+	var div = jQuery( "<div>" ).appendTo( "#qunit-fixture" ),
+		hideCb = this.sandbox.spy(),
+		showCb = this.sandbox.spy(),
+		toggleCb = this.sandbox.spy();
+
+	div.show();
+	div.hide( hideCb );
+	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
+	assert.strictEqual( hideCb.callCount, 0, "callback not invoked too early" );
+	this.clock.tick( jQuery.fx.speeds._default * 0.2 + 1 );
+	assert.strictEqual( hideCb.callCount, 1, "hide(callback) invokes the callback" );
+	assert.ok( div.is( ":hidden" ), "Element is hidden after hide(callback)" );
+
+	div.show( showCb );
+	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
+	assert.strictEqual( showCb.callCount, 0, "callback not invoked too early" );
+	this.clock.tick( jQuery.fx.speeds._default * 0.2 + 1 );
+	assert.strictEqual( showCb.callCount, 1, "show(callback) invokes the callback" );
+	assert.ok( div.is( ":visible" ), "Element is visible after show(callback)" );
+
+	div.toggle( toggleCb );
+	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
+	assert.strictEqual( toggleCb.callCount, 0, "callback not invoked too early" );
+	this.clock.tick( jQuery.fx.speeds._default * 0.2 + 1 );
+	assert.strictEqual( toggleCb.callCount, 1, "toggle(callback) invokes the callback" );
+	assert.ok( div.is( ":hidden" ), "Element is hidden after toggle(callback) from visible" );
+
+	div.remove();
+} );
+
+QUnit.test( "slideDown/slideUp/slideToggle(callback) - animate with default duration (gh-1738)", function( assert ) {
+	assert.expect( 9 );
+
+	var div = jQuery( "<div>" ).appendTo( "#qunit-fixture" ).hide(),
+		slideDownCb = this.sandbox.spy(),
+		slideUpCb = this.sandbox.spy(),
+		slideToggleCb = this.sandbox.spy();
+
+	div.slideDown( slideDownCb );
+	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
+	assert.strictEqual( slideDownCb.callCount, 0, "callback not invoked too early" );
+	this.clock.tick( jQuery.fx.speeds._default * 0.2 + 1 );
+	assert.strictEqual( slideDownCb.callCount, 1, "slideDown(callback) invokes the callback" );
+
+	div.slideUp( slideUpCb );
+	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
+	assert.strictEqual( slideUpCb.callCount, 0, "callback not invoked too early" );
+	this.clock.tick( jQuery.fx.speeds._default * 0.2 + 1 );
+	assert.strictEqual( slideUpCb.callCount, 1, "slideUp(callback) invokes the callback" );
+
+	div.slideToggle( slideToggleCb );
+	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
+	assert.strictEqual( slideToggleCb.callCount, 0, "callback not invoked too early" );
+	this.clock.tick( jQuery.fx.speeds._default * 0.2 + 1 );
+	assert.strictEqual( slideToggleCb.callCount, 1, "slideToggle(callback) invokes the callback" );
+
+	div.remove();
+} );
+
+QUnit.test( "fadeIn/fadeOut/fadeToggle(callback) - animate with default duration (gh-1738)", function( assert ) {
+	assert.expect( 9 );
+
+	var div = jQuery( "<div>" ).appendTo( "#qunit-fixture" ).hide(),
+		fadeInCb = this.sandbox.spy(),
+		fadeOutCb = this.sandbox.spy(),
+		fadeToggleCb = this.sandbox.spy();
+
+	div.fadeIn( fadeInCb );
+	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
+	assert.strictEqual( fadeInCb.callCount, 0, "callback not invoked too early" );
+	this.clock.tick( jQuery.fx.speeds._default * 0.2 + 1 );
+	assert.strictEqual( fadeInCb.callCount, 1, "fadeIn(callback) invokes the callback" );
+
+	div.fadeOut( fadeOutCb );
+	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
+	assert.strictEqual( fadeOutCb.callCount, 0, "callback not invoked too early" );
+	this.clock.tick( jQuery.fx.speeds._default * 0.2 + 1 );
+	assert.strictEqual( fadeOutCb.callCount, 1, "fadeOut(callback) invokes the callback" );
+
+	div.fadeToggle( fadeToggleCb );
+	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
+	assert.strictEqual( fadeToggleCb.callCount, 0, "callback not invoked too early" );
+	this.clock.tick( jQuery.fx.speeds._default * 0.2 + 1 );
+	assert.strictEqual( fadeToggleCb.callCount, 1, "fadeToggle(callback) invokes the callback" );
+
+	div.remove();
+} );
+
 QUnit.test( "jQuery.fx.prototype.cur() - <1.8 Back Compat", function( assert ) {
 	assert.expect( 7 );
 

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -812,21 +812,21 @@ QUnit.test( "show/hide/toggle(callback) - animate with default duration (gh-1738
 	div.hide( hideCb );
 	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
 	assert.strictEqual( hideCb.callCount, 0, "callback not invoked too early" );
-	this.clock.tick( jQuery.fx.speeds._default * 0.2 + 1 );
+	this.clock.tick( jQuery.fx.speeds._default * 0.2 + fxInterval );
 	assert.strictEqual( hideCb.callCount, 1, "hide(callback) invokes the callback" );
 	assert.ok( div.is( ":hidden" ), "Element is hidden after hide(callback)" );
 
 	div.show( showCb );
 	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
 	assert.strictEqual( showCb.callCount, 0, "callback not invoked too early" );
-	this.clock.tick( jQuery.fx.speeds._default * 0.2 + 1 );
+	this.clock.tick( jQuery.fx.speeds._default * 0.2 + fxInterval );
 	assert.strictEqual( showCb.callCount, 1, "show(callback) invokes the callback" );
 	assert.ok( div.is( ":visible" ), "Element is visible after show(callback)" );
 
 	div.toggle( toggleCb );
 	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
 	assert.strictEqual( toggleCb.callCount, 0, "callback not invoked too early" );
-	this.clock.tick( jQuery.fx.speeds._default * 0.2 + 1 );
+	this.clock.tick( jQuery.fx.speeds._default * 0.2 + fxInterval );
 	assert.strictEqual( toggleCb.callCount, 1, "toggle(callback) invokes the callback" );
 	assert.ok( div.is( ":hidden" ), "Element is hidden after toggle(callback) from visible" );
 
@@ -844,21 +844,21 @@ QUnit.test( "slideDown/slideUp/slideToggle(callback) - animate with default dura
 	div.slideDown( slideDownCb );
 	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
 	assert.strictEqual( slideDownCb.callCount, 0, "callback not invoked too early" );
-	this.clock.tick( jQuery.fx.speeds._default * 0.2 + 1 );
+	this.clock.tick( jQuery.fx.speeds._default * 0.2 + fxInterval );
 	assert.strictEqual( slideDownCb.callCount, 1, "slideDown(callback) invokes the callback" );
 	assert.ok( div.is( ":visible" ), "Element is visible after slideDown(callback)" );
 
 	div.slideUp( slideUpCb );
 	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
 	assert.strictEqual( slideUpCb.callCount, 0, "callback not invoked too early" );
-	this.clock.tick( jQuery.fx.speeds._default * 0.2 + 1 );
+	this.clock.tick( jQuery.fx.speeds._default * 0.2 + fxInterval );
 	assert.strictEqual( slideUpCb.callCount, 1, "slideUp(callback) invokes the callback" );
 	assert.ok( div.is( ":hidden" ), "Element is hidden after slideUp(callback)" );
 
 	div.slideToggle( slideToggleCb );
 	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
 	assert.strictEqual( slideToggleCb.callCount, 0, "callback not invoked too early" );
-	this.clock.tick( jQuery.fx.speeds._default * 0.2 + 1 );
+	this.clock.tick( jQuery.fx.speeds._default * 0.2 + fxInterval );
 	assert.strictEqual( slideToggleCb.callCount, 1, "slideToggle(callback) invokes the callback" );
 	assert.ok( div.is( ":visible" ), "Element is visible after slideToggle(callback) from hidden" );
 
@@ -876,21 +876,21 @@ QUnit.test( "fadeIn/fadeOut/fadeToggle(callback) - animate with default duration
 	div.fadeIn( fadeInCb );
 	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
 	assert.strictEqual( fadeInCb.callCount, 0, "callback not invoked too early" );
-	this.clock.tick( jQuery.fx.speeds._default * 0.2 + 1 );
+	this.clock.tick( jQuery.fx.speeds._default * 0.2 + fxInterval );
 	assert.strictEqual( fadeInCb.callCount, 1, "fadeIn(callback) invokes the callback" );
 	assert.ok( div.is( ":visible" ), "Element is visible after fadeIn(callback)" );
 
 	div.fadeOut( fadeOutCb );
 	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
 	assert.strictEqual( fadeOutCb.callCount, 0, "callback not invoked too early" );
-	this.clock.tick( jQuery.fx.speeds._default * 0.2 + 1 );
+	this.clock.tick( jQuery.fx.speeds._default * 0.2 + fxInterval );
 	assert.strictEqual( fadeOutCb.callCount, 1, "fadeOut(callback) invokes the callback" );
 	assert.ok( div.is( ":hidden" ), "Element is hidden after fadeOut(callback)" );
 
 	div.fadeToggle( fadeToggleCb );
 	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
 	assert.strictEqual( fadeToggleCb.callCount, 0, "callback not invoked too early" );
-	this.clock.tick( jQuery.fx.speeds._default * 0.2 + 1 );
+	this.clock.tick( jQuery.fx.speeds._default * 0.2 + fxInterval );
 	assert.strictEqual( fadeToggleCb.callCount, 1, "fadeToggle(callback) invokes the callback" );
 	assert.ok( div.is( ":visible" ), "Element is visible after fadeToggle(callback) from hidden" );
 

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -834,7 +834,7 @@ QUnit.test( "show/hide/toggle(callback) - animate with default duration (gh-1738
 } );
 
 QUnit.test( "slideDown/slideUp/slideToggle(callback) - animate with default duration (gh-1738)", function( assert ) {
-	assert.expect( 6 );
+	assert.expect( 9 );
 
 	var div = jQuery( "<div>" ).appendTo( "#qunit-fixture" ).hide(),
 		slideDownCb = this.sandbox.spy(),
@@ -846,24 +846,27 @@ QUnit.test( "slideDown/slideUp/slideToggle(callback) - animate with default dura
 	assert.strictEqual( slideDownCb.callCount, 0, "callback not invoked too early" );
 	this.clock.tick( jQuery.fx.speeds._default * 0.2 + 1 );
 	assert.strictEqual( slideDownCb.callCount, 1, "slideDown(callback) invokes the callback" );
+	assert.ok( div.is( ":visible" ), "Element is visible after slideDown(callback)" );
 
 	div.slideUp( slideUpCb );
 	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
 	assert.strictEqual( slideUpCb.callCount, 0, "callback not invoked too early" );
 	this.clock.tick( jQuery.fx.speeds._default * 0.2 + 1 );
 	assert.strictEqual( slideUpCb.callCount, 1, "slideUp(callback) invokes the callback" );
+	assert.ok( div.is( ":hidden" ), "Element is hidden after slideUp(callback)" );
 
 	div.slideToggle( slideToggleCb );
 	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
 	assert.strictEqual( slideToggleCb.callCount, 0, "callback not invoked too early" );
 	this.clock.tick( jQuery.fx.speeds._default * 0.2 + 1 );
 	assert.strictEqual( slideToggleCb.callCount, 1, "slideToggle(callback) invokes the callback" );
+	assert.ok( div.is( ":visible" ), "Element is visible after slideToggle(callback) from hidden" );
 
 	div.remove();
 } );
 
 QUnit.test( "fadeIn/fadeOut/fadeToggle(callback) - animate with default duration (gh-1738)", function( assert ) {
-	assert.expect( 6 );
+	assert.expect( 9 );
 
 	var div = jQuery( "<div>" ).appendTo( "#qunit-fixture" ).hide(),
 		fadeInCb = this.sandbox.spy(),
@@ -875,18 +878,21 @@ QUnit.test( "fadeIn/fadeOut/fadeToggle(callback) - animate with default duration
 	assert.strictEqual( fadeInCb.callCount, 0, "callback not invoked too early" );
 	this.clock.tick( jQuery.fx.speeds._default * 0.2 + 1 );
 	assert.strictEqual( fadeInCb.callCount, 1, "fadeIn(callback) invokes the callback" );
+	assert.ok( div.is( ":visible" ), "Element is visible after fadeIn(callback)" );
 
 	div.fadeOut( fadeOutCb );
 	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
 	assert.strictEqual( fadeOutCb.callCount, 0, "callback not invoked too early" );
 	this.clock.tick( jQuery.fx.speeds._default * 0.2 + 1 );
 	assert.strictEqual( fadeOutCb.callCount, 1, "fadeOut(callback) invokes the callback" );
+	assert.ok( div.is( ":hidden" ), "Element is hidden after fadeOut(callback)" );
 
 	div.fadeToggle( fadeToggleCb );
 	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
 	assert.strictEqual( fadeToggleCb.callCount, 0, "callback not invoked too early" );
 	this.clock.tick( jQuery.fx.speeds._default * 0.2 + 1 );
 	assert.strictEqual( fadeToggleCb.callCount, 1, "fadeToggle(callback) invokes the callback" );
+	assert.ok( div.is( ":visible" ), "Element is visible after fadeToggle(callback) from hidden" );
 
 	div.remove();
 } );

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -821,7 +821,7 @@ QUnit.test( "show/hide/toggle(callback) - animate with default duration (gh-1738
 	assert.strictEqual( showCb.callCount, 0, "callback not invoked too early" );
 	this.clock.tick( jQuery.fx.speeds._default * 0.2 + fxInterval );
 	assert.strictEqual( showCb.callCount, 1, "show(callback) invokes the callback" );
-	assert.notStrictEqual( div.css( "display" ), "none", "Element is visible after show(callback)" );
+	assert.strictEqual( div.css( "display" ), "block", "Element is visible after show(callback)" );
 
 	div.toggle( toggleCb );
 	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
@@ -846,7 +846,7 @@ QUnit.test( "slideDown/slideUp/slideToggle(callback) - animate with default dura
 	assert.strictEqual( slideDownCb.callCount, 0, "callback not invoked too early" );
 	this.clock.tick( jQuery.fx.speeds._default * 0.2 + fxInterval );
 	assert.strictEqual( slideDownCb.callCount, 1, "slideDown(callback) invokes the callback" );
-	assert.notStrictEqual( div.css( "display" ), "none", "Element is visible after slideDown(callback)" );
+	assert.strictEqual( div.css( "display" ), "block", "Element is visible after slideDown(callback)" );
 
 	div.slideUp( slideUpCb );
 	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
@@ -860,7 +860,7 @@ QUnit.test( "slideDown/slideUp/slideToggle(callback) - animate with default dura
 	assert.strictEqual( slideToggleCb.callCount, 0, "callback not invoked too early" );
 	this.clock.tick( jQuery.fx.speeds._default * 0.2 + fxInterval );
 	assert.strictEqual( slideToggleCb.callCount, 1, "slideToggle(callback) invokes the callback" );
-	assert.notStrictEqual( div.css( "display" ), "none", "Element is visible after slideToggle(callback) from hidden" );
+	assert.strictEqual( div.css( "display" ), "block", "Element is visible after slideToggle(callback) from hidden" );
 
 	div.remove();
 } );
@@ -878,7 +878,7 @@ QUnit.test( "fadeIn/fadeOut/fadeToggle(callback) - animate with default duration
 	assert.strictEqual( fadeInCb.callCount, 0, "callback not invoked too early" );
 	this.clock.tick( jQuery.fx.speeds._default * 0.2 + fxInterval );
 	assert.strictEqual( fadeInCb.callCount, 1, "fadeIn(callback) invokes the callback" );
-	assert.notStrictEqual( div.css( "display" ), "none", "Element is visible after fadeIn(callback)" );
+	assert.strictEqual( div.css( "display" ), "block", "Element is visible after fadeIn(callback)" );
 
 	div.fadeOut( fadeOutCb );
 	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
@@ -892,7 +892,7 @@ QUnit.test( "fadeIn/fadeOut/fadeToggle(callback) - animate with default duration
 	assert.strictEqual( fadeToggleCb.callCount, 0, "callback not invoked too early" );
 	this.clock.tick( jQuery.fx.speeds._default * 0.2 + fxInterval );
 	assert.strictEqual( fadeToggleCb.callCount, 1, "fadeToggle(callback) invokes the callback" );
-	assert.notStrictEqual( div.css( "display" ), "none", "Element is visible after fadeToggle(callback) from hidden" );
+	assert.strictEqual( div.css( "display" ), "block", "Element is visible after fadeToggle(callback) from hidden" );
 
 	div.remove();
 } );

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -800,7 +800,7 @@ QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "toggle()", function( assert )
 	assert.ok( x.is( ":visible" ), "is visible again" );
 } );
 
-QUnit.test( "show/hide/toggle(callback) - animate with default duration (gh-1738)", function( assert ) {
+QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "show/hide/toggle(callback) - animate with default duration (gh-1738)", function( assert ) {
 	assert.expect( 9 );
 
 	var div = jQuery( "<div>" ).appendTo( "#qunit-fixture" ),
@@ -833,7 +833,7 @@ QUnit.test( "show/hide/toggle(callback) - animate with default duration (gh-1738
 	div.remove();
 } );
 
-QUnit.test( "slideDown/slideUp/slideToggle(callback) - animate with default duration (gh-1738)", function( assert ) {
+QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "slideDown/slideUp/slideToggle(callback) - animate with default duration (gh-1738)", function( assert ) {
 	assert.expect( 9 );
 
 	var div = jQuery( "<div>" ).appendTo( "#qunit-fixture" ).hide(),
@@ -865,7 +865,7 @@ QUnit.test( "slideDown/slideUp/slideToggle(callback) - animate with default dura
 	div.remove();
 } );
 
-QUnit.test( "fadeIn/fadeOut/fadeToggle(callback) - animate with default duration (gh-1738)", function( assert ) {
+QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "fadeIn/fadeOut/fadeToggle(callback) - animate with default duration (gh-1738)", function( assert ) {
 	assert.expect( 9 );
 
 	var div = jQuery( "<div>" ).appendTo( "#qunit-fixture" ).hide(),

--- a/test/unit/effects.js
+++ b/test/unit/effects.js
@@ -800,7 +800,7 @@ QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "toggle()", function( assert )
 	assert.ok( x.is( ":visible" ), "is visible again" );
 } );
 
-QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "show/hide/toggle(callback) - animate with default duration (gh-1738)", function( assert ) {
+QUnit.test( "show/hide/toggle(callback) - animate with default duration (gh-1738)", function( assert ) {
 	assert.expect( 9 );
 
 	var div = jQuery( "<div>" ).appendTo( "#qunit-fixture" ),
@@ -814,26 +814,26 @@ QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "show/hide/toggle(callback) - 
 	assert.strictEqual( hideCb.callCount, 0, "callback not invoked too early" );
 	this.clock.tick( jQuery.fx.speeds._default * 0.2 + fxInterval );
 	assert.strictEqual( hideCb.callCount, 1, "hide(callback) invokes the callback" );
-	assert.ok( div.is( ":hidden" ), "Element is hidden after hide(callback)" );
+	assert.strictEqual( div.css( "display" ), "none", "Element is hidden after hide(callback)" );
 
 	div.show( showCb );
 	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
 	assert.strictEqual( showCb.callCount, 0, "callback not invoked too early" );
 	this.clock.tick( jQuery.fx.speeds._default * 0.2 + fxInterval );
 	assert.strictEqual( showCb.callCount, 1, "show(callback) invokes the callback" );
-	assert.ok( div.is( ":visible" ), "Element is visible after show(callback)" );
+	assert.notStrictEqual( div.css( "display" ), "none", "Element is visible after show(callback)" );
 
 	div.toggle( toggleCb );
 	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
 	assert.strictEqual( toggleCb.callCount, 0, "callback not invoked too early" );
 	this.clock.tick( jQuery.fx.speeds._default * 0.2 + fxInterval );
 	assert.strictEqual( toggleCb.callCount, 1, "toggle(callback) invokes the callback" );
-	assert.ok( div.is( ":hidden" ), "Element is hidden after toggle(callback) from visible" );
+	assert.strictEqual( div.css( "display" ), "none", "Element is hidden after toggle(callback) from visible" );
 
 	div.remove();
 } );
 
-QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "slideDown/slideUp/slideToggle(callback) - animate with default duration (gh-1738)", function( assert ) {
+QUnit.test( "slideDown/slideUp/slideToggle(callback) - animate with default duration (gh-1738)", function( assert ) {
 	assert.expect( 9 );
 
 	var div = jQuery( "<div>" ).appendTo( "#qunit-fixture" ).hide(),
@@ -846,26 +846,26 @@ QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "slideDown/slideUp/slideToggle
 	assert.strictEqual( slideDownCb.callCount, 0, "callback not invoked too early" );
 	this.clock.tick( jQuery.fx.speeds._default * 0.2 + fxInterval );
 	assert.strictEqual( slideDownCb.callCount, 1, "slideDown(callback) invokes the callback" );
-	assert.ok( div.is( ":visible" ), "Element is visible after slideDown(callback)" );
+	assert.notStrictEqual( div.css( "display" ), "none", "Element is visible after slideDown(callback)" );
 
 	div.slideUp( slideUpCb );
 	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
 	assert.strictEqual( slideUpCb.callCount, 0, "callback not invoked too early" );
 	this.clock.tick( jQuery.fx.speeds._default * 0.2 + fxInterval );
 	assert.strictEqual( slideUpCb.callCount, 1, "slideUp(callback) invokes the callback" );
-	assert.ok( div.is( ":hidden" ), "Element is hidden after slideUp(callback)" );
+	assert.strictEqual( div.css( "display" ), "none", "Element is hidden after slideUp(callback)" );
 
 	div.slideToggle( slideToggleCb );
 	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
 	assert.strictEqual( slideToggleCb.callCount, 0, "callback not invoked too early" );
 	this.clock.tick( jQuery.fx.speeds._default * 0.2 + fxInterval );
 	assert.strictEqual( slideToggleCb.callCount, 1, "slideToggle(callback) invokes the callback" );
-	assert.ok( div.is( ":visible" ), "Element is visible after slideToggle(callback) from hidden" );
+	assert.notStrictEqual( div.css( "display" ), "none", "Element is visible after slideToggle(callback) from hidden" );
 
 	div.remove();
 } );
 
-QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "fadeIn/fadeOut/fadeToggle(callback) - animate with default duration (gh-1738)", function( assert ) {
+QUnit.test( "fadeIn/fadeOut/fadeToggle(callback) - animate with default duration (gh-1738)", function( assert ) {
 	assert.expect( 9 );
 
 	var div = jQuery( "<div>" ).appendTo( "#qunit-fixture" ).hide(),
@@ -878,21 +878,21 @@ QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ]( "fadeIn/fadeOut/fadeToggle(cal
 	assert.strictEqual( fadeInCb.callCount, 0, "callback not invoked too early" );
 	this.clock.tick( jQuery.fx.speeds._default * 0.2 + fxInterval );
 	assert.strictEqual( fadeInCb.callCount, 1, "fadeIn(callback) invokes the callback" );
-	assert.ok( div.is( ":visible" ), "Element is visible after fadeIn(callback)" );
+	assert.notStrictEqual( div.css( "display" ), "none", "Element is visible after fadeIn(callback)" );
 
 	div.fadeOut( fadeOutCb );
 	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
 	assert.strictEqual( fadeOutCb.callCount, 0, "callback not invoked too early" );
 	this.clock.tick( jQuery.fx.speeds._default * 0.2 + fxInterval );
 	assert.strictEqual( fadeOutCb.callCount, 1, "fadeOut(callback) invokes the callback" );
-	assert.ok( div.is( ":hidden" ), "Element is hidden after fadeOut(callback)" );
+	assert.strictEqual( div.css( "display" ), "none", "Element is hidden after fadeOut(callback)" );
 
 	div.fadeToggle( fadeToggleCb );
 	this.clock.tick( jQuery.fx.speeds._default * 0.8 );
 	assert.strictEqual( fadeToggleCb.callCount, 0, "callback not invoked too early" );
 	this.clock.tick( jQuery.fx.speeds._default * 0.2 + fxInterval );
 	assert.strictEqual( fadeToggleCb.callCount, 1, "fadeToggle(callback) invokes the callback" );
-	assert.ok( div.is( ":visible" ), "Element is visible after fadeToggle(callback) from hidden" );
+	assert.notStrictEqual( div.css( "display" ), "none", "Element is visible after fadeToggle(callback) from hidden" );
 
 	div.remove();
 } );


### PR DESCRIPTION
## Summary

Adds unit tests for the callback-only signatures of animation methods: `show(callback)`, `hide(callback)`, `toggle(callback)`, and their `slide*` and `fade*` counterparts.

## Problem

Passing only a callback function (without a duration) to `show()`, `hide()`, `toggle()`, `slideDown()`, `slideUp()`, `slideToggle()`, `fadeIn()`, `fadeOut()`, and `fadeToggle()` should trigger an animated transition with the default duration (`jQuery.fx.speeds._default`, 400ms) and invoke the callback on completion.

This behavior has been supported historically but was never explicitly tested.

Ref trac-12821

## Changes

Added 3 new test cases to `test/unit/effects.js` with 12 total assertions:

1. **`show/hide/toggle(callback)`** — verifies callback invocation and correct visibility state after animation completes
2. **`slideDown/slideUp/slideToggle(callback)`** — verifies callback invocation for slide animations
3. **`fadeIn/fadeOut/fadeToggle(callback)`** — verifies callback invocation for fade animations

All tests use the existing `sinon.useFakeTimers` pattern and clean up DOM elements after completion.

Closes gh-1738
Ref trac-12821