### PR TITLE
Deferred: Warn on AggregateError exceptions

### DIFF
--- a/src/deferred/exceptionHook.js
+++ b/src/deferred/exceptionHook.js
@@ -4,7 +4,7 @@ import "../deferred.js";
 
 // These usually indicate a programmer mistake during development,
 // warn about them ASAP rather than swallowing them by default.
-var rerrorNames = /^(Eval|Internal|Range|Reference|Syntax|Type|URI)Error$/;
+var rerrorNames = /^(Aggregate|Eval|Internal|Range|Reference|Syntax|Type|URI)Error$/;
 
 // If `jQuery.Deferred.getErrorHook` is defined, `asyncError` is an error
 // captured before the async barrier to get the original error cause

--- a/test/unit/deferred.js
+++ b/test/unit/deferred.js
@@ -614,6 +614,26 @@ QUnit.test( "jQuery.Deferred.exceptionHook", function( assert ) {
 	defer.resolve();
 } );
 
+QUnit.test( "jQuery.Deferred.exceptionHook warns on AggregateError", function( assert ) {
+
+	assert.expect( 1 );
+
+	var warned,
+		error = new Error( "Make me a sandwich" ),
+		oldWarn = window.console.warn;
+
+	error.name = "AggregateError";
+
+	window.console.warn = function( _intro, warnedError ) {
+		warned = warnedError === error;
+	};
+
+	jQuery.Deferred.exceptionHook( error );
+	window.console.warn = oldWarn;
+
+	assert.ok( warned, "AggregateError is reported" );
+} );
+
 QUnit.test( "jQuery.Deferred.exceptionHook with error hooks", function( assert ) {
 
 	assert.expect( 2 );


### PR DESCRIPTION
AggregateError exceptions thrown from Deferred callbacks now produce the same development warning as other native `Error` subclasses.

- **Sequence:** Throw an `AggregateError` from a Deferred `.then()` callback.
- **Expected:** `jQuery.Deferred.exceptionHook` calls `console.warn`.
- **Actual before this change:** The Deferred rejects without emitting a warning.

Fixes gh-5870

### Summary

- Add `AggregateError` to the existing native-error name allowlist.
- Add a focused regression test for the warning.

### Actual screenshots

Both captures use Chrome 150.0.7871.125 and the same filtered QUnit test.

**Before — `7e1efd77` plus the regression test only (Expected: `true`, Result: `undefined`)**

<img width="1512" height="752" alt="QUnit AggregateError test failing before the fix" src="https://github.com/user-attachments/assets/b6229f83-1763-446a-a5d6-7d9747d2958c" />

**After — `c8041ca6` (1 assertion passed, 0 failed)**

<img width="1512" height="752" alt="QUnit AggregateError test passing after the fix" src="https://github.com/user-attachments/assets/624eab21-9757-40b5-9d5c-24fbb440938a" />

### Validation

- `npm run test:chrome -- --flag module=deferred` — 29 passed, 0 skipped
- `npm test` — full suite passed

### Checklist

* [x] New tests have been added to show the fix works
* [x] No API documentation change is needed
