### PR TITLE
Selector: unescape class names in the CLASS filter matcher

### DIFF
--- a/src/selector.js
+++ b/src/selector.js
@@ -455,16 +455,20 @@ jQuery.expr = {
 		CLASS: function( className ) {
 			var pattern = classCache[ className + " " ];
 
+			// Decode the class name and match whitespace-delimited tokens directly.
+			// Sibling matchers (ID, TAG, ATTR) all unescape their argument; splicing
+			// the still-escaped class name into a RegExp here mis-decoded CSS escapes
+			// such as `\66` (0x66 -> "f") into a regex octal escape, so the jQuery
+			// engine matched a different class than native querySelectorAll.
 			return pattern ||
-				( pattern = new RegExp( "(^|" + whitespace + ")" + className +
-					"(" + whitespace + "|$)" ) ) &&
+				( pattern = " " + unescapeSelector( className ) + " " ) &&
 				classCache( className, function( elem ) {
-					return pattern.test(
+					return ( " " + (
 						typeof elem.className === "string" && elem.className ||
 							typeof elem.getAttribute !== "undefined" &&
 								elem.getAttribute( "class" ) ||
 							""
-					);
+					).replace( rwhitespace, " " ) + " " ).indexOf( pattern ) > -1;
 				} );
 		},
 

--- a/test/unit/selector.js
+++ b/test/unit/selector.js
@@ -417,7 +417,7 @@ QUnit.test( "id", function( assert ) {
 } );
 
 QUnit.test( "class", function( assert ) {
-	assert.expect( 32 );
+	assert.expect( 33 );
 
 	assert.deepEqual( jQuery( ".blog", document.getElementsByTagName( "p" ) ).get(),
 		q( "mozilla", "timmy" ), "Finding elements with a context." );
@@ -447,6 +447,13 @@ QUnit.test( "class", function( assert ) {
 	assert.t( "Descendant escaped Class", "div .test\\.foo\\[5\\]bar", [ "test.foo[5]bar" ] );
 	assert.t( "Child escaped Class", "form > .foo\\:bar", [ "foo:bar" ] );
 	assert.t( "Child escaped Class", "form > .test\\.foo\\[5\\]bar", [ "test.foo[5]bar" ] );
+
+	// The jQuery matcher (reached via `.filter()`) must decode hex CSS escapes
+	// like the native querySelectorAll path does; `\66` is the letter "f".
+	var hexClassNodes = jQuery( "<div class='foo'></div><div class='bar'></div>" );
+	assert.deepEqual( hexClassNodes.filter( ".\\66oo" ).get(),
+		hexClassNodes.filter( ".foo" ).get(),
+		"Class selector with a hex escape matches the unescaped form" );
 
 	var div = document.createElement( "div" );
 	div.innerHTML = "<div class='test e'></div><div class='test'></div>";


### PR DESCRIPTION
expr.filter.CLASS in src/selector.js splices the raw, still-escaped class-selector text straight into a RegExp and never runs it through unescapeSelector, unlike the sibling ID, TAG, and ATTR matchers which all decode their argument first. A hexadecimal CSS escape such as `.\66oo` (the class `foo`, since 0x66 is `f`) is then read as a regex octal escape, so the jQuery matcher selects a different class than native querySelectorAll. This path is reached via .filter()/.is()/.not() over multi-element sets, where the compiled matcher runs instead of qSA. The fix decodes the name with unescapeSelector and compares whitespace-delimited tokens directly, so escaped class names resolve the same way on both paths.