### PR TITLE
CSS: Restore temporary styles after measurement errors

### DIFF
--- a/src/css/var/swap.js
+++ b/src/css/var/swap.js
@@ -1,6 +1,6 @@
 // A method for quickly swapping in/out CSS properties to get correct calculations.
 export function swap( elem, options, callback ) {
-	var ret, name,
+	var name,
 		old = {};
 
 	// Remember the old values, and insert the new ones
@@ -9,12 +9,13 @@ export function swap( elem, options, callback ) {
 		elem.style[ name ] = options[ name ];
 	}
 
-	ret = callback.call( elem );
+	try {
+		return callback.call( elem );
+	} finally {
 
-	// Revert the old values
-	for ( name in options ) {
-		elem.style[ name ] = old[ name ];
+		// Revert the old values
+		for ( name in options ) {
+			elem.style[ name ] = old[ name ];
+		}
 	}
-
-	return ret;
 }

--- a/test/unit/dimensions.js
+++ b/test/unit/dimensions.js
@@ -385,6 +385,42 @@ QUnit.test( "hidden element with implicit content-based dimensions", function( a
 	assert.strictEqual( div.height(), 40, "height of a hidden element" );
 } );
 
+QUnit.test(
+	"temporary styles are restored when dimension measurement throws (gh-5876)", function( assert ) {
+	assert.expect( 4 );
+
+	var oldBoxSizingHook = jQuery.cssHooks.boxSizing,
+		div = jQuery( "<div>" )
+			.css( {
+				display: "none",
+				position: "relative",
+				visibility: "visible"
+			} )
+			.appendTo( "#qunit-fixture" );
+
+	jQuery.cssHooks.boxSizing = {
+		get: function() {
+			throw new Error( "measurement error" );
+		}
+	};
+
+	try {
+		assert.throws( function() {
+			div.width();
+		}, /measurement error/, "Exception is propagated" );
+	} finally {
+		if ( oldBoxSizingHook ) {
+			jQuery.cssHooks.boxSizing = oldBoxSizingHook;
+		} else {
+			delete jQuery.cssHooks.boxSizing;
+		}
+	}
+
+	assert.strictEqual( div[ 0 ].style.display, "none", "Display is restored" );
+	assert.strictEqual( div[ 0 ].style.position, "relative", "Position is restored" );
+	assert.strictEqual( div[ 0 ].style.visibility, "visible", "Visibility is restored" );
+} );
+
 QUnit.test( "table dimensions", function( assert ) {
 	assert.expect( 3 );
 


### PR DESCRIPTION
Hidden-element dimension measurement now restores jQuery's temporary inline styles when a CSS hook throws.

- Sequence: Measure a hidden element through `.width()` while a `boxSizing` hook throws.
- Expected: The error propagates and `display / position / visibility` remain `none / relative / visible`.
- Actual before this change: The error propagates, but those styles remain `block / absolute / hidden`.

Fixes gh-5876

### Summary

- Restore temporary measurement styles from a `finally` block.
- Preserve callback return values and exception propagation.
- Add focused regression coverage through the public `.width()` API.

### Actual screenshots

**Before — upstream `7e1efd77` with the regression test only**

<img width="1512" height="696" alt="QUnit failure showing temporary CSS styles are not restored" src="https://github.com/user-attachments/assets/17c6e84d-c27a-4411-a931-a78b21cf5577" />

**After — commit `8f485fe0`**

<img width="1512" height="696" alt="QUnit pass after temporary CSS style restoration fix" src="https://github.com/user-attachments/assets/de9f7c55-b55f-4b6f-91d1-c232a3e59cbf" />

### Validation

- `npm run test:unit -- -b chrome --headless -f module=dimensions` — 31 passed
- `npm test` — full suite passed, including Chrome (1,189 passed) and Firefox (1,190 passed)

### Checklist

* [x] New tests have been added to show the fix works
* [x] No documentation changes are needed for this internal cleanup