### PR TITLE
Build: Explicitly test on Safari 26, not latest (3.x version)

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -27,10 +27,10 @@ jobs:
           - 'IE_11'
           - 'IE_10'
           - 'IE_9'
-          - 'Safari_latest'
-          # JTR doesn't take into account the jump from Safari 18 to 26,
-          # so we need to specify versions explicitly.
-          # See https://github.com/jquery/jquery-test-runner/issues/17
+          # BrowserStack makes Safari on beta macOS versions available without marking
+          # either the OS or the browser as beta, so we have no way to resolve "latest"
+          # to the lastest stable version.
+          - 'Safari_26'
           - 'Safari_18'
           - 'Chrome_latest'
           - 'Chrome_latest-1'


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

BrowserStack often shares the Safari version included in the next macOS release as soon as that macOS releases a public beta, but there's no indicator in the API that this Safari version is a beta, making JTR pick it up via `Safari_latest`. To avoid this issue, specify Safari versions explicitly. Fortunately, major Safari versions are only released once a year, so the list can usually be updated together with a related iOS yearly major update.

Ref gh-5857

`main` version of this PR: gh-5857

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
