### PR TITLE
Selector: Be more strict in quick selection paths

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -3,8 +3,8 @@ import { access } from "./core/access.js";
 import { nodeName } from "./core/nodeName.js";
 import { rcssNum } from "./var/rcssNum.js";
 import { isIE } from "./var/isIE.js";
+import { rdoubleDash } from "./var/rdoubleDash.js";
 import { rnumnonpx } from "./css/var/rnumnonpx.js";
-import { rcustomProp } from "./css/var/rcustomProp.js";
 import { cssExpand } from "./css/var/cssExpand.js";
 import { isAutoPx } from "./css/isAutoPx.js";
 import { cssCamelCase } from "./css/cssCamelCase.js";
@@ -197,7 +197,7 @@ jQuery.extend( {
 		// Make sure that we're working with the right name
 		var ret, type, hooks,
 			origName = cssCamelCase( name ),
-			isCustomProp = rcustomProp.test( name ),
+			isCustomProp = rdoubleDash.test( name ),
 			style = elem.style;
 
 		// Make sure that we're working with the right name. We don't
@@ -266,7 +266,7 @@ jQuery.extend( {
 	css: function( elem, name, extra, styles ) {
 		var val, num, hooks,
 			origName = cssCamelCase( name ),
-			isCustomProp = rcustomProp.test( name );
+			isCustomProp = rdoubleDash.test( name );
 
 		// Make sure that we're working with the right name. We don't
 		// want to modify the value if it is a CSS custom property

--- a/src/css/curCSS.js
+++ b/src/css/curCSS.js
@@ -1,12 +1,12 @@
 import { jQuery } from "../core.js";
 import { isAttached } from "../core/isAttached.js";
 import { getStyles } from "./var/getStyles.js";
-import { rcustomProp } from "./var/rcustomProp.js";
+import { rdoubleDash } from "../var/rdoubleDash.js";
 import { rtrimCSS } from "../var/rtrimCSS.js";
 
 export function curCSS( elem, name, computed ) {
 	var ret,
-		isCustomProp = rcustomProp.test( name );
+		isCustomProp = rdoubleDash.test( name );
 
 	computed = computed || getStyles( elem );
 

--- a/src/css/var/rcustomProp.js
+++ b/src/css/var/rcustomProp.js
@@ -1,1 +1,0 @@
-export var rcustomProp = /^--/;

--- a/src/selector.js
+++ b/src/selector.js
@@ -5,6 +5,7 @@ import { indexOf } from "./var/indexOf.js";
 import { pop } from "./var/pop.js";
 import { push } from "./var/push.js";
 import { whitespace } from "./var/whitespace.js";
+import { rdoubleDash } from "./var/rdoubleDash.js";
 import { rbuggyQSA } from "./selector/rbuggyQSA.js";
 import { rtrimCSS } from "./var/rtrimCSS.js";
 import { isIE } from "./var/isIE.js";
@@ -62,7 +63,7 @@ var i,
 	rheader = /^h\d$/i,
 
 	// Easily-parseable/retrievable ID or TAG or CLASS selectors
-	rquickExpr = /^(?:#([\w-]+)|(\.?[\w-]+))$/,
+	rquickExpr = /^(?:#([\w-]+)|(\.?[a-z][\w-]*))$/i,
 
 	// Used for iframes; see `setDocument`.
 	// Support: IE 9 - 11+
@@ -132,9 +133,9 @@ function find( selector, context, results, seed ) {
 					// `querySelectorAll` is, depending on the browser, either on par
 					// perf-wise with `getElementsByTagName` & `getElementsByClassName`
 					// or even faster, so we don't use `gEBTN` & `gEBCN` anymore.
-					// Note: we can only get tags & classes matching `[\w-]+` here thanks
-					// to `rquickExpr`, so there's no need to wrap them with
-					// `jQuery.escapeSelector`.
+					// Note: we can only get tags & classes matching `/[a-z][\w-]*/i`
+					// here thanks to `rquickExpr`, so there's no need to wrap them
+					// with `jQuery.escapeSelector`.
 					push.apply( results, context.querySelectorAll( selector ) );
 					return results;
 				}
@@ -388,6 +389,17 @@ jQuery.expr = {
 		},
 
 		TAG: function( tag, context ) {
+
+			// Support: IE <=11+
+			// IE doesn't recognize identifiers starting with a dash,
+			// and identifiers starting with a double dash are not
+			// escaped via jQuery.escapeSelector. Such identifiers
+			// are not valid tag names, but the selection should not
+			// throw when they're used. Fallback to an empty collection.
+			if ( isIE && rdoubleDash.test( tag ) ) {
+				return [];
+			}
+
 			return context.querySelectorAll(
 				tag === "*" ? tag : jQuery.escapeSelector( tag )
 			);
@@ -395,6 +407,15 @@ jQuery.expr = {
 
 		CLASS: function( className, context ) {
 			if ( documentIsHTML ) {
+
+				// Support: IE <=11+
+				// IE doesn't recognize identifiers starting with a dash,
+				// and identifiers starting with a double dash are not
+				// escaped via jQuery.escapeSelector. Fallback to
+				// getElementsByClassName.
+				if ( isIE && rdoubleDash.test( className ) ) {
+					return context.getElementsByClassName( className );
+				}
 				return context.querySelectorAll(
 					"." + jQuery.escapeSelector( className )
 				);

--- a/src/selector.js
+++ b/src/selector.js
@@ -133,9 +133,8 @@ function find( selector, context, results, seed ) {
 					// `querySelectorAll` is, depending on the browser, either on par
 					// perf-wise with `getElementsByTagName` & `getElementsByClassName`
 					// or even faster, so we don't use `gEBTN` & `gEBCN` anymore.
-					// Note: we can only get tags & classes matching `/[a-z][\w-]*/i`
-					// here thanks to `rquickExpr`, so there's no need to wrap them
-					// with `jQuery.escapeSelector`.
+					// Note: thanks to the restrictions of `rquickExpr`, there's no
+					// need to wrap them with `jQuery.escapeSelector`.
 					push.apply( results, context.querySelectorAll( selector ) );
 					return results;
 				}

--- a/src/var/rdoubleDash.js
+++ b/src/var/rdoubleDash.js
@@ -1,0 +1,1 @@
+export var rdoubleDash = /^--/;

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -267,6 +267,31 @@ QUnit.test( "broken selectors throw", function( assert ) {
 	broken( "Attribute equals bad string", "input[name='apostrophe'd']" );
 } );
 
+QUnit[ QUnit.jQuerySelectors ? "test" : "skip" ](
+	"lenient identifier parsing", function( assert ) {
+
+	// Test that jQuery identifier parsing is more lenient than
+	// querySelectorAll's. Note: this may change in a jQuery major
+	// version bump.
+
+	assert.expect( 9 );
+
+	// ID
+	assert.ok( jQuery( "#-0abc" ), "$( \"#-0abc\" ) did not throw" );
+	assert.ok( jQuery( "#0abc" ), "$( \"#0abc\" ) did not throw" );
+	assert.ok( jQuery( "#--0abc" ), "$( \"#--0abc\" ) did not throw" );
+
+	// Type
+	assert.ok( jQuery( "-0abc" ), "$( \"-0abc\" ) did not throw" );
+	assert.ok( jQuery( "0abc" ), "$( \"0abc\" ) did not throw" );
+	assert.ok( jQuery( "--0abc" ), "$( \"--0abc\" ) did not throw" );
+
+	// Class
+	assert.ok( jQuery( ".-0abc" ), "$( \".-0abc\" ) did not throw" );
+	assert.ok( jQuery( ".0abc" ), "$( \".0abc\" ) did not throw" );
+	assert.ok( jQuery( ".--0abc" ), "$( \".--0abc\" ) did not throw" );
+} );
+
 QUnit.test( "identifier ReDoS", function( assert ) {
 	assert.expect( 1 );
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Since we now pass tag/class selectors via querySelectorAll in the quick path,
fix the regex to be more strict in parsing tags/classes and only allow letters
at the first character. The spec allows for more, but:
1. Not all our supported browsers follow that (probably only IE 11 does not).
2. A complete regex would be more complex.

The new version should work everywhere and match the vast majority of simple
use cases; more complex cases can fall back to regular selection.

Also, since IE doesn't support identifiers starting with a dash, and identifiers
starting with a double dash are not escaped via `jQuery.escapeSelector`,
add fallbacks to TAG & CLASS selection in case qSA throws.

Size diffs:
```
main @53a2bcf984ec5d1955d35ea9565e847cbeea0200
   raw     gz     br Filename
   +61    +29    -34 dist/jquery.min.js
   +61    +27    +25 dist/jquery.slim.min.js
   +61    +31    -43 dist-module/jquery.module.min.js
   +61    +30     -5 dist-module/jquery.slim.module.min.js
```

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
