### PR TITLE
Ajax: Add the `responseURL` field to jqXHR

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -713,7 +713,8 @@ jQuery.extend( {
 
 		// Callback for when everything is done
 		function done( status, nativeStatusText, responses, headers ) {
-			var isSuccess, success, error, response, modified, statusText;
+			var isSuccess, success, error, response, modified, statusText,
+				responseURL;
 
 			if ( typeof status === "object" ) {
 
@@ -721,6 +722,7 @@ jQuery.extend( {
 				nativeStatusText = status.statusText;
 				responses = status.responses;
 				headers = status.headers;
+				responseURL = status.responseURL;
 
 				status = status.status;
 			}
@@ -812,6 +814,7 @@ jQuery.extend( {
 			// Set data for the fake xhr object
 			jqXHR.status = status;
 			jqXHR.statusText = ( nativeStatusText || statusText ) + "";
+			jqXHR.responseURL = responseURL;
 
 			// Success/Error
 			if ( isSuccess ) {

--- a/src/ajax/xhr.js
+++ b/src/ajax/xhr.js
@@ -67,7 +67,8 @@ jQuery.ajaxTransport( function( options ) {
 
 								// File: protocol always yields status 0; see trac-8605, trac-14207
 								status: xhr.status,
-								statusText: xhr.statusText
+								statusText: xhr.statusText,
+								responseURL: xhr.responseURL
 							} );
 						} else {
 							complete( {
@@ -78,7 +79,9 @@ jQuery.ajaxTransport( function( options ) {
 								responses: ( xhr.responseType || "text" ) === "text" ?
 									{ text: xhr.responseText } :
 									{ binary: xhr.response },
-								headers: xhr.getAllResponseHeaders()
+
+								headers: xhr.getAllResponseHeaders(),
+								responseURL: xhr.responseURL
 							} );
 						}
 					}

--- a/test/data/mock.php
+++ b/test/data/mock.php
@@ -218,6 +218,14 @@ QUnit.assert.ok( true, "mock executed");';
 		header( "HTTP/1.0 {$req->query['code']} {$req->query['text']}" );
 	}
 
+	protected function redirect( $req ) {
+		$target = isset( $req->query['target'] ) ?
+			$req->query['target'] :
+			'/test/data/mock.php?action=name&name=foo';
+		$code = isset( $req->query['code'] ) ? (int) $req->query['code'] : 302;
+		header( "Location: $target", true, $code );
+	}
+
 	protected function testHTML( $req ) {
 		header( 'Content-type: text/html' );
 		$html = file_get_contents( __DIR__ . '/test.include.html' );

--- a/test/middleware-mockserver.cjs
+++ b/test/middleware-mockserver.cjs
@@ -249,6 +249,13 @@ const mocks = {
 		resp.writeHead( Number( req.query.code ) );
 		resp.end();
 	},
+	redirect: function( req, resp ) {
+		const target = req.query.target ||
+			"/test/data/mock.php?action=name&name=foo";
+		const code = Number( req.query.code ) || 302;
+		resp.writeHead( code, { "Location": target } );
+		resp.end();
+	},
 	testHTML: function( req, resp ) {
 		resp.writeHead( 200, { "Content-Type": "text/html" } );
 		const body = readFileSync(

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -273,6 +273,85 @@ QUnit.module( "ajax", {
 		};
 	} );
 
+	ajaxTest( "jQuery.ajax() - jqXHR.responseURL (gh-4339)", 9, function( assert ) {
+
+		// Support: IE 11+
+		// Some versions of IE 11 don't support location.origin
+		var origin = window.location.protocol + "//" + window.location.host,
+			redirectTarget = "/test/data/mock.php?action=name&name=foo&_=" + Date.now(),
+			expectedRedirectUrl = origin + redirectTarget;
+
+		// Support: IE 11+
+		// IE does not implement XMLHttpRequest.responseURL.
+		// `jqXHR.responseURL` is set to `undefined` in such a case
+		// as jQuery is not polyfilling support.
+		function expectedXhrUrl( absoluteUrl ) {
+			return QUnit.isIE ? undefined : absoluteUrl;
+		}
+
+		return [
+			{
+				url: url( "mock.php?action=name&name=foo" ),
+				beforeSend: function( jqXHR ) {
+					assert.strictEqual( jqXHR.responseURL, undefined,
+						"responseURL is undefined before the request is sent" );
+				},
+				success: function( _data, _textStatus, jqXHR ) {
+					assert.strictEqual( jqXHR.responseURL,
+						expectedXhrUrl( this.url ),
+						"responseURL equals request URL for non-redirected requests" );
+				}
+			},
+			{
+				url: url( "mock.php?action=redirect&target=" +
+					encodeURIComponent( redirectTarget ) ),
+				success: function( data, _textStatus, jqXHR ) {
+					assert.strictEqual( data, "bar",
+						"Redirect followed and final response returned" );
+					assert.strictEqual( jqXHR.responseURL,
+						expectedXhrUrl( expectedRedirectUrl ),
+						"responseURL reflects the final URL after a redirect" );
+				}
+			},
+			{
+				url: url( "mock.php?action=error" ),
+				error: function( jqXHR ) {
+					assert.strictEqual( jqXHR.responseURL,
+						expectedXhrUrl( this.url ),
+						"responseURL is populated for HTTP errors" );
+				}
+			},
+			{
+				url: url( "mock.php?action=jsonp&callback=?" ),
+				dataType: "jsonp",
+				crossDomain: true,
+				success: function( _data, _textStatus, jqXHR ) {
+					assert.strictEqual( jqXHR.responseURL, undefined,
+						"responseURL stays undefined for JSONP requests" );
+				}
+			},
+			{
+				url: url( "mock.php?action=script&header" ),
+				dataType: "script",
+				crossDomain: true,
+				success: function( _data, _textStatus, jqXHR ) {
+					assert.strictEqual( jqXHR.responseURL, undefined,
+						"responseURL stays undefined for cross-domain script requests" );
+				}
+			},
+			{
+				url: url( "mock.php?action=wait&wait=5" ),
+				afterSend: function( request ) {
+					request.abort();
+				},
+				error: function( jqXHR ) {
+					assert.strictEqual( jqXHR.responseURL, undefined,
+						"responseURL stays undefined for aborted requests" );
+				}
+			}
+		];
+	} );
+
 	QUnit.test( "jQuery.ajax() - retry with jQuery.ajax( this )", function( assert ) {
 		assert.expect( 2 );
 		var previousUrl,
@@ -3425,6 +3504,41 @@ QUnit.module( "ajax", {
 					}
 				}
 			]
+		};
+	} );
+
+	ajaxTest(
+		"jQuery.ajaxTransport() - completeCallback object with responseURL (gh-4339)",
+		2, function( assert ) {
+		var testId = assert.test.testId,
+			dataType = "test-obj-url-" + testId,
+			resp = {},
+			customUrl = "https://example.test/redirected";
+		resp[ dataType ] = "done";
+		return {
+			setup: function() {
+				jQuery.ajaxTransport( dataType, function() {
+					return {
+						send: function( _, completeCallback ) {
+							completeCallback( {
+								status: 200,
+								statusText: "OK",
+								responses: resp,
+								responseURL: customUrl
+							} );
+						},
+						abort: jQuery.noop
+					};
+				} );
+			},
+			url: url( "name.html" ),
+			dataType: dataType,
+			success: function( _, __, jqXHR ) {
+				assert.strictEqual( jqXHR.responseURL, customUrl,
+					"responseURL is set from the object-form completeCallback" );
+				assert.strictEqual( jqXHR.status, 200,
+					"jqXHR.status is 200" );
+			}
 		};
 	} );
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Expose `xhr.responseURL` (the final URL after redirects, including any redirects followed by the browser) as `jqXHR.responseURL`. The XHR transport passes it through the object-form `completeCallback` introduced in gh-4634, so the positional signature stays untouched.

Following the existing `responseText`/`responseXML`/`responseJSON` pattern, `jqXHR.responseURL` is only set when a transport reports it. As a result:

* modern-browser XHR: the final URL string
* IE 11 XHR: `undefined` (no native support)
* script / JSONP / aborted requests: `undefined` (transport has no way to know the URL)

A reusable `redirect` mock action has been added to both the Node middleware and `mock.php` so the redirect path can be exercised.

Fixes gh-4339
Ref gh-4634
Ref gh-5793

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
