### PR TITLE
Selector: Fix quadratic backtracking in rtrimCSS whitespace trimming

### DIFF
--- a/src/var/rtrimCSS.js
+++ b/src/var/rtrimCSS.js
@@ -1,6 +1,11 @@
 import { whitespace } from "./whitespace.js";
 
+// Leading and non-escaped trailing whitespace. Escape sequences are captured so
+// they can be preserved via a `$1` replacement, which keeps an escaped trailing
+// whitespace from being trimmed. Consuming each escape as a single unit (rather
+// than re-scanning a `(?:\\.)*` run from every offset) keeps matching linear and
+// avoids quadratic backtracking on long escape-heavy input.
 export var rtrimCSS = new RegExp(
-	"^" + whitespace + "+|((?:^|[^\\\\])(?:\\\\.)*)" + whitespace + "+$",
+	"^" + whitespace + "+|" + whitespace + "+$|(\\\\[\\s\\S])",
 	"g"
 );

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -317,6 +317,32 @@ QUnit.test( "identifier ReDoS", function( assert ) {
 		"Pathological hex escape selector should not hang (took " + elapsed + "ms)" );
 } );
 
+QUnit.test( "trailing-whitespace ReDoS", function( assert ) {
+	assert.expect( 1 );
+
+	// A long run of "\ " escape sequences followed by a non-whitespace
+	// character. The string never ends in whitespace, so the trailing-whitespace
+	// branch of `rtrimCSS` fails at every offset. A naive pattern re-scans the
+	// escape run from each start position, causing quadratic backtracking that
+	// blocks for seconds on large input.
+	//
+	// Support: IE 9 - 11+ only
+	// IE doesn't have String.prototype.repeat.
+	// 100001 empty elements produce 100000 occurrences of the `join` parameter.
+	var selector = "x" + Array( 100001 ).join( "\\ " ) + "!",
+		start, elapsed;
+
+	start = Date.now();
+	try {
+		jQuery( selector );
+	} catch ( _e ) {}
+	elapsed = Date.now() - start;
+
+	assert.ok( elapsed < 1000,
+		"Pathological trailing-whitespace selector should not hang (took " +
+			elapsed + "ms)" );
+} );
+
 QUnit.test( "double-dash identifier prefix", function( assert ) {
 	assert.expect( 5 );
 


### PR DESCRIPTION
### Summary ###

`rtrimCSS` trims leading and non-escaped trailing whitespace from a selector, but its trailing branch `((?:^|[^\\])(?:\\.)*)[ws]+$` re-scans the `(?:\\.)*` escape run from every start offset. A selector made of many escape sequences that never ends in whitespace (e.g. `"x" + "\\ ".repeat(n) + "!"`) never satisfies the trailing `$`, so the engine retries the escape scan from each of the ~n offsets, giving O(n²) work. The regex is reached directly on the raw selector via `selector.replace(rtrimCSS, "$1")` in `src/selector.js` (the `find`/`select`/`compile` fallback) and `curCSS`, so any code that passes attacker-controlled data to `jQuery()`, `.find()`, `.is()`, `.filter()`, or `.closest()` is exposed. A ~160KB selector blocks for several seconds; this is the same threat model as the identifier ReDoS fixed in gh-5808.

The rewrite trims leading and trailing whitespace directly and consumes each escape as one captured `(\\[\s\S])` unit, which is preserved by the existing `$1` replacement. Escaped trailing whitespace stays protected (the escape is matched as a unit before the trailing-whitespace branch can reach it) and matching becomes linear. The `.replace(rtrimCSS, " ")` call in `tokenize` only ever receives a single combinator character, which is unaffected. Added a regression test alongside the existing identifier ReDoS test; it hangs for ~5.5s on the old pattern and completes in a few ms with this change.

### Checklist ###

* [x] New tests have been added to show the fix or feature works
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~
