### PR TITLE
Event: Correct focus handler comment

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -732,7 +732,7 @@ jQuery.each( {
 jQuery.each( { focus: "focusin", blur: "focusout" }, function( type, delegateType ) {
 
 	// Support: IE 11+
-	// Attach a single focusin/focusout handler on the document while someone wants focus/blur.
+	// Attach a focusin/focusout handler to each element with a direct focus/blur handler.
 	// This is because the former are synchronous in IE while the latter are async. In other
 	// browsers, all those handlers are invoked synchronously.
 	function focusMappedHandler( nativeEvent ) {


### PR DESCRIPTION
### Summary ###

The focus/blur compatibility comment now accurately describes where IE's mapped handler is attached.

- **Sequence:** Read the comment above `focusMappedHandler` alongside the special-event `setup` implementation.
- **Expected:** The comment reflects `this.addEventListener( delegateType, focusMappedHandler )`.
- **Actual before:** The comment says one handler is attached to the document.
- **Actual after:** The comment says a handler is attached to each element with a directly bound focus or blur handler.

There is no runtime behavior change.

### Validation ###

- `git diff --check`
- ESLint on `src/event.js`
- Repository pre-push lint and JSON checks

### Checklist ###

* [ ] New tests have been added to show the fix or feature works — not applicable; this is a comment-only correction
* [x] A docs issue/PR is not needed because the correction is limited to an inline source comment
