### PR TITLE
Selector: Decode invalid CSS escapes to the replacement character

### DIFF
--- a/src/selector/unescapeSelector.js
+++ b/src/selector/unescapeSelector.js
@@ -5,21 +5,32 @@ import { whitespace } from "../var/whitespace.js";
 var runescape = new RegExp( "\\\\[\\da-fA-F]{1,6}" + whitespace +
 	"?|\\\\([^\\r\\n\\f])", "g" ),
 	funescape = function( escape, nonHex ) {
-		var high = "0x" + escape.slice( 1 ) - 0x10000;
-
 		if ( nonHex ) {
 
 			// Strip the backslash prefix from a non-hex escape sequence
 			return nonHex;
 		}
 
+		var codePoint = parseInt( escape.slice( 1 ), 16 );
+
+		// Zero, a surrogate half, and values above the maximum code point decode to
+		// the replacement character, matching the native CSS parser.
+		// https://drafts.csswg.org/css-syntax/#consume-escaped-code-point
+		if ( codePoint === 0 || codePoint > 0x10FFFF ||
+			codePoint >= 0xD800 && codePoint <= 0xDFFF ) {
+			return "\uFFFD";
+		}
+
 		// Replace a hexadecimal escape sequence with the encoded Unicode code point
 		// Support: IE <=11+
 		// For values outside the Basic Multilingual Plane (BMP), manually construct a
 		// surrogate pair
-		return high < 0 ?
-			String.fromCharCode( high + 0x10000 ) :
-			String.fromCharCode( high >> 10 | 0xD800, high & 0x3FF | 0xDC00 );
+		return codePoint > 0xFFFF ?
+			String.fromCharCode(
+				( codePoint - 0x10000 ) >> 10 | 0xD800,
+				( codePoint - 0x10000 ) & 0x3FF | 0xDC00
+			) :
+			String.fromCharCode( codePoint );
 	};
 
 export function unescapeSelector( sel ) {

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -764,7 +764,7 @@ QUnit.test( "attributes - hyphen-prefix matches", function( assert ) {
 } );
 
 QUnit.test( "attributes - special characters", function( assert ) {
-	assert.expect( 16 );
+	assert.expect( 19 );
 
 	var attrbad;
 	var div = document.createElement( "div" );
@@ -842,6 +842,19 @@ QUnit.test( "attributes - special characters", function( assert ) {
 	assert.deepEqual( jQuery( attrbad ).filter( "input[data-attr='\\01D306A']" ).get(),
 		q( "attrbad_unicode" ),
 		"Long numeric escape (non-BMP)" );
+
+	// A zero, a surrogate half, and an out-of-range code point all decode to the
+	// replacement character U+FFFD, matching the native CSS parser.
+	document.getElementById( "attrbad_unicode" ).setAttribute( "data-attr", "\uFFFD" );
+	assert.deepEqual( jQuery( attrbad ).filter( "input[data-attr='\\0']" ).get(),
+		q( "attrbad_unicode" ),
+		"Null escape decodes to the replacement character" );
+	assert.deepEqual( jQuery( attrbad ).filter( "input[data-attr='\\D800']" ).get(),
+		q( "attrbad_unicode" ),
+		"Surrogate escape decodes to the replacement character" );
+	assert.deepEqual( jQuery( attrbad ).filter( "input[data-attr='\\110000']" ).get(),
+		q( "attrbad_unicode" ),
+		"Out-of-range escape decodes to the replacement character" );
 } );
 
 QUnit.test( "attributes - others", function( assert ) {


### PR DESCRIPTION
1. `funescape` decoded a zero, a surrogate half (U+D800-U+DFFF), or a value above U+10FFFF into a literal NUL, a lone surrogate, or a corrupt surrogate pair.
2. jQuery's own matcher then decoded such an escape differently from the browser's native CSS parser, so the same selector could match different elements on the engine path (`.filter()`/`.is()` over a multi-element set) than through `querySelectorAll`.

Return U+FFFD for those code points per the CSS Syntax rules; valid BMP and astral escapes are unchanged. Added a regression test next to the existing escape cases.