### PR TITLE
Selector: Fix the runescape regex in unescapeSelector

### DIFF
--- a/src/selector/unescapeSelector.js
+++ b/src/selector/unescapeSelector.js
@@ -3,7 +3,7 @@
 import { whitespace } from "../var/whitespace.js";
 
 var runescape = new RegExp( "\\\\[\\da-fA-F]{1,6}" + whitespace +
-	"?|\\\\([^\\r\\n\\f])", "g" ),
+	"?|\\\\([^\\da-fA-F\\r\\n\\f])", "g" ),
 	funescape = function( escape, nonHex ) {
 		var high = "0x" + escape.slice( 1 ) - 0x10000;
 


### PR DESCRIPTION
### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->

The goal is to match the escape fix in gh-5807 to avoid catastrophic backtracking.

Considering the issue mostly affects invalid selectors and `unescapeSelector` runs on an already parsed selector, this may not be possible to abuse, but for completeness let's replace this regex as well.

We cannot just reuse the escape definition from `escape.js` as the non-hex part is put in a capturing group here.

Size diffs:
```
main @d6fb53bce28d597ac309ec81efe761bd410bdf41
   raw     gz     br Filename
    +9     -1    +51 dist/jquery.min.js
    +9     -1     +8 dist/jquery.slim.min.js
    +9     -1    -12 dist-module/jquery.module.min.js
    +9     -1     +7 dist-module/jquery.slim.module.min.js
```

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* ~~New tests have been added to show the fix or feature works~~
* ~~If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com~~

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
