### PR TITLE
Build: Stop testing on iOS 15

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -50,7 +50,9 @@ jobs:
           - '_:iPhone 16_iOS_18'
           - '_:iPhone 15 Pro_iOS_17'
           - '_:iPhone 14_iOS_16'
-          - '_:iPhone 13_iOS_15'
+          # None of the iOS 15 devices currently work; the browser
+          # doesn't even start.
+          # - '_:iPhone 13_iOS_15'
           - '_:iPhone 12_iOS_14'
           - '_:iPhone 11_iOS_13'
           # iOS 12 & older is not officially supported by BrowserStack as


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

None of the iOS 15 devices on BrowserStack currently work; the browser doesn't even start. Stop testing on it to make CI green.

I've reported it a while ago and they acknowledged the issue, but it's been a few weeks already and it's making it harder to work on `3.x-stable`, so let's disable iOS 15 for now.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
