### PR TITLE
Manipulation: Restore script types after insertion errors

### DIFF
--- a/src/manipulation/domManip.js
+++ b/src/manipulation/domManip.js
@@ -54,29 +54,35 @@ export function domManip( collection, args, callback, ignored ) {
 			scripts = jQuery.map( getAll( fragment, "script" ), disableScript );
 			hasScripts = scripts.length;
 
-			// Use the original fragment for the last item
-			// instead of the first because it can end up
-			// being emptied incorrectly in certain situations (trac-8070).
-			for ( ; i < l; i++ ) {
-				node = fragment;
+			try {
 
-				if ( i !== iNoClone ) {
-					node = jQuery.clone( node, true, true );
+				// Use the original fragment for the last item
+				// instead of the first because it can end up
+				// being emptied incorrectly in certain situations (trac-8070).
+				for ( ; i < l; i++ ) {
+					node = fragment;
 
-					// Keep references to cloned scripts for later restoration
-					if ( hasScripts ) {
-						jQuery.merge( scripts, getAll( node, "script" ) );
+					if ( i !== iNoClone ) {
+						node = jQuery.clone( node, true, true );
+
+						// Keep references to cloned scripts for later restoration
+						if ( hasScripts ) {
+							jQuery.merge( scripts, getAll( node, "script" ) );
+						}
 					}
-				}
 
-				callback.call( collection[ i ], node, i );
+					callback.call( collection[ i ], node, i );
+				}
+			} finally {
+
+				// Re-enable scripts
+				if ( hasScripts ) {
+					jQuery.map( scripts, restoreScript );
+				}
 			}
 
 			if ( hasScripts ) {
 				doc = scripts[ scripts.length - 1 ].ownerDocument;
-
-				// Re-enable scripts
-				jQuery.map( scripts, restoreScript );
 
 				// Evaluate executable scripts on first document insertion
 				for ( i = 0; i < hasScripts; i++ ) {

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -870,6 +870,25 @@ QUnit.test( "before(Element)", function( assert ) {
 	assert.equal( jQuery( "#en" ).text(), expected, "Insert element before" );
 } );
 
+QUnit.test( "script type is restored when insertion throws", function( assert ) {
+
+	assert.expect( 2 );
+
+	var script = document.createElement( "script" );
+
+	script.setAttribute( "type", "application/json" );
+
+	assert.throws( function() {
+		jQuery( document.documentElement ).before( script );
+	}, "Invalid insertion throws" );
+
+	assert.strictEqual(
+		script.getAttribute( "type" ),
+		"application/json",
+		"Script type is restored"
+	);
+} );
+
 QUnit.test( "before(Array<Element>)", function( assert ) {
 
 	assert.expect( 1 );


### PR DESCRIPTION
### Summary ###

A failed DOM insertion no longer leaves caller-owned `<script>` elements with jQuery's temporary `type` prefix.

Fixes #5881.

- Sequence: pass a script with `type="application/json"` to `.before()` where the browser rejects the insertion with `HierarchyRequestError`.
- Expected: the native exception propagates and the script keeps `type="application/json"`.
- Before: the exception propagates, but the script is left as `type="true/application/json"`.
- After: the exception propagates and the original script type is restored.

`domManip` now restores every masked script type in a `finally` block around the clone and insertion loop. This keeps cleanup reliable without swallowing the browser exception. The regression test covers both error propagation and restoration of the caller-owned element.

### Actual screenshots ###

**Before — upstream `main` at `7e1efd77598a527c67d2a674a1259787f7e441fd`, QUnit 2.26.0, Chrome 150, source modules enabled.**

![Failing QUnit regression showing expected application/json and actual true/application/json](https://github.com/user-attachments/assets/28b282d9-50b0-4a63-ab19-b9982882a25a)

**After — commit `a4e6e3e9049ffd8a0b8d936f82ca7acd77297fd8`, the same focused test in Chrome 150 with source modules enabled.**

![Passing focused QUnit regression with two of two assertions passing](https://github.com/user-attachments/assets/09a2a4be-f244-4b1e-be3d-7b16c2a8bb3c)

**Complete manipulation module — commit `a4e6e3e9049ffd8a0b8d936f82ca7acd77297fd8`, Chrome 150 with source modules enabled.**

![Complete manipulation module with 152 tests and 1035 assertions passing](https://github.com/user-attachments/assets/f07d0ffd-6fa7-4de9-a115-9ba4f871d4db)

### Validation ###

- `npm run test` — all builds, lint, browserless, Chrome/Firefox, ESM, slim, no-deprecated, and selector-native checks pass.
- Focused Chrome regression: 1 passed; 2 of 2 assertions passed.
- Complete manipulation module in Chrome: 152 passed; 1035 of 1035 assertions passed.
- Complete manipulation module in Firefox: 152 passed.

### Checklist ###

* [x] New tests have been added to show the fix or feature works
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com