### PR TITLE
Data: clear hasDataAttrs on full .removeData() call

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -158,6 +158,12 @@ jQuery.fn.extend( {
 	removeData: function( key ) {
 		return this.each( function() {
 			dataUser.remove( this, key );
+
+			// When all user data is removed, clear the hasDataAttrs flag
+			// so that a later data() call re-reads data-* attributes.
+			if ( key === undefined ) {
+				dataPriv.remove( this, "hasDataAttrs" );
+			}
 		} );
 	}
 } );

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -507,6 +507,16 @@ QUnit.test( ".removeData()", function( assert ) {
 	assert.equal( div.data( "test.foo" ), undefined, "Make sure data is intact" );
 } );
 
+QUnit.test( ".removeData() clears hasDataAttrs so data-* attributes are re-read (gh-5751)", function( assert ) {
+	assert.expect( 2 );
+
+	var div = jQuery( "<div data-test='123'></div>" );
+	assert.equal( div.data( "test" ), "123", "data-* attribute read initially" );
+
+	div.removeData();
+	assert.equal( div.data( "test" ), "123", "data-* attribute re-read after removeData()" );
+} );
+
 QUnit.test( "JSON serialization (trac-8108)", function( assert ) {
 	assert.expect( 1 );
 


### PR DESCRIPTION
## Summary

Fixes gh-5751

The `hasDataAttrs` private flag was not cleared when `.removeData()` was called without a key argument. This prevented subsequent `.data()` calls from re-reading HTML5 `data-*` attributes, contrary to the [documented behavior](https://api.jquery.com/removeData/):

> A later call to data() will [...] re-retrieve the value from the data- attribute.

### Reproduction

```js
const elem = $("<div data-test=\"123\">");
console.log(elem.data("test")); // 123
elem.removeData();
console.log(elem.data("test")); // Expected: 123, Actual before fix: undefined
```

### Fix

Clear `dataPriv`'s `hasDataAttrs` flag when `.removeData()` is called without a specific key (full data removal). When a key is passed, the flag is left intact since individual key removal should not trigger a full data-attr re-scan.

### Test plan

Added QUnit test `.removeData() clears hasDataAttrs so data-* attributes are re-read (gh-5751)` verifying the documented behavior.