### PR TITLE
Core: Ignore inherited properties in jQuery( html, props )

### DIFF
--- a/src/core/init.js
+++ b/src/core/init.js
@@ -1,6 +1,7 @@
 // Initialize a jQuery object
 import { jQuery } from "../core.js";
 import { document } from "../var/document.js";
+import { hasOwn } from "../var/hasOwn.js";
 import { rsingleTag } from "./var/rsingleTag.js";
 import { isObviousHtml } from "./isObviousHtml.js";
 
@@ -75,6 +76,12 @@ var rootjQuery,
 					// HANDLE: $(html, props)
 					if ( rsingleTag.test( match[ 1 ] ) && jQuery.isPlainObject( context ) ) {
 						for ( match in context ) {
+
+							// Don't apply inherited properties (e.g. from a
+							// polluted Object.prototype) as methods or attributes
+							if ( !hasOwn.call( context, match ) ) {
+								continue;
+							}
 
 							// Properties of context are called as methods if possible
 							if ( typeof this[ match ] === "function" ) {

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -1145,6 +1145,20 @@ QUnit.test( "jQuery.extend( true, ... ) Object.prototype pollution", function( a
 	assert.ok( !( "devMode" in {} ), "Object.prototype not polluted" );
 } );
 
+QUnit.test( "jQuery( html, props ) ignores inherited properties", function( assert ) {
+	assert.expect( 2 );
+
+	Object.prototype.evilProp = "INJECTED";
+	try {
+		var el = jQuery( "<div></div>", { "data-own": "kept" } )[ 0 ];
+		assert.equal( el.getAttribute( "data-own" ), "kept", "Own property is applied" );
+		assert.strictEqual( el.getAttribute( "evilProp" ), null,
+			"Inherited property is not applied" );
+	} finally {
+		delete Object.prototype.evilProp;
+	}
+} );
+
 QUnit.test( "jQuery.each(Object,Function)", function( assert ) {
 	assert.expect( 23 );
 


### PR DESCRIPTION
The `$( html, props )` branch in src/core/init.js walks `context` with a bare for-in, so enumerable keys inherited from a polluted Object.prototype get applied as element attributes or method calls. Guard with hasOwn so only own properties are used, matching the prototype check already in jQuery.extend.