### PR TITLE
Ajax: Restore Global State After beforeSend Errors

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -655,11 +655,18 @@ jQuery.extend( {
 		}
 
 		// Allow custom headers/mimetypes and early abort
-		if ( s.beforeSend &&
-			( s.beforeSend.call( callbackContext, jqXHR, s ) === false || completed ) ) {
+		try {
+			if ( s.beforeSend &&
+				( s.beforeSend.call( callbackContext, jqXHR, s ) === false || completed ) ) {
 
-			// Abort if not done already and return
-			return jqXHR.abort();
+				// Abort if not done already and return
+				return jqXHR.abort();
+			}
+		} catch ( e ) {
+			if ( !completed ) {
+				jqXHR.abort();
+			}
+			throw e;
 		}
 
 		// Aborting is no longer a cancellation

--- a/test/unit/ajax.js
+++ b/test/unit/ajax.js
@@ -930,6 +930,41 @@ QUnit.module( "ajax", {
 		};
 	} );
 
+	QUnit.test( "jQuery.ajax() - beforeSend exception restores global state (gh-5878)",
+		function( assert ) {
+		assert.expect( 3 );
+
+		var activeAfterThrow,
+			active = jQuery.active,
+			events = [],
+			namespace = ".beforeSendException";
+
+		jQuery( document ).on( "ajaxStart" + namespace + " ajaxStop" + namespace,
+			function( event ) {
+				events.push( event.type );
+			}
+		);
+
+		try {
+			assert.throws( function() {
+				jQuery.ajax( {
+					url: url( "name.html" ),
+					beforeSend: function() {
+						throw new Error( "beforeSend error" );
+					}
+				} );
+			}, /beforeSend error/, "Exception is propagated" );
+		} finally {
+			activeAfterThrow = jQuery.active;
+			jQuery.active = active;
+			jQuery( document ).off( namespace );
+		}
+
+		assert.strictEqual( activeAfterThrow, active, "Global active counter is restored" );
+		assert.deepEqual( events, [ "ajaxStart", "ajaxStop" ],
+			"Global lifecycle is completed" );
+	} );
+
 	ajaxTest( "jQuery.ajax() - beforeSend, cancel request manually", 2, function( assert ) {
 		return {
 			create: function() {


### PR DESCRIPTION
### Summary ###

A thrown `beforeSend` callback no longer leaves jQuery's global Ajax lifecycle open.

Fixes gh-5878.

- Sequence: Call `jQuery.ajax()` with global events enabled and throw from `beforeSend`.
- Expected: `jQuery.active` returns to `0`, and `ajaxStart` is followed by `ajaxStop`.
- Actual: `jQuery.active` remains `1`, and only `ajaxStart` fires.

This runs the existing abort cleanup before rethrowing the original callback error and adds a focused regression test.

### Actual screenshots

**Before — `main` at `7e1efd77598a527c67d2a674a1259787f7e441fd`, Chrome 150 on macOS, focused QUnit:**

<img width="1512" height="696" alt="Before: failing QUnit regression shows expected 0, result 1, and missing ajaxStop" src="https://github.com/user-attachments/assets/e2b648dc-c39b-4c69-8718-eaed31695b2b" />


**After — `c38036bb5215ba4b5c6102a8d1bb7ac7f0170403`, same browser, test URL, and viewport:**

<img width="1512" height="696" alt="After: committed QUnit regression shows 3 of 3 assertions passed" src="https://github.com/user-attachments/assets/b1de4641-e3e2-405a-b682-d5889fa4a70e" />


### Testing ###

- `npm run test:unit -- --flag module=ajax` — 193 passed, 0 skipped.
- `npm test` — all configured builds, lint, browserless, Chrome, Firefox, ESM, slim, no-deprecated, and selector-native runs passed.

### Checklist ###

* [x] New tests have been added to show the fix works
* [x] Documentation changes are not needed
