### PR TITLE
Tests: Re-enable the AJAX binary data tests in IE

### DIFF
--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -2335,7 +2335,7 @@ QUnit.module( "ajax", {
 				assert.ok( jqxhr.response instanceof window.ArrayBuffer, "data in jQXHR" );
 			}
 		};
-	}, QUnit.isIE ? QUnit.skip : QUnit.test );
+	} );
 
 	QUnit.test( "trac-11743 - jQuery.ajax() - script, throws exception", function( assert ) {
 		assert.expect( 1 );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The previous check was only filtering out IE <10 which we don't test against on this branch anyway. In gh-5793, this test was erroneously disabled in IE 11 as well. This change re-enables it globally.

Ref gh-5793

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
