### PR TITLE
CSS: Read custom properties from detached elements

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -259,7 +259,7 @@ jQuery.extend( {
 			}
 
 			// Otherwise just get the value from the style object
-			return style[ name ];
+			return isCustomProp ? style.getPropertyValue( name ) : style[ name ];
 		}
 	},
 

--- a/src/css/curCSS.js
+++ b/src/css/curCSS.js
@@ -48,7 +48,7 @@ export function curCSS( elem, name, computed ) {
 			ret = ret.replace( rtrimCSS, "$1" ) || undefined;
 		}
 
-		if ( ret === "" && !isAttached( elem ) ) {
+		if ( ( ret === "" || ( isCustomProp && ret === undefined ) ) && !isAttached( elem ) ) {
 			ret = jQuery.style( elem, name );
 		}
 	}

--- a/test/unit/css.js
+++ b/test/unit/css.js
@@ -1828,7 +1828,13 @@ QUnit.testUnlessIE( "css(--customProperty)", function( assert ) {
 		$elem = jQuery( "<div>" ).addClass( "test__customProperties" )
 			.appendTo( "#qunit-fixture" );
 
-	assert.expect( 20 );
+	assert.expect( 21 );
+
+	assert.equal(
+		jQuery( "<div>" ).css( "--color", "blue" ).css( "--color" ),
+		"blue",
+		"Read CSS custom property on detached element"
+	);
 
 	div.css( "--color", "blue" );
 	assert.equal( div.css( "--color" ), "blue", "Modified CSS custom property using string" );


### PR DESCRIPTION
Fixes gh-5865

### Summary

* Read inline CSS custom properties through `getPropertyValue()`.
* Use the existing inline-style fallback when a detached custom property's computed value is `undefined`.
* Add regression coverage for reading a custom property from a detached element.

The setter stores custom properties with `setProperty()`, but the getter used bracket access. In Chrome, the computed-style path also yields `undefined` for a detached custom property, so the existing empty-string fallback was skipped.

### Screenshots

Before — the inline value is `"5"`, but `.css()` returns `undefined`:

<img width="1280" height="720" alt="Detached custom property returns undefined before the fix" src="https://github.com/user-attachments/assets/60b3b71d-6e66-4baf-ad9e-8a6639199086" />

After — the same detached element returns `"5"`:

<img width="1280" height="720" alt="Detached custom property returns the inline value after the fix" src="https://github.com/user-attachments/assets/3ee18ee2-3291-4353-975d-565c6bcd18d5" />

### Validation

* `npm run test`
* Focused Chrome CSS regression: 61 passed, 0 skipped

### Checklist

* [x] New tests have been added to show the fix works
* [x] A docs issue/PR is not needed; this restores consistent existing `.css()` behavior
