### PR TITLE
Event: Restore leveraged native state after method failures

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -551,9 +551,12 @@ function leverageNative( el, type, isSetup ) {
 					dataPriv.set( this, type, saved );
 
 					// Trigger the native event and capture its result
-					this[ type ]();
-					result = dataPriv.get( this, type );
-					dataPriv.set( this, type, false );
+					try {
+						this[ type ]();
+						result = dataPriv.get( this, type );
+					} finally {
+						dataPriv.set( this, type, false );
+					}
 
 					if ( saved !== result ) {
 

--- a/test/unit/event.js
+++ b/test/unit/event.js
@@ -3410,6 +3410,27 @@ QUnit.test( "native-backed events preserve trigger data (gh-1741, gh-4139)", fun
 		"element not focused after blur event (default action)" );
 } );
 
+QUnit.test( "native-backed click recovers after the native method throws", function( assert ) {
+	assert.expect( 3 );
+
+	var input = jQuery( "<input type='checkbox'>" ).appendTo( "#qunit-fixture" ),
+		nativeClick = input[ 0 ].click;
+
+	input[ 0 ].click = function() {
+		throw new Error( "native click failed" );
+	};
+
+	assert.throws( function() {
+		input.trigger( "click" );
+	}, /native click failed/, "Native error propagates" );
+	assert.strictEqual( input[ 0 ].checked, false, "Failed click does not toggle the input" );
+
+	input[ 0 ].click = nativeClick;
+	input.trigger( "click" );
+
+	assert.strictEqual( input[ 0 ].checked, true, "A later click still uses the native method" );
+} );
+
 QUnit.test( "focus change during a focus handler (gh-4382)", function( assert ) {
 	assert.expect( 2 );
 


### PR DESCRIPTION
### Summary ###

A checkbox can stop responding to jQuery-triggered clicks after an earlier call to its native `click()` throws.

- Sequence: Override a checkbox's native `click()` to throw, call `.trigger( "click" )`, restore `click()`, then trigger it again.
- Expected: The first error propagates, and the later trigger still invokes the native click and checks the checkbox.
- Actual before this PR: The error propagates, but stale per-element trigger state suppresses the later native click; the checkbox remains unchecked.

This change clears the leveraged per-element state in a `finally` block, preserving the original native exception while allowing later native-backed triggers to work normally.

Fixes #5883.

Related to #5868 and #5869, but this is a separate execution path. #5869 restores global trigger state around the generic `elem[ type ]()` call in `src/event/trigger.js`; this change restores per-element `dataPriv` state around the earlier `leverageNative` call in `src/event.js`. The fixes can merge independently.

### Actual screenshots ###

**Before — upstream `main` at `7e1efd77598a527c67d2a674a1259787f7e441fd`, Chrome 150, QUnit 2.26.0**

<img width="1512" height="752" alt="QUnit failure: later native-backed click stays unchecked after an earlier native click throws" src="https://github.com/user-attachments/assets/5f8b99b3-6a43-437e-a514-5999129fdc2f" />

**After — proposed commit `976a75e8c40593a9f0d31ca9c6de4f2594efe18c`, using the same regression and browser; all 3 assertions pass**

<img width="1512" height="752" alt="QUnit success: later native-backed click works after restoring leveraged native state" src="https://github.com/user-attachments/assets/ecd51de5-d0f2-4606-8d59-130bdf070381" />

### Testing ###

- `npm run test`
- `npm run test:unit -- -b chrome -b firefox --headless -f module=event`
  - Chrome: 118 passed, 0 skipped
  - Firefox: 118 passed, 0 skipped

### Checklist ###

* [x] New tests have been added to show the fix or feature works
* [x] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com (not needed; no API or documentation change)
