### PR TITLE
fix: using variable interpolation `${{ in browserstack-dispatch.yml...

### DIFF
--- a/.github/workflows/browserstack-dispatch.yml
+++ b/.github/workflows/browserstack-dispatch.yml
@@ -62,6 +62,9 @@ jobs:
         run: npm run pretest
 
       - name: Run tests
+        env:
+          BROWSER: ${{ inputs.browser }}
+          MODULE: ${{ inputs.module }}
         run: npm run test:unit -- \
-          -v --browserstack ${{ inputs.browser }} \
-          -f module=${{ inputs.module }}
+          -v --browserstack "$BROWSER" \
+          -f "module=$MODULE"


### PR DESCRIPTION
## Summary
Fix high severity security issue in `.github/workflows/browserstack-dispatch.yml`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | yaml.github-actions.security.run-shell-injection.run-shell-injection |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `yaml.github-actions.security.run-shell-injection.run-shell-injection` |
| **File** | `.github/workflows/browserstack-dispatch.yml:65` |

**Description**: Using variable interpolation `${{...}}` with `github` context data in a `run:` step could allow an attacker to inject their own code into the runner. This would allow them to steal secrets and code. `github` context data can have arbitrary user input and should be treated as untrusted. Instead, use an intermediate environment variable with `env:` to store the data and use the environment variable in the `run:` script. Be sure to use double-quotes the environment variable, like this: "$ENVVAR".

## Changes
- `.github/workflows/browserstack-dispatch.yml`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
