### PR TITLE
Ajax: Trim trailing whitespace from response header values

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -15,7 +15,7 @@ var
 	r20 = /%20/g,
 	rhash = /#.*$/,
 	rantiCache = /([?&])_=[^&]*/,
-	rheaders = /^(.*?):[ \t]*([^\r\n]*)$/mg,
+	rheaders = /^(.*?):[ \t]*((?:[^\r\n]*[^ \t\r\n])?)[ \t]*$/mg,
 
 	// trac-7653, trac-8125, trac-8152: local protocol detection
 	rlocalProtocol = /^(?:about|app|app-storage|.+-extension|file|res|widget):$/,

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -3097,6 +3097,40 @@ QUnit.module( "ajax", {
 		};
 	} );
 
+	ajaxTest( "jQuery.ajaxTransport() - getResponseHeader trims surrounding whitespace", 2,
+			function( assert ) {
+		var testId = assert.test.testId,
+			dataType = "test-header-ows-" + testId,
+			resp = {};
+		resp[ dataType ] = "done";
+		return {
+			setup: function() {
+				jQuery.ajaxTransport( dataType, function() {
+					return {
+						send: function( _, completeCallback ) {
+							completeCallback(
+								200,
+								"OK",
+								resp,
+								"X-Custom: test-value   \r\n" +
+									"X-Tabbed:\t\tspaced value\t"
+							);
+						},
+						abort: jQuery.noop
+					};
+				} );
+			},
+			url: url( "name.html" ),
+			dataType: dataType,
+			success: function( data, _, jqXHR ) {
+				assert.strictEqual( jqXHR.getResponseHeader( "X-Custom" ), "test-value",
+					"Trailing whitespace trimmed from response header value" );
+				assert.strictEqual( jqXHR.getResponseHeader( "X-Tabbed" ), "spaced value",
+					"Surrounding tabs trimmed from response header value" );
+			}
+		};
+	} );
+
 	ajaxTest( "jQuery.ajaxTransport() - abort called on jqXHR.abort()", 1, function( assert ) {
 		var testId = assert.test.testId,
 			dataType = "test-tp-abort-" + testId;


### PR DESCRIPTION
jqXHR.getResponseHeader parses the raw header block with rheaders, which strips leading whitespace after the colon but leaves trailing spaces and tabs on the value, so `Content-Type: text/html ` comes back with the trailing space while native getResponseHeader returns it trimmed per RFC 7230. A custom transport or the object-based completeCallback passing an untrimmed header block surfaces the divergence. Trim trailing tabs and spaces in the value capture so the parse matches native XHR.