### PR TITLE
Selector: Decode invalid escape code points to U+FFFD

### DIFF
--- a/src/selector/unescapeSelector.js
+++ b/src/selector/unescapeSelector.js
@@ -5,7 +5,7 @@ import { whitespace } from "../var/whitespace.js";
 var runescape = new RegExp( "\\\\[\\da-fA-F]{1,6}" + whitespace +
 	"?|\\\\([^\\r\\n\\f])", "g" ),
 	funescape = function( escape, nonHex ) {
-		var high = "0x" + escape.slice( 1 ) - 0x10000;
+		var codePoint = "0x" + escape.slice( 1 ) - 0;
 
 		if ( nonHex ) {
 
@@ -13,13 +13,24 @@ var runescape = new RegExp( "\\\\[\\da-fA-F]{1,6}" + whitespace +
 			return nonHex;
 		}
 
+		// Per the CSS spec, a NULL, surrogate, or out-of-range code point is
+		// replaced with the REPLACEMENT CHARACTER (U+FFFD).
+		// https://www.w3.org/TR/css-syntax-3/#consume-escaped-code-point
+		if ( !codePoint || codePoint > 0x10FFFF ||
+			( codePoint >= 0xD800 && codePoint < 0xE000 ) ) {
+			return "\uFFFD";
+		}
+
 		// Replace a hexadecimal escape sequence with the encoded Unicode code point
 		// Support: IE <=11+
 		// For values outside the Basic Multilingual Plane (BMP), manually construct a
 		// surrogate pair
-		return high < 0 ?
-			String.fromCharCode( high + 0x10000 ) :
-			String.fromCharCode( high >> 10 | 0xD800, high & 0x3FF | 0xDC00 );
+		return codePoint < 0x10000 ?
+			String.fromCharCode( codePoint ) :
+			String.fromCharCode(
+				( codePoint - 0x10000 ) >> 10 | 0xD800,
+				( codePoint - 0x10000 ) & 0x3FF | 0xDC00
+			);
 	};
 
 export function unescapeSelector( sel ) {

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -844,6 +844,36 @@ QUnit.test( "attributes - special characters", function( assert ) {
 		"Long numeric escape (non-BMP)" );
 } );
 
+QUnit.test( "attributes - invalid escaped code points", function( assert ) {
+	assert.expect( 5 );
+
+	// Per the CSS spec, NULL, surrogate, and out-of-range escapes decode to the
+	// REPLACEMENT CHARACTER (U+FFFD). Use a seeded set to exercise the matcher
+	// rather than `querySelectorAll`.
+	var match = jQuery( "<input/>" ).attr( "data-attr", "\uFFFD" ),
+		noMatch = jQuery( "<input/>" ).attr( "data-attr", "\0" ),
+		boundary = jQuery( "<input/>" ).attr( "data-attr",
+			"\uFFFD\u0001\uD7FF\uFFFD\uFFFD\uE000\uDBFF\uDFFF\uFFFD" ),
+		els = match.add( noMatch ).add( boundary );
+
+	assert.deepEqual( els.filter( "[data-attr='\\0']" ).get(), match.get(),
+		"NULL escape decodes to U+FFFD, not U+0000" );
+	assert.deepEqual( els.filter( "[data-attr='\\D800']" ).get(), match.get(),
+		"surrogate escape decodes to U+FFFD" );
+	assert.deepEqual( els.filter( "[data-attr='\\110000']" ).get(), match.get(),
+		"out-of-range escape decodes to U+FFFD" );
+	assert.deepEqual( els.filter( "[data-attr='\\FFFFFF']" ).get(), match.get(),
+		"escape above the Unicode maximum decodes to U+FFFD" );
+
+	// Off-by-one coverage at the NULL, surrogate, and Unicode-max boundaries
+	assert.deepEqual(
+		els.filter(
+			"[data-attr='\\0 \\1 \\D7FF \\D800 \\DFFF \\E000 \\10FFFF \\110000']"
+		).get(),
+		boundary.get(),
+		"valid and invalid escapes decode with correct boundaries" );
+} );
+
 QUnit.test( "attributes - others", function( assert ) {
 	assert.expect( 14 );
 


### PR DESCRIPTION
`unescapeSelector` decodes CSS hex escapes that the spec maps to U+FFFD wrong:

    \0       -> U+0000   (literal NUL)
    \D800    -> U+D800   (lone surrogate)
    \110000  -> garbage  (above the Unicode max)

Return U+FFFD for null, surrogate, and out-of-range escapes. Reachable via the seeded `.filter()` matcher; test added alongside the others.