### PR TITLE
Tests: Accept old & new :enabled/:disabled option/optgroup semantics

### DIFF
--- a/test/data/qunit-fixture.html
+++ b/test/data/qunit-fixture.html
@@ -250,18 +250,24 @@ Z</textarea>
 		<span id="enabled-fieldset-span">Neither enabled nor disabled</span>
 	</fieldset>
 	<select id="disabled-select-inherit" name="disabled-select-inherit" disabled="disabled">
-		<optgroup id="disabled-optgroup-inherit" label="and" disabled="disabled">
-			<option id="disabled-optgroup-option">Black</option>
+		<optgroup id="dis_disabled-optgroup-inherit" label="and" disabled="disabled">
+			<option id="dis_disabled-optgroup-option">Black</option>
 		</optgroup>
-		<optgroup id="enabled-optgroup-inherit" label="and">
-			<option id="enabled-optgroup-option">Gold</option>
+		<optgroup id="dis_enabled-optgroup-inherit" label="and">
+			<option id="dis_enabled-optgroup-option">Gold</option>
 		</optgroup>
+		<option id="dis_disabled-option" disabled="disabled">Black</option>
+		<option id="dis_enabled-option">Gold</option>
 	</select>
 	<select id="enabled-select-inherit" name="enabled-select-inherit">
 		<optgroup id="en_disabled-optgroup-inherit" label="and" disabled="disabled">
 			<option id="en_disabled-optgroup-option">Black</option>
 		</optgroup>
-		<option id="enabled-select-option">Black</option>
+		<optgroup id="en_enabled-optgroup-inherit" label="and">
+			<option id="en_enabled-optgroup-option">Gold</option>
+		</optgroup>
+		<option id="en_disabled-option" disabled="disabled">Black</option>
+		<option id="en_enabled-option">Gold</option>
 	</select>
 </form>
 

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -1530,19 +1530,76 @@ QUnit.test( "pseudo - :(dis|en)abled, explicitly disabled", function( assert ) {
 } );
 
 QUnit.test( "pseudo - :(dis|en)abled, optgroup and option", function( assert ) {
-	assert.expect( 2 );
+	assert.expect( 4 );
+
+	var elems = jQuery( "#disabled-select-inherit, #enabled-select-inherit" )
+			.find( "optgroup, option" ),
+		disabledResultsNew = [
+			"dis_disabled-optgroup-inherit", "dis_disabled-optgroup-option",
+			"dis_enabled-optgroup-inherit", "dis_enabled-optgroup-option",
+			"dis_disabled-option", "dis_enabled-option",
+			"en_disabled-optgroup-inherit", "en_disabled-optgroup-option",
+			"en_disabled-option"
+		],
+		enabledResultsNew = [
+			"en_enabled-optgroup-inherit", "en_enabled-optgroup-option",
+			"en_enabled-option"
+		],
+		disabledResultsOld = [
+			"dis_disabled-optgroup-inherit", "dis_disabled-optgroup-option",
+			"dis_disabled-option",
+			"en_disabled-optgroup-inherit", "en_disabled-optgroup-option",
+			"en_disabled-option"
+		],
+		enabledResultsOld = [
+			"dis_enabled-optgroup-inherit", "dis_enabled-optgroup-option",
+			"dis_enabled-option",
+			"en_enabled-optgroup-inherit", "en_enabled-optgroup-option",
+			"en_enabled-option"
+		],
+
+		// Support: Chrome 149+
+		// The HTML spec change at https://github.com/whatwg/html/pull/12205
+		// makes options & optgroups inside a disabled `<select>` match
+		// `:disabled` as well. This change isn't implemented everywhere yet
+		// and for now we accept both behaviors.
+		optionInheritsSelectDisabled =
+			jQuery( "#dis_enabled-option" ).is( ":disabled" );
 
 	assert.t(
 		":disabled",
 		"#disabled-select-inherit :disabled, #enabled-select-inherit :disabled",
-		[ "disabled-optgroup-inherit", "disabled-optgroup-option", "en_disabled-optgroup-inherit",
-			"en_disabled-optgroup-option" ]
+		optionInheritsSelectDisabled ? disabledResultsNew : disabledResultsOld
 	);
 
 	assert.t(
 		":enabled",
 		"#disabled-select-inherit :enabled, #enabled-select-inherit :enabled",
-		[ "enabled-optgroup-inherit", "enabled-optgroup-option", "enabled-select-option" ]
+		optionInheritsSelectDisabled ? enabledResultsNew : enabledResultsOld
+	);
+
+	// Check `:disabled` & `:enabled` matching via `.filter()` which uses
+	// the jQuery built-in selector engine - except when the selector-native
+	// module is used. The jQuery selector engine implements old
+	// semantics inside disabled selects.
+	assert.deepEqual(
+		elems.filter( ":disabled" ).toArray().map( function( node ) {
+			return node.id;
+		} ),
+		optionInheritsSelectDisabled && !QUnit.jQuerySelectors ?
+			disabledResultsNew :
+			disabledResultsOld,
+		":disabled (via .filter())"
+	);
+
+	assert.deepEqual(
+		elems.filter( ":enabled" ).toArray().map( function( node ) {
+			return node.id;
+		} ),
+		optionInheritsSelectDisabled && !QUnit.jQuerySelectors ?
+			enabledResultsNew :
+			enabledResultsOld,
+		":enabled (via .filter())"
 	);
 } );
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

whatwg/html#12205 made options & optgroups inside a disabled `<select>` match `:disabled` (and not `:enabled`), even without their own `disabled` attribute. This broke the "pseudo - :(dis|en)abled, optgroup and option" test in browsers that implement the change. jQuery's internals are left as-is for now; the test now just accepts both the old & new behavior.

A separate companion test was added that forces the jQuery selector engine via `.filter()`; that path keeps the old semantics in every browser.

Ref whatwg/html#12205
Ref gh-5843

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [x] New tests have been added to show the fix or feature works
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
