### PR TITLE
Callbacks: Restore firing state after exceptions

### DIFF
--- a/src/callbacks.js
+++ b/src/callbacks.js
@@ -71,38 +71,42 @@ jQuery.Callbacks = function( options ) {
 			// Execute callbacks for all pending executions,
 			// respecting firingIndex overrides and runtime changes
 			fired = firing = true;
-			for ( ; queue.length; firingIndex = -1 ) {
-				memory = queue.shift();
-				while ( ++firingIndex < list.length ) {
+			try {
+				for ( ; queue.length; firingIndex = -1 ) {
+					memory = queue.shift();
+					while ( ++firingIndex < list.length ) {
 
-					// Run callback and check for early termination
-					if ( list[ firingIndex ].apply( memory[ 0 ], memory[ 1 ] ) === false &&
-						options.stopOnFalse ) {
+						// Run callback and check for early termination
+						if ( list[ firingIndex ].apply( memory[ 0 ], memory[ 1 ] ) === false &&
+							options.stopOnFalse ) {
 
-						// Jump to end and forget the data so .add doesn't re-fire
-						firingIndex = list.length;
-						memory = false;
+							// Jump to end and forget the data so .add doesn't re-fire
+							firingIndex = list.length;
+							memory = false;
+						}
 					}
 				}
-			}
+			} finally {
+				firingIndex = -1;
 
-			// Forget the data if we're done with it
-			if ( !options.memory ) {
-				memory = false;
-			}
+				// Forget the data if we're done with it
+				if ( !options.memory ) {
+					memory = false;
+				}
 
-			firing = false;
+				firing = false;
 
-			// Clean up if we're done firing for good
-			if ( locked ) {
+				// Clean up if we're done firing for good
+				if ( locked ) {
 
-				// Keep an empty list if we have data for future add calls
-				if ( memory ) {
-					list = [];
+					// Keep an empty list if we have data for future add calls
+					if ( memory ) {
+						list = [];
 
-				// Otherwise, this object is spent
-				} else {
-					list = "";
+					// Otherwise, this object is spent
+					} else {
+						list = "";
+					}
 				}
 			}
 		},

--- a/test/unit/callbacks.js
+++ b/test/unit/callbacks.js
@@ -403,4 +403,27 @@ QUnit.test( "jQuery.Callbacks() - list with memory stays locked (gh-3469)", func
 	assert.equal( fired, 11, "Post-lock() fire ignored" );
 } );
 
+QUnit.test( "jQuery.Callbacks() - firing state is restored after an exception (gh-5874)", function( assert ) {
+
+	assert.expect( 3 );
+
+	var cb = jQuery.Callbacks( "memory" ),
+		message = "not called";
+
+	cb.add( function() {
+		throw new Error( "callback error" );
+	} );
+
+	assert.throws( function() {
+		cb.fire( "remembered" );
+	}, /callback error/, "Exception is propagated" );
+
+	cb.add( function( value ) {
+		message = value;
+		assert.strictEqual( value, "remembered", "Memory is retained" );
+	} );
+
+	assert.strictEqual( message, "remembered", "Callback added after the exception fires" );
+} );
+
 } )();


### PR DESCRIPTION
A `jQuery.Callbacks("memory")` list now remains usable after a callback throws.

- Sequence: Fire a memory callback list containing a throwing callback, catch the propagated error, then add another callback.
- Expected: The later callback immediately receives the memorized value.
- Actual before this change: The later callback is never invoked because the list remains in the firing state.

Fixes gh-5874

### Summary

- Move the existing callback-list cleanup into a `finally` block.
- Preserve exception propagation and the memorized value.
- Add focused regression coverage for adding a callback after an exception.

### Actual screenshots

**Before — upstream `7e1efd77` with the regression test only**

<img width="1280" height="720" alt="QUnit failure before callback cleanup fix" src="https://github.com/user-attachments/assets/efdd0f9d-f8fc-456c-8c0f-d31179398c54" />

**After — commit `92884236`**

<img width="1280" height="720" alt="QUnit pass after callback cleanup fix" src="https://github.com/user-attachments/assets/7187efaa-8419-4820-9c2a-93bab4144d04" />

### Validation

- `npm run test:unit -- -b chrome --headless -f module=callbacks` — 52 passed
- `npm test` — full suite passed, including Chrome (1,189 passed) and Firefox (1,190 passed)

### Checklist

* [x] New tests have been added to show the fix or feature works
* [x] No documentation changes are needed for this internal state repair