### PR TITLE
Event: Restore trigger state after native method failure

### DIFF
--- a/src/event/trigger.js
+++ b/src/event/trigger.js
@@ -137,20 +137,22 @@ jQuery.extend( jQuery.event, {
 					// Prevent re-triggering of the same event, since we already bubbled it above
 					jQuery.event.triggered = type;
 
-					if ( event.isPropagationStopped() ) {
-						lastElement.addEventListener( type, stopPropagationCallback );
-					}
+					try {
+						if ( event.isPropagationStopped() ) {
+							lastElement.addEventListener( type, stopPropagationCallback );
+						}
 
-					elem[ type ]();
+						elem[ type ]();
+					} finally {
+						if ( event.isPropagationStopped() ) {
+							lastElement.removeEventListener( type, stopPropagationCallback );
+						}
 
-					if ( event.isPropagationStopped() ) {
-						lastElement.removeEventListener( type, stopPropagationCallback );
-					}
+						jQuery.event.triggered = undefined;
 
-					jQuery.event.triggered = undefined;
-
-					if ( tmp ) {
-						elem[ ontype ] = tmp;
+						if ( tmp ) {
+							elem[ ontype ] = tmp;
+						}
 					}
 				}
 			}

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -460,6 +460,34 @@ QUnit.test( "triggered events stopPropagation() for natively-bound events", func
 	$button.off( "click", stopPropagationCallback );
 } );
 
+QUnit.test( "trigger() restores state after a native method throws", function( assert ) {
+	assert.expect( 3 );
+
+	var elem = document.createElement( "div" ),
+		handlerCalls = 0,
+		inlineHandler = function() {};
+
+	elem.boom = function() {
+		throw new Error( "native method failed" );
+	};
+	elem.onboom = inlineHandler;
+
+	jQuery( elem ).on( "boom", function() {
+		handlerCalls++;
+	} );
+
+	assert.throws( function() {
+		jQuery( elem ).trigger( "boom" );
+	}, /native method failed/, "native error was propagated" );
+	assert.strictEqual( elem.onboom, inlineHandler, "inline handler was restored" );
+
+	var nativeEvent = document.createEvent( "Event" );
+	nativeEvent.initEvent( "boom", true, true );
+	elem.dispatchEvent( nativeEvent );
+
+	assert.strictEqual( handlerCalls, 2, "handler ran for the later native event" );
+} );
+
 QUnit.test( "trigger() works with events that were previously stopped", function( assert ) {
 	assert.expect( 0 );
 


### PR DESCRIPTION
When a same-named native method throws during `.trigger()`, jQuery can silently stop handling later events of that type.

### Summary ###

This restores jQuery's temporary event state with a `finally` block, while preserving the native error for the caller. 

Basically I wrapped it in a try/finally.

Fixes #5868.

### At a glance — visual summary ###

**Before — the later native event is suppressed**

![Visual summary of the failure: expected two handler calls, but only one occurs](https://raw.githubusercontent.com/Kevinjohn/jquery/25813e68e61e0e23e2edc194e142b7564e555ca1/docs/evidence/event-trigger-cleanup/visual-summary-before.png)

**After — temporary event state is restored**

![Visual summary of the intended result: both handler calls occur](https://raw.githubusercontent.com/Kevinjohn/jquery/25813e68e61e0e23e2edc194e142b7564e555ca1/docs/evidence/event-trigger-cleanup/visual-summary-after.png)

### Actual Chrome screenshots ###

**Failing — upstream `main` at `7e1efd77`**

Only the regression test is added to the upstream source. QUnit reports one failed test and two failed assertions, including **Expected: 2, Result: 1**.

![Actual Chrome QUnit screenshot failing on upstream main](https://raw.githubusercontent.com/Kevinjohn/jquery/25813e68e61e0e23e2edc194e142b7564e555ca1/docs/evidence/event-trigger-cleanup/before.png)

**Passing — this PR at `21f17ad9`**

The identical test reports **3 assertions of 3 passed, 0 failed**.

![Actual Chrome QUnit screenshot passing after the fix](https://raw.githubusercontent.com/Kevinjohn/jquery/25813e68e61e0e23e2edc194e142b7564e555ca1/docs/evidence/event-trigger-cleanup/after.png)

### Validation ###

* [x] Added a regression test for state and inline-handler restoration
* [x] `npm test`
* [x] Focused event suite in headless Chrome and Firefox

### Checklist ###

* [x] New tests have been added to show the fix works
* [x] No documentation changes are needed
