### PR TITLE
Preserve CSP nonce in script evaluation paths

### DIFF
--- a/src/core/DOMEval.js
+++ b/src/core/DOMEval.js
@@ -11,12 +11,20 @@ export function DOMEval( code, node, doc ) {
 	doc = doc || document;
 
 	var i,
+		val,
 		script = doc.createElement( "script" );
 
 	script.text = code;
 	for ( i in preservedScriptAttributes ) {
-		if ( node && node[ i ] ) {
-			script[ i ] = node[ i ];
+		if ( node ) {
+			if ( i === "nonce" ) {
+				val = node.getAttribute ? node.getAttribute( i ) : node[ i ];
+				if ( val ) {
+					script.setAttribute( i, val );
+				}
+			} else if ( node[ i ] ) {
+				script[ i ] = node[ i ];
+			}
 		}
 	}
 

--- a/src/manipulation/domManip.js
+++ b/src/manipulation/domManip.js
@@ -90,7 +90,7 @@ export function domManip( collection, args, callback, ignored ) {
 							// Optional AJAX dependency, but won't run scripts if not present
 							if ( jQuery._evalUrl && !node.noModule ) {
 								jQuery._evalUrl( node.src, {
-									nonce: node.nonce,
+									nonce: node.getAttribute ? node.getAttribute( "nonce" ) || node.nonce : node.nonce,
 									crossOrigin: node.crossOrigin
 								}, doc );
 							}

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -3137,6 +3137,33 @@ testIframe(
 	}
 );
 
+QUnit.test( "DOMEval preserves nonce from script elements", function( assert ) {
+	assert.expect( 2 );
+
+	Globals.register( "globalEvalNonceTest" );
+
+	var oldAppend = document.head.appendChild,
+		script = document.createElement( "script" );
+
+	script.setAttribute( "nonce", "test-nonce" );
+	script.textContent = "window.globalEvalNonceTest = 1;";
+
+	document.head.appendChild = function( node ) {
+		assert.strictEqual( node.getAttribute( "nonce" ), "test-nonce",
+			"Injected script carries the original nonce attribute" );
+		return oldAppend.call( this, node );
+	};
+
+	try {
+		jQuery( "#qunit-fixture" ).append( script );
+	} finally {
+		document.head.appendChild = oldAppend;
+	}
+
+	assert.strictEqual( window.globalEvalNonceTest, 1,
+		"Script executed after nonce preservation" );
+} );
+
 QUnit.test( "Sanitized HTML doesn't get unsanitized", function( assert ) {
 
 	var container,


### PR DESCRIPTION
### Summary ###

Fixes loss of CSP nonce during internal script evaluation in jQuery.

When scripts are evaluated via `DOMEval` or `domManip`, the `nonce` attribute is copied using property access (`node[i]`). However, `nonce` is not consistently exposed as a property across browsers and is often only available via `getAttribute("nonce")`.

This can result in the nonce being dropped when scripts are recreated or executed causing them to fail under strict Content Security Policy (CSP).

This patch:
- Reads nonce via `getAttribute("nonce")` when available
- Falls back to property access for compatibility
- Applies the fix in both `DOMEval` and `domManip` paths

Security impact:
Preserving nonce ensures compatibility with strict CSP and prevents applications from weakening their policies (e.g., enabling `unsafe-inline`), which would reduce protection against script injection (XSS).

### Checklist ###

* [x] New tests have been added to show the fix or feature works
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com