### PR TITLE
Data: Shave off some bytes

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -129,7 +129,6 @@ jQuery.fn.extend( {
 		}
 
 		return access( this, function( value ) {
-			var data;
 
 			// The calling jQuery object (element matches) is not empty
 			// (and therefore has an element appears at this[ 0 ]) and the
@@ -138,22 +137,13 @@ jQuery.fn.extend( {
 			// throw an exception if an attempt to read a data cache is made.
 			if ( elem && value === undefined ) {
 
-				// Attempt to get data from the cache
-				// The key will always be camelCased in Data
-				data = dataUser.get( elem, key );
-				if ( data !== undefined ) {
-					return data;
-				}
-
-				// Attempt to "discover" the data in
-				// HTML5 custom data-* attrs
-				data = dataAttr( elem, key );
-				if ( data !== undefined ) {
-					return data;
-				}
-
-				// We tried really hard, but the data doesn't exist.
-				return;
+				// Attempt to get data from the `dataUser` cache.
+				// The key will always be camelCased in Data.
+				// Otherwise, attempt to "discover" the data in
+				// HTML5 custom data-* attrs.
+				// If this fails as well, data doesn't exist, and
+				// we get `undefined`.
+				return dataAttr( elem, key, dataUser.get( elem, key ) );
 			}
 
 			// Set the data...


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The case where a key is passed was needlessly repeating `dataAttr` logic.

Size diffs:
```
main @7aa0179514a2aa9e1d90fbc6a4b332b8f1ae1292
   raw     gz     br Filename
   -42    -10    -34 dist/jquery.min.js
   -42    -12    +31 dist/jquery.slim.min.js
   -42    -10    +32 dist-module/jquery.module.min.js
   -42    -12    -17 dist-module/jquery.slim.module.min.js
```

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
