### PR TITLE
Docs: Fix contributor meeting link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ The jQuery Core team watches [jQuery GitHub Discussions](https://github.com/jque
 
 ### Weekly Status Meetings
 
-The jQuery Core team has a weekly meeting to discuss the progress of current work. The meeting is held in the [#jquery/meeting](hhttps://matrix.to/#/#jquery_meeting:gitter.im) Matrix channel on gitter.im at [Noon EST](https://www.timeanddate.com/worldclock/fixedtime.html?month=10&day=7&year=2024&hour=12&min=0&sec=0&p1=43) on Mondays.
+The jQuery Core team has a weekly meeting to discuss the progress of current work. The meeting is held in the [#jquery/meeting](https://matrix.to/#/#jquery_meeting:gitter.im) Matrix channel on gitter.im at [Noon EST](https://www.timeanddate.com/worldclock/fixedtime.html?month=10&day=7&year=2024&hour=12&min=0&sec=0&p1=43) on Mondays.
 
 [jQuery Core Meeting Notes](https://meetings.jquery.org/category/core/)
 


### PR DESCRIPTION
The contributor guide renders the jQuery meeting channel as plain text instead of a link.

- **Sequence:** Open `CONTRIBUTING.md` and go to “Weekly Status Meetings”.
- **Expected:** `#jquery/meeting` is clickable and opens the Matrix channel.
- **Actual before this change:** GitHub renders `#jquery/meeting` as plain text.

Fixes gh-5872

### Summary ###

Correct the meeting channel URL scheme from `hhttps://` to `https://`.

### Actual screenshots ###

**Before — upstream `main` at `7e1efd77`**

`#jquery/dev` is linked above, but `#jquery/meeting` is plain text:

<img width="1280" height="720" alt="Contributor guide on upstream main showing the meeting channel as plain text" src="https://github.com/user-attachments/assets/a0346f3d-18d6-4e2e-8e8f-f19d5be0247e" />

**After — this PR at `a6898a60`**

The same rendered section now exposes `#jquery/meeting` as a link:

<img width="1280" height="720" alt="Contributor guide after the fix showing the meeting channel as a link" src="https://github.com/user-attachments/assets/04fabd7f-2c69-409a-ae01-de6c22a341d1" />

### Validation ###

- `npm run test`
- `git diff --check`
- The corrected target returns HTTP 200.
- GitHub's rendered branch view exposes one `#jquery/meeting` link with the expected URL.

### Checklist ###

* [ ] New tests have been added to show the fix or feature works (not applicable to a one-character Markdown URL correction)
* [x] An API documentation issue/PR is not needed; this fixes repository contribution guidance
