### PR TITLE
Selector: Unescape class name in filter.CLASS

### DIFF
--- a/src/selector.js
+++ b/src/selector.js
@@ -39,7 +39,6 @@ var i,
 	// Instance-specific data
 	dirruns = 0,
 	done = 0,
-	classCache = createCache(),
 	compilerCache = createCache(),
 	nonnativeSelectorCache = createCache(),
 
@@ -453,19 +452,16 @@ jQuery.expr = {
 		},
 
 		CLASS: function( className ) {
-			var pattern = classCache[ className + " " ];
+			var unescapedClass = " " + unescapeSelector( className ) + " ";
 
-			return pattern ||
-				( pattern = new RegExp( "(^|" + whitespace + ")" + className +
-					"(" + whitespace + "|$)" ) ) &&
-				classCache( className, function( elem ) {
-					return pattern.test(
-						typeof elem.className === "string" && elem.className ||
-							typeof elem.getAttribute !== "undefined" &&
-								elem.getAttribute( "class" ) ||
-							""
-					);
-				} );
+			return function( elem ) {
+				var classAttr = typeof elem.className === "string" && elem.className ||
+					typeof elem.getAttribute !== "undefined" &&
+						elem.getAttribute( "class" ) ||
+					"";
+				return ( " " + classAttr.replace( rwhitespace, " " ) + " " )
+					.indexOf( unescapedClass ) > -1;
+			};
 		},
 
 		ATTR: function( name, operator, check ) {

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -417,7 +417,7 @@ QUnit.test( "id", function( assert ) {
 } );
 
 QUnit.test( "class", function( assert ) {
-	assert.expect( 32 );
+	assert.expect( 34 );
 
 	assert.deepEqual( jQuery( ".blog", document.getElementsByTagName( "p" ) ).get(),
 		q( "mozilla", "timmy" ), "Finding elements with a context." );
@@ -472,6 +472,16 @@ QUnit.test( "class", function( assert ) {
 	div.lastChild.className += " hasOwnProperty toString";
 	assert.deepEqual( jQuery( ".e.hasOwnProperty.toString", div ).get(), [ div.lastChild ],
 		"Classes match Object.prototype properties" );
+
+	// Exercise filter.CLASS (no qSA): the seed-based path through `.filter()`
+	// on multiple elements, with CSS escapes in the class name.
+	div.innerHTML = "<i class='fooAbar'></i><i class='foo!bar'></i><i class='my.dotted'></i>";
+	assert.deepEqual( jQuery( "i", div ).filter( ".foo\\41 bar" ).get(),
+		[ div.firstChild ],
+		"Hex escape in filter.CLASS (\\41 = 'A')" );
+	assert.deepEqual( jQuery( "i", div ).filter( ".my\\.dotted" ).get(),
+		[ div.lastChild ],
+		"Char escape with regex-special in filter.CLASS" );
 
 	div = jQuery( "<div><svg width='200' height='250' version='1.1'" +
 		" xmlns='http://www.w3.org/2000/svg'><rect x='10' y='10' width='30' height='30'" +


### PR DESCRIPTION
Noticed `filter.CLASS` interpolates the raw token text into the cached
regex, while `filter.ID` and `filter.TAG` both run the captured identifier
through `unescapeSelector` first. So when `.foo\41 bar` reaches the
seed-based filter path (e.g. `.filter()` on a multi-element set), it
compares against the literal text `foo\41 bar`, plus `\41` becomes a
JS-regex octal/backreference. Unescape the captured class first and
switch to indexOf, matching the pattern already used by ATTR `~=`.