### PR TITLE
Core: Accept parsererror elements in valid XML

### DIFF
--- a/src/core/parseXML.js
+++ b/src/core/parseXML.js
@@ -13,7 +13,12 @@ jQuery.parseXML = function( data ) {
 		xml = ( new window.DOMParser() ).parseFromString( data, "text/xml" );
 	} catch ( e ) {}
 
-	parserErrorElem = xml && xml.querySelector( "parsererror" );
+	parserErrorElem = xml && jQuery.grep(
+		xml.querySelectorAll( "parsererror" ),
+		function( elem ) {
+			return elem.namespaceURI;
+		}
+	)[ 0 ];
 	if ( !xml || parserErrorElem ) {
 		jQuery.error( "Invalid XML: " + (
 			parserErrorElem ?

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -1419,7 +1419,7 @@ QUnit.test( "jQuery.parseHTML error handling", function( assert ) {
 } );
 
 QUnit.test( "jQuery.parseXML", function( assert ) {
-	assert.expect( 8 );
+	assert.expect( 9 );
 
 	var xml, tmp;
 	try {
@@ -1429,6 +1429,8 @@ QUnit.test( "jQuery.parseXML", function( assert ) {
 		tmp = tmp.getElementsByTagName( "b" )[ 0 ];
 		assert.ok( !!tmp, "<b> present in document" );
 		assert.strictEqual( tmp.childNodes[ 0 ].nodeValue, "well-formed", "<b> text is as expected" );
+		xml = jQuery.parseXML( "<root><parsererror/></root>" );
+		assert.ok( xml.querySelector( "parsererror" ), "<parsererror> present in valid document" );
 	} catch ( e ) {
 		assert.strictEqual( e, undefined, "unexpected error" );
 	}


### PR DESCRIPTION
### Summary ###

Valid XML containing a non-namespaced `<parsererror>` element now parses successfully.

- **Sequence:** Call `jQuery.parseXML( "<root><parsererror/></root>" )`.
- **Expected:** A valid XML document containing the `<parsererror>` element is returned.
- **Actual before:** `jQuery.parseXML()` throws `Error( "Invalid XML: " )`.
- **Actual after:** The valid XML document is returned.

The parser now distinguishes browser-generated, namespaced parse-error elements from ordinary non-namespaced elements. The regression test covers the valid-input case.

Fixes gh-5885.

### Actual screenshots ###

Both captures use the same focused QUnit test, QUnit 2.26.0, and Chrome 150.0.7871.125.

**Before — upstream `main` at `7e1efd77598a527c67d2a674a1259787f7e441fd` with the regression assertion only.** QUnit reports one failed test and `Result: Error( "Invalid XML: " )`.

<img width="1280" height="720" alt="Failing QUnit parseXML regression showing one failed assertion and an Invalid XML error" src="https://github.com/user-attachments/assets/b2cff770-b15f-4e07-bfe9-e5a14756cd7a" />

**After — commit `2dc9c88555109438fbd8579bd9b471ee8cf30588`.** QUnit reports 11 assertions of 11 passed and zero failed.

<img width="1280" height="720" alt="Passing QUnit parseXML regression showing eleven assertions passed and zero failed" src="https://github.com/user-attachments/assets/c9052081-404e-46d3-a2a5-dfb97035d046" />

### Validation ###

- `pnpm run build:all`
- `pnpm run lint:dev`
- `pnpm run lint:json`
- Bundler, Node, Promises/A+, and JSDOM smoke tests
- Full QUnit suite in Chrome and Firefox
- ESM, slim, no-deprecated, and native-selector QUnit variants in Chrome

### Checklist ###

* [x] New tests have been added to show the fix works
* [x] A docs issue/PR is not needed because this does not change the public API
