### PR TITLE
Tests: Fix jQuery.text tests in IE 9

### DIFF
--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -1613,9 +1613,15 @@ QUnit.test( "jQuery.text", function( assert ) {
 		"foo", "Text node" );
 	assert.notEqual( jQuery.text( document ), "",
 		"Document node is non-empty" );
-	assert.strictEqual(
-		jQuery.text( new DOMParser().parseFromString( "<span>example</span>", "text/html" ) ),
-		"example", "DOMParser document node" );
+
+	if ( !document.documentMode || document.documentMode > 9 ) {
+		assert.strictEqual(
+			jQuery.text( new DOMParser().parseFromString( "<span>example</span>", "text/html" ) ),
+			"example", "DOMParser document node" );
+	} else {
+		assert.ok( true, "IE 9 doesn't support DOMParser's parseFromString with text/html" );
+	}
+
 	assert.strictEqual( jQuery.text( jQuery( document.createDocumentFragment() )
 		.append( document.createTextNode( "foo" ) )[ 0 ] ),
 		"foo", "Document fragment" );


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

One of the tests uses `DOMParser`'s `parseFronString` with `"text/html"`, which doesn't work in IE 9. Skip this test there.

Ref gh-5794

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
