### PR TITLE
Propagate csp nonce

### DIFF
--- a/src/ajax/script.js
+++ b/src/ajax/script.js
@@ -1,4 +1,5 @@
 import { jQuery } from "../core.js";
+import { getScriptNonce } from "../core/getScriptNonce.js";
 import { document } from "../var/document.js";
 
 import "../ajax.js";
@@ -48,9 +49,18 @@ jQuery.ajaxPrefilter( "script", function( s ) {
 		s.cache = false;
 	}
 
+	var useScriptTag = canUseScriptTag( s );
+
+	if ( useScriptTag && ( !s.scriptAttrs || !s.scriptAttrs.nonce ) ) {
+		var nonce = getScriptNonce( document );
+		if ( nonce ) {
+			s.scriptAttrs = jQuery.extend( {}, s.scriptAttrs, { nonce: nonce } );
+		}
+	}
+
 	// These types of requests are handled via a script tag
 	// so force their methods to GET.
-	if ( canUseScriptTag( s ) ) {
+	if ( useScriptTag ) {
 		s.type = "GET";
 	}
 } );

--- a/src/ajax/script.js
+++ b/src/ajax/script.js
@@ -49,10 +49,11 @@ jQuery.ajaxPrefilter( "script", function( s ) {
 		s.cache = false;
 	}
 
-	var useScriptTag = canUseScriptTag( s );
+	var useScriptTag = canUseScriptTag( s ),
+		nonce;
 
 	if ( useScriptTag && ( !s.scriptAttrs || !s.scriptAttrs.nonce ) ) {
-		var nonce = getScriptNonce( document );
+		nonce = getScriptNonce( document );
 		if ( nonce ) {
 			s.scriptAttrs = jQuery.extend( {}, s.scriptAttrs, { nonce: nonce } );
 		}

--- a/src/core/DOMEval.js
+++ b/src/core/DOMEval.js
@@ -1,4 +1,5 @@
 import { document } from "../var/document.js";
+import { getScriptNonce } from "./getScriptNonce.js";
 
 var preservedScriptAttributes = {
 	type: true,
@@ -11,12 +12,20 @@ export function DOMEval( code, node, doc ) {
 	doc = doc || document;
 
 	var i,
+		nonce,
 		script = doc.createElement( "script" );
 
 	script.text = code;
 	for ( i in preservedScriptAttributes ) {
 		if ( node && node[ i ] ) {
 			script[ i ] = node[ i ];
+		}
+	}
+
+	if ( !script.nonce ) {
+		nonce = getScriptNonce( doc );
+		if ( nonce ) {
+			script.nonce = nonce;
 		}
 	}
 

--- a/src/core/getScriptNonce.js
+++ b/src/core/getScriptNonce.js
@@ -1,0 +1,11 @@
+import { document } from "../var/document.js";
+
+export function getScriptNonce( doc ) {
+	var script = ( doc || document ).currentScript;
+
+	if ( !script ) {
+		return;
+	}
+
+	return script.nonce || script.getAttribute( "nonce" ) || undefined;
+}

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -1470,6 +1470,22 @@ QUnit.module( "ajax", {
 		}
 	);
 
+	testIframe(
+		"jQuery.getScript() supports CSP nonce",
+		"mock.php?action=cspNonce&test=ajax",
+		function( assert, jQuery, window, document, scriptCalled ) {
+			var done = assert.async();
+
+			assert.expect( 2 );
+
+			assert.strictEqual( scriptCalled, true, "Downloaded script called" );
+			supportjQuery.get( baseURL + "support/csp.log" ).done( function( data ) {
+				assert.equal( data, "", "No log request should be sent" );
+				supportjQuery.get( baseURL + "mock.php?action=cspClean" ).done( done );
+			} );
+		}
+	);
+
 	ajaxTest( "jQuery.ajax() - script, Remote", 2, function( assert ) {
 		return {
 			setup: function() {


### PR DESCRIPTION
### Summary

Automatically propagates the page’s CSP nonce to dynamically executed scripts.

Under strict Content Security Policy (`script-src 'nonce-...'`), dynamically
inserted scripts (e.g., via `jQuery.globalEval` or `$.getScript`) may fail to
execute unless a nonce is explicitly provided. This patch ensures the nonce is
applied automatically when available.

Key points:
- Adds a small helper to read the nonce from the current execution context
- Applies nonce in `DOMEval` for inline script execution
- Applies nonce in `ajaxPrefilter("script")` only when script-tag transport is already used
- Preserves existing behavior (no transport changes, no API changes)

---

### Checklist

* [x] New tests have been added to show the fix works
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com