### PR TITLE
Core: Refactor loops to avoid going behind array bounds

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -59,14 +59,14 @@ function addToPrefiltersOrTransports( structure ) {
 			dataTypeExpression = "*";
 		}
 
-		var dataType,
-			i = 0,
+		var dataType, i,
 			dataTypes = dataTypeExpression.toLowerCase().match( rnothtmlwhite ) || [];
 
 		if ( typeof func === "function" ) {
 
 			// For each dataType in the dataTypeExpression
-			while ( ( dataType = dataTypes[ i++ ] ) ) {
+			for ( i = 0; i < dataTypes.length; i++ ) {
+				dataType = dataTypes[ i ];
 
 				// Prepend if requested
 				if ( dataType[ 0 ] === "+" ) {

--- a/src/attributes/attr.js
+++ b/src/attributes/attr.js
@@ -72,15 +72,15 @@ jQuery.extend( {
 	attrHooks: {},
 
 	removeAttr: function( elem, value ) {
-		var name,
-			i = 0,
+		var i, name,
 
 			// Attribute names can contain non-HTML whitespace characters
 			// https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
 			attrNames = value && value.match( rnothtmlwhite );
 
 		if ( attrNames && elem.nodeType === 1 ) {
-			while ( ( name = attrNames[ i++ ] ) ) {
+			for ( i = 0; i < attrNames.length; i++ ) {
+				name = attrNames[ i ];
 				elem.removeAttribute( name );
 			}
 		}

--- a/src/attributes/classes.js
+++ b/src/attributes/classes.js
@@ -140,11 +140,11 @@ jQuery.fn.extend( {
 	},
 
 	hasClass: function( selector ) {
-		var className, elem,
-			i = 0;
+		var className, elem, i;
 
 		className = " " + selector + " ";
-		while ( ( elem = this[ i++ ] ) ) {
+		for ( i = 0; i < this.length; i++ ) {
+			elem = this[ i ];
 			if ( elem.nodeType === 1 &&
 				( " " + stripAndCollapse( getClass( elem ) ) + " " ).indexOf( className ) > -1 ) {
 				return true;

--- a/src/core.js
+++ b/src/core.js
@@ -258,15 +258,15 @@ jQuery.extend( {
 
 	// Retrieve the text value of an array of DOM nodes
 	text: function( elem ) {
-		var node,
+		var i, node,
 			ret = "",
-			i = 0,
 			nodeType = elem.nodeType;
 
 		if ( !nodeType ) {
 
 			// If no nodeType, this is expected to be an array
-			while ( ( node = elem[ i++ ] ) ) {
+			for ( i = 0; i < elem.length; i++ ) {
+				node = elem[ i ];
 
 				// Do not traverse comment nodes
 				ret += jQuery.text( node );

--- a/src/event.js
+++ b/src/event.js
@@ -304,13 +304,16 @@ jQuery.event = {
 		handlerQueue = jQuery.event.handlers.call( this, event, handlers );
 
 		// Run delegates first; they may want to stop propagation beneath us
-		i = 0;
-		while ( ( matched = handlerQueue[ i++ ] ) && !event.isPropagationStopped() ) {
+		for ( i = 0; i < handlerQueue.length && !event.isPropagationStopped(); i++ ) {
+			matched = handlerQueue[ i ];
 			event.currentTarget = matched.elem;
 
-			j = 0;
-			while ( ( handleObj = matched.handlers[ j++ ] ) &&
-				!event.isImmediatePropagationStopped() ) {
+			for (
+				j = 0;
+				j < matched.handlers.length && !event.isImmediatePropagationStopped();
+				j++
+			) {
+				handleObj = matched.handlers[ j ];
 
 				// If the event is namespaced, then each handler is only invoked if it is
 				// specially universal or its namespaces are a superset of the event's.

--- a/src/event/trigger.js
+++ b/src/event/trigger.js
@@ -91,10 +91,10 @@ jQuery.extend( jQuery.event, {
 		}
 
 		// Fire handlers on the event path
-		i = 0;
-		while ( ( cur = eventPath[ i++ ] ) && !event.isPropagationStopped() ) {
+		for ( i = 0; i < eventPath.length && !event.isPropagationStopped(); i++ ) {
+			cur = eventPath[ i ];
 			lastElement = cur;
-			event.type = i > 1 ?
+			event.type = i > 0 ?
 				bubbleType :
 				special.bindType || type;
 

--- a/src/manipulation/buildFragment.js
+++ b/src/manipulation/buildFragment.js
@@ -12,13 +12,12 @@ import { isArrayLike } from "../core/isArrayLike.js";
 var rhtml = /<|&#?\w+;/;
 
 export function buildFragment( elems, context, scripts, selection, ignored ) {
-	var elem, tmp, tag, wrap, attached, j,
+	var elem, tmp, tag, wrap, attached, i, j,
 		fragment = context.createDocumentFragment(),
 		nodes = [],
-		i = 0,
 		l = elems.length;
 
-	for ( ; i < l; i++ ) {
+	for ( i = 0; i < l; i++ ) {
 		elem = elems[ i ];
 
 		if ( elem || elem === 0 ) {
@@ -61,8 +60,8 @@ export function buildFragment( elems, context, scripts, selection, ignored ) {
 	// Remove wrapper from fragment
 	fragment.textContent = "";
 
-	i = 0;
-	while ( ( elem = nodes[ i++ ] ) ) {
+	for ( i = 0; i < nodes.length; i++ ) {
+		elem = nodes[ i ];
 
 		// Skip elements already in the context collection (trac-4087)
 		if ( selection && jQuery.inArray( elem, selection ) > -1 ) {
@@ -84,8 +83,8 @@ export function buildFragment( elems, context, scripts, selection, ignored ) {
 
 		// Capture executables
 		if ( scripts ) {
-			j = 0;
-			while ( ( elem = tmp[ j++ ] ) ) {
+			for ( j = 0; j < tmp.length; j++ ) {
+				elem = tmp[ j ];
 				if ( rscriptType.test( elem.type || "" ) ) {
 					scripts.push( elem );
 				}

--- a/src/selector-native.js
+++ b/src/selector-native.js
@@ -45,12 +45,11 @@ var matchExpr = jQuery.extend( {
 
 jQuery.extend( {
 	find: function( selector, context, results, seed ) {
-		var elem, nid, groups, newSelector,
+		var elem, nid, groups, newSelector, i,
 			newContext = context && context.ownerDocument,
 
 			// nodeType defaults to 9, since context defaults to document
-			nodeType = context ? context.nodeType : 9,
-			i = 0;
+			nodeType = context ? context.nodeType : 9;
 
 		results = results || [];
 		context = context || document;
@@ -66,7 +65,8 @@ jQuery.extend( {
 		}
 
 		if ( seed ) {
-			while ( ( elem = seed[ i++ ] ) ) {
+			for ( i = 0; i < seed.length; i++ ) {
+				elem = seed[ i ];
 				if ( jQuery.find.matchesSelector( elem, selector ) ) {
 					results.push( elem );
 				}

--- a/src/selector.js
+++ b/src/selector.js
@@ -1171,7 +1171,6 @@ function matcherFromGroupMatchers( elementMatchers, setMatchers ) {
 			// Add elements passing elementMatchers directly to results
 			for ( ; ( elem = elems[ i ] ) != null; i++ ) {
 				if ( byElement && elem ) {
-					j = 0;
 
 					// Support: IE 11+
 					// IE sometimes throws a "Permission denied" error when strict-comparing
@@ -1181,8 +1180,10 @@ function matcherFromGroupMatchers( elementMatchers, setMatchers ) {
 						setDocument( elem );
 						xml = !documentIsHTML;
 					}
-					while ( ( matcher = elementMatchers[ j++ ] ) ) {
-						if ( matcher( elem, context || document, xml ) ) {
+					matcher = undefined;
+					for ( j = 0; j < elementMatchers.length; j++ ) {
+						if ( elementMatchers[ j ]( elem, context || document, xml ) ) {
+							matcher = elementMatchers[ j ];
 							push.call( results, elem );
 							break;
 						}
@@ -1219,8 +1220,8 @@ function matcherFromGroupMatchers( elementMatchers, setMatchers ) {
 			// case, which will result in a "00" `matchedCount` that differs from `i` but is also
 			// numerically zero.
 			if ( bySet && i !== matchedCount ) {
-				j = 0;
-				while ( ( matcher = setMatchers[ j++ ] ) ) {
+				for ( j = 0; j < setMatchers.length; j++ ) {
+					matcher = setMatchers[ j ];
 					matcher( unmatched, setMatched, context, xml );
 				}
 

--- a/src/selector/uniqueSort.js
+++ b/src/selector/uniqueSort.js
@@ -70,8 +70,8 @@ function sortOrder( a, b ) {
  * @param {ArrayLike} results
  */
 jQuery.uniqueSort = function( results ) {
-	var j = 1,
-		i = 1;
+	var i,
+		j = 1;
 
 	hasDuplicate = false;
 
@@ -82,7 +82,7 @@ jQuery.uniqueSort = function( results ) {
 		// Pack the first instance of each unique element into the start of
 		// results (starting at index 1 because index 0 is always kept), then
 		// splice away the tail of duplicates.
-		for ( ; i < results.length; i++ ) {
+		for ( i = 1; i < results.length; i++ ) {
 			if ( results[ i ] !== results[ i - 1 ] ) {
 				results[ j++ ] = results[ i ];
 			}


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

Reaching behind array bounds - which is what effectively happens if you check for `null`/`undefined` value instead of doing a `length` check - can trigger deopts in various JS engines. Switch to regular `length`-based loops.

In the past, this was impractical as IE <9 used to clobber the `length` property if an element with the `name="length"` attribute was present, but this is no longer a concern.

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
